### PR TITLE
travis: fix formatting again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,7 @@ go_import_path: gonum.org/v1/gonum
 # Get deps, build, test, and ensure the code is gofmt'ed.
 # If we are building as gonum, then we have access to the coveralls api key, so we can run coverage as well.
 script:
- - test -z "$(goimports -d .)"
- - if [[ -n "$(gofmt -s -l .)" ]]; then echo -e '\e[31mCode not gofmt simplified in:\n\n'; gofmt -s -l .; echo -e "\e[0"; fi
+ - ${TRAVIS_BUILD_DIR}/.travis/check-formatting.sh
  - go get -d -t -v ./...
  - go build -v ./...
  - go test -v ./...

--- a/.travis/check-formatting.sh
+++ b/.travis/check-formatting.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+test -z "$(goimports -d .)"
+if [[ -n "$(gofmt -s -l .)" ]]; then
+	echo -e '\e[31mCode not gofmt simplified in:\n\n'
+	gofmt -s -l .
+	echo -e "\e[0"
+fi


### PR DESCRIPTION
The intention of the previous commit touching this was to avoid RED on the log unless there was a problem. That commit did not achieve this goal, so I'm hiding the ANSI codes in a script.

Please take a look.