### PR TITLE
graph,graph/{encoding/dot,internal/set,topo,traverse}: remove intsets imports

### DIFF
--- a/graph/community/louvain_common.go
+++ b/graph/community/louvain_common.go
@@ -8,8 +8,10 @@ package community // import "gonum.org/v1/gonum/graph/community"
 import (
 	"fmt"
 	"math/rand"
+	"sort"
 
 	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/internal/set"
 )
 
 // Q returns the modularity Q score of the graph g subdivided into the
@@ -303,6 +305,36 @@ func (d *dense) TakeMin(p *int) bool {
 	}
 	*p = d.pos
 	d.pos++
+	return true
+}
+
+// slice is a sparse integer set iterator.
+type slice struct {
+	pos   int
+	elems []int
+}
+
+// newSlice returns a new slice of elements from s, sorted ascending.
+func newSlice(s set.Ints) *slice {
+	elems := make([]int, 0, len(s))
+	for i := range s {
+		elems = append(elems, i)
+	}
+	sort.Ints(elems)
+	return &slice{elems: elems}
+}
+
+// TakeMin mimics intsets.Sparse TakeMin for a sorted set. If the set
+// iterator position is less than the iterator size, TakeMin sets *p
+// to the the iterator position's element and increments the position
+// and returns true.
+// Otherwise, it returns false and *p is undefined.
+func (s *slice) TakeMin(p *int) bool {
+	if s.pos >= len(s.elems) {
+		return false
+	}
+	*p = s.elems[s.pos]
+	s.pos++
 	return true
 }
 

--- a/graph/community/louvain_directed.go
+++ b/graph/community/louvain_directed.go
@@ -9,10 +9,9 @@ import (
 	"math/rand"
 	"sort"
 
-	"golang.org/x/tools/container/intsets"
-
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
+	"gonum.org/v1/gonum/graph/internal/set"
 )
 
 // qDirected returns the modularity Q score of the graph g subdivided into the
@@ -555,33 +554,38 @@ func (l *directedLocalMover) deltaQ(n graph.Node) (deltaQ float64, dst int, src 
 	gamma := l.resolution
 
 	// Find communites connected to n.
-	var connected intsets.Sparse
+	connected := make(set.Ints)
 	// The following for loop is equivalent to:
 	//
 	//  for _, v := range l.g.From(n) {
-	//  	connected.Insert(l.memberships[v.ID()])
+	//  	connected.Add(l.memberships[v.ID()])
 	//  }
 	//  for _, v := range l.g.To(n) {
-	//  	connected.Insert(l.memberships[v.ID()])
+	//  	connected.Add(l.memberships[v.ID()])
 	//  }
 	//
 	// This is done to avoid two allocations.
 	for _, vid := range l.g.edgesFrom[id] {
-		connected.Insert(l.memberships[vid])
+		connected.Add(l.memberships[vid])
 	}
 	for _, vid := range l.g.edgesTo[id] {
-		connected.Insert(l.memberships[vid])
+		connected.Add(l.memberships[vid])
 	}
 	// Insert the node's own community.
-	connected.Insert(l.memberships[id])
+	connected.Add(l.memberships[id])
+
+	candidates := make([]int, 0, len(connected))
+	for i := range connected {
+		candidates = append(candidates, i)
+	}
+	sort.Ints(candidates)
 
 	// Calculate the highest modularity gain
 	// from moving into another community and
 	// keep the index of that community.
 	var dQremove float64
 	dQadd, dst, src := math.Inf(-1), -1, commIdx{-1, -1}
-	var i int
-	for connected.TakeMin(&i) {
+	for _, i := range candidates {
 		c := l.communities[i]
 		var k_aC, sigma_totC directedWeights // C is a substitution for ^𝛼 or ^𝛽.
 		var removal bool

--- a/graph/community/louvain_directed_multiplex_test.go
+++ b/graph/community/louvain_directed_multiplex_test.go
@@ -30,7 +30,7 @@ var communityDirectedMultiplexQTests = []struct {
 		structures: []structure{
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0),
 					1: linksTo(1),
 					2: linksTo(2),
@@ -63,7 +63,7 @@ var communityDirectedMultiplexQTests = []struct {
 		structures: []structure{
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1),
 					1: linksTo(2, 3, 4),
 				},
@@ -102,7 +102,7 @@ var communityDirectedMultiplexQTests = []struct {
 		structures: []structure{
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1),
 					1: linksTo(2, 3, 4),
 				},
@@ -139,7 +139,7 @@ var communityDirectedMultiplexQTests = []struct {
 		structures: []structure{
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2),
 					1: linksTo(3, 4, 5),
 				},
@@ -147,7 +147,7 @@ var communityDirectedMultiplexQTests = []struct {
 			},
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 3, 4, 5),
 				},
 				want: 0, tol: 1e-14,
@@ -180,7 +180,7 @@ var communityDirectedMultiplexQTests = []struct {
 		structures: []structure{
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2),
 					1: linksTo(3, 4, 5),
 				},
@@ -188,7 +188,7 @@ var communityDirectedMultiplexQTests = []struct {
 			},
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0),
 					1: linksTo(1),
 					2: linksTo(2),
@@ -229,7 +229,7 @@ var communityDirectedMultiplexQTests = []struct {
 		structures: []structure{
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 6),
 					1: linksTo(1, 7, 9, 12),
 					2: linksTo(2, 8, 11),
@@ -239,7 +239,7 @@ var communityDirectedMultiplexQTests = []struct {
 			},
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 2, 3, 4, 5, 10),
 					1: linksTo(1, 7, 9, 12),
 					2: linksTo(6),
@@ -249,7 +249,7 @@ var communityDirectedMultiplexQTests = []struct {
 			},
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12),
 				},
 				want: 0, tol: 1e-14,
