### PR TITLE
mat: remove View* methods and extend semantics of Slice

### DIFF
--- a/mat/dense.go
+++ b/mat/dense.go
@@ -16,7 +16,6 @@ var (
 	_ Mutable = dense
 
 	_ Cloner       = dense
-	_ Viewer       = dense
 	_ RowViewer    = dense
 	_ ColViewer    = dense
 	_ RawRowViewer = dense
@@ -273,15 +272,6 @@ func (m *Dense) RawRowView(i int) []float64 {
 
 func (m *Dense) rawRowView(i int) []float64 {
 	return m.mat.Data[i*m.mat.Stride : i*m.mat.Stride+m.mat.Cols]
-}
-
-// View returns a new Matrix that shares backing data with the receiver.
-// The new matrix is located from row i, column j extending r rows and c
-// columns. View panics if the view is outside the bounds of the receiver.
-//
-// View is deprecated and should not be used. It will be removed at a later date.
-func (m *Dense) View(i, j, r, c int) Matrix {
-	return m.Slice(i, i+r, j, j+c)
 }
 
 // Slice returns a new Matrix that shares backing data with the receiver.

--- a/mat/dense.go
+++ b/mat/dense.go
@@ -275,13 +275,13 @@ func (m *Dense) rawRowView(i int) []float64 {
 }
 
 // Slice returns a new Matrix that shares backing data with the receiver.
-// The returned matrix starts at {i,j} of the recevier and extends k-i rows
+// The returned matrix starts at {i,j} of the receiver and extends k-i rows
 // and l-j columns. The final row in the resulting matrix is k-1 and the
 // final column is l-1.
-// Slice panics with ErrIndexOutOfRange if the slice is outside the bounds
+// Slice panics with ErrIndexOutOfRange if the slice is outside the capacity
 // of the receiver.
 func (m *Dense) Slice(i, k, j, l int) Matrix {
-	mr, mc := m.Dims()
+	mr, mc := m.Caps()
 	if i < 0 || mr <= i || j < 0 || mc <= j || k <= i || mr < k || l <= j || mc < l {
 		panic(ErrIndexOutOfRange)
 	}

--- a/mat/matrix.go
+++ b/mat/matrix.go
@@ -143,15 +143,6 @@ type Copier interface {
 	Copy(a Matrix) (r, c int)
 }
 
-// A Viewer returns a submatrix view of the Matrix parameter, starting at row i, column j
-// and extending r rows and c columns. If i or j are out of range, or r or c are zero or
-// extend beyond the bounds of the matrix View will panic with ErrIndexOutOfRange. The
-// returned matrix must retain the receiver's reference to the original matrix such that
-// changes in the elements of the submatrix are reflected in the original and vice versa.
-type Viewer interface {
-	View(i, j, r, c int) Matrix
-}
-
 // A Grower can grow the size of the represented matrix by the given number of rows and columns.
 // Growing beyond the size given by the Caps method will result in the allocation of a new
 // matrix and copying of the elements. If Grow is called with negative increments it will

--- a/mat/symmetric.go
+++ b/mat/symmetric.go
@@ -401,15 +401,6 @@ func (s *SymDense) SubsetSym(a Symmetric, set []int) {
 	}
 }
 
-// ViewSquare returns a view of the submatrix starting at {i, i} and extending
-// for n rows and columns. ViewSquare panics if the view is outside the bounds
-// of the receiver.
-//
-// ViewSquare is deprecated and should not be used. It will be removed at a later date.
-func (s *SymDense) ViewSquare(i, n int) Matrix {
-	return s.SliceSquare(i, i+n)
-}
-
 // SliceSquare returns a new Matrix that shares backing data with the receiver.
 // The returned matrix starts at {i,i} of the recevier and extends k-i rows
 // and columns. The final row and column in the resulting matrix is k-1.

--- a/mat/symmetric.go
+++ b/mat/symmetric.go
@@ -79,8 +79,14 @@ func NewSymDense(n int, data []float64) *SymDense {
 	}
 }
 
+// Dims returns the number of rows and columns in the matrix.
 func (s *SymDense) Dims() (r, c int) {
 	return s.mat.N, s.mat.N
+}
+
+// Caps returns the number of rows and columns in the backing matrix.
+func (s *SymDense) Caps() (r, c int) {
+	return s.cap, s.cap
 }
 
 // T implements the Matrix interface. Symmetric matrices, by definition, are
@@ -402,12 +408,12 @@ func (s *SymDense) SubsetSym(a Symmetric, set []int) {
 }
 
 // SliceSquare returns a new Matrix that shares backing data with the receiver.
-// The returned matrix starts at {i,i} of the recevier and extends k-i rows
+// The returned matrix starts at {i,i} of the receiver and extends k-i rows
 // and columns. The final row and column in the resulting matrix is k-1.
-// SliceSquare panics with ErrIndexOutOfRange if the slice is outside the bounds
+// SliceSquare panics with ErrIndexOutOfRange if the slice is outside the capacity
 // of the receiver.
 func (s *SymDense) SliceSquare(i, k int) Matrix {
-	sz := s.Symmetric()
+	sz := s.cap
 	if i < 0 || sz < i || k < i || sz < k {
 		panic(ErrIndexOutOfRange)
 	}

--- a/mat/vector.go
+++ b/mat/vector.go
@@ -47,16 +47,6 @@ func NewVector(n int, data []float64) *Vector {
 	}
 }
 
-// ViewVec returns a sub-vector view of the receiver starting at element i and
-// extending n rows. If i is out of range, n is zero, or the view extends
-// beyond the bounds of the Vector, ViewVec will panic with ErrIndexOutOfRange.
-// The returned Vector retains reference to the underlying vector.
-//
-// ViewVec is deprecated and should not be used. It will be removed at a later date.
-func (v *Vector) ViewVec(i, n int) *Vector {
-	return v.SliceVec(i, i+n)
-}
-
 // SliceVec returns a new Vector that shares backing data with the receiver.
 // The returned matrix starts at i of the receiver and extends k-i elements.
 // SliceVec panics with ErrIndexOutOfRange if the slice is outside the bounds

--- a/mat/vector.go
+++ b/mat/vector.go
@@ -64,6 +64,7 @@ func (v *Vector) SliceVec(i, k int) *Vector {
 	}
 }
 
