### PR TITLE
dense: add SliceRows method

### DIFF
--- a/mat64/dense.go
+++ b/mat64/dense.go
@@ -5,6 +5,8 @@
 package mat64
 
 import (
+	"sort"
+
 	"github.com/gonum/blas"
 	"github.com/gonum/blas/blas64"
 	"github.com/gonum/matrix"
@@ -302,6 +304,27 @@ func (m *Dense) Slice(i, k, j, l int) Matrix {
 	t.mat.Cols = l - j
 	t.capRows -= i
 	t.capCols -= j
+	return &t
+}
+
+// SliceRows returns a new Matrix with the rows specified in the indices array.
+// SliceRows panics with ErrIndexOutOfRange if any index from the indices array
+// is outside the bounds of the receiver.
+func (m *Dense) SliceRows(indices []int) Matrix {
+	mr, _ := m.Dims()
+	t := *m
+	sliced := []float64{}
+	sort.Ints(indices)
+	for _, i := range indices {
+		if i < 0 || i >= mr {
+			panic(matrix.ErrIndexOutOfRange)
+		}
+		sliced = append(sliced, t.mat.Data[i*t.mat.Stride:(i+1)*t.mat.Stride]...)
+	}
+
+	t.mat.Data = sliced
+	t.mat.Rows = len(indices)
+	t.capRows = len(indices)
 	return &t
 }
 

--- a/mat64/dense_test.go
+++ b/mat64/dense_test.go
@@ -1871,6 +1871,37 @@ func TestInverse(t *testing.T) {
 	}
 }
 
+func TestSliceRows(t *testing.T) {
+	m := NewDense(3, 3, []float64{0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0})
+	m = m.SliceRows([]int{0, 2}).(*Dense)
+	rows, cols := m.Dims()
+	capRows, capCols := m.Caps()
+	if rows != 2 {
+		t.Errorf("unexpected value for rows: got: %d want: 2", rows)
+	}
+	if cols != 3 {
+		t.Errorf("unexpected value for cols: got: %d want: 3", cols)
+	}
+	if capRows != 2 {
+		t.Errorf("unexpected value for capRows: got: %d want: 2", capRows)
+	}
+	if capCols != 3 {
+		t.Errorf("unexpected value for capCols: got: %d want: 3", capCols)
+	}
+	want := []float64{0.0, 1.0, 2.0, 6.0, 7.0, 8.0}
+	if len(want) != len(m.mat.Data) {
+		t.Errorf("unexpected value for mat.Data: got: %d want: %v", m.mat.Data, want)
+	} else {
+		for i, w := range want {
+			if w != m.mat.Data[i] {
+				t.Errorf("unexpected value for mat.Data: got: %d want: %v", m.mat.Data, want)
+				break
+			}
+		}
+	}
+
+}
+
 var (
 	wd *Dense
 )


### PR DESCRIPTION
I've noticed that mat64.Dense doesn't have a method for slicing specified rows. In my opinion it would be very useful (at least for me ;>) so I've created a simple implementation. What do you think? Does it have any sense?