### PR TITLE
all: cleanup spelling, ineffassign and vet errors

### DIFF
--- a/blas/gonum/cmplx.go
+++ b/blas/gonum/cmplx.go
@@ -11,7 +11,7 @@ var (
 	_ blas.Complex128 = Implementation{}
 )
 
-// TOOD(btracey): Replace this as complex routines are added, and instead
+// TODO(btracey): Replace this as complex routines are added, and instead
 // automatically generate the complex64 routines from the complex128 ones.
 
 var noComplex = "native: implementation does not implement this routine, see the cgo wrapper in gonum.org/v1/netlib/blas"

--- a/blas/gonum/dgemm.go
+++ b/blas/gonum/dgemm.go
@@ -121,7 +121,7 @@ func dgemmParallel(aTrans, bTrans bool, m, n, k int, a []float64, lda int, b []f
 		go func() {
 			defer wg.Done()
 			// Make local copies of otherwise global variables to reduce shared memory.
-			// This has a noticable effect on benchmarks in some cases.
+			// This has a noticeable effect on benchmarks in some cases.
 			alpha := alpha
 			aTrans := aTrans
 			bTrans := bTrans

--- a/blas/gonum/gonum.go
+++ b/blas/gonum/gonum.go
@@ -62,7 +62,7 @@ func min(a, b int) int {
 	return a
 }
 
-// blocks returns the number of divisons of the dimension length with the given
+// blocks returns the number of divisions of the dimension length with the given
 // block size.
 func blocks(dim, bsize int) int {
 	return (dim + bsize - 1) / bsize

--- a/floats/floats_test.go
+++ b/floats/floats_test.go
@@ -186,7 +186,7 @@ func TestCumProd(t *testing.T) {
 	emptyReceiver := make([]float64, 0)
 	truth = []float64{}
 	CumProd(emptyReceiver, emptyReceiver)
-	AreSlicesEqual(t, truth, emptyReceiver, "Wrong cumprod returned with emtpy receiver")
+	AreSlicesEqual(t, truth, emptyReceiver, "Wrong cumprod returned with empty receiver")
 
 }
 
@@ -209,7 +209,7 @@ func TestCumSum(t *testing.T) {
 	emptyReceiver := make([]float64, 0)
 	truth = []float64{}
 	CumSum(emptyReceiver, emptyReceiver)
-	AreSlicesEqual(t, truth, emptyReceiver, "Wrong cumsum returned with emtpy receiver")
+	AreSlicesEqual(t, truth, emptyReceiver, "Wrong cumsum returned with empty receiver")
 
 }
 

--- a/graph/community/bisect_test.go
+++ b/graph/community/bisect_test.go
@@ -154,7 +154,7 @@ func TestProfileUndirected(t *testing.T) {
 				t.Errorf("%s: failed to recover low end score: got: %v want: %v", test.name, score, d.Score)
 			}
 			if i != 0 && d.Score >= p[i-1].Score {
-				t.Errorf("%s: not monotonically decreasing: ", test.name, p[i-1], d)
+				t.Errorf("%s: not monotonically decreasing: %v -> %v", test.name, p[i-1], d)
 			}
 		}
 	}
@@ -192,7 +192,7 @@ func TestProfileDirected(t *testing.T) {
 				t.Errorf("%s: failed to recover low end score: got: %v want: %v", test.name, score, d.Score)
 			}
 			if i != 0 && d.Score >= p[i-1].Score {
-				t.Errorf("%s: not monotonically decreasing: ", test.name, p[i-1], d)
+				t.Errorf("%s: not monotonically decreasing: %v -> %v", test.name, p[i-1], d)
 			}
 		}
 	}
@@ -227,7 +227,7 @@ func TestProfileUndirectedMultiplex(t *testing.T) {
 				t.Errorf("%s: failed to recover low end score: got: %v want: %v", test.name, score, d.Score)
 			}
 			if i != 0 && d.Score >= p[i-1].Score {
-				t.Errorf("%s: not monotonically decreasing: ", test.name, p[i-1], d)
+				t.Errorf("%s: not monotonically decreasing: %v -> %v", test.name, p[i-1], d)
 			}
 		}
 	}
@@ -262,7 +262,7 @@ func TestProfileDirectedMultiplex(t *testing.T) {
 				t.Errorf("%s: failed to recover low end score: got: %v want: %v", test.name, score, d.Score)
 			}
 			if i != 0 && d.Score >= p[i-1].Score {
-				t.Errorf("%s: not monotonically decreasing: ", test.name, p[i-1], d)
+				t.Errorf("%s: not monotonically decreasing: %v -> %v", test.name, p[i-1], d)
 			}
 		}
 	}