+// Dims returns the number of rows and columns in the matrix. Columns is always 1.
 func (v *Vector) Dims() (r, c int) {
 	if v.isZero() {
 		return 0, 0

--- a/optimize/convex/lp/convert.go
+++ b/optimize/convex/lp/convert.go
@@ -122,20 +122,16 @@ func Convert(c []float64, g mat.Matrix, h []float64, a mat.Matrix, b []float64) 
 	// Construct aNew = [G, -G, I; A, -A, 0].
 	aNew = mat.NewDense(nNewEq, nNewVar, nil)
 	if nIneq != 0 {
-		aView := (aNew.View(0, 0, nIneq, nVar)).(*mat.Dense)
-		aView.Copy(g)
-		aView = (aNew.View(0, nVar, nIneq, nVar)).(*mat.Dense)
-		aView.Scale(-1, g)
-		aView = (aNew.View(0, 2*nVar, nIneq, nIneq)).(*mat.Dense)
+		aNew.Slice(0, nIneq, 0, nVar).(*mat.Dense).Copy(g)
+		aNew.Slice(0, nIneq, nVar, 2*nVar).(*mat.Dense).Scale(-1, g)
+		aView := aNew.Slice(0, nIneq, 2*nVar, 2*nVar+nIneq).(*mat.Dense)
 		for i := 0; i < nIneq; i++ {
 			aView.Set(i, i, 1)
 		}
 	}
 	if nEq != 0 {
-		aView := (aNew.View(nIneq, 0, nEq, nVar)).(*mat.Dense)
-		aView.Copy(a)
-		aView = (aNew.View(nIneq, nVar, nEq, nVar)).(*mat.Dense)
-		aView.Scale(-1, a)
+		aNew.Slice(nIneq, nIneq+nEq, 0, nVar).(*mat.Dense).Copy(a)
+		aNew.Slice(nIneq, nIneq+nEq, nVar, 2*nVar).(*mat.Dense).Scale(-1, a)
 	}
 	return cNew, aNew, bNew
 }

--- a/optimize/convex/lp/simplex.go
+++ b/optimize/convex/lp/simplex.go
@@ -609,7 +609,7 @@ func findLinearlyIndependent(A mat.Matrix) []int {
 			idxs = append(idxs, i)
 			continue
 		}
-		if mat.Cond(columns.View(0, 0, m, len(idxs)+1), 1) > 1e12 {
+		if mat.Cond(columns.Slice(0, m, 0, len(idxs)+1), 1) > 1e12 {
 			// Not linearly independent.
 			continue
 		}

--- a/stat/distmv/normal_test.go
+++ b/stat/distmv/normal_test.go
@@ -343,7 +343,7 @@ func TestConditionNormal(t *testing.T) {
 			t.Errorf("bad test, not enough samples")
 			continue
 		}
-		samples = samples.View(0, 0, nSamp, len(test.mu)).(*mat.Dense)
+		samples = samples.Slice(0, nSamp, 0, len(test.mu)).(*mat.Dense)
 
 		// Compute mean and covariance matrix.
 		estMean := make([]float64, len(test.mu))

--- a/stat/samplemv/metropolishastings.go
+++ b/stat/samplemv/metropolishastings.go
@@ -84,7 +84,7 @@ func (m MetropolisHastingser) Sample(batch *mat.Dense) {
 	copy(initial, m.Initial)
 	for remaining != 0 {
 		newSamp := min(rTmp, remaining)
-		MetropolisHastings(tmp.View(0, 0, newSamp, c).(*mat.Dense), initial, m.Target, m.Proposal, m.Src)
+		MetropolisHastings(tmp.Slice(0, newSamp, 0, c).(*mat.Dense), initial, m.Target, m.Proposal, m.Src)
 		copy(initial, tmp.RawRowView(newSamp-1))
 		remaining -= newSamp
 	}
@@ -99,7 +99,7 @@ func (m MetropolisHastingser) Sample(batch *mat.Dense) {
 	}
 
 	// Take a single sample from the chain.
-	MetropolisHastings(batch.View(0, 0, 1, c).(*mat.Dense), initial, m.Target, m.Proposal, m.Src)
+	MetropolisHastings(batch.Slice(0, 1, 0, c).(*mat.Dense), initial, m.Target, m.Proposal, m.Src)
 
 	copy(initial, batch.RawRowView(0))
 	// For all of the other samples, first generate Rate samples and then actually

--- a/stat/samplemv/sample_test.go
+++ b/stat/samplemv/sample_test.go
@@ -150,7 +150,7 @@ func TestMetropolisHastings(t *testing.T) {
 	batch := mat.NewDense(nSamples, dim, nil)
 	initial := make([]float64, dim)
 	MetropolisHastings(batch, initial, target, proposal, nil)
-	batch = batch.View(burnin, 0, nSamples-burnin, dim).(*mat.Dense)
+	batch = batch.Slice(burnin, nSamples, 0, dim).(*mat.Dense)
 
 	compareNormal(t, target, batch, nil)
 }


### PR DESCRIPTION
@btracey Please take a look.

Fixes #67.

I'm going to come back to `*Vector` when I'm not tired.