@@ -483,7 +483,7 @@ var localDirectedMultiplexMoveTests = []struct {
 		layers: []layer{{g: blondel, weight: 1}, {g: blondel, weight: 0.5}},
 		structures: []moveStructures{
 			{
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 4, 5),
 					1: linksTo(3, 6, 7),
 					2: linksTo(8, 9, 10, 12, 14, 15),
@@ -494,7 +494,7 @@ var localDirectedMultiplexMoveTests = []struct {
 				tol:         1e-14,
 			},
 			{
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 4, 5),
 					1: linksTo(3, 6, 7),
 					2: linksTo(8, 9, 10, 12, 14, 15),
@@ -505,7 +505,7 @@ var localDirectedMultiplexMoveTests = []struct {
 				tol:         1e-14,
 			},
 			{
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 4, 5),
 					1: linksTo(3, 6, 7),
 					2: linksTo(8, 9, 10, 12, 14, 15),

--- a/graph/community/louvain_directed_test.go
+++ b/graph/community/louvain_directed_test.go
@@ -19,7 +19,7 @@ import (
 
 var communityDirectedQTests = []struct {
 	name       string
-	g          []set
+	g          []intset
 	structures []structure
 
 	wantLevels []level
@@ -32,7 +32,7 @@ var communityDirectedQTests = []struct {
 		structures: []structure{
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1),
 					1: linksTo(2, 3, 4),
 				},
@@ -68,7 +68,7 @@ var communityDirectedQTests = []struct {
 		structures: []structure{
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21),
 					1: linksTo(4, 5, 6, 10, 16),
 					2: linksTo(8, 9, 14, 15, 18, 20, 22, 26, 29, 30, 32, 33),
@@ -148,7 +148,7 @@ var communityDirectedQTests = []struct {
 		structures: []structure{
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 3, 4, 5, 6, 7),
 					1: linksTo(8, 9, 10, 11, 12, 13, 14, 15),
 				},
@@ -382,7 +382,7 @@ tests:
 
 var localDirectedMoveTests = []struct {
 	name       string
-	g          []set
+	g          []intset
 	structures []moveStructures
 }{
 	{
@@ -390,7 +390,7 @@ var localDirectedMoveTests = []struct {
 		g:    blondel,
 		structures: []moveStructures{
 			{
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 4, 5),
 					1: linksTo(3, 6, 7),
 					2: linksTo(8, 9, 10, 12, 14, 15),
@@ -401,7 +401,7 @@ var localDirectedMoveTests = []struct {
 				tol:         1e-14,
 			},
 			{
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 4, 5),
 					1: linksTo(3, 6, 7),
 					2: linksTo(8, 9, 10, 12, 14, 15),
@@ -412,7 +412,7 @@ var localDirectedMoveTests = []struct {
 				tol:         1e-14,
 			},
 			{
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 4, 5),
 					1: linksTo(3, 6, 7),
 					2: linksTo(8, 9, 10, 12, 14, 15),

--- a/graph/community/louvain_test.go
+++ b/graph/community/louvain_test.go
@@ -13,14 +13,14 @@ import (
 	"gonum.org/v1/gonum/graph/simple"
 )
 
-// set is an integer set.
-type set map[int]struct{}
+// intset is an integer set.
+type intset map[int]struct{}
 
-func linksTo(i ...int) set {
+func linksTo(i ...int) intset {
 	if len(i) == 0 {
 		return nil
 	}
-	s := make(set)
+	s := make(intset)
 	for _, v := range i {
 		s[v] = struct{}{}
 	}
@@ -28,15 +28,15 @@ func linksTo(i ...int) set {
 }
 
 type layer struct {
-	g          []set
+	g          []intset
 	edgeWeight float64 // Zero edge weight is interpreted as 1.0.
 	weight     float64
 }
 
 var (
-	unconnected = []set{ /* Nodes 0-4 are implicit .*/ 5: nil}
+	unconnected = []intset{ /* Nodes 0-4 are implicit .*/ 5: nil}
 
-	smallDumbell = []set{
+	smallDumbell = []intset{
 		0: linksTo(1, 2),
 		1: linksTo(2),
 		2: linksTo(3),
@@ -44,7 +44,7 @@ var (
 		4: linksTo(5),
 		5: nil,
 	}
-	dumbellRepulsion = []set{
+	dumbellRepulsion = []intset{
 		0: linksTo(4),
 		1: linksTo(5),
 		2: nil,
@@ -53,7 +53,7 @@ var (
 		5: nil,
 	}
 
-	repulsion = []set{
+	repulsion = []intset{
 		0: linksTo(3, 4, 5),
 		1: linksTo(3, 4, 5),
 		2: linksTo(3, 4, 5),
@@ -62,7 +62,7 @@ var (
 		5: linksTo(0, 1, 2),
 	}
 
-	simpleDirected = []set{
+	simpleDirected = []intset{
 		0: linksTo(1),
 		1: linksTo(0, 4),
 		2: linksTo(1),
@@ -71,9 +71,9 @@ var (
 	}
 
 	// http://www.slate.com/blogs/the_world_/2014/07/17/the_middle_east_friendship_chart.html
-	middleEast = struct{ friends, complicated, enemies []set }{
+	middleEast = struct{ friends, complicated, enemies []intset }{
 		// green cells
-		friends: []set{
+		friends: []intset{
 			0:  nil,
 			1:  linksTo(5, 7, 9, 12),
 			2:  linksTo(11),
@@ -90,7 +90,7 @@ var (
 		},
 
 		// yellow cells
-		complicated: []set{
+		complicated: []intset{
 			0:  linksTo(2, 4),
 			1:  linksTo(4, 8),
 			2:  linksTo(0, 3, 4, 5, 8, 9),
@@ -107,7 +107,7 @@ var (
 		},
 
 		// red cells
-		enemies: []set{
+		enemies: []intset{
 			0:  linksTo(1, 3, 5, 6, 7, 8, 9, 10, 11, 12),
 			1:  linksTo(0, 2, 3, 6, 10, 11),
 			2:  linksTo(1, 6, 7, 10, 12),
@@ -131,7 +131,7 @@ var (
 	// head from a node with lower Page Rank to a node with higher Page
 	// Rank. This has no impact on undirected tests, but allows a sensible
 	// view for directed tests.
-	zachary = []set{
+	zachary = []intset{
 		0:  nil,                     // rank=0.097
 		1:  linksTo(0, 2),           // rank=0.05288
 		2:  linksTo(0, 32),          // rank=0.05708
@@ -174,7 +174,7 @@ var (
 	// head from a node with lower Page Rank to a node with higher Page
 	// Rank. This has no impact on undirected tests, but allows a sensible
 	// view for directed tests.
-	blondel = []set{
+	blondel = []intset{
 		0:  linksTo(2),           // rank=0.06858
 		1:  linksTo(2, 4, 7),     // rank=0.05264
 		2:  nil,                  // rank=0.08249
@@ -196,7 +196,7 @@ var (
 
 type structure struct {
 	resolution  float64
-	memberships []set
+	memberships []intset
 	want, tol   float64
 }
 
@@ -206,7 +206,7 @@ type level struct {
 }
 
 type moveStructures struct {
-	memberships []set
+	memberships []intset
 	targetNodes []graph.Node
 
 	resolution float64
@@ -255,11 +255,11 @@ func init() {
 
 // This init function checks the Middle East relationship data.
 func init() {
-	world := make([]set, len(middleEast.friends))
+	world := make([]intset, len(middleEast.friends))
 	for i := range world {
-		world[i] = make(set)
+		world[i] = make(intset)
 	}
-	for _, relationships := range [][]set{middleEast.friends, middleEast.complicated, middleEast.enemies} {
+	for _, relationships := range [][]intset{middleEast.friends, middleEast.complicated, middleEast.enemies} {
 		for i, rel := range relationships {
 			for inter := range rel {
 				if _, ok := world[i][inter]; ok {

--- a/graph/community/louvain_undirected_multiplex.go
+++ b/graph/community/louvain_undirected_multiplex.go
@@ -10,10 +10,9 @@ import (
 	"math/rand"
 	"sort"
 
-	"golang.org/x/tools/container/intsets"
-
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
+	"gonum.org/v1/gonum/graph/internal/set"
 )
 
 // UndirectedMultiplex is an undirected multiplex graph.
@@ -124,16 +123,16 @@ func NewUndirectedLayers(layers ...graph.Undirected) (UndirectedLayers, error) {
 	if len(layers) == 0 {
 		return nil, nil
 	}
-	var base, next intsets.Sparse
+	base := make(set.Ints)
 	for _, n := range layers[0].Nodes() {
-		base.Insert(n.ID())
+		base.Add(n.ID())
 	}
 	for i, l := range layers[1:] {
-		next.Clear()
+		next := make(set.Ints)
 		for _, n := range l.Nodes() {
-			next.Insert(n.ID())
+			next.Add(n.ID())
 		}
-		if !next.Equals(&base) {
+		if !set.IntsEqual(next, base) {
 			return nil, fmt.Errorf("community: layer ID mismatch between layers: %d", i+1)
 		}
 	}
@@ -702,12 +701,12 @@ func (l *undirectedMultiplexLocalMover) deltaQ(n graph.Node) (deltaQ float64, ds
 		iterator = &dense{n: len(l.communities)}
 	} else {
 		// Find communities connected to n.
-		var connected intsets.Sparse
+		connected := make(set.Ints)
 		// The following for loop is equivalent to:
 		//
 		//  for i := 0; i < l.g.Depth(); i++ {
 		//  	for _, v := range l.g.Layer(i).From(n) {
-		//  		connected.Insert(l.memberships[v.ID()])
+		//  		connected.Add(l.memberships[v.ID()])
 		//  	}
 		//  }
 		//
@@ -715,12 +714,12 @@ func (l *undirectedMultiplexLocalMover) deltaQ(n graph.Node) (deltaQ float64, ds
 		// each layer.
 		for _, layer := range l.g.layers {
 			for _, vid := range layer.edges[id] {
-				connected.Insert(l.memberships[vid])
+				connected.Add(l.memberships[vid])
 			}
 		}
 		// Insert the node's own community.
-		connected.Insert(l.memberships[id])
-		iterator = &connected
+		connected.Add(l.memberships[id])
+		iterator = newSlice(connected)
 	}
 
 	// Calculate the highest modularity gain

--- a/graph/community/louvain_undirected_multiplex_test.go
+++ b/graph/community/louvain_undirected_multiplex_test.go
@@ -30,7 +30,7 @@ var communityUndirectedMultiplexQTests = []struct {
 		structures: []structure{
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0),
 					1: linksTo(1),
 					2: linksTo(2),
@@ -64,7 +64,7 @@ var communityUndirectedMultiplexQTests = []struct {
 		structures: []structure{
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2),
 					1: linksTo(3, 4, 5),
 				},
@@ -72,7 +72,7 @@ var communityUndirectedMultiplexQTests = []struct {
 			},
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 3, 4, 5),
 				},
 				want: 0, tol: 1e-14,
@@ -108,7 +108,7 @@ var communityUndirectedMultiplexQTests = []struct {
 		structures: []structure{
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2),
 					1: linksTo(3, 4, 5),
 				},
@@ -116,7 +116,7 @@ var communityUndirectedMultiplexQTests = []struct {
 			},
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 3, 4, 5),
 				},
 				want: 0, tol: 1e-14,
@@ -149,7 +149,7 @@ var communityUndirectedMultiplexQTests = []struct {
 		structures: []structure{
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2),
 					1: linksTo(3, 4, 5),
 				},
@@ -157,7 +157,7 @@ var communityUndirectedMultiplexQTests = []struct {
 			},
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0),
 					1: linksTo(1),
 					2: linksTo(2),
@@ -198,7 +198,7 @@ var communityUndirectedMultiplexQTests = []struct {
 		structures: []structure{
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 6),
 					1: linksTo(1, 7, 9, 12),
 					2: linksTo(2, 8, 11),
@@ -208,7 +208,7 @@ var communityUndirectedMultiplexQTests = []struct {
 			},
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 2, 3, 4, 5, 10),
 					1: linksTo(1, 7, 9, 12),
 					2: linksTo(6),
@@ -218,7 +218,7 @@ var communityUndirectedMultiplexQTests = []struct {
 			},
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12),
 				},
 				want: 0, tol: 1e-14,
@@ -452,7 +452,7 @@ var localUndirectedMultiplexMoveTests = []struct {
 		layers: []layer{{g: blondel, weight: 1}, {g: blondel, weight: 0.5}},
 		structures: []moveStructures{
 			{
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 4, 5),
 					1: linksTo(3, 6, 7),
 					2: linksTo(8, 9, 10, 12, 14, 15),
@@ -463,7 +463,7 @@ var localUndirectedMultiplexMoveTests = []struct {
 				tol:         1e-14,
 			},
 			{
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 4, 5),
 					1: linksTo(3, 6, 7),
 					2: linksTo(8, 9, 10, 12, 14, 15),
@@ -474,7 +474,7 @@ var localUndirectedMultiplexMoveTests = []struct {
 				tol:         1e-14,
 			},
 			{
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 4, 5),
 					1: linksTo(3, 6, 7),
 					2: linksTo(8, 9, 10, 12, 14, 15),

--- a/graph/community/louvain_undirected_test.go
+++ b/graph/community/louvain_undirected_test.go
@@ -19,7 +19,7 @@ import (
 
 var communityUndirectedQTests = []struct {
 	name       string
-	g          []set
+	g          []intset
 	structures []structure
 
 	wantLevels []level
@@ -31,7 +31,7 @@ var communityUndirectedQTests = []struct {
 		structures: []structure{
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0),
 					1: linksTo(1),
 					2: linksTo(2),
@@ -63,7 +63,7 @@ var communityUndirectedQTests = []struct {
 			{
 				resolution: 1,
 				// community structure and modularity calculated by java reference implementation.
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2),
 					1: linksTo(3, 4, 5),
 				},
@@ -71,7 +71,7 @@ var communityUndirectedQTests = []struct {
 			},
 			{
 				resolution: 1,
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 3, 4, 5),
 				},
 				// theoretical expectation.
@@ -106,7 +106,7 @@ var communityUndirectedQTests = []struct {
 			{
 				resolution: 1,
 				// community structure and modularity from doi: 10.1140/epjb/e2013-40829-0
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21),
 					1: linksTo(4, 5, 6, 10, 16),
 					2: linksTo(8, 9, 14, 15, 18, 20, 22, 26, 29, 30, 32, 33),
@@ -118,7 +118,7 @@ var communityUndirectedQTests = []struct {
 			{
 				resolution: 0.5,
 				// community structure and modularity calculated by java reference implementation.
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 16, 17, 19, 21),
 					1: linksTo(8, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33),
 				},
@@ -127,7 +127,7 @@ var communityUndirectedQTests = []struct {
 			{
 				resolution: 2,
 				// community structure and modularity calculated by java reference implementation.
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(14, 18, 20, 22, 32, 33, 15),
 					1: linksTo(0, 1, 11, 17, 19, 21),
 					2: linksTo(2, 3, 7, 9, 12, 13),
@@ -207,7 +207,7 @@ var communityUndirectedQTests = []struct {
 			{
 				resolution: 1,
 				// community structure and modularity calculated by java reference implementation.
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 3, 4, 5, 6, 7),
 					1: linksTo(8, 9, 10, 11, 12, 13, 14, 15),
 				},
@@ -441,7 +441,7 @@ tests:
 
 var localUndirectedMoveTests = []struct {
 	name       string
-	g          []set
+	g          []intset
 	structures []moveStructures
 }{
 	{
@@ -449,7 +449,7 @@ var localUndirectedMoveTests = []struct {
 		g:    blondel,
 		structures: []moveStructures{
 			{
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 4, 5),
 					1: linksTo(3, 6, 7),
 					2: linksTo(8, 9, 10, 12, 14, 15),
@@ -460,7 +460,7 @@ var localUndirectedMoveTests = []struct {
 				tol:         1e-14,
 			},
 			{
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 4, 5),
 					1: linksTo(3, 6, 7),
 					2: linksTo(8, 9, 10, 12, 14, 15),
@@ -471,7 +471,7 @@ var localUndirectedMoveTests = []struct {
 				tol:         1e-14,
 			},
 			{
-				memberships: []set{
+				memberships: []intset{
 					0: linksTo(0, 1, 2, 4, 5),
 					1: linksTo(3, 6, 7),
 					2: linksTo(8, 9, 10, 12, 14, 15),

--- a/graph/encoding/dot/decode.go
+++ b/graph/encoding/dot/decode.go
@@ -7,11 +7,10 @@ package dot
 import (
 	"fmt"
 
-	"golang.org/x/tools/container/intsets"
-
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/formats/dot"
 	"gonum.org/v1/gonum/graph/formats/dot/ast"
+	"gonum.org/v1/gonum/graph/internal/set"
 )
 
 // Builder is a graph that can have user-defined nodes and edges added.
@@ -267,14 +266,14 @@ func (gen *generator) popSubgraph() []graph.Node {
 // unique returns the set of unique nodes contained within ns.
 func unique(ns []graph.Node) []graph.Node {
 	var nodes []graph.Node
-	var set intsets.Sparse
+	seen := make(set.Ints)
 	for _, n := range ns {
 		id := n.ID()
-		if set.Has(id) {
+		if seen.Has(id) {
 			// skip duplicate node
 			continue
 		}
-		set.Insert(id)
+		seen.Add(id)
 		nodes = append(nodes, n)
 	}
 	return nodes

--- a/graph/encoding/dot/dot_test.go
+++ b/graph/encoding/dot/dot_test.go
@@ -12,14 +12,14 @@ import (
 	"gonum.org/v1/gonum/graph/simple"
 )
 
-// set is an integer set.
-type set map[int]struct{}
+// intset is an integer set.
+type intset map[int]struct{}
 
-func linksTo(i ...int) set {
+func linksTo(i ...int) intset {
 	if len(i) == 0 {
 		return nil
 	}
-	s := make(set)
+	s := make(intset)
 	for _, v := range i {
 		s[v] = struct{}{}
 	}
@@ -29,7 +29,7 @@ func linksTo(i ...int) set {
 var (
 	// Example graph from http://en.wikipedia.org/wiki/File:PageRanks-Example.svg 16:17, 8 July 2009
 	// Node identities are rewritten here to use integers from 0 to match with the DOT output.
-	pageRankGraph = []set{
+	pageRankGraph = []intset{
 		0:  nil,
 		1:  linksTo(2),
 		2:  linksTo(1),
@@ -44,7 +44,7 @@ var (
 	}
 
 	// Example graph from http://en.wikipedia.org/w/index.php?title=PageRank&oldid=659286279#Power_Method
-	powerMethodGraph = []set{
+	powerMethodGraph = []intset{
 		0: linksTo(1, 2),
 		1: linksTo(3),
 		2: linksTo(3, 4),
@@ -53,7 +53,7 @@ var (
 	}
 )
 
-func directedGraphFrom(g []set) graph.Directed {
+func directedGraphFrom(g []intset) graph.Directed {
 	dg := simple.NewDirectedGraph(0, math.Inf(1))
 	for u, e := range g {
 		for v := range e {
@@ -63,7 +63,7 @@ func directedGraphFrom(g []set) graph.Directed {
 	return dg
 }
 
-func undirectedGraphFrom(g []set) graph.Graph {
+func undirectedGraphFrom(g []intset) graph.Graph {
 	dg := simple.NewUndirectedGraph(0, math.Inf(1))
 	for u, e := range g {
 		for v := range e {
@@ -83,7 +83,7 @@ type namedNode struct {
 func (n namedNode) ID() int       { return n.id }
 func (n namedNode) DOTID() string { return n.name }
 
-func directedNamedIDGraphFrom(g []set) graph.Directed {
+func directedNamedIDGraphFrom(g []intset) graph.Directed {
 	dg := simple.NewDirectedGraph(0, math.Inf(1))
 	for u, e := range g {
 		nu := namedNode{id: u, name: alpha[u : u+1]}
@@ -95,7 +95,7 @@ func directedNamedIDGraphFrom(g []set) graph.Directed {
 	return dg
 }
 
-func undirectedNamedIDGraphFrom(g []set) graph.Graph {
+func undirectedNamedIDGraphFrom(g []intset) graph.Graph {
 	dg := simple.NewUndirectedGraph(0, math.Inf(1))
 	for u, e := range g {
 		nu := namedNode{id: u, name: alpha[u : u+1]}
@@ -116,7 +116,7 @@ type attrNode struct {
 func (n attrNode) ID() int                    { return n.id }
 func (n attrNode) DOTAttributes() []Attribute { return n.attr }
 
-func directedNodeAttrGraphFrom(g []set, attr [][]Attribute) graph.Directed {
+func directedNodeAttrGraphFrom(g []intset, attr [][]Attribute) graph.Directed {
 	dg := simple.NewDirectedGraph(0, math.Inf(1))
 	for u, e := range g {
 		var at []Attribute
@@ -135,7 +135,7 @@ func directedNodeAttrGraphFrom(g []set, attr [][]Attribute) graph.Directed {
 	return dg
 }
 
-func undirectedNodeAttrGraphFrom(g []set, attr [][]Attribute) graph.Graph {
+func undirectedNodeAttrGraphFrom(g []intset, attr [][]Attribute) graph.Graph {
 	dg := simple.NewUndirectedGraph(0, math.Inf(1))
 	for u, e := range g {
 		var at []Attribute
@@ -164,7 +164,7 @@ func (n namedAttrNode) ID() int                    { return n.id }
 func (n namedAttrNode) DOTID() string              { return n.name }
 func (n namedAttrNode) DOTAttributes() []Attribute { return n.attr }
 
-func directedNamedIDNodeAttrGraphFrom(g []set, attr [][]Attribute) graph.Directed {
+func directedNamedIDNodeAttrGraphFrom(g []intset, attr [][]Attribute) graph.Directed {
 	dg := simple.NewDirectedGraph(0, math.Inf(1))
 	for u, e := range g {
 		var at []Attribute
@@ -183,7 +183,7 @@ func directedNamedIDNodeAttrGraphFrom(g []set, attr [][]Attribute) graph.Directe
 	return dg
 }
 
-func undirectedNamedIDNodeAttrGraphFrom(g []set, attr [][]Attribute) graph.Graph {
+func undirectedNamedIDNodeAttrGraphFrom(g []intset, attr [][]Attribute) graph.Graph {
 	dg := simple.NewUndirectedGraph(0, math.Inf(1))
 	for u, e := range g {
 		var at []Attribute
@@ -213,7 +213,7 @@ func (e attrEdge) To() graph.Node             { return e.to }
 func (e attrEdge) Weight() float64            { return 0 }
 func (e attrEdge) DOTAttributes() []Attribute { return e.attr }
 
-func directedEdgeAttrGraphFrom(g []set, attr map[edge][]Attribute) graph.Directed {
+func directedEdgeAttrGraphFrom(g []intset, attr map[edge][]Attribute) graph.Directed {
 	dg := simple.NewDirectedGraph(0, math.Inf(1))
 	for u, e := range g {
 		for v := range e {
@@ -223,7 +223,7 @@ func directedEdgeAttrGraphFrom(g []set, attr map[edge][]Attribute) graph.Directe
 	return dg
 }
 
-func undirectedEdgeAttrGraphFrom(g []set, attr map[edge][]Attribute) graph.Graph {
+func undirectedEdgeAttrGraphFrom(g []intset, attr map[edge][]Attribute) graph.Graph {
 	dg := simple.NewUndirectedGraph(0, math.Inf(1))
 	for u, e := range g {
 		for v := range e {
@@ -263,7 +263,7 @@ func (e portedEdge) ToPort() (port, compass string) {
 	return e.toPort, e.toCompass
 }
 
-func directedPortedAttrGraphFrom(g []set, attr [][]Attribute, ports map[edge]portedEdge) graph.Directed {
+func directedPortedAttrGraphFrom(g []intset, attr [][]Attribute, ports map[edge]portedEdge) graph.Directed {
 	dg := simple.NewDirectedGraph(0, math.Inf(1))
 	for u, e := range g {
 		var at []Attribute
@@ -284,7 +284,7 @@ func directedPortedAttrGraphFrom(g []set, attr [][]Attribute, ports map[edge]por
 	return dg
 }
 
-func undirectedPortedAttrGraphFrom(g []set, attr [][]Attribute, ports map[edge]portedEdge) graph.Graph {
+func undirectedPortedAttrGraphFrom(g []intset, attr [][]Attribute, ports map[edge]portedEdge) graph.Graph {
 	dg := simple.NewUndirectedGraph(0, math.Inf(1))
 	for u, e := range g {
 		var at []Attribute
@@ -325,7 +325,7 @@ type structuredGraph struct {
 	sub []Graph
 }
 
-func undirectedStructuredGraphFrom(c []edge, g ...[]set) graph.Graph {
+func undirectedStructuredGraphFrom(c []edge, g ...[]intset) graph.Graph {
 	s := &structuredGraph{UndirectedGraph: simple.NewUndirectedGraph(0, math.Inf(1))}
 	var base int
 	for i, sg := range g {
@@ -366,7 +366,7 @@ func (g subGraph) Subgraph() graph.Graph {
 	return namedGraph{id: g.id, Graph: g.Graph}
 }
 
-func undirectedSubGraphFrom(g []set, s map[int][]set) graph.Graph {
+func undirectedSubGraphFrom(g []intset, s map[int][]intset) graph.Graph {
 	var base int
 	subs := make(map[int]subGraph)
 	for i, sg := range s {
@@ -1264,7 +1264,7 @@ var encodeTests = []struct {
 
 	// Handling subgraphs.
 	{
-		g: undirectedSubGraphFrom(pageRankGraph, map[int][]set{2: powerMethodGraph}),
+		g: undirectedSubGraphFrom(pageRankGraph, map[int][]intset{2: powerMethodGraph}),
 
 		want: `graph {
 	// Node definitions.
@@ -1315,7 +1315,7 @@ var encodeTests = []struct {
 	},
 	{
 		name:   "H",
-		g:      undirectedSubGraphFrom(pageRankGraph, map[int][]set{1: powerMethodGraph}),
+		g:      undirectedSubGraphFrom(pageRankGraph, map[int][]intset{1: powerMethodGraph}),
 		strict: true,
 
 		want: `strict graph H {

--- a/graph/internal/set/same.go
+++ b/graph/internal/set/same.go
@@ -16,3 +16,12 @@ import "unsafe"
 func same(a, b Nodes) bool {
 	return *(*uintptr)(unsafe.Pointer(&a)) == *(*uintptr)(unsafe.Pointer(&b))
 }
+
+// intsSame determines whether two sets are backed by the same store. In the
+// current implementation using hash maps it makes use of the fact that
+// hash maps are passed as a pointer to a runtime Hmap struct. A map is
+// not seen by the runtime as a pointer though, so we use unsafe to get
+// the maps' pointer values to compare.
+func intsSame(a, b Ints) bool {
+	return *(*uintptr)(unsafe.Pointer(&a)) == *(*uintptr)(unsafe.Pointer(&b))
+}

--- a/graph/internal/set/same_appengine.go
+++ b/graph/internal/set/same_appengine.go
@@ -16,3 +16,12 @@ import "reflect"
 func same(a, b Nodes) bool {
 	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
 }
+
+// intsSame determines whether two sets are backed by the same store. In the
+// current implementation using hash maps it makes use of the fact that
+// hash maps are passed as a pointer to a runtime Hmap struct. A map is
+// not seen by the runtime as a pointer though, so we use reflect to get
+// the maps' pointer values to compare.
+func intsSame(a, b Ints) bool {
+	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
+}

--- a/graph/internal/set/set.go
+++ b/graph/internal/set/set.go
@@ -34,6 +34,26 @@ func (s Ints) Count() int {
 	return len(s)
 }
 
+// IntsEqual reports set equality between the parameters. Sets are equal if
+// and only if they have the same elements.
+func IntsEqual(a, b Ints) bool {
+	if intsSame(a, b) {
+		return true
+	}
+
+	if len(a) != len(b) {
+		return false
+	}
+
+	for e := range a {
+		if _, ok := b[e]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Nodes is a set of nodes keyed in their integer identifiers.
 type Nodes map[int]graph.Node
 

--- a/graph/topo/tarjan.go
+++ b/graph/topo/tarjan.go
@@ -8,10 +8,9 @@ import (
 	"fmt"
 	"sort"
 
-	"golang.org/x/tools/container/intsets"
-
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
+	"gonum.org/v1/gonum/graph/internal/set"
 )
 
 // Unorderable is an error containing sets of unorderable graph.Nodes.
@@ -122,7 +121,7 @@ func tarjanSCCstabilized(g graph.Directed, order func([]graph.Node)) [][]graph.N
 
 		indexTable: make(map[int]int, len(nodes)),
 		lowLink:    make(map[int]int, len(nodes)),
-		onStack:    &intsets.Sparse{},
+		onStack:    make(set.Ints),
 	}
 	for _, v := range nodes {
 		if t.indexTable[v.ID()] == 0 {
@@ -143,7 +142,7 @@ type tarjan struct {
 	index      int
 	indexTable map[int]int
 	lowLink    map[int]int
-	onStack    *intsets.Sparse
+	onStack    set.Ints
 
 	stack []graph.Node
 
@@ -160,7 +159,7 @@ func (t *tarjan) strongconnect(v graph.Node) {
 	t.indexTable[vID] = t.index
 	t.lowLink[vID] = t.index
 	t.stack = append(t.stack, v)
-	t.onStack.Insert(vID)
+	t.onStack.Add(vID)
 
 	// Consider successors of v.
 	for _, w := range t.succ(v) {

--- a/graph/traverse/traverse.go
+++ b/graph/traverse/traverse.go
@@ -6,10 +6,9 @@
 package traverse // import "gonum.org/v1/gonum/graph/traverse"
 
 import (
-	"golang.org/x/tools/container/intsets"
-
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/linear"
+	"gonum.org/v1/gonum/graph/internal/set"
 )
 
 // BreadthFirst implements stateful breadth-first graph traversal.
@@ -17,7 +16,7 @@ type BreadthFirst struct {
 	EdgeFilter func(graph.Edge) bool
 	Visit      func(u, v graph.Node)
 	queue      linear.NodeQueue
-	visited    *intsets.Sparse
+	visited    set.Ints
 }
 
 // Walk performs a breadth-first traversal of the graph g starting from the given node,
@@ -27,10 +26,10 @@ type BreadthFirst struct {
 // non-nil, it is called with the nodes joined by each followed edge.
 func (b *BreadthFirst) Walk(g graph.Graph, from graph.Node, until func(n graph.Node, d int) bool) graph.Node {
 	if b.visited == nil {
-		b.visited = &intsets.Sparse{}
+		b.visited = make(set.Ints)
 	}
 	b.queue.Enqueue(from)
-	b.visited.Insert(from.ID())
+	b.visited.Add(from.ID())
 
 	var (
 		depth     int
@@ -52,7 +51,7 @@ func (b *BreadthFirst) Walk(g graph.Graph, from graph.Node, until func(n graph.N
 			if b.Visit != nil {
 				b.Visit(t, n)
 			}
-			b.visited.Insert(n.ID())
+			b.visited.Add(n.ID())
 			children++
 			b.queue.Enqueue(n)
 		}
@@ -93,15 +92,13 @@ func (b *BreadthFirst) WalkAll(g graph.Undirected, before, after func(), during 
 
 // Visited returned whether the node n was visited during a traverse.
 func (b *BreadthFirst) Visited(n graph.Node) bool {
-	return b.visited != nil && b.visited.Has(n.ID())
+	return b.visited.Has(n.ID())
 }
 
 // Reset resets the state of the traverser for reuse.
 func (b *BreadthFirst) Reset() {
 	b.queue.Reset()
-	if b.visited != nil {
-		b.visited.Clear()
-	}
+	b.visited = nil
 }
 
 // DepthFirst implements stateful depth-first graph traversal.
@@ -109,7 +106,7 @@ type DepthFirst struct {
 	EdgeFilter func(graph.Edge) bool
 	Visit      func(u, v graph.Node)
 	stack      linear.NodeStack
-	visited    *intsets.Sparse
+	visited    set.Ints
 }
 
 // Walk performs a depth-first traversal of the graph g starting from the given node,
@@ -119,10 +116,10 @@ type DepthFirst struct {
 // is called with the nodes joined by each followed edge.
 func (d *DepthFirst) Walk(g graph.Graph, from graph.Node, until func(graph.Node) bool) graph.Node {
 	if d.visited == nil {
-		d.visited = &intsets.Sparse{}
+		d.visited = make(set.Ints)
 	}
 	d.stack.Push(from)
-	d.visited.Insert(from.ID())
+	d.visited.Add(from.ID())
 
 	for d.stack.Len() > 0 {
 		t := d.stack.Pop()
@@ -139,7 +136,7 @@ func (d *DepthFirst) Walk(g graph.Graph, from graph.Node, until func(graph.Node)
 			if d.Visit != nil {
 				d.Visit(t, n)
 			}
-			d.visited.Insert(n.ID())
+			d.visited.Add(n.ID())
 			d.stack.Push(n)
 		}
 	}
@@ -174,13 +171,11 @@ func (d *DepthFirst) WalkAll(g graph.Undirected, before, after func(), during fu
 
 // Visited returned whether the node n was visited during a traverse.
 func (d *DepthFirst) Visited(n graph.Node) bool {
-	return d.visited != nil && d.visited.Has(n.ID())
+	return d.visited.Has(n.ID())
 }
 
 // Reset resets the state of the traverser for reuse.
 func (d *DepthFirst) Reset() {
 	d.stack = d.stack[:0]
-	if d.visited != nil {
-		d.visited.Clear()
-	}
+	d.visited = nil
 }

--- a/graph/traverse/traverse_test.go
+++ b/graph/traverse/traverse_test.go
@@ -20,7 +20,7 @@ import (
 var (
 	// batageljZaversnikGraph is the example graph from
 	// figure 1 of http://arxiv.org/abs/cs/0310049v1
-	batageljZaversnikGraph = []set{
+	batageljZaversnikGraph = []intset{
 		0: nil,
 
 		1: linksTo(2, 3),
@@ -48,7 +48,7 @@ var (
 
 	// wpBronKerboschGraph is the example given in the Bron-Kerbosch article on wikipedia (renumbered).
 	// http://en.wikipedia.org/w/index.php?title=Bron%E2%80%93Kerbosch_algorithm&oldid=656805858
-	wpBronKerboschGraph = []set{
+	wpBronKerboschGraph = []intset{
 		0: linksTo(1, 4),
 		1: linksTo(2, 4),
 		2: linksTo(3),
@@ -59,7 +59,7 @@ var (
 )
 
 var breadthFirstTests = []struct {
-	g     []set
+	g     []intset
 	from  graph.Node
 	edge  func(graph.Edge) bool
 	until func(graph.Node, int) bool
@@ -171,7 +171,7 @@ func TestBreadthFirst(t *testing.T) {
 }
 
 var depthFirstTests = []struct {
-	g     []set
+	g     []intset
 	from  graph.Node
 	edge  func(graph.Edge) bool
 	until func(graph.Node) bool
@@ -254,7 +254,7 @@ func TestDepthFirst(t *testing.T) {
 }
 
 var walkAllTests = []struct {
-	g    []set
+	g    []intset
 	edge func(graph.Edge) bool
 	want [][]int
 }{
@@ -342,14 +342,14 @@ func TestWalkAll(t *testing.T) {
 	}
 }
 
-// set is an integer set.
-type set map[int]struct{}
+// intset is an integer set.
+type intset map[int]struct{}
 
-func linksTo(i ...int) set {
+func linksTo(i ...int) intset {
 	if len(i) == 0 {
 		return nil
 	}
-	s := make(set)
+	s := make(intset)
 	for _, v := range i {
 		s[v] = struct{}{}
 	}
@@ -378,8 +378,8 @@ func benchmarkWalkAllBreadthFirst(b *testing.B, g graph.Undirected) {
 	for i := 0; i < b.N; i++ {
 		bft.WalkAll(g, nil, nil, nil)
 	}
-	if bft.visited.Len() != n {
-		b.Fatalf("unexpected number of nodes visited: want: %d got %d", n, bft.visited.Len())
+	if len(bft.visited) != n {
+		b.Fatalf("unexpected number of nodes visited: want: %d got %d", n, len(bft.visited))
 	}
 }
 
@@ -409,8 +409,8 @@ func benchmarkWalkAllDepthFirst(b *testing.B, g graph.Undirected) {
 	for i := 0; i < b.N; i++ {
 		dft.WalkAll(g, nil, nil, nil)
 	}
-	if dft.visited.Len() != n {
-		b.Fatalf("unexpected number of nodes visited: want: %d got %d", n, dft.visited.Len())
+	if len(dft.visited) != n {
+		b.Fatalf("unexpected number of nodes visited: want: %d got %d", n, len(dft.visited))
 	}
 }
 

--- a/graph/undirect.go
+++ b/graph/undirect.go
@@ -4,10 +4,6 @@
 
 package graph
 
-import (
-	"golang.org/x/tools/container/intsets"
-)
-
 // Undirect converts a directed graph to an undirected graph, resolving
 // edge weight conflicts.
 type Undirect struct {
@@ -47,20 +43,18 @@ func (g Undirect) Nodes() []Node { return g.G.Nodes() }
 
 // From returns all nodes in g that can be reached directly from u.
 func (g Undirect) From(u Node) []Node {
-	var (
-		nodes []Node
-		seen  intsets.Sparse
-	)
+	var nodes []Node
+	seen := make(map[int]struct{})
 	for _, n := range g.G.From(u) {
-		seen.Insert(n.ID())
+		seen[n.ID()] = struct{}{}
 		nodes = append(nodes, n)
 	}
 	for _, n := range g.G.To(u) {
 		id := n.ID()
-		if seen.Has(id) {
+		if _, ok := seen[id]; ok {
 			continue
 		}
-		seen.Insert(id)
+		seen[n.ID()] = struct{}{}
 		nodes = append(nodes, n)
 	}
 	return nodes


### PR DESCRIPTION
This is a first step towards allowing `int64` ID values and addresses the simple-to-handle cases.

Another PR for the more hairy community package will follow when I figure out a good approach; the problem is that `intsets.Sparse` iterates via a stateful method, which allows a nice method-based approach to handle subset iteration, versus complete set iteration without filling a complete set for the complete set case. `set.Ints` cannot do this because of limitations with `range`. Suggestions welcomed.

@vladimir-ch @mewmew Please take a look.