### PR TITLE
graph/simple: do not use intsets.Sparse for ID sets

### DIFF
--- a/graph/simple/directed.go
+++ b/graph/simple/directed.go
@@ -31,6 +31,8 @@ func NewDirectedGraph(self, absent float64) *DirectedGraph {
 
 		self:   self,
 		absent: absent,
+
+		nodeIDs: newIDSet(),
 	}
 }
 

--- a/graph/simple/undirected.go
+++ b/graph/simple/undirected.go
@@ -29,6 +29,8 @@ func NewUndirectedGraph(self, absent float64) *UndirectedGraph {
 
 		self:   self,
 		absent: absent,
+
+		nodeIDs: newIDSet(),
 	}
 }
 


### PR DESCRIPTION
This does not go the complete way to the kind of implementation referred to in the gonum-dev [thread](https://groups.google.com/d/topic/gonum-dev/twUcG1rEMIU/discussion), but covers a reasonable set of use cases. If we make an `IDSource` interface to use, this would be a good default.

@leoneu Would you please try this in your problematic code and see if it is satisfactory.

@leoneu @vladimir-ch Please take a look.

Updates #32.