--- a/graph/community/louvain_directed.go
+++ b/graph/community/louvain_directed.go
@@ -553,7 +553,7 @@ func (l *directedLocalMover) deltaQ(n graph.Node) (deltaQ float64, dst int, src 
 	m := l.m
 	gamma := l.resolution
 
-	// Find communites connected to n.
+	// Find communities connected to n.
 	connected := make(set.Ints)
 	// The following for loop is equivalent to:
 	//

--- a/graph/community/louvain_undirected.go
+++ b/graph/community/louvain_undirected.go
@@ -500,7 +500,7 @@ func (l *undirectedLocalMover) deltaQ(n graph.Node) (deltaQ float64, dst int, sr
 	m2 := l.m2
 	gamma := l.resolution
 
-	// Find communites connected to n.
+	// Find communities connected to n.
 	connected := make(set.Ints)
 	// The following for loop is equivalent to:
 	//

--- a/graph/graphs/gen/duplication.go
+++ b/graph/graphs/gen/duplication.go
@@ -73,7 +73,7 @@ func Duplication(dst UndirectedMutator, n int, delta, alpha, sigma float64, src 
 		// Loop until we have connectivity
 		// into the rest of the graph.
 		for {
-			// Add edges to parent's neigbours.
+			// Add edges to parent's neighbours.
 			to := dst.From(u)
 			sort.Sort(ordered.ByID(to))
 			for _, v := range to {

--- a/graph/graphs/gen/small_world_test.go
+++ b/graph/graphs/gen/small_world_test.go
@@ -58,7 +58,7 @@ func TestNavigableSmallWorldDirected(t *testing.T) {
 						n *= d
 					}
 					if err != nil {
-						t.Fatalf("unexpected error: dims=%v n=%d, p=%d, q=%d, r=%v, r=%v: %v", dims, n, p, q, r, err)
+						t.Fatalf("unexpected error: dims=%v n=%d, p=%d, q=%d, r=%v: %v", dims, n, p, q, r, err)
 					}
 					if g.addSelfLoop {
 						t.Errorf("unexpected self edge: dims=%v n=%d, p=%d, q=%d, r=%v", dims, n, p, q, r)

--- a/graph/internal/set/set_test.go
+++ b/graph/internal/set/set_test.go
@@ -85,7 +85,7 @@ func TestAdd(t *testing.T) {
 
 	for e, n := range s {
 		if e != n.ID() {
-			t.Error("Element ID did not match key: %d != %d", e, n.ID())
+			t.Errorf("Element ID did not match key: %d != %d", e, n.ID())
 		}
 	}
 }
@@ -229,7 +229,7 @@ func TestUnionSame(t *testing.T) {
 	for i, s := range []Nodes{a, b, c} {
 		for e, n := range s {
 			if e != n.ID() {
-				t.Error("Element ID did not match key in s%d: %d != %d", i+1, e, n.ID())
+				t.Errorf("Element ID did not match key in s%d: %d != %d", i+1, e, n.ID())
 			}
 		}
 	}
@@ -266,7 +266,7 @@ func TestUnionDiff(t *testing.T) {
 	for i, s := range []Nodes{a, b, c} {
 		for e, n := range s {
 			if e != n.ID() {
-				t.Error("Element ID did not match key in s%d: %d != %d", i+1, e, n.ID())
+				t.Errorf("Element ID did not match key in s%d: %d != %d", i+1, e, n.ID())
 			}
 		}
 	}
@@ -304,7 +304,7 @@ func TestUnionOverlapping(t *testing.T) {
 	for i, s := range []Nodes{a, b, c} {
 		for e, n := range s {
 			if e != n.ID() {
-				t.Error("Element ID did not match key in s%d: %d != %d", i+1, e, n.ID())
+				t.Errorf("Element ID did not match key in s%d: %d != %d", i+1, e, n.ID())
 			}
 		}
 	}
@@ -334,7 +334,7 @@ func TestIntersectSame(t *testing.T) {
 	for i, s := range []Nodes{a, b, c} {
 		for e, n := range s {
 			if e != n.ID() {
-				t.Error("Element ID did not match key in s%d: %d != %d", i+1, e, n.ID())
+				t.Errorf("Element ID did not match key in s%d: %d != %d", i+1, e, n.ID())
 			}
 		}
 	}
@@ -368,7 +368,7 @@ func TestIntersectDiff(t *testing.T) {
 	for i, s := range []Nodes{a, b, c} {
 		for e, n := range s {
 			if e != n.ID() {
-				t.Error("Element ID did not match key in s%d: %d != %d", i+1, e, n.ID())
+				t.Errorf("Element ID did not match key in s%d: %d != %d", i+1, e, n.ID())
 			}
 		}
 	}
@@ -406,7 +406,7 @@ func TestIntersectOverlapping(t *testing.T) {
 	for i, s := range []Nodes{a, b, c} {
 		for e, n := range s {
 			if e != n.ID() {
-				t.Error("Element ID did not match key in s%d: %d != %d", i+1, e, n.ID())
+				t.Errorf("Element ID did not match key in s%d: %d != %d", i+1, e, n.ID())
 			}
 		}
 	}

--- a/graph/path/a_star_test.go
+++ b/graph/path/a_star_test.go
@@ -72,7 +72,7 @@ var aStarTests = []struct {
 		g: func() graph.Graph {
 			tg := internal.NewGrid(10, 10, true)
 
-			// Create a partial "wall" accross the middle
+			// Create a partial "wall" across the middle
 			// row with a gap at the left-hand end.
 			tg.Set(4, 1, false)
 			tg.Set(4, 2, false)
@@ -94,7 +94,7 @@ var aStarTests = []struct {
 		g: func() graph.Graph {
 			tg := internal.NewGrid(10, 10, true)
 
-			// Create a partial "wall" accross the middle
+			// Create a partial "wall" across the middle
 			// row with a gap at the left-hand end.
 			tg.Set(4, 1, false)
 			tg.Set(4, 2, false)

--- a/graph/path/a_star_test.go
+++ b/graph/path/a_star_test.go
@@ -132,7 +132,7 @@ func TestAStar(t *testing.T) {
 		p, cost := pt.To(simple.Node(test.t))
 
 		if !topo.IsPathIn(test.g, p) {
-			t.Error("got path that is not path in input graph for %q", test.name)
+			t.Errorf("got path that is not path in input graph for %q", test.name)
 		}
 
 		bfp, ok := BellmanFordFrom(simple.Node(test.s), test.g)
@@ -199,7 +199,7 @@ func TestExhaustiveAStar(t *testing.T) {
 			gotPath, gotWeight := pt.To(goal)
 			wantPath, wantWeight, _ := ps.Between(start, goal)
 			if gotWeight != wantWeight {
-				t.Errorf("unexpected path weight from %v to %v result: got:%s want:%s",
+				t.Errorf("unexpected path weight from %v to %v result: got:%f want:%f",
 					start, goal, gotWeight, wantWeight)
 			}
 			if !reflect.DeepEqual(gotPath, wantPath) {
@@ -272,7 +272,7 @@ func TestAStarNullHeuristic(t *testing.T) {
 		}
 
 		if pt.From().ID() != test.Query.From().ID() {
-			t.Fatalf("%q: unexpected from node ID: got:%d want:%d", pt.From().ID(), test.Query.From().ID())
+			t.Fatalf("%q: unexpected from node ID: got:%d want:%d", test.Name, pt.From().ID(), test.Query.From().ID())
 		}
 
 		p, weight := pt.To(test.Query.To())

--- a/graph/path/bellman_ford_moore_test.go
+++ b/graph/path/bellman_ford_moore_test.go
@@ -32,7 +32,7 @@ func TestBellmanFordFrom(t *testing.T) {
 		}
 
 		if pt.From().ID() != test.Query.From().ID() {
-			t.Fatalf("%q: unexpected from node ID: got:%d want:%d", pt.From().ID(), test.Query.From().ID())
+			t.Fatalf("%q: unexpected from node ID: got:%d want:%d", test.Name, pt.From().ID(), test.Query.From().ID())
 		}
 
 		p, weight := pt.To(test.Query.To())

--- a/graph/path/dijkstra_test.go
+++ b/graph/path/dijkstra_test.go
@@ -44,7 +44,7 @@ func TestDijkstraFrom(t *testing.T) {
 		}
 
 		if pt.From().ID() != test.Query.From().ID() {
-			t.Fatalf("%q: unexpected from node ID: got:%d want:%d", pt.From().ID(), test.Query.From().ID())
+			t.Fatalf("%q: unexpected from node ID: got:%d want:%d", test.Name, pt.From().ID(), test.Query.From().ID())
 		}
 
 		p, weight := pt.To(test.Query.To())

--- a/graph/path/dynamic/dstarlite_test.go
+++ b/graph/path/dynamic/dstarlite_test.go
@@ -62,7 +62,7 @@ func TestDStarLiteNullHeuristic(t *testing.T) {
 		p, weight := d.Path()
 
 		if !math.IsInf(weight, 1) && p[0].ID() != test.Query.From().ID() {
-			t.Fatalf("%q: unexpected from node ID: got:%d want:%d", p[0].ID(), test.Query.From().ID())
+			t.Fatalf("%q: unexpected from node ID: got:%d want:%d", test.Name, p[0].ID(), test.Query.From().ID())
 		}
 		if weight != test.Weight {
 			t.Errorf("%q: unexpected weight from Between: got:%f want:%f",

--- a/graph/topo/bron_kerbosch_test.go
+++ b/graph/topo/bron_kerbosch_test.go
@@ -74,7 +74,7 @@ func TestVertexOrdering(t *testing.T) {
 			}
 			sort.Ints(got)
 			if !reflect.DeepEqual(got, want) {
-				t.Errorf("unexpected %d-core for test %d:\ngot: %v\nwant:%v", got, test.wantCore)
+				t.Errorf("unexpected %d-core for test %d:\ngot: %v\nwant:%v", k, i, got, test.wantCore)
 			}
 
 			for j, n := range core[k] {
@@ -82,7 +82,7 @@ func TestVertexOrdering(t *testing.T) {
 			}
 			sort.Ints(got)
 			if !reflect.DeepEqual(got, want) {
-				t.Errorf("unexpected %d-core for test %d:\ngot: %v\nwant:%v", got, test.wantCore)
+				t.Errorf("unexpected %d-core for test %d:\ngot: %v\nwant:%v", k, i, got, test.wantCore)
 			}
 			offset += len(want)
 		}

--- a/graph/topo/topo_test.go
+++ b/graph/topo/topo_test.go
@@ -85,7 +85,7 @@ func TestPathExistsInUndirected(t *testing.T) {
 
 		got := PathExistsIn(g, simple.Node(test.from), simple.Node(test.to))
 		if got != test.want {
-			t.Errorf("unexpected result for path existance in test %d: got:%t want %t", i, got, test.want)
+			t.Errorf("unexpected result for path existence in test %d: got:%t want %t", i, got, test.want)
 		}
 	}
 }
@@ -124,7 +124,7 @@ func TestPathExistsInDirected(t *testing.T) {
 
 		got := PathExistsIn(g, simple.Node(test.from), simple.Node(test.to))
 		if got != test.want {
-			t.Errorf("unexpected result for path existance in test %d: got:%t want %t", i, got, test.want)
+			t.Errorf("unexpected result for path existence in test %d: got:%t want %t", i, got, test.want)
 		}
 	}
 }

--- a/lapack/testlapack/dgebal.go
+++ b/lapack/testlapack/dgebal.go
@@ -56,10 +56,10 @@ func testDgebal(t *testing.T, impl Dgebaler, job lapack.Job, a blas64.General) {
 
 	if n == 0 {
 		if ilo != 0 {
-			t.Errorf("%v: unexpected ilo when n=0. Want 0, got %v", prefix, n, ilo)
+			t.Errorf("%v: unexpected ilo when n=0. Want 0, got %v", prefix, ilo)
 		}
 		if ihi != -1 {
-			t.Errorf("%v: unexpected ihi when n=0. Want -1, got %v", prefix, n, ihi)
+			t.Errorf("%v: unexpected ihi when n=0. Want -1, got %v", prefix, ihi)
 		}
 		return
 	}

--- a/lapack/testlapack/dgeev.go
+++ b/lapack/testlapack/dgeev.go
@@ -606,7 +606,7 @@ func testDgeev(t *testing.T, impl Dgeever, tc string, test dgeevTest, jobvl lapa
 	}
 
 	if first > 0 {
-		t.Log("%v: all eigenvalues haven't been computed, first=%v", prefix, first)
+		t.Logf("%v: all eigenvalues haven't been computed, first=%v", prefix, first)
 	}
 
 	// Check that conjugate pair eigevalues are ordered correctly.

--- a/lapack/testlapack/dhseqr.go
+++ b/lapack/testlapack/dhseqr.go
@@ -78,7 +78,7 @@ func testDhseqr(t *testing.T, impl Dhseqrer, i int, test dhseqrTest, job lapack.
 	prefix := fmt.Sprintf("Case %v: job=%v, compz=%v, n=%v, ilo=%v, ihi=%v, extra=%v, optwk=%v",
 		i, job, compz, n, ilo, ihi, extra, optwork)
 	if unconverged > 0 {
-		t.Log("%v: Dhseqr did not compute all eigenvalues. unconverged=%v", prefix, unconverged)
+		t.Logf("%v: Dhseqr did not compute all eigenvalues. unconverged=%v", prefix, unconverged)
 		if unconverged <= ilo {
 			t.Fatalf("%v: 0 < unconverged <= ilo", prefix)
 		}

--- a/lapack/testlapack/dlaexc.go
+++ b/lapack/testlapack/dlaexc.go
@@ -90,7 +90,7 @@ func testDlaexc(t *testing.T, impl Dlaexcer, wantq bool, n, j1, n1, n2, extra in
 		if n1 == 1 && n2 == 1 {
 			t.Errorf("%v: unexpected failure", prefix)
 		} else {
-			t.Logf("%v: Dlaexc returned false")
+			t.Logf("%v: Dlaexc returned false", prefix)
 		}
 	}
 

--- a/lapack/testlapack/dlaqp2.go
+++ b/lapack/testlapack/dlaqp2.go
@@ -63,7 +63,7 @@ func Dlaqp2Test(t *testing.T, impl Dlaqp2er) {
 
 			impl.Dlaqp2(m, n, test.offset, a.Data, a.Stride, jpiv, tau, vn1, vn2, work)
 
-			prefix := fmt.Sprintf("Case %v (offset=%t,m=%v,n=%v,extra=%v)", ti, test.offset, m, n, extra)
+			prefix := fmt.Sprintf("Case %v (offset=%d,m=%v,n=%v,extra=%v)", ti, test.offset, m, n, extra)
 			if !generalOutsideAllNaN(a) {
 				t.Errorf("%v: out-of-range write to A", prefix)
 			}

--- a/lapack/testlapack/dlaqps.go
+++ b/lapack/testlapack/dlaqps.go
@@ -59,7 +59,7 @@ func DlaqpsTest(t *testing.T, impl Dlaqpser) {
 
 			kb := impl.Dlaqps(m, n, test.offset, test.nb, a.Data, a.Stride, jpiv, tau, vn1, vn2, auxv, f.Data, f.Stride)
 
-			prefix := fmt.Sprintf("Case %v (offset=%t,m=%v,n=%v,extra=%v)", ti, test.offset, m, n, extra)
+			prefix := fmt.Sprintf("Case %v (offset=%d,m=%v,n=%v,extra=%v)", ti, test.offset, m, n, extra)
 			if !generalOutsideAllNaN(a) {
 				t.Errorf("%v: out-of-range write to A", prefix)
 			}

--- a/lapack/testlapack/dlaqr23.go
+++ b/lapack/testlapack/dlaqr23.go
@@ -282,10 +282,10 @@ func testDlaqr23(t *testing.T, impl Dlaqr23er, test dlaqr23Test, opt bool, recur
 		t.Errorf("%v: out-of-range write to WV\n%v", prefix, wv.Data)
 	}
 	if !isAllNaN(sr[:kbot-nd-ns+1]) || !isAllNaN(sr[kbot+1:]) {
-		t.Errorf("%v: out-of-range write to sr")
+		t.Errorf("%v: out-of-range write to sr", prefix)
 	}
 	if !isAllNaN(si[:kbot-nd-ns+1]) || !isAllNaN(si[kbot+1:]) {
-		t.Errorf("%v: out-of-range write to si")
+		t.Errorf("%v: out-of-range write to si", prefix)
 	}
 
 	if !isUpperHessenberg(h) {

--- a/lapack/testlapack/dlaset.go
+++ b/lapack/testlapack/dlaset.go
@@ -49,14 +49,14 @@ func DlasetTest(t *testing.T, impl Dlaseter) {
 				}
 				for i := 0; i < min(m, n); i++ {
 					if a.Data[i*a.Stride+i] != beta {
-						t.Errorf("%v: unexpected diagonal of A")
+						t.Errorf("%v: unexpected diagonal of A", prefix)
 					}
 				}
 				if uplo == blas.Upper || uplo == blas.All {
 					for i := 0; i < m; i++ {
 						for j := i + 1; j < n; j++ {
 							if a.Data[i*a.Stride+j] != alpha {
-								t.Errorf("%v: unexpected upper triangle of A")
+								t.Errorf("%v: unexpected upper triangle of A", prefix)
 							}
 						}
 					}
@@ -65,7 +65,7 @@ func DlasetTest(t *testing.T, impl Dlaseter) {
 					for i := 1; i < m; i++ {
 						for j := 0; j < min(i, n); j++ {
 							if a.Data[i*a.Stride+j] != alpha {
-								t.Errorf("%v: unexpected lower triangle of A")
+								t.Errorf("%v: unexpected lower triangle of A", prefix)
 							}
 						}
 					}

--- a/lapack/testlapack/dlatrs.go
+++ b/lapack/testlapack/dlatrs.go
@@ -68,7 +68,7 @@ func testDlatrs(t *testing.T, impl Dlatrser, imat int, uplo blas.Uplo, trans bla
 	if hasNaN {
 		t.Errorf("%v: unexpected NaN (scale=%v,normin=false)", prefix, scale)
 	} else if resid > tol {
-		t.Errorf("%v: residual %v too large (scale=%v,normin=false)", prefix, scale)
+		t.Errorf("%v: residual %v too large (scale=%v,normin=false)", prefix, resid, scale)
 	}
 
 	// Call Dlatrs with normin=true because cnorm has been filled.
@@ -78,7 +78,7 @@ func testDlatrs(t *testing.T, impl Dlatrser, imat int, uplo blas.Uplo, trans bla
 	if hasNaN {
 		t.Errorf("%v: unexpected NaN (scale=%v,normin=true)", prefix, scale)
 	} else if resid > tol {
-		t.Errorf("%v: residual %v too large (scale=%v,normin=true)", prefix, scale)
+		t.Errorf("%v: residual %v too large (scale=%v,normin=true)", prefix, resid, scale)
 	}
 }
 

--- a/lapack/testlapack/general.go
+++ b/lapack/testlapack/general.go
@@ -583,7 +583,7 @@ func constructQK(kind string, m, n, k int, a []float64, lda int, tau []float64) 
 		}
 		blas64.Ger(-tau[i], vVec, vVec, h)
 		copy(qCopy.Data, q.Data)
-		// Mulitply q by the new h
+		// Multiply q by the new h.
 		switch kind {
 		case "QR", "RQ":
 			blas64.Gemm(blas.NoTrans, blas.NoTrans, 1, qCopy, h, 0, q)
@@ -608,7 +608,7 @@ func checkBidiagonal(t *testing.T, m, n, nb int, a []float64, lda int, d, e, tau
 	qMat := constructQPBidiagonal(lapack.ApplyQ, m, n, nb, a, lda, tauQ)
 	pMat := constructQPBidiagonal(lapack.ApplyP, m, n, nb, a, lda, tauP)
 
-	// Compute Q^T * A * P
+	// Compute Q^T * A * P.
 	aMat := blas64.General{
 		Rows:   m,
 		Cols:   n,

--- a/mat/cholesky.go
+++ b/mat/cholesky.go
@@ -287,7 +287,7 @@ func (s *SymDense) InverseCholesky(chol *Cholesky) error {
 }
 
 // SymRankOne performs a rank-1 update of the original matrix A and refactorizes
-// its Cholesky factorization, storing the result into the reciever. That is, if
+// its Cholesky factorization, storing the result into the receiver. That is, if
 // in the original Cholesky factorization
 //  U^T * U = A,
 // in the updated factorization

--- a/mat/cholesky_example_test.go
+++ b/mat/cholesky_example_test.go
@@ -69,7 +69,7 @@ func ExampleCholesky() {
 	//           ⎣-16  -24   17   73⎦
 }
 
-func ExampleCholeskySymRankOne() {
+func ExampleCholesky_SymRankOne() {
 	a := mat.NewSymDense(4, []float64{
 		1, 1, 1, 1,
 		0, 2, 3, 4,

--- a/mat/hogsvd_example_test.go
+++ b/mat/hogsvd_example_test.go
@@ -20,7 +20,7 @@ func ExampleHOGSVD() {
 	var gsvd mat.HOGSVD
 	ok := gsvd.Factorize(FAO.Africa, FAO.Asia, FAO.LatinAmericaCaribbean, FAO.Oceania)
 	if !ok {
-		log.Fatal("HOGSVD factorization failed: %v", gsvd.Err())
+		log.Fatalf("HOGSVD factorization failed: %v", gsvd.Err())
 	}
 
 	for i, n := range []string{"Africa", "Asia", "Latin America/Caribbean", "Oceania"} {

--- a/mat/io_test.go
+++ b/mat/io_test.go
@@ -271,7 +271,7 @@ func TestDenseIORoundTrip(t *testing.T) {
 		}
 
 		if !bytes.Equal(buf, wbuf.Bytes()) {
-			t.Errorf("encoding via MarshalBinary and MarshalBinaryTo differ:\nwith-stream: %q\n  no-stream: %q\n",
+			t.Errorf("r/w test #%d encoding via MarshalBinary and MarshalBinaryTo differ:\nwith-stream: %q\n  no-stream: %q\n",
 				i, wbuf.Bytes(), buf,
 			)
 		}
@@ -532,7 +532,7 @@ func TestVectorIORoundTrip(t *testing.T) {
 		}
 
 		if !bytes.Equal(buf, wbuf.Bytes()) {
-			t.Errorf("encoding via MarshalBinary and MarshalBinaryTo differ:\nwith-stream: %q\n  no-stream: %q\n",
+			t.Errorf("test #%d encoding via MarshalBinary and MarshalBinaryTo differ:\nwith-stream: %q\n  no-stream: %q\n",
 				i, wbuf.Bytes(), buf,
 			)
 		}

--- a/mat/symmetric_test.go
+++ b/mat/symmetric_test.go
@@ -687,7 +687,7 @@ func TestPowPSD(t *testing.T) {
 			dense.Pow(&mat, pow)
 
 			if !EqualApprox(&sym, &dense, 1e-10) {
-				t.Errorf("Dim %d: pow mismatch")
+				t.Errorf("Dim %d: pow mismatch", dim)
 			}
 		}
 	}

--- a/mathext/gamma_inc_inv.go
+++ b/mathext/gamma_inc_inv.go
@@ -46,7 +46,7 @@ func gammaIncInv(a, y float64) float64 {
 
 	// Also, after we generate a small interval by bisection above, false
 	// position will do a large step from an interval of width ~1e-4 to ~1e-14
-	// in one step (a=10, x=0.05, but similiar for other values).
+	// in one step (a=10, x=0.05, but similar for other values).
 	result, bestX, _, errEst := falsePosition(lo, hi, flo, fhi, 2*machEp, 2*machEp, 1e-2*a, gammaInc, params)
 	if result == fSolveMaxIterations && errEst > allowedATol+allowedRTol*math.Abs(bestX) {
 		bestX = math.NaN()

--- a/mathext/internal/amos/amos.go
+++ b/mathext/internal/amos/amos.go
@@ -235,7 +235,7 @@ func Zairy(ZR, ZI float64, ID, KODE int) (AIR, AII float64, NZ int) {
 	}
 	AA = AZ * AZ
 	if AA < TOL/AZ {
-		goto Fourty
+		goto Forty
 	}
 	TRM1R = CONER
 	TRM1I = CONEI
@@ -272,12 +272,12 @@ func Zairy(ZR, ZI float64, ID, KODE int) (AIR, AII float64, NZ int) {
 		D2 = D2 + BK
 		AD = math.Min(D1, D2)
 		if ATRM < TOL*AD {
-			goto Fourty
+			goto Forty
 		}
 		AK = AK + 18.0E0
 		BK = BK + 18.0E0
 	}
-Fourty:
+Forty:
 	if ID == 1 {
 		goto Fifty
 	}
@@ -539,7 +539,7 @@ func Zbknu(ZR, ZI, FNU float64, KODE, N int, YR, YI []float64, NZ int, TOL, ELIM
 	     * CYI(2)
 	*/
 
-	// TOOD(btracey): Find which of these are inputs/outputs/both and clean up
+	// TODO(btracey): Find which of these are inputs/outputs/both and clean up
 	// the function call.
 	// YR and YI have length n (but n+1 with better indexing)
 	var AA, AK, ASCLE, A1, A2, BB, BK, CAZ,
@@ -641,7 +641,7 @@ Ten:
 	T2 = math.Exp(-dgamln(A2, IDUM))
 	T1 = 1.0E0 / (T2 * FC)
 	if math.Abs(DNU) > 0.1E0 {
-		goto Fourty
+		goto Forty
 	}
 
 	// SERIES FOR F0 TO RESOLVE INDETERMINACY FOR SMALL ABS(DNU).
@@ -658,7 +658,7 @@ Ten:
 Thirty:
 	G1 = -S
 	goto Fifty
-Fourty:
+Forty:
 	G1 = (T1 - T2) / (DNU + DNU)
 Fifty:
 	G2 = (T1 + T2) * 0.5E0
@@ -1352,7 +1352,7 @@ Twenty:
 		YI[I] = CSI
 		NZ = NZ - 1
 		if IC == KK-1 {
-			goto Fourty
+			goto Forty
 		}
 		IC = KK
 		continue
@@ -1371,7 +1371,7 @@ Twenty:
 		NZ = N - 1
 	}
 	goto FourtyFive
-Fourty:
+Forty:
 	NZ = KK - 2
 FourtyFive:
 	for I = 1; I <= NZ; I++ {
@@ -1452,7 +1452,7 @@ Ten:
 		YR[i] = real(v)
 		YI[i] = imag(v)
 	}
-	goto Fourty
+	goto Forty
 Twenty:
 	if AZ < RL {
 		goto Thirty
@@ -1462,14 +1462,14 @@ Twenty:
 	if NW < 0 {
 		goto Eighty
 	}
-	goto Fourty
+	goto Forty
 Thirty:
 	// MILLER ALGORITHM NORMALIZED BY THE SERIES FOR THE I FUNCTION
 	ZNR, ZNI, FNU, KODE, NN, YR, YI, NW, TOL = Zmlri(ZNR, ZNI, FNU, KODE, NN, YR, YI, NW, TOL)
 	if NW < 0 {
 		goto Eighty
 	}
-Fourty:
+Forty:
 	// ANALYTIC CONTINUATION TO THE LEFT HALF PLANE FOR THE K FUNCTION.
 	ZNR, ZNI, FNU, KODE, _, CYR, CYI, NW, TOL, ELIM, ALIM = Zbknu(ZNR, ZNI, FNU, KODE, 1, CYR, CYI, NW, TOL, ELIM, ALIM)
 	if NW != 0 {
@@ -1796,7 +1796,7 @@ Twenty:
 	I = I + 1
 	K = 0
 	if INU < IAZ {
-		goto Fourty
+		goto Forty
 	}
 	// COMPUTE RELATIVE TRUNCATION ERROR FOR RATIOS.
 	P1R = ZEROR
@@ -1825,7 +1825,7 @@ Twenty:
 			continue
 		}
 		if ITIME == 2 {
-			goto Fourty
+			goto Forty
 		}
 		ACK = cmplx.Abs(complex(CKR, CKI))
 		FLAM = ACK + math.Sqrt(ACK*ACK-1.0E0)
@@ -1835,7 +1835,7 @@ Twenty:
 		ITIME = 2
 	}
 	goto OneTen
-Fourty:
+Forty:
 	// BACKWARD RECURRENCE AND SUM NORMALIZING RELATION.
 	K = K + 1
 	KK = max(I+IAZ, K+INU)
@@ -1957,7 +1957,7 @@ OneTen:
 // condition |z| <= 2*sqrt(fnu+1) was violated and the computation must be
 // completed in another routine with n -= abs(nz).
 func Zseri(z complex128, fnu float64, kode, n int, y []complex128, tol, elim, alim float64) (nz int) {
-	// TOOD(btracey): The original fortran line is "ARM = 1.0D+3*D1MACH(1)". Evidently, in Fortran
+	// TODO(btracey): The original fortran line is "ARM = 1.0D+3*D1MACH(1)". Evidently, in Fortran
 	// this is interpreted as one to the power of +3*D1MACH(1). While it is possible
 	// this was intentional, it seems unlikely.
 	arm := 1000 * dmach[1]

--- a/mathext/internal/amos/origcode_test.go
+++ b/mathext/internal/amos/origcode_test.go
@@ -226,7 +226,7 @@ func zairyOrig(ZR, ZI float64, ID, KODE int) (AIR, AII float64, NZ int) {
 	}
 	AA = AZ * AZ
 	if AA < TOL/AZ {
-		goto Fourty
+		goto Forty
 	}
 	TRM1R = CONER
 	TRM1I = CONEI
@@ -263,12 +263,12 @@ func zairyOrig(ZR, ZI float64, ID, KODE int) (AIR, AII float64, NZ int) {
 		D2 = D2 + BK
 		AD = dmin(D1, D2)
 		if ATRM < TOL*AD {
-			goto Fourty
+			goto Forty
 		}
 		AK = AK + 18.0E0
 		BK = BK + 18.0E0
 	}
-Fourty:
+Forty:
 	if ID == 1 {
 		goto Fifty
 	}
@@ -530,7 +530,7 @@ func zbknuOrig(ZR, ZI, FNU float64, KODE, N int, YR, YI []float64, NZ int, TOL, 
 	     * CYI(2)
 	*/
 
-	// TOOD(btracey): Find which of these are inputs/outputs/both and clean up
+	// TODO(btracey): Find which of these are inputs/outputs/both and clean up
 	// the function call.
 	// YR and YI have length n (but n+1 with better indexing)
 	var AA, AK, ASCLE, A1, A2, BB, BK, CAZ,
@@ -623,7 +623,7 @@ Ten:
 	T2 = dexp(-dgamln(A2, IDUM))
 	T1 = 1.0E0 / (T2 * FC)
 	if dabs(DNU) > 0.1E0 {
-		goto Fourty
+		goto Forty
 	}
 
 	// SERIES FOR F0 TO RESOLVE INDETERMINACY FOR SMALL ABS(DNU).
@@ -640,7 +640,7 @@ Ten:
 Thirty:
 	G1 = -S
 	goto Fifty
-Fourty:
+Forty:
 	G1 = (T1 - T2) / (DNU + DNU)
 Fifty:
 	G2 = (T1 + T2) * 0.5E0
@@ -1325,7 +1325,7 @@ Twenty:
 		YI[I] = CSI
 		NZ = NZ - 1
 		if IC == KK-1 {
-			goto Fourty
+			goto Forty
 		}
 		IC = KK
 		continue
@@ -1344,7 +1344,7 @@ Twenty:
 		NZ = N - 1
 	}
 	goto FourtyFive
-Fourty:
+Forty:
 	NZ = KK - 2
 FourtyFive:
 	for I = 1; I <= NZ; I++ {
@@ -1413,7 +1413,7 @@ func zacaiOrig(ZR, ZI, FNU float64, KODE, MR, N int, YR, YI []float64, NZ int, R
 Ten:
 	// POWER SERIES FOR THE I FUNCTION.
 	ZNR, ZNI, FNU, KODE, NN, YR, YI, NW, TOL, ELIM, ALIM = zseriOrig(ZNR, ZNI, FNU, KODE, NN, YR, YI, NW, TOL, ELIM, ALIM)
-	goto Fourty
+	goto Forty
 Twenty:
 	if AZ < RL {
 		goto Thirty
@@ -1423,14 +1423,14 @@ Twenty:
 	if NW < 0 {
 		goto Eighty
 	}
-	goto Fourty
+	goto Forty
 Thirty:
 	// MILLER ALGORITHM NORMALIZED BY THE SERIES FOR THE I FUNCTION
 	ZNR, ZNI, FNU, KODE, NN, YR, YI, NW, TOL = zmlriOrig(ZNR, ZNI, FNU, KODE, NN, YR, YI, NW, TOL)
 	if NW < 0 {
 		goto Eighty
 	}
-Fourty:
+Forty:
 	// ANALYTIC CONTINUATION TO THE LEFT HALF PLANE FOR THE K FUNCTION.
 	ZNR, ZNI, FNU, KODE, _, CYR, CYI, NW, TOL, ELIM, ALIM = zbknuOrig(ZNR, ZNI, FNU, KODE, 1, CYR, CYI, NW, TOL, ELIM, ALIM)
 	if NW != 0 {
@@ -1746,7 +1746,7 @@ Twenty:
 	I = I + 1
 	K = 0
 	if INU < IAZ {
-		goto Fourty
+		goto Forty
 	}
 	// COMPUTE RELATIVE TRUNCATION ERROR FOR RATIOS.
 	P1R = ZEROR
@@ -1775,7 +1775,7 @@ Twenty:
 			continue
 		}
 		if ITIME == 2 {
-			goto Fourty
+			goto Forty
 		}
 		ACK = zabs(complex(CKR, CKI))
 		FLAM = ACK + dsqrt(ACK*ACK-1.0E0)
@@ -1785,7 +1785,7 @@ Twenty:
 		ITIME = 2
 	}
 	goto OneTen
-Fourty:
+Forty:
 	// BACKWARD RECURRENCE AND SUM NORMALIZING RELATION.
 	K = K + 1
 	KK = max0(I+IAZ, K+INU)
@@ -1964,7 +1964,7 @@ Twenty:
 		AK1R = AK1R - ZR
 	}
 	if AK1R > (-ELIM) {
-		goto Fourty
+		goto Forty
 	}
 Thirty:
 	NZ = NZ + 1
@@ -1978,7 +1978,7 @@ Thirty:
 		return ZR, ZI, FNU, KODE, N, YR, YI, NZ, TOL, ELIM, ALIM
 	}
 	goto Twenty
-Fourty:
+Forty:
 	if AK1R > (-ALIM) {
 		goto Fifty
 	}

--- a/mathext/roots.go
+++ b/mathext/roots.go
@@ -46,7 +46,7 @@ const (
 //  errEst: error estimation
 func falsePosition(x1, x2, f1, f2, absErr, relErr, bisectTil float64, f objectiveFunc, fExtra []float64) (fSolveResult, float64, float64, float64) {
 	// The false position steps are either unmodified, or modified with the
-	// Anderson-Bjorck method as appropiate. Theoretically, this has a "speed of
+	// Anderson-Bjorck method as appropriate. Theoretically, this has a "speed of
 	// convergence" of 1.7 (bisection is 1, Newton is 2).
 	// Note that this routine was designed initially to work with gammaincinv, so
 	// it may not be tuned right for other problems. Don't use it blindly.

--- a/optimize/convex/lp/simplex.go
+++ b/optimize/convex/lp/simplex.go
@@ -141,7 +141,7 @@ func simplex(initialBasic []int, c []float64, A mat.Matrix, b []float64, tol flo
 		basicIdxs = make([]int, len(initialBasic))
 		copy(basicIdxs, initialBasic)
 	} else {
-		// No inital basis supplied. Solve the PhaseI problem.
+		// No initial basis supplied. Solve the PhaseI problem.
 		basicIdxs, ab, xb, err = findInitialBasic(A, b)
 		if err != nil {
 			return math.NaN(), nil, nil, err

--- a/optimize/convex/lp/simplex_test.go
+++ b/optimize/convex/lp/simplex_test.go
@@ -5,7 +5,6 @@
 package lp
 
 import (
-	"fmt"
 	"math/rand"
 	"testing"
 
@@ -241,8 +240,6 @@ func testSimplex(t *testing.T, initialBasic []int, c []float64, a mat.Matrix, b 
 	// b^T *nu instead of maximizing -b^T*nu), so flip it back.
 	if errPrimal == nil {
 		if errDual != nil {
-			fmt.Println("errDual", errDual)
-			panic("here")
 			t.Errorf("Primal feasible but dual errored: %s", errDual)
 		}
 		dualOpt *= -1

--- a/optimize/global.go
+++ b/optimize/global.go
@@ -24,7 +24,7 @@ type GlobalMethod interface {
 	Done()
 }
 
-// Global uses a global optimizer to search for the gloabl minimum of a
+// Global uses a global optimizer to search for the global minimum of a
 // function. A maximization problem can be transformed into a
 // minimization problem by multiplying the function by -1.
 //

--- a/optimize/interfaces.go
+++ b/optimize/interfaces.go
@@ -70,7 +70,7 @@ type Statuser interface {
 // dir_k starting at the most recent location x_k, i.e., it tries to minimize
 // the function
 //  φ(step) := f(x_k + step * dir_k) where step > 0.
-// Typically, a Linesearcher will be used in conjuction with LinesearchMethod
+// Typically, a Linesearcher will be used in conjunction with LinesearchMethod
 // for performing gradient-based optimization through sequential line searches.
 type Linesearcher interface {
 	// Init initializes the Linesearcher and a new line search. Value and
@@ -100,7 +100,7 @@ type Linesearcher interface {
 
 // NextDirectioner implements a strategy for computing a new line search
 // direction at each major iteration. Typically, a NextDirectioner will be
-// used in conjuction with LinesearchMethod for performing gradient-based
+// used in conjunction with LinesearchMethod for performing gradient-based
 // optimization through sequential line searches.
 type NextDirectioner interface {
 	// InitDirection initializes the NextDirectioner at the given starting location,

--- a/optimize/linesearcher_test.go
+++ b/optimize/linesearcher_test.go
@@ -84,7 +84,7 @@ func testLinesearcher(t *testing.T, ls Linesearcher, decrease, curvature float64
 
 			op := ls.Init(f0, g0, initStep)
 			if !op.isEvaluation() {
-				t.Errorf("%v: Linesearcher.Init returned non-evaluating operation %v", op)
+				t.Errorf("%v: Linesearcher.Init returned non-evaluating operation %v", prefix, op)
 				continue
 			}
 
@@ -115,7 +115,7 @@ func testLinesearcher(t *testing.T, ls Linesearcher, decrease, curvature float64
 					f = prob.f(step)
 					g = prob.g(step)
 				default:
-					t.Errorf("%v: Linesearcher returned an invalid operation %v", op)
+					t.Errorf("%v: Linesearcher returned an invalid operation %v", prefix, op)
 					break loop
 				}
 

--- a/optimize/local.go
+++ b/optimize/local.go
@@ -162,7 +162,6 @@ func minimize(p *Problem, method Method, settings *Settings, stats *Stats, optLo
 			return
 		}
 	}
-	panic("optimize: unreachable")
 }
 
 func getDefaultMethod(p *Problem) Method {

--- a/optimize/types.go
+++ b/optimize/types.go
@@ -184,7 +184,7 @@ type Settings struct {
 	//
 	// If f < f_best and
 	//  f_best - f > FunctionConverge.Relative * maxabs(f, f_best) + FunctionConverge.Absolute
-	// then a significant decrease has occured, and f_best is updated.
+	// then a significant decrease has occurred, and f_best is updated.
 	//
 	// If there is no significant decrease for FunctionConverge.Iterations
 	// major iterations, FunctionConvergence status is returned.

--- a/stat/distmv/studentst_test.go
+++ b/stat/distmv/studentst_test.go
@@ -163,6 +163,9 @@ func TestStudentsTConditional(t *testing.T) {
 		}
 
 		sUp, ok := s.ConditionStudentsT(test.idx, test.value, src)
+		if !ok {
+			t.Error("unexpected failure of ConditionStudentsT")
+		}
 
 		// Compute the other values by hand the inefficient way to compare
 		newNu := test.nu + float64(len(test.idx))

--- a/stat/distuv/categorical.go
+++ b/stat/distuv/categorical.go
@@ -9,7 +9,7 @@ import (
 	"math/rand"
 )
 
-// Categorical is an extension of the Bernouilli distribution where x takes
+// Categorical is an extension of the Bernoulli distribution where x takes
 // values {0, 1, ..., len(w)-1} where w is the weight vector. Categorical must
 // be initialized with NewCategorical.
 type Categorical struct {

--- a/stat/pca_example_test.go
+++ b/stat/pca_example_test.go
@@ -11,7 +11,7 @@ import (
 	"gonum.org/v1/gonum/stat"
 )
 
-func ExamplePrincipalComponents() {
+func ExamplePC() {
 	// iris is a truncated sample of the Fisher's Iris dataset.
 	n := 10
 	d := 4

--- a/stat/samplemv/metropolishastings.go
+++ b/stat/samplemv/metropolishastings.go
@@ -23,7 +23,7 @@ type MHProposal interface {
 	ConditionalLogProb(x, y []float64) (prob float64)
 
 	// ConditionalRand generates a new random location conditioned being at the
-	// location y. If the first arguement is nil, a new slice is allocated and
+	// location y. If the first argument is nil, a new slice is allocated and
 	// returned. Otherwise, the random location is stored in-place into the first
 	// argument, and ConditionalRand will panic if the input slice lengths differ.
 	ConditionalRand(x, y []float64) []float64
@@ -114,7 +114,7 @@ func (m MetropolisHastingser) Sample(batch *mat.Dense) {
 
 // MetropolisHastings generates rows(batch) samples using the Metropolis Hastings
 // algorithm (http://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm),
-// with the given target and proposal distributions, starting at the intial location
+// with the given target and proposal distributions, starting at the initial location
 // and storing the results in-place into samples. If src != nil, it will be used to generate random
 // numbers, otherwise rand.Float64 will be used.
 //
@@ -204,7 +204,7 @@ func (p *ProposalNormal) ConditionalLogProb(x, y []float64) (prob float64) {
 }
 
 // ConditionalRand generates a new random location conditioned being at the
-// location y. If the first arguement is nil, a new slice is allocated and
+// location y. If the first argument is nil, a new slice is allocated and
 // returned. Otherwise, the random location is stored in-place into the first
 // argument, and ConditionalRand will panic if the input slice lengths differ or
 // if they are not equal to the dimension of the covariance matrix.

--- a/stat/sampleuv/sample.go
+++ b/stat/sampleuv/sample.go
@@ -333,7 +333,7 @@ func (m MetropolisHastingser) Sample(batch []float64) {
 
 // MetropolisHastings generates len(batch) samples using the Metropolis Hastings
 // algorithm (http://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm),
-// with the given target and proposal distributions, starting at the intial location
+// with the given target and proposal distributions, starting at the initial location
 // and storing the results in-place into samples. If src != nil, it will be used to generate random
 // numbers, otherwise rand.Float64 will be used.
 //

--- a/stat/sampleuv/weighted_test.go
+++ b/stat/sampleuv/weighted_test.go
@@ -162,11 +162,11 @@ func TestWeightZero(t *testing.T) {
 		t.Errorf("unexpected selection rate for zero-weighted item: got: %v want:%v", f[6], 0)
 	}
 	if reflect.DeepEqual(f[:6], obt[:6]) {
-		t.Fatal("unexpected selection: too few elements chosen in range:\ngot: %v\nwant:%v",
+		t.Fatalf("unexpected selection: too few elements chosen in range:\ngot: %v\nwant:%v",
 			f[:6], obt[:6])
 	}
 	if reflect.DeepEqual(f[7:], obt[7:]) {
-		t.Fatal("unexpected selection: too few elements chosen in range:\ngot: %v\nwant:%v",
+		t.Fatalf("unexpected selection: too few elements chosen in range:\ngot: %v\nwant:%v",
 			f[7:], obt[7:])
 	}
 }
@@ -217,11 +217,11 @@ func TestWeightIncrease(t *testing.T) {
 		t.Errorf("unexpected selection rate for re-weighted item: got: %v want:%v", f[6], f[9])
 	}
 	if reflect.DeepEqual(f[:6], obt[:6]) {
-		t.Fatal("unexpected selection: too many elements chosen in range:\ngot: %v\nwant:%v",
+		t.Fatalf("unexpected selection: too many elements chosen in range:\ngot: %v\nwant:%v",
 			f[:6], obt[:6])
 	}
 	if reflect.DeepEqual(f[7:], obt[7:]) {
-		t.Fatal("unexpected selection: too many elements chosen in range:\ngot: %v\nwant:%v",
+		t.Fatalf("unexpected selection: too many elements chosen in range:\ngot: %v\nwant:%v",
 			f[7:], obt[7:])
 	}
 }
@@ -253,7 +253,7 @@ func TestWeightedNoResample(t *testing.T) {
 			item, ok := ts.Take()
 			if !ok {
 				if c != n {
-					t.Errorf("unexpected number of items: got: %d want: %d", c, n)
+					t.Errorf("unexpected number of items: got: %d want: %d", c, int(n))
 				}
 				break
 			}

--- a/unit/unit_test.go
+++ b/unit/unit_test.go
@@ -248,19 +248,21 @@ func (u *UnitMap) Mul(aU UnitMapper) *UnitMap {
 	return u
 }
 
+var sink float64
+
 func BenchmarkAddFloat(b *testing.B) {
-	a := 0.0
+	sink = 0
 	c := 10.0
 	for i := 0; i < b.N; i++ {
-		a += c
+		sink += c
 	}
 }
 
 func BenchmarkMulFloat(b *testing.B) {
-	a := 0.0
+	sink = 0
 	c := 10.0
 	for i := 0; i < b.N; i++ {
-		a *= c
+		sink *= c
 	}
 }
 

--- a/unit/unittype.go
+++ b/unit/unittype.go
@@ -138,7 +138,7 @@ var (
 
 // Dimensions represent the dimensionality of the unit in powers
 // of that dimension. If a key is not present, the power of that
-// dimension is zero. Dimensions is used in conjuction with New.
+// dimension is zero. Dimensions is used in conjunction with New.
 type Dimensions map[Dimension]int
 
 func (d Dimensions) String() string {
@@ -253,7 +253,7 @@ func DimensionsMatch(a, b Uniter) bool {
 	return true
 }
 
-// Add adds the function argument to the reciever. Panics if the units of
+// Add adds the function argument to the receiver. Panics if the units of
 // the receiver and the argument don't match.
 func (u *Unit) Add(uniter Uniter) *Unit {
 	a := uniter.Unit()


### PR DESCRIPTION
This covers most of the errors found by goreport [here](https://goreportcard.com/report/github.com/gonum/gonum#go_vet).

@btracey @vladimir-ch @sbinet Please take a look.