### PR TITLE
graph/...: use int64 IDs

### DIFF
--- a/graph/community/louvain_common.go
+++ b/graph/community/louvain_common.go
@@ -230,8 +230,18 @@ type directedEdges struct {
 	weights   map[[2]int]float64
 }
 
+// isValidID returns whether id is a valid ID for a community,
+// multiplexCommunity or node. These are all graph.Node types
+// stored in []T with a mapping between their index and their ID
+// so IDs must be positive and fit within the int type.
+func isValidID(id int64) bool {
+	return id == int64(int(id)) && id >= 0
+}
+
 // community is a reduced graph node describing its membership.
 type community struct {
+	// community graphs are internal, in-memory
+	// with dense IDs, so id is always an int.
 	id int
 
 	nodes []graph.Node
@@ -239,7 +249,7 @@ type community struct {
 	weight float64
 }
 
-func (n community) ID() int { return n.id }
+func (n community) ID() int64 { return int64(n.id) }
 
 // edge is a reduced graph edge.
 type edge struct {
@@ -253,6 +263,8 @@ func (e edge) Weight() float64  { return e.weight }
 
 // multiplexCommunity is a reduced multiplex graph node describing its membership.
 type multiplexCommunity struct {
+	// community graphs are internal, in-memory
+	// with dense IDs, so id is always an int.
 	id int
 
 	nodes []graph.Node
@@ -260,7 +272,7 @@ type multiplexCommunity struct {
 	weights []float64
 }
 
-func (n multiplexCommunity) ID() int { return n.id }
+func (n multiplexCommunity) ID() int64 { return int64(n.id) }
 
 // multiplexEdge is a reduced graph edge for a multiplex graph.
 type multiplexEdge struct {
@@ -278,10 +290,11 @@ type commIdx struct {
 	node      int
 }
 
-// node is defined to avoid an import of .../graph/simple.
+// node is defined to avoid an import of .../graph/simple. node is
+// used in in-memory, dense ID graphs and so is always an int.
 type node int
 
-func (n node) ID() int { return int(n) }
+func (n node) ID() int64 { return int64(n) }
 
 // minTaker is a set iterator.
 type minTaker interface {

--- a/graph/community/louvain_directed_multiplex_test.go
+++ b/graph/community/louvain_directed_multiplex_test.go
@@ -326,10 +326,11 @@ tests:
 
 		rnd := rand.New(rand.NewSource(1)).Intn
 		for _, structure := range test.structures {
-			communityOf := make(map[int]int)
+			communityOf := make(map[int64]int)
 			communities := make([][]graph.Node, len(structure.memberships))
 			for i, c := range structure.memberships {
 				for n := range c {
+					n := int64(n)
 					communityOf[n] = i
 					communities[i] = append(communities[i], simple.Node(n))
 				}
@@ -365,6 +366,7 @@ tests:
 				migrated := make([][]graph.Node, len(structure.memberships))
 				for i, c := range structure.memberships {
 					for n := range c {
+						n := int64(n)
 						if n == target.ID() {
 							continue
 						}

--- a/graph/community/louvain_directed_test.go
+++ b/graph/community/louvain_directed_test.go
@@ -244,10 +244,11 @@ tests:
 
 		rnd := rand.New(rand.NewSource(1)).Intn
 		for _, structure := range test.structures {
-			communityOf := make(map[int]int)
+			communityOf := make(map[int64]int)
 			communities := make([][]graph.Node, len(structure.memberships))
 			for i, c := range structure.memberships {
 				for n := range c {
+					n := int64(n)
 					communityOf[n] = i
 					communities[i] = append(communities[i], simple.Node(n))
 				}
@@ -277,6 +278,7 @@ tests:
 				migrated := make([][]graph.Node, len(structure.memberships))
 				for i, c := range structure.memberships {
 					for n := range c {
+						n := int64(n)
 						if n == target.ID() {
 							continue
 						}

--- a/graph/community/louvain_undirected_multiplex_test.go
+++ b/graph/community/louvain_undirected_multiplex_test.go
@@ -295,10 +295,11 @@ tests:
 
 		rnd := rand.New(rand.NewSource(1)).Intn
 		for _, structure := range test.structures {
-			communityOf := make(map[int]int)
+			communityOf := make(map[int64]int)
 			communities := make([][]graph.Node, len(structure.memberships))
 			for i, c := range structure.memberships {
 				for n := range c {
+					n := int64(n)
 					communityOf[n] = i
 					communities[i] = append(communities[i], simple.Node(n))
 				}
@@ -334,6 +335,7 @@ tests:
 				migrated := make([][]graph.Node, len(structure.memberships))
 				for i, c := range structure.memberships {
 					for n := range c {
+						n := int64(n)
 						if n == target.ID() {
 							continue
 						}

--- a/graph/community/louvain_undirected_test.go
+++ b/graph/community/louvain_undirected_test.go
@@ -303,10 +303,11 @@ tests:
 
 		rnd := rand.New(rand.NewSource(1)).Intn
 		for _, structure := range test.structures {
-			communityOf := make(map[int]int)
+			communityOf := make(map[int64]int)
 			communities := make([][]graph.Node, len(structure.memberships))
 			for i, c := range structure.memberships {
 				for n := range c {
+					n := int64(n)
 					communityOf[n] = i
 					communities[i] = append(communities[i], simple.Node(n))
 				}
@@ -336,6 +337,7 @@ tests:
 				migrated := make([][]graph.Node, len(structure.memberships))
 				for i, c := range structure.memberships {
 					for n := range c {
+						n := int64(n)
 						if n == target.ID() {
 							continue
 						}

--- a/graph/encoding/dot/decode.go
+++ b/graph/encoding/dot/decode.go
@@ -266,7 +266,7 @@ func (gen *generator) popSubgraph() []graph.Node {
 // unique returns the set of unique nodes contained within ns.
 func unique(ns []graph.Node) []graph.Node {
 	var nodes []graph.Node
-	seen := make(set.Ints)
+	seen := make(set.Int64s)
 	for _, n := range ns {
 		id := n.ID()
 		if seen.Has(id) {

--- a/graph/encoding/dot/dot.go
+++ b/graph/encoding/dot/dot.go
@@ -119,7 +119,7 @@ type printer struct {
 
 type edge struct {
 	inGraph  string
-	from, to int
+	from, to int64
 }
 
 func (p *printer) print(g graph.Graph, name string, needsIndent, isSubgraph bool) error {

--- a/graph/encoding/dot/dot_test.go
+++ b/graph/encoding/dot/dot_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 // intset is an integer set.
-type intset map[int]struct{}
+type intset map[int64]struct{}
 
-func linksTo(i ...int) intset {
+func linksTo(i ...int64) intset {
 	if len(i) == 0 {
 		return nil
 	}
@@ -76,16 +76,17 @@ func undirectedGraphFrom(g []intset) graph.Graph {
 const alpha = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 type namedNode struct {
-	id   int
+	id   int64
 	name string
 }
 
-func (n namedNode) ID() int       { return n.id }
+func (n namedNode) ID() int64     { return n.id }
 func (n namedNode) DOTID() string { return n.name }
 
 func directedNamedIDGraphFrom(g []intset) graph.Directed {
 	dg := simple.NewDirectedGraph(0, math.Inf(1))
 	for u, e := range g {
+		u := int64(u)
 		nu := namedNode{id: u, name: alpha[u : u+1]}
 		for v := range e {
 			nv := namedNode{id: v, name: alpha[v : v+1]}
@@ -98,6 +99,7 @@ func directedNamedIDGraphFrom(g []intset) graph.Directed {
 func undirectedNamedIDGraphFrom(g []intset) graph.Graph {
 	dg := simple.NewUndirectedGraph(0, math.Inf(1))
 	for u, e := range g {
+		u := int64(u)
 		nu := namedNode{id: u, name: alpha[u : u+1]}
 		for v := range e {
 			nv := namedNode{id: v, name: alpha[v : v+1]}
@@ -108,24 +110,25 @@ func undirectedNamedIDGraphFrom(g []intset) graph.Graph {
 }
 
 type attrNode struct {
-	id   int
+	id   int64
 	name string
 	attr []Attribute
 }
 
-func (n attrNode) ID() int                    { return n.id }
+func (n attrNode) ID() int64                  { return n.id }
 func (n attrNode) DOTAttributes() []Attribute { return n.attr }
 
 func directedNodeAttrGraphFrom(g []intset, attr [][]Attribute) graph.Directed {
 	dg := simple.NewDirectedGraph(0, math.Inf(1))
 	for u, e := range g {
+		u := int64(u)
 		var at []Attribute
-		if u < len(attr) {
+		if u < int64(len(attr)) {
 			at = attr[u]
 		}
 		nu := attrNode{id: u, attr: at}
 		for v := range e {
-			if v < len(attr) {
+			if v < int64(len(attr)) {
 				at = attr[v]
 			}
 			nv := attrNode{id: v, attr: at}
@@ -138,13 +141,14 @@ func directedNodeAttrGraphFrom(g []intset, attr [][]Attribute) graph.Directed {
 func undirectedNodeAttrGraphFrom(g []intset, attr [][]Attribute) graph.Graph {
 	dg := simple.NewUndirectedGraph(0, math.Inf(1))
 	for u, e := range g {
+		u := int64(u)
 		var at []Attribute
-		if u < len(attr) {
+		if u < int64(len(attr)) {
 			at = attr[u]
 		}
 		nu := attrNode{id: u, attr: at}
 		for v := range e {
-			if v < len(attr) {
+			if v < int64(len(attr)) {
 				at = attr[v]
 			}
 			nv := attrNode{id: v, attr: at}
@@ -155,25 +159,26 @@ func undirectedNodeAttrGraphFrom(g []intset, attr [][]Attribute) graph.Graph {
 }
 
 type namedAttrNode struct {
-	id   int
+	id   int64
 	name string
 	attr []Attribute
 }
 
-func (n namedAttrNode) ID() int                    { return n.id }
+func (n namedAttrNode) ID() int64                  { return n.id }
 func (n namedAttrNode) DOTID() string              { return n.name }
 func (n namedAttrNode) DOTAttributes() []Attribute { return n.attr }
 
 func directedNamedIDNodeAttrGraphFrom(g []intset, attr [][]Attribute) graph.Directed {
 	dg := simple.NewDirectedGraph(0, math.Inf(1))
 	for u, e := range g {
+		u := int64(u)
 		var at []Attribute
-		if u < len(attr) {
+		if u < int64(len(attr)) {
 			at = attr[u]
 		}
 		nu := namedAttrNode{id: u, name: alpha[u : u+1], attr: at}
 		for v := range e {
-			if v < len(attr) {
+			if v < int64(len(attr)) {
 				at = attr[v]
 			}
 			nv := namedAttrNode{id: v, name: alpha[v : v+1], attr: at}
@@ -186,13 +191,14 @@ func directedNamedIDNodeAttrGraphFrom(g []intset, attr [][]Attribute) graph.Dire
 func undirectedNamedIDNodeAttrGraphFrom(g []intset, attr [][]Attribute) graph.Graph {
 	dg := simple.NewUndirectedGraph(0, math.Inf(1))
 	for u, e := range g {
+		u := int64(u)
 		var at []Attribute
-		if u < len(attr) {
+		if u < int64(len(attr)) {
 			at = attr[u]
 		}
 		nu := namedAttrNode{id: u, name: alpha[u : u+1], attr: at}
 		for v := range e {
-			if v < len(attr) {
+			if v < int64(len(attr)) {
 				at = attr[v]
 			}
 			nv := namedAttrNode{id: v, name: alpha[v : v+1], attr: at}
@@ -216,6 +222,7 @@ func (e attrEdge) DOTAttributes() []Attribute { return e.attr }
 func directedEdgeAttrGraphFrom(g []intset, attr map[edge][]Attribute) graph.Directed {
 	dg := simple.NewDirectedGraph(0, math.Inf(1))
 	for u, e := range g {
+		u := int64(u)
 		for v := range e {
 			dg.SetEdge(attrEdge{from: simple.Node(u), to: simple.Node(v), attr: attr[edge{from: u, to: v}]})
 		}
@@ -226,6 +233,7 @@ func directedEdgeAttrGraphFrom(g []intset, attr map[edge][]Attribute) graph.Dire
 func undirectedEdgeAttrGraphFrom(g []intset, attr map[edge][]Attribute) graph.Graph {
 	dg := simple.NewUndirectedGraph(0, math.Inf(1))
 	for u, e := range g {
+		u := int64(u)
 		for v := range e {
 			dg.SetEdge(attrEdge{from: simple.Node(u), to: simple.Node(v), attr: attr[edge{from: u, to: v}]})
 		}
@@ -266,13 +274,14 @@ func (e portedEdge) ToPort() (port, compass string) {
 func directedPortedAttrGraphFrom(g []intset, attr [][]Attribute, ports map[edge]portedEdge) graph.Directed {
 	dg := simple.NewDirectedGraph(0, math.Inf(1))
 	for u, e := range g {
+		u := int64(u)
 		var at []Attribute
-		if u < len(attr) {
+		if u < int64(len(attr)) {
 			at = attr[u]
 		}
 		nu := attrNode{id: u, attr: at}
 		for v := range e {
-			if v < len(attr) {
+			if v < int64(len(attr)) {
 				at = attr[v]
 			}
 			pe := ports[edge{from: u, to: v}]
@@ -287,13 +296,14 @@ func directedPortedAttrGraphFrom(g []intset, attr [][]Attribute, ports map[edge]
 func undirectedPortedAttrGraphFrom(g []intset, attr [][]Attribute, ports map[edge]portedEdge) graph.Graph {
 	dg := simple.NewUndirectedGraph(0, math.Inf(1))
 	for u, e := range g {
+		u := int64(u)
 		var at []Attribute
-		if u < len(attr) {
+		if u < int64(len(attr)) {
 			at = attr[u]
 		}
 		nu := attrNode{id: u, attr: at}
 		for v := range e {
-			if v < len(attr) {
+			if v < int64(len(attr)) {
 				at = attr[v]
 			}
 			pe := ports[edge{from: u, to: v}]
@@ -327,17 +337,18 @@ type structuredGraph struct {
 
 func undirectedStructuredGraphFrom(c []edge, g ...[]intset) graph.Graph {
 	s := &structuredGraph{UndirectedGraph: simple.NewUndirectedGraph(0, math.Inf(1))}
-	var base int
+	var base int64
 	for i, sg := range g {
 		sub := simple.NewUndirectedGraph(0, math.Inf(1))
 		for u, e := range sg {
+			u := int64(u)
 			for v := range e {
 				ce := simple.Edge{F: simple.Node(u + base), T: simple.Node(v + base)}
 				sub.SetEdge(ce)
 			}
 		}
-		s.sub = append(s.sub, namedGraph{id: i, Graph: sub})
-		base += len(sg)
+		s.sub = append(s.sub, namedGraph{id: int64(i), Graph: sub})
+		base += int64(len(sg))
 	}
 	for _, e := range c {
 		s.SetEdge(simple.Edge{F: simple.Node(e.from), T: simple.Node(e.to)})
@@ -350,39 +361,41 @@ func (g structuredGraph) Structure() []Graph {
 }
 
 type namedGraph struct {
-	id int
+	id int64
 	graph.Graph
 }
 
 func (g namedGraph) DOTID() string { return alpha[g.id : g.id+1] }
 
 type subGraph struct {
-	id int
+	id int64
 	graph.Graph
 }
 
-func (g subGraph) ID() int { return g.id }
+func (g subGraph) ID() int64 { return g.id }
 func (g subGraph) Subgraph() graph.Graph {
 	return namedGraph{id: g.id, Graph: g.Graph}
 }
 
-func undirectedSubGraphFrom(g []intset, s map[int][]intset) graph.Graph {
-	var base int
-	subs := make(map[int]subGraph)
+func undirectedSubGraphFrom(g []intset, s map[int64][]intset) graph.Graph {
+	var base int64
+	subs := make(map[int64]subGraph)
 	for i, sg := range s {
 		sub := simple.NewUndirectedGraph(0, math.Inf(1))
 		for u, e := range sg {
+			u := int64(u)
 			for v := range e {
 				ce := simple.Edge{F: simple.Node(u + base), T: simple.Node(v + base)}
 				sub.SetEdge(ce)
 			}
 		}
-		subs[i] = subGraph{id: i, Graph: sub}
-		base += len(sg)
+		subs[i] = subGraph{id: int64(i), Graph: sub}
+		base += int64(len(sg))
 	}
 
 	dg := simple.NewUndirectedGraph(0, math.Inf(1))
 	for u, e := range g {
+		u := int64(u)
 		var nu graph.Node
 		if sg, ok := subs[u]; ok {
 			sg.id += base
@@ -1264,7 +1277,7 @@ var encodeTests = []struct {
 
 	// Handling subgraphs.
 	{
-		g: undirectedSubGraphFrom(pageRankGraph, map[int][]intset{2: powerMethodGraph}),
+		g: undirectedSubGraphFrom(pageRankGraph, map[int64][]intset{2: powerMethodGraph}),
 
 		want: `graph {
 	// Node definitions.
@@ -1315,7 +1328,7 @@ var encodeTests = []struct {
 	},
 	{
 		name:   "H",
-		g:      undirectedSubGraphFrom(pageRankGraph, map[int][]intset{1: powerMethodGraph}),
+		g:      undirectedSubGraphFrom(pageRankGraph, map[int64][]intset{1: powerMethodGraph}),
 		strict: true,
 
 		want: `strict graph H {

--- a/graph/ex/fdpclust/gn.go
+++ b/graph/ex/fdpclust/gn.go
@@ -6,7 +6,7 @@ import (
 )
 
 type GraphNode struct {
-	id        int
+	id        int64
 	neighbors []graph.Node
 	roots     []*GraphNode
 }
@@ -16,7 +16,7 @@ func (g *GraphNode) Has(n graph.Node) bool {
 		return true
 	}
 
-	visited := map[int]struct{}{g.id: {}}
+	visited := map[int64]struct{}{g.id: {}}
 	for _, root := range g.roots {
 		if root.ID() == n.ID() {
 			return true
@@ -42,7 +42,7 @@ func (g *GraphNode) Has(n graph.Node) bool {
 	return false
 }
 
-func (g *GraphNode) has(n graph.Node, visited map[int]struct{}) bool {
+func (g *GraphNode) has(n graph.Node, visited map[int64]struct{}) bool {
 	for _, root := range g.roots {
 		if _, ok := visited[root.ID()]; ok {
 			continue
@@ -82,7 +82,7 @@ func (g *GraphNode) has(n graph.Node, visited map[int]struct{}) bool {
 
 func (g *GraphNode) Nodes() []graph.Node {
 	toReturn := []graph.Node{g}
-	visited := map[int]struct{}{g.id: {}}
+	visited := map[int64]struct{}{g.id: {}}
 
 	for _, root := range g.roots {
 		toReturn = append(toReturn, root)
@@ -103,7 +103,7 @@ func (g *GraphNode) Nodes() []graph.Node {
 	return toReturn
 }
 
-func (g *GraphNode) nodes(list []graph.Node, visited map[int]struct{}) []graph.Node {
+func (g *GraphNode) nodes(list []graph.Node, visited map[int64]struct{}) []graph.Node {
 	for _, root := range g.roots {
 		if _, ok := visited[root.ID()]; ok {
 			continue
@@ -133,7 +133,7 @@ func (g *GraphNode) From(n graph.Node) []graph.Node {
 		return g.neighbors
 	}
 
-	visited := map[int]struct{}{g.id: {}}
+	visited := map[int64]struct{}{g.id: {}}
 	for _, root := range g.roots {
 		visited[root.ID()] = struct{}{}
 
@@ -155,7 +155,7 @@ func (g *GraphNode) From(n graph.Node) []graph.Node {
 	return nil
 }
 
-func (g *GraphNode) findNeighbors(n graph.Node, visited map[int]struct{}) []graph.Node {
+func (g *GraphNode) findNeighbors(n graph.Node, visited map[int64]struct{}) []graph.Node {
 	if n.ID() == g.ID() {
 		return g.neighbors
 	}
@@ -205,7 +205,7 @@ func (g *GraphNode) EdgeBetween(u, v graph.Node) graph.Edge {
 		return nil
 	}
 
-	visited := map[int]struct{}{g.id: {}}
+	visited := map[int64]struct{}{g.id: {}}
 	for _, root := range g.roots {
 		visited[root.ID()] = struct{}{}
 		if result := root.edgeBetween(u, v, visited); result != nil {
@@ -225,7 +225,7 @@ func (g *GraphNode) EdgeBetween(u, v graph.Node) graph.Edge {
 	return nil
 }
 
-func (g *GraphNode) edgeBetween(u, v graph.Node, visited map[int]struct{}) graph.Edge {
+func (g *GraphNode) edgeBetween(u, v graph.Node, visited map[int64]struct{}) graph.Edge {
 	if u.ID() == g.id || v.ID() == g.id {
 		for _, neigh := range g.neighbors {
 			if neigh.ID() == u.ID() || neigh.ID() == v.ID() {
@@ -261,7 +261,7 @@ func (g *GraphNode) edgeBetween(u, v graph.Node, visited map[int]struct{}) graph
 	return nil
 }
 
-func (g *GraphNode) ID() int {
+func (g *GraphNode) ID() int64 {
 	return g.id
 }
 
@@ -273,6 +273,6 @@ func (g *GraphNode) AddRoot(n *GraphNode) {
 	g.roots = append(g.roots, n)
 }
 
-func NewGraphNode(id int) *GraphNode {
-	return &GraphNode{id: id, neighbors: make([]graph.Node, 0), roots: make([]*GraphNode, 0)}
+func NewGraphNode(id int64) *GraphNode {
+	return &GraphNode{id: id}
 }

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -6,7 +6,7 @@ package graph
 
 // Node is a graph node. It returns a graph-unique integer ID.
 type Node interface {
-	ID() int
+	ID() int64
 }
 
 // Edge is a graph edge. In directed graphs, the direction of the
@@ -77,7 +77,7 @@ type Weighter interface {
 // NodeAdder is an interface for adding arbitrary nodes to a graph.
 type NodeAdder interface {
 	// NewNodeID returns a new unique arbitrary ID.
-	NewNodeID() int
+	NewNodeID() int64
 
 	// Adds a node to the graph. AddNode panics if
 	// the added node ID matches an existing node ID.

--- a/graph/graphs/gen/holme_kim.go
+++ b/graph/graphs/gen/holme_kim.go
@@ -69,7 +69,7 @@ func TunableClusteringScaleFree(dst graph.UndirectedBuilder, n, m int, p float64
 			if i != 0 && rnd() < p {
 				for _, w := range permute(dst.From(simple.Node(u)), rndN) {
 					wid := w.ID()
-					if wid == v || dst.HasEdgeBetween(w, simple.Node(v)) {
+					if wid == int64(v) || dst.HasEdgeBetween(w, simple.Node(v)) {
 						continue
 					}
 					dst.SetEdge(simple.Edge{F: w, T: simple.Node(v), W: 1})

--- a/graph/internal/ordered/sort.go
+++ b/graph/internal/ordered/sort.go
@@ -16,8 +16,8 @@ func (n ByID) Less(i, j int) bool { return n[i].ID() < n[j].ID() }
 func (n ByID) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
 
 // BySliceValues implements the sort.Interface sorting a slice of
-// []int lexically by the values of the []int.
-type BySliceValues [][]int
+// []int64 lexically by the values of the []int64.
+type BySliceValues [][]int64
 
 func (c BySliceValues) Len() int { return len(c) }
 func (c BySliceValues) Less(i, j int) bool {
@@ -60,3 +60,11 @@ func (c BySliceIDs) Less(i, j int) bool {
 	return len(a) < len(b)
 }
 func (c BySliceIDs) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+
+// Int64s implements the sort.Interface sorting a slice of
+// int64.
+type Int64s []int64
+
+func (s Int64s) Len() int           { return len(s) }
+func (s Int64s) Less(i, j int) bool { return s[i] < s[j] }
+func (s Int64s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }

--- a/graph/internal/set/same.go
+++ b/graph/internal/set/same.go
@@ -25,3 +25,12 @@ func same(a, b Nodes) bool {
 func intsSame(a, b Ints) bool {
 	return *(*uintptr)(unsafe.Pointer(&a)) == *(*uintptr)(unsafe.Pointer(&b))
 }
+
+// int64sSame determines whether two sets are backed by the same store. In the
+// current implementation using hash maps it makes use of the fact that
+// hash maps are passed as a pointer to a runtime Hmap struct. A map is
+// not seen by the runtime as a pointer though, so we use unsafe to get
+// the maps' pointer values to compare.
+func int64sSame(a, b Int64s) bool {
+	return *(*uintptr)(unsafe.Pointer(&a)) == *(*uintptr)(unsafe.Pointer(&b))
+}

--- a/graph/internal/set/same_appengine.go
+++ b/graph/internal/set/same_appengine.go
@@ -25,3 +25,12 @@ func same(a, b Nodes) bool {
 func intsSame(a, b Ints) bool {
 	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
 }
+
+// int64sSame determines whether two sets are backed by the same store. In the
+// current implementation using hash maps it makes use of the fact that
+// hash maps are passed as a pointer to a runtime Hmap struct. A map is
+// not seen by the runtime as a pointer though, so we use reflect to get
+// the maps' pointer values to compare.
+func int64sSame(a, b Int64s) bool {
+	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
+}

--- a/graph/internal/set/set.go
+++ b/graph/internal/set/set.go
@@ -7,7 +7,7 @@ package set // import "gonum.org/v1/gonum/graph/internal/set"
 
 import "gonum.org/v1/gonum/graph"
 
-// Ints is a set of integer identifiers.
+// Ints is a set of int identifiers.
 type Ints map[int]struct{}
 
 // The simple accessor methods for Ints are provided to allow ease of
@@ -54,8 +54,55 @@ func IntsEqual(a, b Ints) bool {
 	return true
 }
 
+// Int64s is a set of int64 identifiers.
+type Int64s map[int64]struct{}
+
+// The simple accessor methods for Ints are provided to allow ease of
+// implementation change should the need arise.
+
+// Add inserts an element into the set.
+func (s Int64s) Add(e int64) {
+	s[e] = struct{}{}
+}
+
+// Has reports the existence of the element in the set.
+func (s Int64s) Has(e int64) bool {
+	_, ok := s[e]
+	return ok
+}
+
+// Remove deletes the specified element from the set.
+func (s Int64s) Remove(e int64) {
+	delete(s, e)
+}
+
+// Count reports the number of elements stored in the set.
+func (s Int64s) Count() int {
+	return len(s)
+}
+
+// Int64sEqual reports set equality between the parameters. Sets are equal if
+// and only if they have the same elements.
+func Int64sEqual(a, b Int64s) bool {
+	if int64sSame(a, b) {
+		return true
+	}
+
+	if len(a) != len(b) {
+		return false
+	}
+
+	for e := range a {
+		if _, ok := b[e]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Nodes is a set of nodes keyed in their integer identifiers.
-type Nodes map[int]graph.Node
+type Nodes map[int64]graph.Node
 
 // The simple accessor methods for Nodes are provided to allow ease of
 // implementation change should the need arise.

--- a/graph/internal/set/set_test.go
+++ b/graph/internal/set/set_test.go
@@ -6,9 +6,9 @@ package set
 
 import "testing"
 
-type node int
+type node int64
 
-func (n node) ID() int { return int(n) }
+func (n node) ID() int64 { return int64(n) }
 
 // count reports the number of elements stored in the node set.
 func (s Nodes) count() int {

--- a/graph/network/betweenness.go
+++ b/graph/network/betweenness.go
@@ -18,7 +18,7 @@ import (
 //
 // where \sigma_{st} and \sigma_{st}(v) are the number of shortest paths from s to t,
 // and the subset of those paths containing v respectively.
-func Betweenness(g graph.Graph) map[int]float64 {
+func Betweenness(g graph.Graph) map[int64]float64 {
 	// Brandes' algorithm for finding betweenness centrality for nodes in
 	// and unweighted graph:
 	//
@@ -32,8 +32,8 @@ func Betweenness(g graph.Graph) map[int]float64 {
 	// Also note special case for sparse networks:
 	// http://wwwold.iit.cnr.it/staff/marco.pellegrini/papiri/asonam-final.pdf
 
-	cb := make(map[int]float64)
-	brandes(g, func(s graph.Node, stack linear.NodeStack, p map[int][]graph.Node, delta, sigma map[int]float64) {
+	cb := make(map[int64]float64)
+	brandes(g, func(s graph.Node, stack linear.NodeStack, p map[int64][]graph.Node, delta, sigma map[int64]float64) {
 		for stack.Len() != 0 {
 			w := stack.Pop()
 			for _, v := range p[w.ID()] {
@@ -59,15 +59,15 @@ func Betweenness(g graph.Graph) map[int]float64 {
 //
 // If g is undirected, edges are retained such that u.ID < v.ID where u and v are
 // the nodes of e.
-func EdgeBetweenness(g graph.Graph) map[[2]int]float64 {
+func EdgeBetweenness(g graph.Graph) map[[2]int64]float64 {
 	// Modified from Brandes' original algorithm as described in Algorithm 7
 	// with the exception that node betweenness is not calculated:
 	//
 	// http://algo.uni-konstanz.de/publications/b-vspbc-08.pdf
 
 	_, isUndirected := g.(graph.Undirected)
-	cb := make(map[[2]int]float64)
-	brandes(g, func(s graph.Node, stack linear.NodeStack, p map[int][]graph.Node, delta, sigma map[int]float64) {
+	cb := make(map[[2]int64]float64)
+	brandes(g, func(s graph.Node, stack linear.NodeStack, p map[int64][]graph.Node, delta, sigma map[int64]float64) {
 		for stack.Len() != 0 {
 			w := stack.Pop()
 			for _, v := range p[w.ID()] {
@@ -77,7 +77,7 @@ func EdgeBetweenness(g graph.Graph) map[[2]int]float64 {
 				if isUndirected && wid < vid {
 					vid, wid = wid, vid
 				}
-				cb[[2]int{vid, wid}] += c
+				cb[[2]int64{vid, wid}] += c
 				delta[v.ID()] += c
 			}
 		}
@@ -88,14 +88,14 @@ func EdgeBetweenness(g graph.Graph) map[[2]int]float64 {
 // brandes is the common code for Betweenness and EdgeBetweenness. It corresponds
 // to algorithm 1 in http://algo.uni-konstanz.de/publications/b-vspbc-08.pdf with
 // the accumulation loop provided by the accumulate closure.
-func brandes(g graph.Graph, accumulate func(s graph.Node, stack linear.NodeStack, p map[int][]graph.Node, delta, sigma map[int]float64)) {
+func brandes(g graph.Graph, accumulate func(s graph.Node, stack linear.NodeStack, p map[int64][]graph.Node, delta, sigma map[int64]float64)) {
 	var (
 		nodes = g.Nodes()
 		stack linear.NodeStack
-		p     = make(map[int][]graph.Node, len(nodes))
-		sigma = make(map[int]float64, len(nodes))
-		d     = make(map[int]int, len(nodes))
-		delta = make(map[int]float64, len(nodes))
+		p     = make(map[int64][]graph.Node, len(nodes))
+		sigma = make(map[int64]float64, len(nodes))
+		d     = make(map[int64]int, len(nodes))
+		delta = make(map[int64]float64, len(nodes))
 		queue linear.NodeQueue
 	)
 	for _, s := range nodes {
@@ -152,8 +152,8 @@ type WeightedGraph interface {
 //
 // where \sigma_{st} and \sigma_{st}(v) are the number of shortest paths from s to t,
 // and the subset of those paths containing v respectively.
-func BetweennessWeighted(g WeightedGraph, p path.AllShortest) map[int]float64 {
-	cb := make(map[int]float64)
+func BetweennessWeighted(g WeightedGraph, p path.AllShortest) map[int64]float64 {
+	cb := make(map[int64]float64)
 
 	nodes := g.Nodes()
 	for i, s := range nodes {
@@ -203,8 +203,8 @@ func BetweennessWeighted(g WeightedGraph, p path.AllShortest) map[int]float64 {
 //
 // If g is undirected, edges are retained such that u.ID < v.ID where u and v are
 // the nodes of e.
-func EdgeBetweennessWeighted(g WeightedGraph, p path.AllShortest) map[[2]int]float64 {
-	cb := make(map[[2]int]float64)
+func EdgeBetweennessWeighted(g WeightedGraph, p path.AllShortest) map[[2]int64]float64 {
+	cb := make(map[[2]int64]float64)
 
 	_, isUndirected := g.(graph.Undirected)
 	nodes := g.Nodes()
@@ -231,7 +231,7 @@ func EdgeBetweennessWeighted(g WeightedGraph, p path.AllShortest) map[[2]int]flo
 					if isUndirected && vid < uid {
 						uid, vid = vid, uid
 					}
-					cb[[2]int{uid, vid}]++
+					cb[[2]int64{uid, vid}]++
 				}
 				continue
 			}
@@ -246,7 +246,7 @@ func EdgeBetweennessWeighted(g WeightedGraph, p path.AllShortest) map[[2]int]flo
 					if isUndirected && vid < uid {
 						uid, vid = vid, uid
 					}
-					cb[[2]int{uid, vid}] += stFrac
+					cb[[2]int64{uid, vid}] += stFrac
 				}
 			}
 		}

--- a/graph/network/betweenness_test.go
+++ b/graph/network/betweenness_test.go
@@ -19,8 +19,8 @@ var betweennessTests = []struct {
 	g []set
 
 	wantTol   float64
-	want      map[int]float64
-	wantEdges map[[2]int]float64
+	want      map[int64]float64
+	wantEdges map[[2]int64]float64
 }{
 	{
 		// Example graph from http://en.wikipedia.org/wiki/File:PageRanks-Example.svg 16:17, 8 July 2009
@@ -39,12 +39,12 @@ var betweennessTests = []struct {
 		},
 
 		wantTol: 1e-1,
-		want: map[int]float64{
+		want: map[int64]float64{
 			B: 32,
 			D: 18,
 			E: 48,
 		},
-		wantEdges: map[[2]int]float64{
+		wantEdges: map[[2]int64]float64{
 			{A, D}: 20,
 			{B, C}: 20,
 			{B, D}: 16,
@@ -73,14 +73,14 @@ var betweennessTests = []struct {
 		},
 
 		wantTol: 1e-3,
-		want: map[int]float64{
+		want: map[int64]float64{
 			A: 2,
 			B: 0.6667,
 			C: 0.6667,
 			D: 2,
 			E: 0.6667,
 		},
-		wantEdges: map[[2]int]float64{
+		wantEdges: map[[2]int64]float64{
 			{A, B}: 2 + 2/3. + 4/2.,
 			{A, C}: 2 + 2/3. + 2/2.,
 			{A, E}: 2 + 2/3. + 2/2.,
@@ -98,10 +98,10 @@ var betweennessTests = []struct {
 		},
 
 		wantTol: 1e-3,
-		want: map[int]float64{
+		want: map[int64]float64{
 			B: 2,
 		},
-		wantEdges: map[[2]int]float64{
+		wantEdges: map[[2]int64]float64{
 			{A, B}: 4,
 			{B, C}: 4,
 		},
@@ -116,12 +116,12 @@ var betweennessTests = []struct {
 		},
 
 		wantTol: 1e-3,
-		want: map[int]float64{
+		want: map[int64]float64{
 			B: 6,
 			C: 8,
 			D: 6,
 		},
-		wantEdges: map[[2]int]float64{
+		wantEdges: map[[2]int64]float64{
 			{A, B}: 8,
 			{B, C}: 12,
 			{C, D}: 12,
@@ -138,10 +138,10 @@ var betweennessTests = []struct {
 		},
 
 		wantTol: 1e-3,
-		want: map[int]float64{
+		want: map[int64]float64{
 			C: 12,
 		},
-		wantEdges: map[[2]int]float64{
+		wantEdges: map[[2]int64]float64{
 			{A, C}: 8,
 			{B, C}: 8,
 			{C, D}: 8,
@@ -158,8 +158,8 @@ var betweennessTests = []struct {
 		},
 
 		wantTol: 1e-3,
-		want:    map[int]float64{},
-		wantEdges: map[[2]int]float64{
+		want:    map[int64]float64{},
+		wantEdges: map[[2]int64]float64{
 			{A, B}: 2,
 			{A, C}: 2,
 			{A, D}: 2,
@@ -190,8 +190,8 @@ func TestBetweenness(t *testing.T) {
 		got := Betweenness(g)
 		prec := 1 - int(math.Log10(test.wantTol))
 		for n := range test.g {
-			wantN, gotOK := got[n]
-			gotN, wantOK := test.want[n]
+			wantN, gotOK := got[int64(n)]
+			gotN, wantOK := test.want[int64(n)]
 			if gotOK != wantOK {
 				t.Errorf("unexpected betweenness result for test %d, node %c", i, n+'A')
 			}
@@ -222,8 +222,8 @@ func TestEdgeBetweenness(t *testing.T) {
 	outer:
 		for u := range test.g {
 			for v := range test.g {
-				wantQ, gotOK := got[[2]int{u, v}]
-				gotQ, wantOK := test.wantEdges[[2]int{u, v}]
+				wantQ, gotOK := got[[2]int64{int64(u), int64(v)}]
+				gotQ, wantOK := test.wantEdges[[2]int64{int64(u), int64(v)}]
 				if gotOK != wantOK {
 					t.Errorf("unexpected betweenness result for test %d, edge (%c,%c)", i, u+'A', v+'A')
 				}
@@ -259,8 +259,8 @@ func TestBetweennessWeighted(t *testing.T) {
 		got := BetweennessWeighted(g, p)
 		prec := 1 - int(math.Log10(test.wantTol))
 		for n := range test.g {
-			gotN, gotOK := got[n]
-			wantN, wantOK := test.want[n]
+			gotN, gotOK := got[int64(n)]
+			wantN, wantOK := test.want[int64(n)]
 			if gotOK != wantOK {
 				t.Errorf("unexpected betweenness existence for test %d, node %c", i, n+'A')
 			}
@@ -297,8 +297,8 @@ func TestEdgeBetweennessWeighted(t *testing.T) {
 	outer:
 		for u := range test.g {
 			for v := range test.g {
-				wantQ, gotOK := got[[2]int{u, v}]
-				gotQ, wantOK := test.wantEdges[[2]int{u, v}]
+				wantQ, gotOK := got[[2]int64{int64(u), int64(v)}]
+				gotQ, wantOK := test.wantEdges[[2]int64{int64(u), int64(v)}]
 				if gotOK != wantOK {
 					t.Errorf("unexpected betweenness result for test %d, edge (%c,%c)", i, u+'A', v+'A')
 				}
@@ -312,7 +312,7 @@ func TestEdgeBetweennessWeighted(t *testing.T) {
 	}
 }
 
-func orderedPairFloats(w map[[2]int]float64, prec int) []pairKeyFloatVal {
+func orderedPairFloats(w map[[2]int64]float64, prec int) []pairKeyFloatVal {
 	o := make(orderedPairFloatsMap, 0, len(w))
 	for k, v := range w {
 		o = append(o, pairKeyFloatVal{prec: prec, key: k, val: v})
@@ -323,7 +323,7 @@ func orderedPairFloats(w map[[2]int]float64, prec int) []pairKeyFloatVal {
 
 type pairKeyFloatVal struct {
 	prec int
-	key  [2]int
+	key  [2]int64
 	val  float64
 }
 

--- a/graph/network/distance.go
+++ b/graph/network/distance.go
@@ -18,9 +18,9 @@ import (
 //
 // For directed graphs the incoming paths are used. Infinite distances are
 // not considered.
-func Closeness(g graph.Graph, p path.AllShortest) map[int]float64 {
+func Closeness(g graph.Graph, p path.AllShortest) map[int64]float64 {
 	nodes := g.Nodes()
-	c := make(map[int]float64, len(nodes))
+	c := make(map[int64]float64, len(nodes))
 	for _, u := range nodes {
 		var sum float64
 		for _, v := range nodes {
@@ -45,9 +45,9 @@ func Closeness(g graph.Graph, p path.AllShortest) map[int]float64 {
 //
 // For directed graphs the incoming paths are used. Infinite distances are
 // not considered.
-func Farness(g graph.Graph, p path.AllShortest) map[int]float64 {
+func Farness(g graph.Graph, p path.AllShortest) map[int64]float64 {
 	nodes := g.Nodes()
-	f := make(map[int]float64, len(nodes))
+	f := make(map[int64]float64, len(nodes))
 	for _, u := range nodes {
 		var sum float64
 		for _, v := range nodes {
@@ -72,9 +72,9 @@ func Farness(g graph.Graph, p path.AllShortest) map[int]float64 {
 //
 // For directed graphs the incoming paths are used. Infinite distances are
 // not considered.
-func Harmonic(g graph.Graph, p path.AllShortest) map[int]float64 {
+func Harmonic(g graph.Graph, p path.AllShortest) map[int64]float64 {
 	nodes := g.Nodes()
-	h := make(map[int]float64, len(nodes))
+	h := make(map[int64]float64, len(nodes))
 	for i, u := range nodes {
 		var sum float64
 		for j, v := range nodes {
@@ -101,9 +101,9 @@ func Harmonic(g graph.Graph, p path.AllShortest) map[int]float64 {
 //
 // For directed graphs the incoming paths are used. Infinite distances are
 // not considered.
-func Residual(g graph.Graph, p path.AllShortest) map[int]float64 {
+func Residual(g graph.Graph, p path.AllShortest) map[int64]float64 {
 	nodes := g.Nodes()
-	r := make(map[int]float64, len(nodes))
+	r := make(map[int64]float64, len(nodes))
 	for i, u := range nodes {
 		var sum float64
 		for j, v := range nodes {

--- a/graph/network/distance_test.go
+++ b/graph/network/distance_test.go
@@ -16,9 +16,9 @@ import (
 var undirectedCentralityTests = []struct {
 	g []set
 
-	farness  map[int]float64
-	harmonic map[int]float64
-	residual map[int]float64
+	farness  map[int64]float64
+	harmonic map[int64]float64
+	residual map[int64]float64
 }{
 	{
 		g: []set{
@@ -27,17 +27,17 @@ var undirectedCentralityTests = []struct {
 			C: nil,
 		},
 
-		farness: map[int]float64{
+		farness: map[int64]float64{
 			A: 1 + 2,
 			B: 1 + 1,
 			C: 2 + 1,
 		},
-		harmonic: map[int]float64{
+		harmonic: map[int64]float64{
 			A: 1 + 1.0/2.0,
 			B: 1 + 1,
 			C: 1.0/2.0 + 1,
 		},
-		residual: map[int]float64{
+		residual: map[int64]float64{
 			A: 1/math.Exp2(1) + 1/math.Exp2(2),
 			B: 1/math.Exp2(1) + 1/math.Exp2(1),
 			C: 1/math.Exp2(2) + 1/math.Exp2(1),
@@ -52,21 +52,21 @@ var undirectedCentralityTests = []struct {
 			E: nil,
 		},
 
-		farness: map[int]float64{
+		farness: map[int64]float64{
 			A: 1 + 2 + 3 + 4,
 			B: 1 + 1 + 2 + 3,
 			C: 2 + 1 + 1 + 2,
 			D: 3 + 2 + 1 + 1,
 			E: 4 + 3 + 2 + 1,
 		},
-		harmonic: map[int]float64{
+		harmonic: map[int64]float64{
 			A: 1 + 1.0/2.0 + 1.0/3.0 + 1.0/4.0,
 			B: 1 + 1 + 1.0/2.0 + 1.0/3.0,
 			C: 1.0/2.0 + 1 + 1 + 1.0/2.0,
 			D: 1.0/3.0 + 1.0/2.0 + 1 + 1,
 			E: 1.0/4.0 + 1.0/3.0 + 1.0/2.0 + 1,
 		},
-		residual: map[int]float64{
+		residual: map[int64]float64{
 			A: 1/math.Exp2(1) + 1/math.Exp2(2) + 1/math.Exp2(3) + 1/math.Exp2(4),
 			B: 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(2) + 1/math.Exp2(3),
 			C: 1/math.Exp2(2) + 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(2),
@@ -83,21 +83,21 @@ var undirectedCentralityTests = []struct {
 			E: linksTo(C),
 		},
 
-		farness: map[int]float64{
+		farness: map[int64]float64{
 			A: 2 + 2 + 1 + 2,
 			B: 2 + 1 + 2 + 2,
 			C: 1 + 1 + 1 + 1,
 			D: 2 + 1 + 2 + 2,
 			E: 2 + 2 + 1 + 2,
 		},
-		harmonic: map[int]float64{
+		harmonic: map[int64]float64{
 			A: 1.0/2.0 + 1.0/2.0 + 1 + 1.0/2.0,
 			B: 1.0/2.0 + 1 + 1.0/2.0 + 1.0/2.0,
 			C: 1 + 1 + 1 + 1,
 			D: 1.0/2.0 + 1 + 1.0/2.0 + 1.0/2.0,
 			E: 1.0/2.0 + 1.0/2.0 + 1 + 1.0/2.0,
 		},
-		residual: map[int]float64{
+		residual: map[int64]float64{
 			A: 1/math.Exp2(2) + 1/math.Exp2(2) + 1/math.Exp2(1) + 1/math.Exp2(2),
 			B: 1/math.Exp2(2) + 1/math.Exp2(1) + 1/math.Exp2(2) + 1/math.Exp2(2),
 			C: 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1),
@@ -114,21 +114,21 @@ var undirectedCentralityTests = []struct {
 			E: nil,
 		},
 
-		farness: map[int]float64{
+		farness: map[int64]float64{
 			A: 1 + 1 + 1 + 1,
 			B: 1 + 1 + 1 + 1,
 			C: 1 + 1 + 1 + 1,
 			D: 1 + 1 + 1 + 1,
 			E: 1 + 1 + 1 + 1,
 		},
-		harmonic: map[int]float64{
+		harmonic: map[int64]float64{
 			A: 1 + 1 + 1 + 1,
 			B: 1 + 1 + 1 + 1,
 			C: 1 + 1 + 1 + 1,
 			D: 1 + 1 + 1 + 1,
 			E: 1 + 1 + 1 + 1,
 		},
-		residual: map[int]float64{
+		residual: map[int64]float64{
 			A: 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1),
 			B: 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1),
 			C: 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1),
@@ -159,12 +159,12 @@ func TestDistanceCentralityUndirected(t *testing.T) {
 			continue
 		}
 
-		var got map[int]float64
+		var got map[int64]float64
 
 		got = Closeness(g, p)
 		for n := range test.g {
-			if !floats.EqualWithinAbsOrRel(got[n], 1/test.farness[n], tol, tol) {
-				want := make(map[int]float64)
+			if !floats.EqualWithinAbsOrRel(got[int64(n)], 1/test.farness[int64(n)], tol, tol) {
+				want := make(map[int64]float64)
 				for n, v := range test.farness {
 					want[n] = 1 / v
 				}
@@ -176,7 +176,7 @@ func TestDistanceCentralityUndirected(t *testing.T) {
 
 		got = Farness(g, p)
 		for n := range test.g {
-			if !floats.EqualWithinAbsOrRel(got[n], test.farness[n], tol, tol) {
+			if !floats.EqualWithinAbsOrRel(got[int64(n)], test.farness[int64(n)], tol, tol) {
 				t.Errorf("unexpected farness for test %d:\ngot: %v\nwant:%v",
 					i, orderedFloats(got, prec), orderedFloats(test.farness, prec))
 				break
@@ -185,7 +185,7 @@ func TestDistanceCentralityUndirected(t *testing.T) {
 
 		got = Harmonic(g, p)
 		for n := range test.g {
-			if !floats.EqualWithinAbsOrRel(got[n], test.harmonic[n], tol, tol) {
+			if !floats.EqualWithinAbsOrRel(got[int64(n)], test.harmonic[int64(n)], tol, tol) {
 				t.Errorf("unexpected harmonic centrality for test %d:\ngot: %v\nwant:%v",
 					i, orderedFloats(got, prec), orderedFloats(test.harmonic, prec))
 				break
@@ -194,7 +194,7 @@ func TestDistanceCentralityUndirected(t *testing.T) {
 
 		got = Residual(g, p)
 		for n := range test.g {
-			if !floats.EqualWithinAbsOrRel(got[n], test.residual[n], tol, tol) {
+			if !floats.EqualWithinAbsOrRel(got[int64(n)], test.residual[int64(n)], tol, tol) {
 				t.Errorf("unexpected residual closeness for test %d:\ngot: %v\nwant:%v",
 					i, orderedFloats(got, prec), orderedFloats(test.residual, prec))
 				break
@@ -206,9 +206,9 @@ func TestDistanceCentralityUndirected(t *testing.T) {
 var directedCentralityTests = []struct {
 	g []set
 
-	farness  map[int]float64
-	harmonic map[int]float64
-	residual map[int]float64
+	farness  map[int64]float64
+	harmonic map[int64]float64
+	residual map[int64]float64
 }{
 	{
 		g: []set{
@@ -217,17 +217,17 @@ var directedCentralityTests = []struct {
 			C: nil,
 		},
 
-		farness: map[int]float64{
+		farness: map[int64]float64{
 			A: 0,
 			B: 1,
 			C: 2 + 1,
 		},
-		harmonic: map[int]float64{
+		harmonic: map[int64]float64{
 			A: 0,
 			B: 1,
 			C: 1.0/2.0 + 1,
 		},
-		residual: map[int]float64{
+		residual: map[int64]float64{
 			A: 0,
 			B: 1 / math.Exp2(1),
 			C: 1/math.Exp2(2) + 1/math.Exp2(1),
@@ -242,21 +242,21 @@ var directedCentralityTests = []struct {
 			E: nil,
 		},
 
-		farness: map[int]float64{
+		farness: map[int64]float64{
 			A: 0,
 			B: 1,
 			C: 2 + 1,
 			D: 3 + 2 + 1,
 			E: 4 + 3 + 2 + 1,
 		},
-		harmonic: map[int]float64{
+		harmonic: map[int64]float64{
 			A: 0,
 			B: 1,
 			C: 1.0/2.0 + 1,
 			D: 1.0/3.0 + 1.0/2.0 + 1,
 			E: 1.0/4.0 + 1.0/3.0 + 1.0/2.0 + 1,
 		},
-		residual: map[int]float64{
+		residual: map[int64]float64{
 			A: 0,
 			B: 1 / math.Exp2(1),
 			C: 1/math.Exp2(2) + 1/math.Exp2(1),
@@ -273,21 +273,21 @@ var directedCentralityTests = []struct {
 			E: linksTo(C),
 		},
 
-		farness: map[int]float64{
+		farness: map[int64]float64{
 			A: 0,
 			B: 0,
 			C: 1 + 1 + 1 + 1,
 			D: 0,
 			E: 0,
 		},
-		harmonic: map[int]float64{
+		harmonic: map[int64]float64{
 			A: 0,
 			B: 0,
 			C: 1 + 1 + 1 + 1,
 			D: 0,
 			E: 0,
 		},
-		residual: map[int]float64{
+		residual: map[int64]float64{
 			A: 0,
 			B: 0,
 			C: 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1) + 1/math.Exp2(1),
@@ -304,21 +304,21 @@ var directedCentralityTests = []struct {
 			E: nil,
 		},
 
-		farness: map[int]float64{
+		farness: map[int64]float64{
 			A: 0,
 			B: 1,
 			C: 1 + 1,
 			D: 1 + 1 + 1,
 			E: 1 + 1 + 1 + 1,
 		},
-		harmonic: map[int]float64{
+		harmonic: map[int64]float64{
 			A: 0,
 			B: 1,
 			C: 1 + 1,
 			D: 1 + 1 + 1,
 			E: 1 + 1 + 1 + 1,
 		},
-		residual: map[int]float64{
+		residual: map[int64]float64{
 			A: 0,
 			B: 1 / math.Exp2(1),
 			C: 1/math.Exp2(1) + 1/math.Exp2(1),
@@ -349,14 +349,14 @@ func TestDistanceCentralityDirected(t *testing.T) {
 			continue
 		}
 
-		var got map[int]float64
+		var got map[int64]float64
 
 		got = Closeness(g, p)
 		for n := range test.g {
-			if !floats.EqualWithinAbsOrRel(got[n], 1/test.farness[n], tol, tol) {
-				want := make(map[int]float64)
+			if !floats.EqualWithinAbsOrRel(got[int64(n)], 1/test.farness[int64(n)], tol, tol) {
+				want := make(map[int64]float64)
 				for n, v := range test.farness {
-					want[n] = 1 / v
+					want[int64(n)] = 1 / v
 				}
 				t.Errorf("unexpected closeness centrality for test %d:\ngot: %v\nwant:%v",
 					i, orderedFloats(got, prec), orderedFloats(want, prec))
@@ -366,7 +366,7 @@ func TestDistanceCentralityDirected(t *testing.T) {
 
 		got = Farness(g, p)
 		for n := range test.g {
-			if !floats.EqualWithinAbsOrRel(got[n], test.farness[n], tol, tol) {
+			if !floats.EqualWithinAbsOrRel(got[int64(n)], test.farness[int64(n)], tol, tol) {
 				t.Errorf("unexpected farness for test %d:\ngot: %v\nwant:%v",
 					i, orderedFloats(got, prec), orderedFloats(test.farness, prec))
 				break
@@ -375,7 +375,7 @@ func TestDistanceCentralityDirected(t *testing.T) {
 
 		got = Harmonic(g, p)
 		for n := range test.g {
-			if !floats.EqualWithinAbsOrRel(got[n], test.harmonic[n], tol, tol) {
+			if !floats.EqualWithinAbsOrRel(got[int64(n)], test.harmonic[int64(n)], tol, tol) {
 				t.Errorf("unexpected harmonic centrality for test %d:\ngot: %v\nwant:%v",
 					i, orderedFloats(got, prec), orderedFloats(test.harmonic, prec))
 				break
@@ -384,7 +384,7 @@ func TestDistanceCentralityDirected(t *testing.T) {
 
 		got = Residual(g, p)
 		for n := range test.g {
-			if !floats.EqualWithinAbsOrRel(got[n], test.residual[n], tol, tol) {
+			if !floats.EqualWithinAbsOrRel(got[int64(n)], test.residual[int64(n)], tol, tol) {
 				t.Errorf("unexpected residual closeness for test %d:\ngot: %v\nwant:%v",
 					i, orderedFloats(got, prec), orderedFloats(test.residual, prec))
 				break

--- a/graph/network/hits.go
+++ b/graph/network/hits.go
@@ -21,11 +21,11 @@ type HubAuthority struct {
 // nodes of the directed graph g. HITS terminates when the 2-norm of the
 // vector difference between iterations is below tol. The returned map is
 // keyed on the graph node IDs.
-func HITS(g graph.Directed, tol float64) map[int]HubAuthority {
+func HITS(g graph.Directed, tol float64) map[int64]HubAuthority {
 	nodes := g.Nodes()
 
 	// Make a topological copy of g with dense node IDs.
-	indexOf := make(map[int]int, len(nodes))
+	indexOf := make(map[int64]int, len(nodes))
 	for i, n := range nodes {
 		indexOf[n.ID()] = i
 	}
@@ -92,7 +92,7 @@ func HITS(g graph.Directed, tol float64) map[int]HubAuthority {
 		}
 	}
 
-	hubAuth := make(map[int]HubAuthority, len(nodes))
+	hubAuth := make(map[int64]HubAuthority, len(nodes))
 	for i, n := range nodes {
 		hubAuth[n.ID()] = HubAuthority{Hub: hub[i], Authority: auth[i]}
 	}

--- a/graph/network/hits_test.go
+++ b/graph/network/hits_test.go
@@ -19,7 +19,7 @@ var hitsTests = []struct {
 	tol float64
 
 	wantTol float64
-	want    map[int]HubAuthority
+	want    map[int64]HubAuthority
 }{
 	{
 		// Example graph from http://www.cis.hut.fi/Opinnot/T-61.6020/2008/pagerank_hits.pdf page 8.
@@ -32,7 +32,7 @@ var hitsTests = []struct {
 		tol: 1e-4,
 
 		wantTol: 1e-4,
-		want: map[int]HubAuthority{
+		want: map[int64]HubAuthority{
 			A: {Hub: 0.7887, Authority: 0},
 			B: {Hub: 0.5774, Authority: 0.4597},
 			C: {Hub: 0.2113, Authority: 0.6280},
@@ -56,12 +56,12 @@ func TestHITS(t *testing.T) {
 		got := HITS(g, test.tol)
 		prec := 1 - int(math.Log10(test.wantTol))
 		for n := range test.g {
-			if !floats.EqualWithinAbsOrRel(got[n].Hub, test.want[n].Hub, test.wantTol, test.wantTol) {
+			if !floats.EqualWithinAbsOrRel(got[int64(n)].Hub, test.want[int64(n)].Hub, test.wantTol, test.wantTol) {
 				t.Errorf("unexpected HITS result for test %d:\ngot: %v\nwant:%v",
 					i, orderedHubAuth(got, prec), orderedHubAuth(test.want, prec))
 				break
 			}
-			if !floats.EqualWithinAbsOrRel(got[n].Authority, test.want[n].Authority, test.wantTol, test.wantTol) {
+			if !floats.EqualWithinAbsOrRel(got[int64(n)].Authority, test.want[int64(n)].Authority, test.wantTol, test.wantTol) {
 				t.Errorf("unexpected HITS result for test %d:\ngot: %v\nwant:%v",
 					i, orderedHubAuth(got, prec), orderedHubAuth(test.want, prec))
 				break
@@ -70,7 +70,7 @@ func TestHITS(t *testing.T) {
 	}
 }
 
-func orderedHubAuth(w map[int]HubAuthority, prec int) []keyHubAuthVal {
+func orderedHubAuth(w map[int64]HubAuthority, prec int) []keyHubAuthVal {
 	o := make(orderedHubAuthMap, 0, len(w))
 	for k, v := range w {
 		o = append(o, keyHubAuthVal{prec: prec, key: k, val: v})
@@ -81,7 +81,7 @@ func orderedHubAuth(w map[int]HubAuthority, prec int) []keyHubAuthVal {
 
 type keyHubAuthVal struct {
 	prec int
-	key  int
+	key  int64
 	val  HubAuthority
 }
 

--- a/graph/network/network_test.go
+++ b/graph/network/network_test.go
@@ -19,9 +19,9 @@ const (
 )
 
 // set is an integer set.
-type set map[int]struct{}
+type set map[int64]struct{}
 
-func linksTo(i ...int) set {
+func linksTo(i ...int64) set {
 	if len(i) == 0 {
 		return nil
 	}

--- a/graph/network/page.go
+++ b/graph/network/page.go
@@ -17,7 +17,7 @@ import (
 // using the given damping factor and terminating when the 2-norm of the
 // vector difference between iterations is below tol. The returned map is
 // keyed on the graph node IDs.
-func PageRank(g graph.Directed, damp, tol float64) map[int]float64 {
+func PageRank(g graph.Directed, damp, tol float64) map[int64]float64 {
 	// PageRank is implemented according to "How Google Finds Your Needle
 	// in the Web's Haystack".
 	//
@@ -26,7 +26,7 @@ func PageRank(g graph.Directed, damp, tol float64) map[int]float64 {
 	// http://www.ams.org/samplings/feature-column/fcarc-pagerank
 
 	nodes := g.Nodes()
-	indexOf := make(map[int]int, len(nodes))
+	indexOf := make(map[int64]int, len(nodes))
 	for i, n := range nodes {
 		indexOf[n.ID()] = i
 	}
@@ -78,7 +78,7 @@ func PageRank(g graph.Directed, damp, tol float64) map[int]float64 {
 		}
 	}
 
-	ranks := make(map[int]float64, len(nodes))
+	ranks := make(map[int64]float64, len(nodes))
 	for i, r := range v.RawVector().Data {
 		ranks[nodes[i].ID()] = r
 	}
@@ -90,7 +90,7 @@ func PageRank(g graph.Directed, damp, tol float64) map[int]float64 {
 // graph g using the given damping factor and terminating when the 2-norm of the
 // vector difference between iterations is below tol. The returned map is
 // keyed on the graph node IDs.
-func PageRankSparse(g graph.Directed, damp, tol float64) map[int]float64 {
+func PageRankSparse(g graph.Directed, damp, tol float64) map[int64]float64 {
 	// PageRankSparse is implemented according to "How Google Finds Your Needle
 	// in the Web's Haystack".
 	//
@@ -99,7 +99,7 @@ func PageRankSparse(g graph.Directed, damp, tol float64) map[int]float64 {
 	// http://www.ams.org/samplings/feature-column/fcarc-pagerank
 
 	nodes := g.Nodes()
-	indexOf := make(map[int]int, len(nodes))
+	indexOf := make(map[int64]int, len(nodes))
 	for i, n := range nodes {
 		indexOf[n.ID()] = i
 	}
@@ -151,7 +151,7 @@ func PageRankSparse(g graph.Directed, damp, tol float64) map[int]float64 {
 		}
 	}
 
-	ranks := make(map[int]float64, len(nodes))
+	ranks := make(map[int64]float64, len(nodes))
 	for i, r := range v.RawVector().Data {
 		ranks[nodes[i].ID()] = r
 	}

--- a/graph/network/page_test.go
+++ b/graph/network/page_test.go
@@ -20,7 +20,7 @@ var pageRankTests = []struct {
 	tol  float64
 
 	wantTol float64
-	want    map[int]float64
+	want    map[int64]float64
 }{
 	{
 		// Example graph from http://en.wikipedia.org/wiki/File:PageRanks-Example.svg 16:17, 8 July 2009
@@ -41,7 +41,7 @@ var pageRankTests = []struct {
 		tol:  1e-8,
 
 		wantTol: 1e-8,
-		want: map[int]float64{
+		want: map[int64]float64{
 			A: 0.03278149,
 			B: 0.38440095,
 			C: 0.34291029,
@@ -69,7 +69,7 @@ var pageRankTests = []struct {
 		tol:  1e-3,
 
 		wantTol: 1e-3,
-		want: map[int]float64{
+		want: map[int64]float64{
 			A: 0.250,
 			B: 0.140,
 			C: 0.140,
@@ -94,7 +94,7 @@ func TestPageRank(t *testing.T) {
 		got := PageRank(g, test.damp, test.tol)
 		prec := 1 - int(math.Log10(test.wantTol))
 		for n := range test.g {
-			if !floats.EqualWithinAbsOrRel(got[n], test.want[n], test.wantTol, test.wantTol) {
+			if !floats.EqualWithinAbsOrRel(got[int64(n)], test.want[int64(n)], test.wantTol, test.wantTol) {
 				t.Errorf("unexpected PageRank result for test %d:\ngot: %v\nwant:%v",
 					i, orderedFloats(got, prec), orderedFloats(test.want, prec))
 				break
@@ -118,7 +118,7 @@ func TestPageRankSparse(t *testing.T) {
 		got := PageRankSparse(g, test.damp, test.tol)
 		prec := 1 - int(math.Log10(test.wantTol))
 		for n := range test.g {
-			if !floats.EqualWithinAbsOrRel(got[n], test.want[n], test.wantTol, test.wantTol) {
+			if !floats.EqualWithinAbsOrRel(got[int64(n)], test.want[int64(n)], test.wantTol, test.wantTol) {
 				t.Errorf("unexpected PageRank result for test %d:\ngot: %v\nwant:%v",
 					i, orderedFloats(got, prec), orderedFloats(test.want, prec))
 				break
@@ -127,7 +127,7 @@ func TestPageRankSparse(t *testing.T) {
 	}
 }
 
-func orderedFloats(w map[int]float64, prec int) []keyFloatVal {
+func orderedFloats(w map[int64]float64, prec int) []keyFloatVal {
 	o := make(orderedFloatsMap, 0, len(w))
 	for k, v := range w {
 		o = append(o, keyFloatVal{prec: prec, key: k, val: v})
@@ -138,7 +138,7 @@ func orderedFloats(w map[int]float64, prec int) []keyFloatVal {
 
 type keyFloatVal struct {
 	prec int
-	key  int
+	key  int64
 	val  float64
 }
 

--- a/graph/path/a_star.go
+++ b/graph/path/a_star.go
@@ -44,8 +44,8 @@ func AStar(s, t graph.Node, g graph.Graph, h Heuristic) (path Shortest, expanded
 	path = newShortestFrom(s, g.Nodes())
 	tid := t.ID()
 
-	visited := make(set.Ints)
-	open := &aStarQueue{indexOf: make(map[int]int)}
+	visited := make(set.Int64s)
+	open := &aStarQueue{indexOf: make(map[int64]int)}
 	heap.Push(open, aStarNode{node: s, gscore: 0, fscore: h(s, t)})
 
 	for open.Len() != 0 {
@@ -101,7 +101,7 @@ type aStarNode struct {
 
 // aStarQueue is an A* priority queue.
 type aStarQueue struct {
-	indexOf map[int]int
+	indexOf map[int64]int
 	nodes   []aStarNode
 }
 
@@ -132,7 +132,7 @@ func (q *aStarQueue) Pop() interface{} {
 	return n
 }
 
-func (q *aStarQueue) update(id int, g, f float64) {
+func (q *aStarQueue) update(id int64, g, f float64) {
 	i, ok := q.indexOf[id]
 	if !ok {
 		return
@@ -142,7 +142,7 @@ func (q *aStarQueue) update(id int, g, f float64) {
 	heap.Fix(q, i)
 }
 
-func (q *aStarQueue) node(id int) (aStarNode, bool) {
+func (q *aStarQueue) node(id int64) (aStarNode, bool) {
 	loc, ok := q.indexOf[id]
 	if ok {
 		return q.nodes[loc], true

--- a/graph/path/a_star_test.go
+++ b/graph/path/a_star_test.go
@@ -20,9 +20,9 @@ var aStarTests = []struct {
 	name string
 	g    graph.Graph
 
-	s, t      int
+	s, t      int64
 	heuristic Heuristic
-	wantPath  []int
+	wantPath  []int64
 }{
 	{
 		name: "simple path",
@@ -36,7 +36,7 @@ var aStarTests = []struct {
 		}(),
 
 		s: 1, t: 14,
-		wantPath: []int{1, 2, 6, 10, 14},
+		wantPath: []int64{1, 2, 6, 10, 14},
 	},
 	{
 		name: "small open graph",
@@ -143,7 +143,7 @@ func TestAStar(t *testing.T) {
 			t.Errorf("unexpected cost for %q: got:%v want:%v", test.name, cost, want)
 		}
 
-		var got = make([]int, 0, len(p))
+		var got = make([]int64, 0, len(p))
 		for _, n := range p {
 			got = append(got, n.ID())
 		}
@@ -211,11 +211,11 @@ func TestExhaustiveAStar(t *testing.T) {
 }
 
 type locatedNode struct {
-	id   int
+	id   int64
 	x, y float64
 }
 
-func (n locatedNode) ID() int { return n.id }
+func (n locatedNode) ID() int64 { return n.id }
 
 type weightedEdge struct {
 	from, to graph.Node
@@ -285,7 +285,7 @@ func TestAStarNullHeuristic(t *testing.T) {
 				test.Name, weight, test.Weight)
 		}
 
-		var got []int
+		var got []int64
 		for _, n := range p {
 			got = append(got, n.ID())
 		}

--- a/graph/path/bellman_ford_moore_test.go
+++ b/graph/path/bellman_ford_moore_test.go
@@ -45,7 +45,7 @@ func TestBellmanFordFrom(t *testing.T) {
 				test.Name, weight, test.Weight)
 		}
 
-		var got []int
+		var got []int64
 		for _, n := range p {
 			got = append(got, n.ID())
 		}

--- a/graph/path/bench_test.go
+++ b/graph/path/bench_test.go
@@ -72,10 +72,10 @@ func navigableSmallWorldUndirected(n, p, q int, r float64) graph.Undirected {
 
 func coordinatesForID(n graph.Node, c, r int) [2]int {
 	id := n.ID()
-	if id >= c*r {
+	if id >= int64(c*r) {
 		panic("out of range")
 	}
-	return [2]int{id / r, id % r}
+	return [2]int{int(id) / r, int(id) % r}
 }
 
 // manhattanBetween returns the Manhattan distance between a and b.

--- a/graph/path/control_flow.go
+++ b/graph/path/control_flow.go
@@ -13,10 +13,10 @@ import (
 // prune for strict post-dominators, immediate dominators etc.
 //
 // A dominates B if and only if the only path through B travels through A.
-func Dominators(start graph.Node, g graph.Graph) map[int]set.Nodes {
+func Dominators(start graph.Node, g graph.Graph) map[int64]set.Nodes {
 	allNodes := make(set.Nodes)
 	nlist := g.Nodes()
-	dominators := make(map[int]set.Nodes, len(nlist))
+	dominators := make(map[int64]set.Nodes, len(nlist))
 	for _, node := range nlist {
 		allNodes.Add(node)
 	}
@@ -71,10 +71,10 @@ func Dominators(start graph.Node, g graph.Graph) map[int]set.Nodes {
 // prune for strict post-dominators, immediate post-dominators etc.
 //
 // A post-dominates B if and only if all paths from B travel through A.
-func PostDominators(end graph.Node, g graph.Graph) map[int]set.Nodes {
+func PostDominators(end graph.Node, g graph.Graph) map[int64]set.Nodes {
 	allNodes := make(set.Nodes)
 	nlist := g.Nodes()
-	dominators := make(map[int]set.Nodes, len(nlist))
+	dominators := make(map[int64]set.Nodes, len(nlist))
 	for _, node := range nlist {
 		allNodes.Add(node)
 	}

--- a/graph/path/dijkstra_test.go
+++ b/graph/path/dijkstra_test.go
@@ -57,7 +57,7 @@ func TestDijkstraFrom(t *testing.T) {
 				test.Name, weight, test.Weight)
 		}
 
-		var got []int
+		var got []int64
 		for _, n := range p {
 			got = append(got, n.ID())
 		}
@@ -125,7 +125,7 @@ func TestDijkstraAllPaths(t *testing.T) {
 					test.Name, unique, test.HasUniquePath)
 			}
 
-			var got []int
+			var got []int64
 			for _, n := range p {
 				got = append(got, n.ID())
 			}
@@ -154,9 +154,9 @@ func TestDijkstraAllPaths(t *testing.T) {
 				test.Name, weight, test.Weight)
 		}
 
-		var got [][]int
+		var got [][]int64
 		if len(paths) != 0 {
-			got = make([][]int, len(paths))
+			got = make([][]int64, len(paths))
 		}
 		for i, p := range paths {
 			for _, v := range p {

--- a/graph/path/disjoint.go
+++ b/graph/path/disjoint.go
@@ -18,7 +18,7 @@ package path
 // two sets when an edge is created between two vertices, and refuses to make an edge between two
 // vertices if they're part of the same set.
 type disjointSet struct {
-	master map[int]*disjointSetNode
+	master map[int64]*disjointSetNode
 }
 
 type disjointSetNode struct {
@@ -27,11 +27,11 @@ type disjointSetNode struct {
 }
 
 func newDisjointSet() *disjointSet {
-	return &disjointSet{master: make(map[int]*disjointSetNode)}
+	return &disjointSet{master: make(map[int64]*disjointSetNode)}
 }
 
 // If the element isn't already somewhere in there, adds it to the master set and its own tiny set.
-func (ds *disjointSet) makeSet(e int) {
+func (ds *disjointSet) makeSet(e int64) {
 	if _, ok := ds.master[e]; ok {
 		return
 	}
@@ -41,7 +41,7 @@ func (ds *disjointSet) makeSet(e int) {
 }
 
 // Returns the set the element belongs to, or nil if none.
-func (ds *disjointSet) find(e int) *disjointSetNode {
+func (ds *disjointSet) find(e int64) *disjointSetNode {
 	dsNode, ok := ds.master[e]
 	if !ok {
 		return nil

--- a/graph/path/dynamic/dstarlite.go
+++ b/graph/path/dynamic/dstarlite.go
@@ -35,7 +35,7 @@ type DStarLite struct {
 type WorldModel interface {
 	graph.DirectedBuilder
 	graph.Weighter
-	Node(id int) graph.Node
+	Node(id int64) graph.Node
 }
 
 // NewDStarLite returns a new DStarLite planner for the path from s to t in g using the

--- a/graph/path/dynamic/dstarlite_test.go
+++ b/graph/path/dynamic/dstarlite_test.go
@@ -69,7 +69,7 @@ func TestDStarLiteNullHeuristic(t *testing.T) {
 				test.Name, weight, test.Weight)
 		}
 
-		var got []int
+		var got []int64
 		for _, n := range p {
 			got = append(got, n.ID())
 		}
@@ -101,7 +101,7 @@ var dynamicDStarLiteTests = []struct {
 
 	want        []graph.Node
 	weight      float64
-	wantedPaths map[int][]graph.Node
+	wantedPaths map[int64][]graph.Node
 }{
 	{
 		// This is the example shown in figures 6 and 7 of doi:10.1109/tro.2004.838026.
@@ -167,7 +167,7 @@ var dynamicDStarLiteTests = []struct {
 			simple.Node(14),
 		},
 		weight: 7.242640687119285,
-		wantedPaths: map[int][]graph.Node{
+		wantedPaths: map[int64][]graph.Node{
 			12: {simple.Node(12), simple.Node(7), simple.Node(3), simple.Node(9), simple.Node(14)},
 		},
 	},
@@ -558,7 +558,7 @@ func TestDStarLiteDynamic(t *testing.T) {
 				Location:     test.s,
 			}
 			if remember {
-				l.Known = make(map[int]bool)
+				l.Known = make(map[int64]bool)
 			}
 
 			l.Grid.AllVisible = test.all

--- a/graph/path/dynamic/dumper_test.go
+++ b/graph/path/dynamic/dumper_test.go
@@ -30,9 +30,9 @@ func (d *dumper) dump(withpath bool) {
 	if d == nil {
 		return
 	}
-	var pathStep map[int]int
+	var pathStep map[int64]int
 	if withpath {
-		pathStep = make(map[int]int)
+		pathStep = make(map[int64]int)
 		path, _ := d.dStarLite.Path()
 		for i, n := range path {
 			pathStep[n.ID()] = i

--- a/graph/path/floydwarshall_test.go
+++ b/graph/path/floydwarshall_test.go
@@ -49,7 +49,7 @@ func TestFloydWarshall(t *testing.T) {
 					test.Name, unique, test.HasUniquePath)
 			}
 
-			var got []int
+			var got []int64
 			for _, n := range p {
 				got = append(got, n.ID())
 			}
@@ -78,9 +78,9 @@ func TestFloydWarshall(t *testing.T) {
 				test.Name, weight, test.Weight)
 		}
 
-		var got [][]int
+		var got [][]int64
 		if len(paths) != 0 {
-			got = make([][]int, len(paths))
+			got = make([][]int64, len(paths))
 		}
 		for i, p := range paths {
 			for _, v := range p {

--- a/graph/path/internal/grid.go
+++ b/graph/path/internal/grid.go
@@ -108,14 +108,14 @@ func (g *Grid) Has(n graph.Node) bool {
 	return g.has(n.ID())
 }
 
-func (g *Grid) has(id int) bool {
-	return id >= 0 && id < len(g.open) && (g.AllVisible || g.open[id])
+func (g *Grid) has(id int64) bool {
+	return 0 <= id && id < int64(len(g.open)) && (g.AllVisible || g.open[id])
 }
 
 // HasOpen returns whether n is an open node in the grid.
 func (g *Grid) HasOpen(n graph.Node) bool {
 	id := n.ID()
-	return id >= 0 && id < len(g.open) && g.open[id]
+	return 0 <= id && id < int64(len(g.open)) && g.open[id]
 }
 
 // Set sets the node at position (r, c) to the specified open state.
@@ -136,11 +136,11 @@ func (g *Grid) Dims() (r, c int) {
 
 // RowCol returns the row and column of the id. RowCol will panic if the
 // node id is outside the range of the grid.
-func (g *Grid) RowCol(id int) (r, c int) {
-	if id < 0 || id >= len(g.open) {
+func (g *Grid) RowCol(id int64) (r, c int) {
+	if id < 0 || int64(len(g.open)) <= id {
 		panic("grid: illegal node id")
 	}
-	return id / g.c, id % g.c
+	return int(id) / g.c, int(id) % g.c
 }
 
 // XY returns the cartesian coordinates of n. If n is not a node
@@ -266,7 +266,7 @@ func (g *Grid) Render(path []graph.Node) ([]byte, error) {
 	for i, n := range path {
 		if !g.Has(n) || (i != 0 && !g.HasEdgeBetween(path[i-1], n)) {
 			id := n.ID()
-			if id >= 0 && id < len(g.open) {
+			if 0 <= id && id < int64(len(g.open)) {
 				r, c := g.RowCol(n.ID())
 				b[r*(g.c+1)+c] = '!'
 			}

--- a/graph/path/internal/grid_test.go
+++ b/graph/path/internal/grid_test.go
@@ -19,9 +19,9 @@ var _ graph.Graph = (*Grid)(nil)
 
 func join(g ...string) string { return strings.Join(g, "\n") }
 
-type node int
+type node int64
 
-func (n node) ID() int { return int(n) }
+func (n node) ID() int64 { return int64(n) }
 
 func TestGrid(t *testing.T) {
 	g := NewGrid(4, 4, false)
@@ -205,7 +205,7 @@ func TestGrid(t *testing.T) {
 
 	var coords = []struct {
 		r, c int
-		id   int
+		id   int64
 	}{
 		{r: 0, c: 0, id: 0},
 		{r: 0, c: 3, id: 3},

--- a/graph/path/internal/limited.go
+++ b/graph/path/internal/limited.go
@@ -29,7 +29,7 @@ type LimitedVisionGrid struct {
 
 	// Known holds a store of known
 	// nodes, if not nil.
-	Known map[int]bool
+	Known map[int64]bool
 }
 
 // MoveTo moves to the node n on the grid and returns a slice of newly seen and
@@ -39,7 +39,7 @@ func (l *LimitedVisionGrid) MoveTo(n graph.Node) (new, old []graph.Edge) {
 	row, column := l.RowCol(n.ID())
 	x := float64(column)
 	y := float64(row)
-	seen := make(map[[2]int]bool)
+	seen := make(map[[2]int64]bool)
 	bound := int(l.VisionRadius + 0.5)
 	for r := row - bound; r <= row+bound; r++ {
 		for c := column - bound; c <= column+bound; c++ {
@@ -52,10 +52,10 @@ func (l *LimitedVisionGrid) MoveTo(n graph.Node) (new, old []graph.Edge) {
 				continue
 			}
 			for _, v := range l.allPossibleFrom(u) {
-				if seen[[2]int{u.ID(), v.ID()}] {
+				if seen[[2]int64{u.ID(), v.ID()}] {
 					continue
 				}
-				seen[[2]int{u.ID(), v.ID()}] = true
+				seen[[2]int64{u.ID(), v.ID()}] = true
 
 				vx, vy := l.XY(v)
 				if !l.Known[v.ID()] && math.Hypot(x-vx, y-vy) > l.VisionRadius {
@@ -128,7 +128,7 @@ func (l *LimitedVisionGrid) allPossibleFrom(u graph.Node) []graph.Node {
 
 // RowCol returns the row and column of the id. RowCol will panic if the
 // node id is outside the range of the grid.
-func (l *LimitedVisionGrid) RowCol(id int) (r, c int) {
+func (l *LimitedVisionGrid) RowCol(id int64) (r, c int) {
 	return l.Grid.RowCol(id)
 }
 
@@ -161,8 +161,8 @@ func (l *LimitedVisionGrid) Has(n graph.Node) bool {
 	return l.has(n.ID())
 }
 
-func (l *LimitedVisionGrid) has(id int) bool {
-	return id >= 0 && id < len(l.Grid.open)
+func (l *LimitedVisionGrid) has(id int64) bool {
+	return 0 <= id && id < int64(len(l.Grid.open))
 }
 
 // From returns nodes that are optimistically reachable from u.
@@ -268,7 +268,7 @@ func (l *LimitedVisionGrid) Render(path []graph.Node) ([]byte, error) {
 	b := make([]byte, rows*(cols+1)-1)
 	for r := 0; r < rows; r++ {
 		for c := 0; c < cols; c++ {
-			if !l.Known[r*cols+c] {
+			if !l.Known[int64(r*cols+c)] {
 				b[r*(cols+1)+c] = Unknown
 			} else if l.Grid.open[r*cols+c] {
 				b[r*(cols+1)+c] = Open
@@ -286,7 +286,7 @@ func (l *LimitedVisionGrid) Render(path []graph.Node) ([]byte, error) {
 	for i, n := range path {
 		if !l.Has(n) || (i != 0 && !l.HasEdgeBetween(path[i-1], n)) {
 			id := n.ID()
-			if id >= 0 && id < len(l.Grid.open) {
+			if 0 <= id && id < int64(len(l.Grid.open)) {
 				r, c := l.RowCol(n.ID())
 				b[r*(cols+1)+c] = '!'
 			}

--- a/graph/path/internal/limited_test.go
+++ b/graph/path/internal/limited_test.go
@@ -1161,7 +1161,7 @@ func TestLimitedVisionGrid(t *testing.T) {
 			Location:     test.path[0],
 		}
 		if test.remember {
-			l.Known = make(map[int]bool)
+			l.Known = make(map[int64]bool)
 		}
 		l.Grid.AllowDiagonal = test.diag
 

--- a/graph/path/internal/testgraphs/shortest.go
+++ b/graph/path/internal/testgraphs/shortest.go
@@ -32,7 +32,7 @@ var ShortestPathTests = []struct {
 
 	Query         simple.Edge
 	Weight        float64
-	WantPaths     [][]int
+	WantPaths     [][]int64
 	HasUniquePath bool
 
 	NoPathFor simple.Edge
@@ -65,7 +65,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(1)},
 		Weight: 1,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1},
 		},
 		HasUniquePath: true,
@@ -81,7 +81,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(0)},
 		Weight: 0,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0},
 		},
 		HasUniquePath: true,
@@ -97,7 +97,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(1)},
 		Weight: 1,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1},
 		},
 		HasUniquePath: true,
@@ -115,7 +115,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(2)},
 		Weight: 2,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1, 2},
 			{0, 2},
 		},
@@ -134,7 +134,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(2)},
 		Weight: 2,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1, 2},
 			{0, 2},
 		},
@@ -167,7 +167,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(5)},
 		Weight: 4,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1, 2, 3, 5},
 			{0, 2, 3, 5},
 			{0, 5},
@@ -201,7 +201,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(5)},
 		Weight: 4,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1, 2, 3, 5},
 			{0, 2, 3, 5},
 			{0, 5},
@@ -236,7 +236,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(5)},
 		Weight: 4,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1, 2, 3, 5},
 			{0, 2, 3, 5},
 			{0, 6, 5},
@@ -271,7 +271,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(5)},
 		Weight: 4,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1, 2, 3, 5},
 			{0, 2, 3, 5},
 			{0, 6, 5},
@@ -297,7 +297,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(4)},
 		Weight: 4,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1, 2, 3, 4},
 		},
 		HasUniquePath: false,
@@ -324,7 +324,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(4)},
 		Weight: 4,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1, 2, 3, 4},
 		},
 		HasUniquePath: false,
@@ -353,7 +353,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(4)},
 		Weight: 4,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1, 2, 3, 4},
 			{0, 1, 5, 4},
 		},
@@ -384,7 +384,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(4)},
 		Weight: 4,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1, 2, 3, 4},
 		},
 		HasUniquePath: false,
@@ -417,7 +417,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(4)},
 		Weight: 4,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1, 2, 3, 4},
 			{0, 1, 5, 4},
 			{0, 1, 5, 6, 4},
@@ -453,7 +453,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(4)},
 		Weight: 4,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1, 2, 3, 4},
 			{0, 5, 3, 4},
 			{0, 6, 5, 3, 4},
@@ -489,7 +489,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(4)},
 		Weight: 4,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1, 2, 3, 4},
 		},
 		HasUniquePath: false,
@@ -522,7 +522,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(4)},
 		Weight: 4,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1, 2, 3, 4},
 		},
 		HasUniquePath: false,
@@ -567,7 +567,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(4)},
 		Weight: 4,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1, 2, 3, 4},
 			{0, 1, 2, 6, 10, 14, 20, 4},
 		},
@@ -587,7 +587,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(1)},
 		Weight: -1,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{0, 1},
 		},
 		HasUniquePath: true,
@@ -621,7 +621,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node('z'), T: simple.Node('y')},
 		Weight: -4,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{'z', 'x', 'y'},
 		},
 		HasUniquePath: true,
@@ -644,7 +644,7 @@ var ShortestPathTests = []struct {
 
 		Query:  simple.Edge{F: simple.Node('a'), T: simple.Node('y')},
 		Weight: -6,
-		WantPaths: [][]int{
+		WantPaths: [][]int64{
 			{'a', 'b', 'c', 'y'},
 		},
 		HasUniquePath: true,

--- a/graph/path/johnson_apsp.go
+++ b/graph/path/johnson_apsp.go
@@ -30,11 +30,11 @@ func JohnsonAllPaths(g graph.Graph) (paths AllShortest, ok bool) {
 
 	paths = newAllShortest(g.Nodes(), false)
 
-	sign := -1
+	sign := int64(-1)
 	for {
 		// Choose a random node ID until we find
 		// one that is not in g.
-		jg.q = sign * rand.Int()
+		jg.q = sign * rand.Int63()
 		if _, exists := paths.indexOf[jg.q]; !exists {
 			break
 		}
@@ -65,7 +65,7 @@ func JohnsonAllPaths(g graph.Graph) (paths AllShortest, ok bool) {
 }
 
 type johnsonWeightAdjuster struct {
-	q int
+	q int64
 	g graph.Graph
 
 	from   func(graph.Node) []graph.Node
@@ -133,6 +133,6 @@ func (johnsonWeightAdjuster) HasEdgeBetween(_, _ graph.Node) bool {
 	panic("path: unintended use of johnsonWeightAdjuster")
 }
 
-type johnsonGraphNode int
+type johnsonGraphNode int64
 
-func (n johnsonGraphNode) ID() int { return int(n) }
+func (n johnsonGraphNode) ID() int64 { return int64(n) }

--- a/graph/path/johnson_apsp_test.go
+++ b/graph/path/johnson_apsp_test.go
@@ -49,7 +49,7 @@ func TestJohnsonAllPaths(t *testing.T) {
 					test.Name, unique, test.HasUniquePath)
 			}
 
-			var got []int
+			var got []int64
 			for _, n := range p {
 				got = append(got, n.ID())
 			}
@@ -78,9 +78,9 @@ func TestJohnsonAllPaths(t *testing.T) {
 				test.Name, weight, test.Weight)
 		}
 
-		var got [][]int
+		var got [][]int64
 		if len(paths) != 0 {
-			got = make([][]int, len(paths))
+			got = make([][]int64, len(paths))
 		}
 		for i, p := range paths {
 			for _, v := range p {

--- a/graph/path/shortest.go
+++ b/graph/path/shortest.go
@@ -26,7 +26,7 @@ type Shortest struct {
 	// the id-dense representation of the
 	// graph and the potentially id-sparse
 	// nodes held in nodes.
-	indexOf map[int]int
+	indexOf map[int64]int
 
 	// dist and next represent the shortest
 	// paths between nodes.
@@ -45,7 +45,7 @@ type Shortest struct {
 }
 
 func newShortestFrom(u graph.Node, nodes []graph.Node) Shortest {
-	indexOf := make(map[int]int, len(nodes))
+	indexOf := make(map[int64]int, len(nodes))
 	uid := u.ID()
 	for i, n := range nodes {
 		indexOf[n.ID()] = i
@@ -115,7 +115,7 @@ type AllShortest struct {
 	// the id-dense representation of the
 	// graph and the potentially id-sparse
 	// nodes held in nodes.
-	indexOf map[int]int
+	indexOf map[int64]int
 
 	// dist, next and forward represent
 	// the shortest paths between nodes.
@@ -147,7 +147,7 @@ type AllShortest struct {
 }
 
 func newAllShortest(nodes []graph.Node, forward bool) AllShortest {
-	indexOf := make(map[int]int, len(nodes))
+	indexOf := make(map[int64]int, len(nodes))
 	for i, n := range nodes {
 		indexOf[n.ID()] = i
 	}

--- a/graph/path/spanning_tree.go
+++ b/graph/path/spanning_tree.go
@@ -32,7 +32,7 @@ func Prim(dst graph.UndirectedBuilder, g UndirectedWeighter) float64 {
 	}
 
 	q := &primQueue{
-		indexOf: make(map[int]int, len(nodes)-1),
+		indexOf: make(map[int64]int, len(nodes)-1),
 		nodes:   make([]simple.Edge, 0, len(nodes)-1),
 	}
 	for _, u := range nodes[1:] {
@@ -77,7 +77,7 @@ func Prim(dst graph.UndirectedBuilder, g UndirectedWeighter) float64 {
 // a node in the set of nodes already connected to the minimum
 // spanning forest.
 type primQueue struct {
-	indexOf map[int]int
+	indexOf map[int64]int
 	nodes   []simple.Edge
 }
 

--- a/graph/simple/dense_undirected_matrix.go
+++ b/graph/simple/dense_undirected_matrix.go
@@ -54,7 +54,7 @@ func NewUndirectedMatrix(n int, init, self, absent float64) *UndirectedMatrix {
 func NewUndirectedMatrixFrom(nodes []graph.Node, init, self, absent float64) *UndirectedMatrix {
 	sort.Sort(ordered.ByID(nodes))
 	for i, n := range nodes {
-		if i != n.ID() {
+		if int64(i) != n.ID() {
 			panic("simple: non-contiguous node IDs")
 		}
 	}
@@ -64,7 +64,7 @@ func NewUndirectedMatrixFrom(nodes []graph.Node, init, self, absent float64) *Un
 }
 
 // Node returns the node in the graph with the given ID.
-func (g *UndirectedMatrix) Node(id int) graph.Node {
+func (g *UndirectedMatrix) Node(id int64) graph.Node {
 	if !g.has(id) {
 		return nil
 	}
@@ -79,9 +79,9 @@ func (g *UndirectedMatrix) Has(n graph.Node) bool {
 	return g.has(n.ID())
 }
 
-func (g *UndirectedMatrix) has(id int) bool {
+func (g *UndirectedMatrix) has(id int64) bool {
 	r := g.mat.Symmetric()
-	return 0 <= id && id < r
+	return 0 <= id && id < int64(r)
 }
 
 // Nodes returns all the nodes in the graph.
@@ -106,7 +106,7 @@ func (g *UndirectedMatrix) Edges() []graph.Edge {
 	for i := 0; i < r; i++ {
 		for j := i + 1; j < r; j++ {
 			if w := g.mat.At(i, j); !isSame(w, g.absent) {
-				edges = append(edges, Edge{F: g.Node(i), T: g.Node(j), W: w})
+				edges = append(edges, Edge{F: g.Node(int64(i)), T: g.Node(int64(j)), W: w})
 			}
 		}
 	}
@@ -122,11 +122,12 @@ func (g *UndirectedMatrix) From(n graph.Node) []graph.Node {
 	var neighbors []graph.Node
 	r := g.mat.Symmetric()
 	for i := 0; i < r; i++ {
-		if i == id {
+		if int64(i) == id {
 			continue
 		}
-		if !isSame(g.mat.At(id, i), g.absent) {
-			neighbors = append(neighbors, g.Node(i))
+		// id is not greater than maximum int by this point.
+		if !isSame(g.mat.At(int(id), i), g.absent) {
+			neighbors = append(neighbors, g.Node(int64(i)))
 		}
 	}
 	return neighbors
@@ -142,7 +143,8 @@ func (g *UndirectedMatrix) HasEdgeBetween(u, v graph.Node) bool {
 	if !g.has(vid) {
 		return false
 	}
-	return uid != vid && !isSame(g.mat.At(uid, vid), g.absent)
+	// uid and vid are not greater than maximum int by this point.
+	return uid != vid && !isSame(g.mat.At(int(uid), int(vid)), g.absent)
 }
 
 // Edge returns the edge from u to v if such an edge exists and nil otherwise.
@@ -154,7 +156,8 @@ func (g *UndirectedMatrix) Edge(u, v graph.Node) graph.Edge {
 // EdgeBetween returns the edge between nodes x and y.
 func (g *UndirectedMatrix) EdgeBetween(u, v graph.Node) graph.Edge {
 	if g.HasEdgeBetween(u, v) {
-		return Edge{F: g.Node(u.ID()), T: g.Node(v.ID()), W: g.mat.At(u.ID(), v.ID())}
+		// u.ID() and v.ID() are not greater than maximum int by this point.
+		return Edge{F: g.Node(u.ID()), T: g.Node(v.ID()), W: g.mat.At(int(u.ID()), int(v.ID()))}
 	}
 	return nil
 }
@@ -170,7 +173,8 @@ func (g *UndirectedMatrix) Weight(x, y graph.Node) (w float64, ok bool) {
 		return g.self, true
 	}
 	if g.has(xid) && g.has(yid) {
-		return g.mat.At(xid, yid), true
+		// xid and yid are not greater than maximum int by this point.
+		return g.mat.At(int(xid), int(yid)), true
 	}
 	return g.absent, false
 }
@@ -183,7 +187,14 @@ func (g *UndirectedMatrix) SetEdge(e graph.Edge) {
 	if fid == tid {
 		panic("simple: set illegal edge")
 	}
-	g.mat.SetSym(fid, tid, e.Weight())
+	if int64(int(fid)) != fid {
+		panic("simple: unavailable from node ID for dense graph")
+	}
+	if int64(int(tid)) != tid {
+		panic("simple: unavailable to node ID for dense graph")
+	}
+	// fid and tid are not greater than maximum int by this point.
+	g.mat.SetSym(int(fid), int(tid), e.Weight())
 }
 
 // RemoveEdge removes e from the graph, leaving the terminal nodes. If the edge does not exist
@@ -197,19 +208,24 @@ func (g *UndirectedMatrix) RemoveEdge(e graph.Edge) {
 	if !g.has(tid) {
 		return
 	}
-	g.mat.SetSym(fid, tid, g.absent)
+	// fid and tid are not greater than maximum int by this point.
+	g.mat.SetSym(int(fid), int(tid), g.absent)
 }
 
 // Degree returns the degree of n in g.
 func (g *UndirectedMatrix) Degree(n graph.Node) int {
 	id := n.ID()
+	if !g.has(id) {
+		return 0
+	}
 	var deg int
 	r := g.mat.Symmetric()
 	for i := 0; i < r; i++ {
-		if i == id {
+		if int64(i) == id {
 			continue
 		}
-		if !isSame(g.mat.At(id, i), g.absent) {
+		// id is not greater than maximum int by this point.
+		if !isSame(g.mat.At(int(id), i), g.absent) {
 			deg++
 		}
 	}

--- a/graph/simple/densegraph_test.go
+++ b/graph/simple/densegraph_test.go
@@ -122,7 +122,7 @@ func TestDenseLists(t *testing.T) {
 	sort.Sort(ordered.ByID(nodes))
 
 	for i, node := range dg.Nodes() {
-		if i != node.ID() {
+		if int64(i) != node.ID() {
 			t.Errorf("Node list doesn't return properly id'd nodes")
 		}
 	}

--- a/graph/simple/directed.go
+++ b/graph/simple/directed.go
@@ -12,9 +12,9 @@ import (
 
 // DirectedGraph implements a generalized directed graph.
 type DirectedGraph struct {
-	nodes map[int]graph.Node
-	from  map[int]map[int]graph.Edge
-	to    map[int]map[int]graph.Edge
+	nodes map[int64]graph.Node
+	from  map[int64]map[int64]graph.Edge
+	to    map[int64]map[int64]graph.Edge
 
 	self, absent float64
 
@@ -25,9 +25,9 @@ type DirectedGraph struct {
 // edge weight values.
 func NewDirectedGraph(self, absent float64) *DirectedGraph {
 	return &DirectedGraph{
-		nodes: make(map[int]graph.Node),
-		from:  make(map[int]map[int]graph.Edge),
-		to:    make(map[int]map[int]graph.Edge),
+		nodes: make(map[int64]graph.Node),
+		from:  make(map[int64]map[int64]graph.Edge),
+		to:    make(map[int64]map[int64]graph.Edge),
 
 		self:   self,
 		absent: absent,
@@ -38,11 +38,11 @@ func NewDirectedGraph(self, absent float64) *DirectedGraph {
 
 // NewNodeID returns a new unique ID for a node to be added to g. The returned ID does
 // not become a valid ID in g until it is added to g.
-func (g *DirectedGraph) NewNodeID() int {
+func (g *DirectedGraph) NewNodeID() int64 {
 	if len(g.nodes) == 0 {
 		return 0
 	}
-	if len(g.nodes) == maxInt {
+	if int64(len(g.nodes)) == maxInt {
 		panic("simple: cannot allocate node: no slot")
 	}
 	return g.nodeIDs.newID()
@@ -54,8 +54,8 @@ func (g *DirectedGraph) AddNode(n graph.Node) {
 		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
 	}
 	g.nodes[n.ID()] = n
-	g.from[n.ID()] = make(map[int]graph.Edge)
-	g.to[n.ID()] = make(map[int]graph.Edge)
+	g.from[n.ID()] = make(map[int64]graph.Edge)
+	g.to[n.ID()] = make(map[int64]graph.Edge)
 	g.nodeIDs.use(n.ID())
 }
 
@@ -121,7 +121,7 @@ func (g *DirectedGraph) RemoveEdge(e graph.Edge) {
 }
 
 // Node returns the node in the graph with the given ID.
-func (g *DirectedGraph) Node(id int) graph.Node {
+func (g *DirectedGraph) Node(id int64) graph.Node {
 	return g.nodes[id]
 }
 

--- a/graph/simple/simple.go
+++ b/graph/simple/simple.go
@@ -14,11 +14,11 @@ import (
 )
 
 // Node is a simple graph node.
-type Node int
+type Node int64
 
 // ID returns the ID number of the node.
-func (n Node) ID() int {
-	return int(n)
+func (n Node) ID() int64 {
+	return int64(n)
 }
 
 // Edge is a simple graph edge.
@@ -42,31 +42,31 @@ func isSame(a, b float64) bool {
 	return a == b || (math.IsNaN(a) && math.IsNaN(b))
 }
 
-// maxInt is the maximum value of the machine-dependent int type.
-const maxInt int = int(^uint(0) >> 1)
+// maxInt is the maximum value of int64.
+const maxInt = int64(^uint64(0) >> 1)
 
 // idSet implements available ID storage.
 type idSet struct {
-	maxID      int
-	used, free set.Ints
+	maxID      int64
+	used, free set.Int64s
 }
 
 // newIDSet returns a new idSet. The returned value should not be passed
 // except by pointer.
 func newIDSet() idSet {
-	return idSet{maxID: -1, used: make(set.Ints), free: make(set.Ints)}
+	return idSet{maxID: -1, used: make(set.Int64s), free: make(set.Int64s)}
 }
 
 // newID returns a new unique ID. The ID returned is not considered used
 // until passed in a call to use.
-func (s *idSet) newID() int {
+func (s *idSet) newID() int64 {
 	for id := range s.free {
 		return id
 	}
 	if s.maxID != maxInt {
 		return s.maxID + 1
 	}
-	for id := 0; id <= s.maxID+1; id++ {
+	for id := int64(0); id <= s.maxID+1; id++ {
 		if !s.used.Has(id) {
 			return id
 		}
@@ -75,7 +75,7 @@ func (s *idSet) newID() int {
 }
 
 // use adds the id to the used IDs in the idSet.
-func (s *idSet) use(id int) {
+func (s *idSet) use(id int64) {
 	s.used.Add(id)
 	s.free.Remove(id)
 	if id > s.maxID {
@@ -84,7 +84,7 @@ func (s *idSet) use(id int) {
 }
 
 // free frees the id for reuse.
-func (s *idSet) release(id int) {
+func (s *idSet) release(id int64) {
 	s.free.Add(id)
 	s.used.Remove(id)
 }

--- a/graph/simple/undirected.go
+++ b/graph/simple/undirected.go
@@ -12,8 +12,8 @@ import (
 
 // UndirectedGraph implements a generalized undirected graph.
 type UndirectedGraph struct {
-	nodes map[int]graph.Node
-	edges map[int]map[int]graph.Edge
+	nodes map[int64]graph.Node
+	edges map[int64]map[int64]graph.Edge
 
 	self, absent float64
 
@@ -24,8 +24,8 @@ type UndirectedGraph struct {
 // edge weight values.
 func NewUndirectedGraph(self, absent float64) *UndirectedGraph {
 	return &UndirectedGraph{
-		nodes: make(map[int]graph.Node),
-		edges: make(map[int]map[int]graph.Edge),
+		nodes: make(map[int64]graph.Node),
+		edges: make(map[int64]map[int64]graph.Edge),
 
 		self:   self,
 		absent: absent,
@@ -36,11 +36,11 @@ func NewUndirectedGraph(self, absent float64) *UndirectedGraph {
 
 // NewNodeID returns a new unique ID for a node to be added to g. The returned ID does
 // not become a valid ID in g until it is added to g.
-func (g *UndirectedGraph) NewNodeID() int {
+func (g *UndirectedGraph) NewNodeID() int64 {
 	if len(g.nodes) == 0 {
 		return 0
 	}
-	if len(g.nodes) == maxInt {
+	if int64(len(g.nodes)) == maxInt {
 		panic("simple: cannot allocate node: no slot")
 	}
 	return g.nodeIDs.newID()
@@ -52,7 +52,7 @@ func (g *UndirectedGraph) AddNode(n graph.Node) {
 		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
 	}
 	g.nodes[n.ID()] = n
-	g.edges[n.ID()] = make(map[int]graph.Edge)
+	g.edges[n.ID()] = make(map[int64]graph.Edge)
 	g.nodeIDs.use(n.ID())
 }
 
@@ -113,7 +113,7 @@ func (g *UndirectedGraph) RemoveEdge(e graph.Edge) {
 }
 
 // Node returns the node in the graph with the given ID.
-func (g *UndirectedGraph) Node(id int) graph.Node {
+func (g *UndirectedGraph) Node(id int64) graph.Node {
 	return g.nodes[id]
 }
 
@@ -139,16 +139,16 @@ func (g *UndirectedGraph) Nodes() []graph.Node {
 func (g *UndirectedGraph) Edges() []graph.Edge {
 	var edges []graph.Edge
 
-	seen := make(map[[2]int]struct{})
+	seen := make(map[[2]int64]struct{})
 	for _, u := range g.edges {
 		for _, e := range u {
 			uid := e.From().ID()
 			vid := e.To().ID()
-			if _, ok := seen[[2]int{uid, vid}]; ok {
+			if _, ok := seen[[2]int64{uid, vid}]; ok {
 				continue
 			}
-			seen[[2]int{uid, vid}] = struct{}{}
-			seen[[2]int{vid, uid}] = struct{}{}
+			seen[[2]int64{uid, vid}] = struct{}{}
+			seen[[2]int64{vid, uid}] = struct{}{}
 			edges = append(edges, e)
 		}
 	}

--- a/graph/topo/bron_kerbosch.go
+++ b/graph/topo/bron_kerbosch.go
@@ -23,10 +23,10 @@ func VertexOrdering(g graph.Undirected) (order []graph.Node, cores [][]graph.Nod
 	// Compute a number d_v for each vertex v in G,
 	// the number of neighbors of v that are not already in L.
 	// Initially, these numbers are just the degrees of the vertices.
-	dv := make(map[int]int, len(nodes))
+	dv := make(map[int64]int, len(nodes))
 	var (
 		maxDegree  int
-		neighbours = make(map[int][]graph.Node)
+		neighbours = make(map[int64][]graph.Node)
 	)
 	for _, n := range nodes {
 		adj := g.From(n)
@@ -203,7 +203,7 @@ func (*bronKerbosch) choosePivotFrom(g graph.Undirected, p, x set.Nodes) (neighb
 				continue
 			}
 			for n := range nb {
-				if _, ok := p[n]; ok {
+				if _, ok := p[int64(n)]; ok {
 					continue
 				}
 				c--

--- a/graph/topo/bron_kerbosch_test.go
+++ b/graph/topo/bron_kerbosch_test.go
@@ -16,7 +16,7 @@ import (
 
 var vOrderTests = []struct {
 	g        []intset
-	wantCore [][]int
+	wantCore [][]int64
 	wantK    int
 }{
 	{
@@ -29,7 +29,7 @@ var vOrderTests = []struct {
 			5: nil,
 			6: nil,
 		},
-		wantCore: [][]int{
+		wantCore: [][]int64{
 			{},
 			{5},
 			{3},
@@ -39,7 +39,7 @@ var vOrderTests = []struct {
 	},
 	{
 		g: batageljZaversnikGraph,
-		wantCore: [][]int{
+		wantCore: [][]int64{
 			{0},
 			{5, 9, 10, 16},
 			{1, 2, 3, 4, 11, 12, 13, 15},
@@ -67,12 +67,12 @@ func TestVertexOrdering(t *testing.T) {
 		}
 		var offset int
 		for k, want := range test.wantCore {
-			sort.Ints(want)
-			got := make([]int, len(want))
+			sort.Sort(ordered.Int64s(want))
+			got := make([]int64, len(want))
 			for j, n := range order[len(order)-len(want)-offset : len(order)-offset] {
 				got[j] = n.ID()
 			}
-			sort.Ints(got)
+			sort.Sort(ordered.Int64s(got))
 			if !reflect.DeepEqual(got, want) {
 				t.Errorf("unexpected %d-core for test %d:\ngot: %v\nwant:%v", got, test.wantCore)
 			}
@@ -80,7 +80,7 @@ func TestVertexOrdering(t *testing.T) {
 			for j, n := range core[k] {
 				got[j] = n.ID()
 			}
-			sort.Ints(got)
+			sort.Sort(ordered.Int64s(got))
 			if !reflect.DeepEqual(got, want) {
 				t.Errorf("unexpected %d-core for test %d:\ngot: %v\nwant:%v", got, test.wantCore)
 			}
@@ -91,7 +91,7 @@ func TestVertexOrdering(t *testing.T) {
 
 var bronKerboschTests = []struct {
 	g    []intset
-	want [][]int
+	want [][]int64
 }{
 	{
 		// This is the example given in the Bron-Kerbosch article on wikipedia (renumbered).
@@ -104,7 +104,7 @@ var bronKerboschTests = []struct {
 			4: nil,
 			5: nil,
 		},
-		want: [][]int{
+		want: [][]int64{
 			{0, 1, 4},
 			{1, 2},
 			{2, 3},
@@ -114,7 +114,7 @@ var bronKerboschTests = []struct {
 	},
 	{
 		g: batageljZaversnikGraph,
-		want: [][]int{
+		want: [][]int64{
 			{0},
 			{1, 2},
 			{1, 3},
@@ -147,13 +147,13 @@ func TestBronKerbosch(t *testing.T) {
 			}
 		}
 		cliques := BronKerbosch(g)
-		got := make([][]int, len(cliques))
+		got := make([][]int64, len(cliques))
 		for j, c := range cliques {
-			ids := make([]int, len(c))
+			ids := make([]int64, len(c))
 			for k, n := range c {
 				ids[k] = n.ID()
 			}
-			sort.Ints(ids)
+			sort.Sort(ordered.Int64s(ids))
 			got[j] = ids
 		}
 		sort.Sort(ordered.BySliceValues(got))

--- a/graph/topo/common_test.go
+++ b/graph/topo/common_test.go
@@ -33,9 +33,9 @@ var batageljZaversnikGraph = []intset{
 }
 
 // intset is an integer set.
-type intset map[int]struct{}
+type intset map[int64]struct{}
 
-func linksTo(i ...int) intset {
+func linksTo(i ...int64) intset {
 	if len(i) == 0 {
 		return nil
 	}

--- a/graph/topo/johnson_cycles.go
+++ b/graph/topo/johnson_cycles.go
@@ -28,8 +28,8 @@ type johnson struct {
 	result [][]graph.Node
 }
 
-// CyclesIn returns the set of elementary cycles in the graph g.
-func CyclesIn(g graph.Directed) [][]graph.Node {
+// DirectedCyclesIn returns the set of elementary cycles in the graph g.
+func DirectedCyclesIn(g graph.Directed) [][]graph.Node {
 	jg := johnsonGraphFrom(g)
 	j := johnson{
 		adjacent: jg,
@@ -78,7 +78,7 @@ func (j *johnson) circuit(v int) bool {
 
 	//L1:
 	for w := range j.adjacent.succ[n.ID()] {
-		w = j.adjacent.indexOf(w)
+		w := j.adjacent.indexOf(w)
 		if w == j.s {
 			// Output circuit composed of stack followed by s.
 			r := make([]graph.Node, len(j.stack)+1)
@@ -124,10 +124,10 @@ type johnsonGraph struct {
 	// look-up to into the non-sparse
 	// collection of potentially sparse IDs.
 	orig  []graph.Node
-	index map[int]int
+	index map[int64]int
 
-	nodes set.Ints
-	succ  map[int]set.Ints
+	nodes set.Int64s
+	succ  map[int64]set.Int64s
 }
 
 // johnsonGraphFrom returns a deep copy of the graph g.
@@ -136,16 +136,16 @@ func johnsonGraphFrom(g graph.Directed) johnsonGraph {
 	sort.Sort(ordered.ByID(nodes))
 	c := johnsonGraph{
 		orig:  nodes,
-		index: make(map[int]int, len(nodes)),
+		index: make(map[int64]int, len(nodes)),
 
-		nodes: make(set.Ints, len(nodes)),
-		succ:  make(map[int]set.Ints),
+		nodes: make(set.Int64s, len(nodes)),
+		succ:  make(map[int64]set.Int64s),
 	}
 	for i, u := range nodes {
 		c.index[u.ID()] = i
 		for _, v := range g.From(u) {
 			if c.succ[u.ID()] == nil {
-				c.succ[u.ID()] = make(set.Ints)
+				c.succ[u.ID()] = make(set.Int64s)
 				c.nodes.Add(u.ID())
 			}
 			c.nodes.Add(v.ID())
@@ -159,7 +159,7 @@ func johnsonGraphFrom(g graph.Directed) johnsonGraph {
 func (g johnsonGraph) order() int { return g.nodes.Count() }
 
 // indexOf returns the index of the retained node for the given node ID.
-func (g johnsonGraph) indexOf(id int) int {
+func (g johnsonGraph) indexOf(id int64) int {
 	return g.index[id]
 }
 
@@ -205,8 +205,8 @@ func (g johnsonGraph) sccSubGraph(sccs [][]graph.Node, min int) johnsonGraph {
 	sub := johnsonGraph{
 		orig:  g.orig,
 		index: g.index,
-		nodes: make(set.Ints),
-		succ:  make(map[int]set.Ints),
+		nodes: make(set.Int64s),
+		succ:  make(map[int64]set.Int64s),
 	}
 
 	var n int
@@ -219,7 +219,7 @@ func (g johnsonGraph) sccSubGraph(sccs [][]graph.Node, min int) johnsonGraph {
 			for _, v := range scc {
 				if _, ok := g.succ[u.ID()][v.ID()]; ok {
 					if sub.succ[u.ID()] == nil {
-						sub.succ[u.ID()] = make(set.Ints)
+						sub.succ[u.ID()] = make(set.Int64s)
 						sub.nodes.Add(u.ID())
 					}
 					sub.nodes.Add(v.ID())
@@ -275,6 +275,6 @@ func (johnsonGraph) To(graph.Node) []graph.Node {
 	panic("topo: unintended use of johnsonGraph")
 }
 
-type johnsonGraphNode int
+type johnsonGraphNode int64
 
-func (n johnsonGraphNode) ID() int { return int(n) }
+func (n johnsonGraphNode) ID() int64 { return int64(n) }

--- a/graph/topo/johnson_cycles_test.go
+++ b/graph/topo/johnson_cycles_test.go
@@ -16,7 +16,7 @@ import (
 
 var cyclesInTests = []struct {
 	g    []intset
-	want [][]int
+	want [][]int64
 }{
 	{
 		g: []intset{
@@ -28,7 +28,7 @@ var cyclesInTests = []struct {
 			6: linksTo(3, 5),
 			7: linksTo(0, 6),
 		},
-		want: [][]int{
+		want: [][]int64{
 			{0, 1, 7, 0},
 			{2, 3, 4, 2},
 			{2, 6, 3, 4, 2},
@@ -41,7 +41,7 @@ var cyclesInTests = []struct {
 			2: linksTo(3),
 			3: linksTo(1),
 		},
-		want: [][]int{
+		want: [][]int64{
 			{1, 2, 3, 1},
 		},
 	},
@@ -51,7 +51,7 @@ var cyclesInTests = []struct {
 			1: linksTo(0, 2),
 			2: linksTo(1),
 		},
-		want: [][]int{
+		want: [][]int64{
 			{0, 1, 0},
 			{1, 2, 1},
 		},
@@ -76,14 +76,14 @@ var cyclesInTests = []struct {
 			3: linksTo(4),
 			4: linksTo(3),
 		},
-		want: [][]int{
+		want: [][]int64{
 			{0, 1, 2, 0},
 			{3, 4, 3},
 		},
 	},
 }
 
-func TestCyclesIn(t *testing.T) {
+func TestDirectedCyclesIn(t *testing.T) {
 	for i, test := range cyclesInTests {
 		g := simple.NewDirectedGraph(0, math.Inf(1))
 		g.AddNode(simple.Node(-10)) // Make sure we test graphs with sparse IDs.
@@ -96,15 +96,15 @@ func TestCyclesIn(t *testing.T) {
 				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 			}
 		}
-		cycles := CyclesIn(g)
-		var got [][]int
+		cycles := DirectedCyclesIn(g)
+		var got [][]int64
 		if cycles != nil {
-			got = make([][]int, len(cycles))
+			got = make([][]int64, len(cycles))
 		}
 		// johnson.circuit does range iteration over maps,
 		// so sort to ensure consistent ordering.
 		for j, c := range cycles {
-			ids := make([]int, len(c))
+			ids := make([]int64, len(c))
 			for k, n := range c {
 				ids[k] = n.ID()
 			}

--- a/graph/topo/tarjan.go
+++ b/graph/topo/tarjan.go
@@ -119,9 +119,9 @@ func tarjanSCCstabilized(g graph.Directed, order func([]graph.Node)) [][]graph.N
 	t := tarjan{
 		succ: succ,
 
-		indexTable: make(map[int]int, len(nodes)),
-		lowLink:    make(map[int]int, len(nodes)),
-		onStack:    make(set.Ints),
+		indexTable: make(map[int64]int, len(nodes)),
+		lowLink:    make(map[int64]int, len(nodes)),
+		onStack:    make(set.Int64s),
 	}
 	for _, v := range nodes {
 		if t.indexTable[v.ID()] == 0 {
@@ -140,9 +140,9 @@ type tarjan struct {
 	succ func(graph.Node) []graph.Node
 
 	index      int
-	indexTable map[int]int
-	lowLink    map[int]int
-	onStack    set.Ints
+	indexTable map[int64]int
+	lowLink    map[int64]int
+	onStack    set.Int64s
 
 	stack []graph.Node
 

--- a/graph/topo/tarjan_test.go
+++ b/graph/topo/tarjan_test.go
@@ -21,7 +21,7 @@ var tarjanTests = []struct {
 	g []intset
 
 	ambiguousOrder []interval
-	want           [][]int
+	want           [][]int64
 
 	sortedLength      int
 	unorderableLength int
@@ -38,7 +38,7 @@ var tarjanTests = []struct {
 			7: linksTo(0, 6),
 		},
 
-		want: [][]int{
+		want: [][]int64{
 			{5},
 			{2, 3, 4, 6},
 			{0, 1, 7},
@@ -56,7 +56,7 @@ var tarjanTests = []struct {
 			3: linksTo(1),
 		},
 
-		want: [][]int{
+		want: [][]int64{
 			{1, 2, 3},
 			{0},
 		},
@@ -72,7 +72,7 @@ var tarjanTests = []struct {
 			2: linksTo(1),
 		},
 
-		want: [][]int{
+		want: [][]int64{
 			{0, 1, 2},
 		},
 
@@ -97,7 +97,7 @@ var tarjanTests = []struct {
 			{0, 3}, // This includes node 6 since it only needs to be before 4 in topo sort.
 			{3, 5},
 		},
-		want: [][]int{
+		want: [][]int64{
 			{6}, {5}, {4}, {3}, {2}, {1}, {0},
 		},
 
@@ -117,7 +117,7 @@ var tarjanTests = []struct {
 		ambiguousOrder: []interval{
 			{0, 2},
 		},
-		want: [][]int{
+		want: [][]int64{
 			{0, 1, 2},
 			{3, 4},
 		},
@@ -174,13 +174,13 @@ func TestTarjanSCC(t *testing.T) {
 		gotSCCs := TarjanSCC(g)
 		// tarjan.strongconnect does range iteration over maps,
 		// so sort SCC members to ensure consistent ordering.
-		gotIDs := make([][]int, len(gotSCCs))
+		gotIDs := make([][]int64, len(gotSCCs))
 		for i, scc := range gotSCCs {
-			gotIDs[i] = make([]int, len(scc))
+			gotIDs[i] = make([]int64, len(scc))
 			for j, id := range scc {
 				gotIDs[i][j] = id.ID()
 			}
-			sort.Ints(gotIDs[i])
+			sort.Sort(ordered.Int64s(gotIDs[i]))
 		}
 		for _, iv := range test.ambiguousOrder {
 			sort.Sort(ordered.BySliceValues(test.want[iv.start:iv.end]))

--- a/graph/topo/topo_test.go
+++ b/graph/topo/topo_test.go
@@ -131,11 +131,11 @@ func TestPathExistsInDirected(t *testing.T) {
 
 var connectedComponentTests = []struct {
 	g    []intset
-	want [][]int
+	want [][]int64
 }{
 	{
 		g: batageljZaversnikGraph,
-		want: [][]int{
+		want: [][]int64{
 			{0},
 			{1, 2, 3, 4, 5},
 			{6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
@@ -159,13 +159,13 @@ func TestConnectedComponents(t *testing.T) {
 			}
 		}
 		cc := ConnectedComponents(g)
-		got := make([][]int, len(cc))
+		got := make([][]int64, len(cc))
 		for j, c := range cc {
-			ids := make([]int, len(c))
+			ids := make([]int64, len(c))
 			for k, n := range c {
 				ids[k] = n.ID()
 			}
-			sort.Ints(ids)
+			sort.Sort(ordered.Int64s(ids))
 			got[j] = ids
 		}
 		sort.Sort(ordered.BySliceValues(got))

--- a/graph/traverse/traverse.go
+++ b/graph/traverse/traverse.go
@@ -16,7 +16,7 @@ type BreadthFirst struct {
 	EdgeFilter func(graph.Edge) bool
 	Visit      func(u, v graph.Node)
 	queue      linear.NodeQueue
-	visited    set.Ints
+	visited    set.Int64s
 }
 
 // Walk performs a breadth-first traversal of the graph g starting from the given node,
@@ -26,7 +26,7 @@ type BreadthFirst struct {
 // non-nil, it is called with the nodes joined by each followed edge.
 func (b *BreadthFirst) Walk(g graph.Graph, from graph.Node, until func(n graph.Node, d int) bool) graph.Node {
 	if b.visited == nil {
-		b.visited = make(set.Ints)
+		b.visited = make(set.Int64s)
 	}
 	b.queue.Enqueue(from)
 	b.visited.Add(from.ID())
@@ -106,7 +106,7 @@ type DepthFirst struct {
 	EdgeFilter func(graph.Edge) bool
 	Visit      func(u, v graph.Node)
 	stack      linear.NodeStack
-	visited    set.Ints
+	visited    set.Int64s
 }
 
 // Walk performs a depth-first traversal of the graph g starting from the given node,
@@ -116,7 +116,7 @@ type DepthFirst struct {
 // is called with the nodes joined by each followed edge.
 func (d *DepthFirst) Walk(g graph.Graph, from graph.Node, until func(graph.Node) bool) graph.Node {
 	if d.visited == nil {
-		d.visited = make(set.Ints)
+		d.visited = make(set.Int64s)
 	}
 	d.stack.Push(from)
 	d.visited.Add(from.ID())

--- a/graph/traverse/traverse_test.go
+++ b/graph/traverse/traverse_test.go
@@ -64,13 +64,13 @@ var breadthFirstTests = []struct {
 	edge  func(graph.Edge) bool
 	until func(graph.Node, int) bool
 	final map[graph.Node]bool
-	want  [][]int
+	want  [][]int64
 }{
 	{
 		g:     wpBronKerboschGraph,
 		from:  simple.Node(1),
 		final: map[graph.Node]bool{nil: true},
-		want: [][]int{
+		want: [][]int64{
 			{1},
 			{0, 2, 4},
 			{3},
@@ -85,7 +85,7 @@ var breadthFirstTests = []struct {
 		},
 		from:  simple.Node(1),
 		final: map[graph.Node]bool{nil: true},
-		want: [][]int{
+		want: [][]int64{
 			{1},
 			{0, 2, 4},
 			{3},
@@ -96,7 +96,7 @@ var breadthFirstTests = []struct {
 		from:  simple.Node(1),
 		until: func(n graph.Node, _ int) bool { return n == simple.Node(3) },
 		final: map[graph.Node]bool{simple.Node(3): true},
-		want: [][]int{
+		want: [][]int64{
 			{1},
 			{0, 2, 4},
 		},
@@ -105,7 +105,7 @@ var breadthFirstTests = []struct {
 		g:     batageljZaversnikGraph,
 		from:  simple.Node(13),
 		final: map[graph.Node]bool{nil: true},
-		want: [][]int{
+		want: [][]int64{
 			{13},
 			{14, 15},
 			{6, 7, 8, 16, 17},
@@ -124,7 +124,7 @@ var breadthFirstTests = []struct {
 			simple.Node(19): true,
 			simple.Node(20): true,
 		},
-		want: [][]int{
+		want: [][]int64{
 			{13},
 			{14, 15},
 			{6, 7, 8, 16, 17},
@@ -147,13 +147,13 @@ func TestBreadthFirst(t *testing.T) {
 		w := BreadthFirst{
 			EdgeFilter: test.edge,
 		}
-		var got [][]int
+		var got [][]int64
 		final := w.Walk(g, test.from, func(n graph.Node, d int) bool {
 			if test.until != nil && test.until(n, d) {
 				return true
 			}
 			if d >= len(got) {
-				got = append(got, []int(nil))
+				got = append(got, []int64(nil))
 			}
 			got[d] = append(got[d], n.ID())
 			return false
@@ -162,7 +162,7 @@ func TestBreadthFirst(t *testing.T) {
 			t.Errorf("unexepected final node for test %d:\ngot:  %v\nwant: %v", i, final, test.final)
 		}
 		for _, l := range got {
-			sort.Ints(l)
+			sort.Sort(ordered.Int64s(l))
 		}
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexepected BFS level structure for test %d:\ngot:  %v\nwant: %v", i, got, test.want)
@@ -176,13 +176,13 @@ var depthFirstTests = []struct {
 	edge  func(graph.Edge) bool
 	until func(graph.Node) bool
 	final map[graph.Node]bool
-	want  []int
+	want  []int64
 }{
 	{
 		g:     wpBronKerboschGraph,
 		from:  simple.Node(1),
 		final: map[graph.Node]bool{nil: true},
-		want:  []int{0, 1, 2, 3, 4, 5},
+		want:  []int64{0, 1, 2, 3, 4, 5},
 	},
 	{
 		g: wpBronKerboschGraph,
@@ -192,7 +192,7 @@ var depthFirstTests = []struct {
 		},
 		from:  simple.Node(1),
 		final: map[graph.Node]bool{nil: true},
-		want:  []int{0, 1, 2, 3, 4},
+		want:  []int64{0, 1, 2, 3, 4},
 	},
 	{
 		g:     wpBronKerboschGraph,
@@ -204,19 +204,19 @@ var depthFirstTests = []struct {
 		g:     batageljZaversnikGraph,
 		from:  simple.Node(0),
 		final: map[graph.Node]bool{nil: true},
-		want:  []int{0},
+		want:  []int64{0},
 	},
 	{
 		g:     batageljZaversnikGraph,
 		from:  simple.Node(3),
 		final: map[graph.Node]bool{nil: true},
-		want:  []int{1, 2, 3, 4, 5},
+		want:  []int64{1, 2, 3, 4, 5},
 	},
 	{
 		g:     batageljZaversnikGraph,
 		from:  simple.Node(13),
 		final: map[graph.Node]bool{nil: true},
-		want:  []int{6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
+		want:  []int64{6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
 	},
 }
 
@@ -235,7 +235,7 @@ func TestDepthFirst(t *testing.T) {
 		w := DepthFirst{
 			EdgeFilter: test.edge,
 		}
-		var got []int
+		var got []int64
 		final := w.Walk(g, test.from, func(n graph.Node) bool {
 			if test.until != nil && test.until(n) {
 				return true
@@ -246,7 +246,7 @@ func TestDepthFirst(t *testing.T) {
 		if !test.final[final] {
 			t.Errorf("unexepected final node for test %d:\ngot:  %v\nwant: %v", i, final, test.final)
 		}
-		sort.Ints(got)
+		sort.Sort(ordered.Int64s(got))
 		if test.want != nil && !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexepected DFS traversed nodes for test %d:\ngot:  %v\nwant: %v", i, got, test.want)
 		}
@@ -256,11 +256,11 @@ func TestDepthFirst(t *testing.T) {
 var walkAllTests = []struct {
 	g    []intset
 	edge func(graph.Edge) bool
-	want [][]int
+	want [][]int64
 }{
 	{
 		g: batageljZaversnikGraph,
-		want: [][]int{
+		want: [][]int64{
 			{0},
 			{1, 2, 3, 4, 5},
 			{6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
@@ -272,7 +272,7 @@ var walkAllTests = []struct {
 			// Do not traverse an edge between 3 and 5.
 			return (e.From().ID() != 4 || e.To().ID() != 5) && (e.From().ID() != 5 || e.To().ID() != 4)
 		},
-		want: [][]int{
+		want: [][]int64{
 			{0},
 			{1, 2, 3, 4},
 			{5},
@@ -325,13 +325,13 @@ func TestWalkAll(t *testing.T) {
 			}
 			w.WalkAll(g, nil, after, during)
 
-			got := make([][]int, len(cc))
+			got := make([][]int64, len(cc))
 			for j, c := range cc {
-				ids := make([]int, len(c))
+				ids := make([]int64, len(c))
 				for k, n := range c {
 					ids[k] = n.ID()
 				}
-				sort.Ints(ids)
+				sort.Sort(ordered.Int64s(ids))
 				got[j] = ids
 			}
 			sort.Sort(ordered.BySliceValues(got))

--- a/graph/undirect.go
+++ b/graph/undirect.go
@@ -44,7 +44,7 @@ func (g Undirect) Nodes() []Node { return g.G.Nodes() }
 // From returns all nodes in g that can be reached directly from u.
 func (g Undirect) From(u Node) []Node {
 	var nodes []Node
-	seen := make(map[int]struct{})
+	seen := make(map[int64]struct{})
 	for _, n := range g.G.From(u) {
 		seen[n.ID()] = struct{}{}
 		nodes = append(nodes, n)


### PR DESCRIPTION
Two commits that deserve careful review are "graph/topo: update for int64 IDs" (the Bron-Kerbosch routine) and "graph/community: update for int64 IDs" which is a little subtle.

@vladimir-ch @mewmew Please take a look.

After #68.

Updates #31.
Fixes #69.
Updates gonum/graph#197.
Closes gonum/graph#114.