### PR TITLE
gonum: clean away old files and fix-up travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ language: go
 
 # Versions of go that are explicitly supported by gonum.
 go:
- - 1.6.3
- - 1.7.3
+ - 1.6
+ - 1.7
  - 1.8
 
 # Required for coverage.
@@ -13,12 +13,14 @@ before_install:
  - go get golang.org/x/tools/cmd/cover
  - go get github.com/mattn/goveralls
 
+go_import_path: gonum.org/v1/gonum
+
 # Get deps, build, test, and ensure the code is gofmt'ed.
 # If we are building as gonum, then we have access to the coveralls api key, so we can run coverage as well.
 script:
- - go get -d -t -v ./...
- - go build -v ./...
- - go test -v ./...
+ - go get -d -t -v gonum.org/v1/gonum/...
+ - go build -v gonum.org/v1/gonum/...
+ - go test -v gonum.org/v1/gonum/...
  - test -z "$(gofmt -d .)"
  - if [[ $TRAVIS_SECURE_ENV_VARS = "true" ]]; then bash ./.travis/test-coverage.sh; fi
 

--- a/gonum.txt
+++ b/gonum.txt
@@ -1,3 +1,0 @@
-"The ideas of science germinate in a matrix of established knowledge gained by experiment; they are not lonesome thoughts, born in a rarified realm where no researcher has gone before."
-
-Seth Shostak

--- a/hello.go
+++ b/hello.go
@@ -1,3 +1,0 @@
-package gonum
-
-const theMatrix = -1

--- a/hello_test.go
+++ b/hello_test.go
@@ -1,9 +1,0 @@
-package gonum
-
-import "testing"
-
-func TestTheMatrix(t *testing.T) {
-	if theMatrix != -1 {
-		t.Errorf("Bad constant value")
-	}
-}


### PR DESCRIPTION
Partial fix for travis failures. The next step is to move cgo-dependent code out into netlib.

@btracey Please take a look.