### PR TITLE
mathext: add elliptic integrals (Carlson and Legendre).

### DIFF
--- a/mathext/ell_carlson.go
+++ b/mathext/ell_carlson.go
@@ -13,11 +13,19 @@ import (
 //	R_F(x,y,z) = (1/2)\int_{0}^{\infty}{1/s(t)} dt,
 //	s(t) = \sqrt{(t+x)(t+y)(t+z)}.
 //
+// The arguments x, y, z must satisfy the following conditions, otherwise the function returns math.NaN():
+//	0 ≤ x,y,z ≤ upper,
+//	lower ≤ x+y,y+z,z+x,
+// where:
+//	lower = 5/(2^1022) = 1.112536929253601e-307,
+//	upper = (2^1022)/5 = 8.988465674311580e+306.
 // See: http://dlmf.nist.gov/19.16.E1 for the definition.
 //
 // See: http://doi.org/10.1145/355958.355970 for the original Fortran code.
 //
 // See: http://dx.doi.org/10.1007/BF02198293 for the modified method of computation.
+//
+// See: https://arxiv.org/abs/math/9409227 for the preprint of the above.
 func EllipticRF(x, y, z float64) float64 {
 	const (
 		lower = 5.0 / (1 << 256) / (1 << 256) / (1 << 256) / (1 << 254) // 5*2^-1022
@@ -65,11 +73,20 @@ func EllipticRF(x, y, z float64) float64 {
 //	R_D(x,y,z) = (1/2)\int_{0}^{\infty}{1/(s(t)(t+z))} dt,
 //	s(t) = \sqrt{(t+x)(t+y)(t+z)}.
 //
+// The arguments x, y, z must satisfy the following conditions, otherwise the function returns math.NaN():
+//	0 ≤ x,y ≤ upper,
+//	lower ≤ z ≤ upper,
+//	lower ≤ x+y,
+// where:
+//	lower = (5/(2^1022))^(1/3) = 4.809554074311679e-103,
+//	upper = ((2^1022)/5)^(1/3) = 2.079194837087086e+102.
 // See: http://dlmf.nist.gov/19.16.E5 for the definition.
 //
 // See: http://doi.org/10.1145/355958.355970 for the original Fortran code.
 //
 // See: http://dx.doi.org/10.1007/BF02198293 for the modified method of computation.
+//
+// See: https://arxiv.org/abs/math/9409227 for the preprint of the above.
 func EllipticRD(x, y, z float64) float64 {
 	const (
 		lower = 4.8095540743116787026618007863123676393525016818363e-103 // (5*2^-1022)^(1/3)
@@ -115,9 +132,9 @@ func EllipticRD(x, y, z float64) float64 {
 	return ((471240-540540*E2)*E5+(612612*E2-540540*E3-556920)*E4+E3*(306306*E3+E2*(675675*E2-706860)+680680)+E2*((417690-255255*E2)*E2-875160)+4084080)/(4084080*mul*An*math.Sqrt(An)) + 3*s
 }
 
-// EllipticF computes the Legendre's elliptic integral of the 1st kind F(\phi|m):
+// EllipticF computes the Legendre's elliptic integral of the 1st kind F(\phi|m), 0≤m<1:
 //
-//	F(\phi|m) = \int_{0}^{\phi}1 / \sqrt{1-m\sin^2\theta} d\theta
+//	F(\phi|m) = \int_{0}^{\phi} 1 / \sqrt{1-m\sin^2(\theta)} d\theta
 //
 // Legendre's elliptic integrals can be expressed as symmetric elliptic integrals, in this case:
 //
@@ -129,9 +146,9 @@ func EllipticF(phi, m float64) float64 {
 	return s * EllipticRF(c*c, 1-m*s*s, 1)
 }
 
-// EllipticE computes the Legendre's elliptic integral of the 2nd kind E(\phi|m):
+// EllipticE computes the Legendre's elliptic integral of the 2nd kind E(\phi|m), 0≤m<1:
 //
-//	E(\phi|m) = \int_{0}^{\phi} \sqrt{1-m\sin^2\theta} d\theta
+//	E(\phi|m) = \int_{0}^{\phi} \sqrt{1-m\sin^2(\theta)} d\theta
 //
 // Legendre's elliptic integrals can be expressed as symmetric elliptic integrals, in this case:
 //

--- a/mathext/ell_carlson.go
+++ b/mathext/ell_carlson.go
@@ -9,16 +9,16 @@ import (
 )
 
 // EllipticRF computes the symmetric elliptic integral R_F(x,y,z):
-//
-//	R_F(x,y,z) = (1/2)\int_{0}^{\infty}{1/s(t)} dt,
-//	s(t) = \sqrt{(t+x)(t+y)(t+z)}.
+//  R_F(x,y,z) = (1/2)\int_{0}^{\infty}{1/s(t)} dt,
+//  s(t) = \sqrt{(t+x)(t+y)(t+z)}.
 //
 // The arguments x, y, z must satisfy the following conditions, otherwise the function returns math.NaN():
-//	0 ≤ x,y,z ≤ upper,
-//	lower ≤ x+y,y+z,z+x,
+//  0 ≤ x,y,z ≤ upper,
+//  lower ≤ x+y,y+z,z+x,
 // where:
-//	lower = 5/(2^1022) = 1.112536929253601e-307,
-//	upper = (2^1022)/5 = 8.988465674311580e+306.
+//  lower = 5/(2^1022) = 1.112536929253601e-307,
+//  upper = (2^1022)/5 = 8.988465674311580e+306.
+//
 // See: http://dlmf.nist.gov/19.16.E1 for the definition.
 //
 // See: http://doi.org/10.1145/355958.355970 for the original Fortran code.
@@ -69,17 +69,17 @@ func EllipticRF(x, y, z float64) float64 {
 }
 
 // EllipticRD computes the symmetric elliptic integral R_D(x,y,z):
-//
-//	R_D(x,y,z) = (1/2)\int_{0}^{\infty}{1/(s(t)(t+z))} dt,
-//	s(t) = \sqrt{(t+x)(t+y)(t+z)}.
+//  R_D(x,y,z) = (1/2)\int_{0}^{\infty}{1/(s(t)(t+z))} dt,
+//  s(t) = \sqrt{(t+x)(t+y)(t+z)}.
 //
 // The arguments x, y, z must satisfy the following conditions, otherwise the function returns math.NaN():
-//	0 ≤ x,y ≤ upper,
-//	lower ≤ z ≤ upper,
-//	lower ≤ x+y,
+//  0 ≤ x,y ≤ upper,
+//  lower ≤ z ≤ upper,
+//  lower ≤ x+y,
 // where:
-//	lower = (5/(2^1022))^(1/3) = 4.809554074311679e-103,
-//	upper = ((2^1022)/5)^(1/3) = 2.079194837087086e+102.
+//  lower = (5/(2^1022))^(1/3) = 4.809554074311679e-103,
+//  upper = ((2^1022)/5)^(1/3) = 2.079194837087086e+102.
+//
 // See: http://dlmf.nist.gov/19.16.E5 for the definition.
 //
 // See: http://doi.org/10.1145/355958.355970 for the original Fortran code.
@@ -133,12 +133,10 @@ func EllipticRD(x, y, z float64) float64 {
 }
 
 // EllipticF computes the Legendre's elliptic integral of the 1st kind F(\phi|m), 0≤m<1:
-//
-//	F(\phi|m) = \int_{0}^{\phi} 1 / \sqrt{1-m\sin^2(\theta)} d\theta
+//  F(\phi|m) = \int_{0}^{\phi} 1 / \sqrt{1-m\sin^2(\theta)} d\theta
 //
 // Legendre's elliptic integrals can be expressed as symmetric elliptic integrals, in this case:
-//
-//	F(\phi|m) = \sin\phi R_F(\cos^2\phi,1-m\sin^2\phi,1)
+//  F(\phi|m) = \sin\phi R_F(\cos^2\phi,1-m\sin^2\phi,1)
 //
 // See http://dlmf.nist.gov/19.2.E4 for the definition.
 func EllipticF(phi, m float64) float64 {
@@ -147,12 +145,10 @@ func EllipticF(phi, m float64) float64 {
 }
 
 // EllipticE computes the Legendre's elliptic integral of the 2nd kind E(\phi|m), 0≤m<1:
-//
-//	E(\phi|m) = \int_{0}^{\phi} \sqrt{1-m\sin^2(\theta)} d\theta
+//  E(\phi|m) = \int_{0}^{\phi} \sqrt{1-m\sin^2(\theta)} d\theta
 //
 // Legendre's elliptic integrals can be expressed as symmetric elliptic integrals, in this case:
-//
-//	E(\phi|m) = \sin\phi R_F(\cos^2\phi,1-m\sin^2\phi,1)-(m/3)\sin^3\phi R_D(\cos^2\phi,1-m\sin^2\phi,1)
+//  E(\phi|m) = \sin\phi R_F(\cos^2\phi,1-m\sin^2\phi,1)-(m/3)\sin^3\phi R_D(\cos^2\phi,1-m\sin^2\phi,1)
 //
 // See http://dlmf.nist.gov/19.2.E5 for the definition.
 func EllipticE(phi, m float64) float64 {

--- a/mathext/ell_carlson.go
+++ b/mathext/ell_carlson.go
@@ -19,13 +19,10 @@ import (
 //  lower = 5/(2^1022) = 1.112536929253601e-307,
 //  upper = (2^1022)/5 = 8.988465674311580e+306.
 //
-// See: http://dlmf.nist.gov/19.16.E1 for the definition.
-//
-// See: http://doi.org/10.1145/355958.355970 for the original Fortran code.
-//
-// See: http://dx.doi.org/10.1007/BF02198293 for the modified method of computation.
-//
-// See: https://arxiv.org/abs/math/9409227 for the preprint of the above.
+// The definition of the symmetric elliptic integral R_F can be found in NIST Digital Library of Mathematical Functions
+// (http://dlmf.nist.gov/19.16.E1). The original Fortran code was published as Algorithm 577 in ACM TOMS (http://doi.org/10.1145/355958.355970).
+// This code is also available as a part of SLATEC Common Mathematical Library (http://netlib.org/slatec/index.html). Later, Carlson described
+// an improved version in http://dx.doi.org/10.1007/BF02198293 (also available at https://arxiv.org/abs/math/9409227).
 func EllipticRF(x, y, z float64) float64 {
 	const (
 		lower = 5.0 / (1 << 256) / (1 << 256) / (1 << 256) / (1 << 254) // 5*2^-1022
@@ -80,13 +77,10 @@ func EllipticRF(x, y, z float64) float64 {
 //  lower = (5/(2^1022))^(1/3) = 4.809554074311679e-103,
 //  upper = ((2^1022)/5)^(1/3) = 2.079194837087086e+102.
 //
-// See: http://dlmf.nist.gov/19.16.E5 for the definition.
-//
-// See: http://doi.org/10.1145/355958.355970 for the original Fortran code.
-//
-// See: http://dx.doi.org/10.1007/BF02198293 for the modified method of computation.
-//
-// See: https://arxiv.org/abs/math/9409227 for the preprint of the above.
+// The definition of the symmetric elliptic integral R_D can be found in NIST Digital Library of Mathematical Functions
+// (http://dlmf.nist.gov/19.16.E5). The original Fortran code was published as Algorithm 577 in ACM TOMS (http://doi.org/10.1145/355958.355970).
+// This code is also available as a part of SLATEC Common Mathematical Library (http://netlib.org/slatec/index.html). Later, Carlson described
+// an improved version in http://dx.doi.org/10.1007/BF02198293 (also available at https://arxiv.org/abs/math/9409227).
 func EllipticRD(x, y, z float64) float64 {
 	const (
 		lower = 4.8095540743116787026618007863123676393525016818363e-103 // (5*2^-1022)^(1/3)
@@ -138,7 +132,8 @@ func EllipticRD(x, y, z float64) float64 {
 // Legendre's elliptic integrals can be expressed as symmetric elliptic integrals, in this case:
 //  F(\phi|m) = \sin\phi R_F(\cos^2\phi,1-m\sin^2\phi,1)
 //
-// See http://dlmf.nist.gov/19.2.E4 for the definition.
+// The definition of F(\phi,k) where k=\sqrt{m} can be found in NIST Digital Library of Mathematical
+// Functions (http://dlmf.nist.gov/19.2.E4).
 func EllipticF(phi, m float64) float64 {
 	s, c := math.Sincos(phi)
 	return s * EllipticRF(c*c, 1-m*s*s, 1)
@@ -150,7 +145,8 @@ func EllipticF(phi, m float64) float64 {
 // Legendre's elliptic integrals can be expressed as symmetric elliptic integrals, in this case:
 //  E(\phi|m) = \sin\phi R_F(\cos^2\phi,1-m\sin^2\phi,1)-(m/3)\sin^3\phi R_D(\cos^2\phi,1-m\sin^2\phi,1)
 //
-// See http://dlmf.nist.gov/19.2.E5 for the definition.
+// The definition of E(\phi,k) where k=\sqrt{m} can be found in NIST Digital Library of Mathematical
+// Functions (http://dlmf.nist.gov/19.2.E5).
 func EllipticE(phi, m float64) float64 {
 	s, c := math.Sincos(phi)
 	x, y := c*c, 1-m*s*s

--- a/mathext/ell_carlson.go
+++ b/mathext/ell_carlson.go
@@ -1,0 +1,141 @@
+// Copyright ©2017 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mathext
+
+import (
+	"math"
+)
+
+// CarlsonRF computes the symmetric elliptic integral R_F(x,y,z):
+//
+//	R_F(x,y,z) = (1/2)\int_{0}^{\infty}{s^{-1}(t)} dt,
+//	s(t) = \sqrt{t+x}\sqrt{t+y}\sqrt{t+z}.
+//
+// See: http://dlmf.nist.gov/19.16.E1 for the definition.
+//
+// See: http://doi.org/10.1145/355958.355970 for the original Fortran code.
+//
+// See: http://dx.doi.org/10.1007/BF02198293 for the modified method of computation.
+func CarlsonRF(x, y, z float64) float64 {
+	const lower = 1.1125369292536006915451163586662020321096079902312e-307 // 5*2^-1022
+	const upper = 1 / lower
+	if x < 0 || y < 0 || z < 0 || math.IsNaN(x) || math.IsNaN(y) || math.IsNaN(z) {
+		return math.NaN()
+	}
+	if upper < x || upper < y || upper < z {
+		return math.NaN()
+	}
+	if x+y < lower || y+z < lower || z+x < lower {
+		return math.NaN()
+	}
+
+	const tol = 1.2674918778210762260320167734407048051023273568443e-02 // (3ε)^(1/8)
+	A0 := (x + y + z) / 3
+	An := A0
+	Q := math.Max(math.Max(math.Abs(A0-x), math.Abs(A0-y)), math.Abs(A0-z)) / tol
+	xn, yn, zn := x, y, z
+	mul := 1.0
+
+	for Q >= mul*math.Abs(An) {
+		xnsqrt, ynsqrt, znsqrt := math.Sqrt(xn), math.Sqrt(yn), math.Sqrt(zn)
+		lambda := xnsqrt*ynsqrt + ynsqrt*znsqrt + znsqrt*xnsqrt
+		An = (An + lambda) * 0.25
+		xn = (xn + lambda) * 0.25
+		yn = (yn + lambda) * 0.25
+		zn = (zn + lambda) * 0.25
+		mul *= 4
+	}
+
+	X := (A0 - x) / (mul * An)
+	Y := (A0 - y) / (mul * An)
+	Z := -(X + Y)
+	E2 := X*Y - Z*Z
+	E3 := X * Y * Z
+
+	// http://dlmf.nist.gov/19.36.E1
+	return (E3*(6930*E3+E2*(15015*E2-16380)+17160) + E2*((10010-5775*E2)*E2-24024) + 240240) / (240240 * math.Sqrt(An))
+}
+
+// CarlsonRD computes the symmetric elliptic integral R_D(x,y,z):
+//
+//	R_D(x,y,z) = (1/2)\int_{0}^{\infty}{s^{-1}(t)}{(t+z)^{-1}} dt,
+//	s(t) = \sqrt{t+x}\sqrt{t+y}\sqrt{t+z}.
+//
+// See: http://dlmf.nist.gov/19.16.E5 for the definition.
+//
+// See: http://doi.org/10.1145/355958.355970 for the original Fortran code.
+//
+// See: http://dx.doi.org/10.1007/BF02198293 for the modified method of computation.
+func CarlsonRD(x, y, z float64) float64 {
+	const lower = 4.8095540743116787026618007863123676393525016818363e-103 // (5*2^-1022)^(1/3)
+	const upper = 1 / lower
+	if x < 0 || y < 0 || math.IsNaN(x) || math.IsNaN(y) || math.IsNaN(z) {
+		return math.NaN()
+	}
+	if upper < x || upper < y || upper < z {
+		return math.NaN()
+	}
+	if x+y < lower || z < lower {
+		return math.NaN()
+	}
+
+	const tol = 9.03511693393157704747601225470683249938574888493817e-03 // (ε/5)^(1/8)
+	A0 := (x + y + 3*z) / 5
+	An := A0
+	Q := math.Max(math.Max(math.Abs(A0-x), math.Abs(A0-y)), math.Abs(A0-z)) / tol
+	xn, yn, zn := x, y, z
+	mul, s := 1.0, 0.0
+
+	for Q >= mul*math.Abs(An) {
+		xnsqrt, ynsqrt, znsqrt := math.Sqrt(xn), math.Sqrt(yn), math.Sqrt(zn)
+		lambda := xnsqrt*ynsqrt + ynsqrt*znsqrt + znsqrt*xnsqrt
+		s += 1 / (mul * znsqrt * (zn + lambda))
+		An = (An + lambda) * 0.25
+		xn = (xn + lambda) * 0.25
+		yn = (yn + lambda) * 0.25
+		zn = (zn + lambda) * 0.25
+		mul *= 4
+	}
+
+	X := (A0 - x) / (mul * An)
+	Y := (A0 - y) / (mul * An)
+	Z := -(X + Y) / 3
+	E2 := X*Y - 6*Z*Z
+	E3 := (3*X*Y - 8*Z*Z) * Z
+	E4 := 3 * (X*Y - Z*Z) * Z * Z
+	E5 := X * Y * Z * Z * Z
+
+	// http://dlmf.nist.gov/19.36.E2
+	return ((471240-540540*E2)*E5+(612612*E2-540540*E3-556920)*E4+E3*(306306*E3+E2*(675675*E2-706860)+680680)+E2*((417690-255255*E2)*E2-875160)+4084080)/(4084080*mul*An*math.Sqrt(An)) + 3*s
+}
+
+// EllipticF computes the Legendre's elliptic integral of the 1st kind F(\phi|m):
+//
+//	F(\phi|m) = \int_{0}^{\phi}1 / \sqrt{1-m\sin^2\theta} d\theta
+//
+// Legendre's elliptic integrals can be expressed as symmetric elliptic integrals, in this case:
+//
+//	F(\phi|m) = \sin\phi R_F(\cos^2\phi,1-m\sin^2\phi,1)
+//
+// See http://dlmf.nist.gov/19.2.E4 for the definition.
+func EllipticF(phi, m float64) float64 {
+	s, c := math.Sincos(phi)
+	return s * CarlsonRF(c*c, 1-m*s*s, 1)
+}
+
+// EllipticE computes the Legendre's elliptic integral of the 2nd kind E(\phi|m):
+//
+//	E(\phi|m) = \int_{0}^{\phi} \sqrt{1-m\sin^2\theta} d\theta
+//
+// Legendre's elliptic integrals can be expressed as symmetric elliptic integrals, in this case:
+//
+//	E(\phi|m) = \sin\phi R_F(\cos^2\phi,1-m\sin^2\phi,1)-(m/3)\sin^3\phi R_D(\cos^2\phi,1-m\sin^2\phi,1)
+//
+// See http://dlmf.nist.gov/19.2.E5 for the definition.
+func EllipticE(phi, m float64) float64 {
+	s, c := math.Sincos(phi)
+	x, y := c*c, 1-m*s*s
+	return s * (CarlsonRF(x, y, 1) - (m/3)*s*s*CarlsonRD(x, y, 1))
+}

--- a/mathext/ell_carlson.go
+++ b/mathext/ell_carlson.go
@@ -19,11 +19,12 @@ import (
 //  lower = 5/(2^1022) = 1.112536929253601e-307,
 //  upper = (2^1022)/5 = 8.988465674311580e+306.
 //
-// The definition of the symmetric elliptic integral R_F can be found in NIST Digital Library of Mathematical Functions
-// (http://dlmf.nist.gov/19.16.E1). The original Fortran code was published as Algorithm 577 in ACM TOMS (http://doi.org/10.1145/355958.355970).
-// This code is also available as a part of SLATEC Common Mathematical Library (http://netlib.org/slatec/index.html). Later, Carlson described
-// an improved version in http://dx.doi.org/10.1007/BF02198293 (also available at https://arxiv.org/abs/math/9409227).
+// The definition of the symmetric elliptic integral R_F can be found in NIST
+// Digital Library of Mathematical Functions (http://dlmf.nist.gov/19.16.E1).
 func EllipticRF(x, y, z float64) float64 {
+	// The original Fortran code was published as Algorithm 577 in ACM TOMS (http://doi.org/10.1145/355958.355970).
+	// This code is also available as a part of SLATEC Common Mathematical Library (http://netlib.org/slatec/index.html). Later, Carlson described
+	// an improved version in http://dx.doi.org/10.1007/BF02198293 (also available at https://arxiv.org/abs/math/9409227).
 	const (
 		lower = 5.0 / (1 << 256) / (1 << 256) / (1 << 256) / (1 << 254) // 5*2^-1022
 		upper = 1 / lower
@@ -62,7 +63,7 @@ func EllipticRF(x, y, z float64) float64 {
 	E3 := X * Y * Z
 
 	// http://dlmf.nist.gov/19.36.E1
-	return (E3*(6930*E3+E2*(15015*E2-16380)+17160) + E2*((10010-5775*E2)*E2-24024) + 240240) / (240240 * math.Sqrt(An))
+	return (1 - 1/10.0*E2 + 1/14.0*E3 + 1/24.0*E2*E2 - 3/44.0*E2*E3 - 5/208.0*E2*E2*E2 + 3/104.0*E3*E3 + 1/16.0*E2*E2*E3) / math.Sqrt(An)
 }
 
 // EllipticRD computes the symmetric elliptic integral R_D(x,y,z):
@@ -77,11 +78,12 @@ func EllipticRF(x, y, z float64) float64 {
 //  lower = (5/(2^1022))^(1/3) = 4.809554074311679e-103,
 //  upper = ((2^1022)/5)^(1/3) = 2.079194837087086e+102.
 //
-// The definition of the symmetric elliptic integral R_D can be found in NIST Digital Library of Mathematical Functions
-// (http://dlmf.nist.gov/19.16.E5). The original Fortran code was published as Algorithm 577 in ACM TOMS (http://doi.org/10.1145/355958.355970).
-// This code is also available as a part of SLATEC Common Mathematical Library (http://netlib.org/slatec/index.html). Later, Carlson described
-// an improved version in http://dx.doi.org/10.1007/BF02198293 (also available at https://arxiv.org/abs/math/9409227).
+// The definition of the symmetric elliptic integral R_D can be found in NIST
+// Digital Library of Mathematical Functions (http://dlmf.nist.gov/19.16.E5).
 func EllipticRD(x, y, z float64) float64 {
+	// The original Fortran code was published as Algorithm 577 in ACM TOMS (http://doi.org/10.1145/355958.355970).
+	// This code is also available as a part of SLATEC Common Mathematical Library (http://netlib.org/slatec/index.html). Later, Carlson described
+	// an improved version in http://dx.doi.org/10.1007/BF02198293 (also available at https://arxiv.org/abs/math/9409227).
 	const (
 		lower = 4.8095540743116787026618007863123676393525016818363e-103 // (5*2^-1022)^(1/3)
 		upper = 1 / lower
@@ -123,29 +125,29 @@ func EllipticRD(x, y, z float64) float64 {
 	E5 := X * Y * Z * Z * Z
 
 	// http://dlmf.nist.gov/19.36.E2
-	return ((471240-540540*E2)*E5+(612612*E2-540540*E3-556920)*E4+E3*(306306*E3+E2*(675675*E2-706860)+680680)+E2*((417690-255255*E2)*E2-875160)+4084080)/(4084080*mul*An*math.Sqrt(An)) + 3*s
+	return (1-3/14.0*E2+1/6.0*E3+9/88.0*E2*E2-3/22.0*E4-9/52.0*E2*E3+3/26.0*E5-1/16.0*E2*E2*E2+3/40.0*E3*E3+3/20.0*E2*E4+45/272.0*E2*E2*E3-9/68.0*(E3*E4+E2*E5))/(mul*An*math.Sqrt(An)) + 3*s
 }
 
-// EllipticF computes the Legendre's elliptic integral of the 1st kind F(\phi|m), 0≤m<1:
-//  F(\phi|m) = \int_{0}^{\phi} 1 / \sqrt{1-m\sin^2(\theta)} d\theta
+// EllipticF computes the Legendre's elliptic integral of the 1st kind F(phi,m), 0≤m<1:
+//  F(\phi,m) = \int_{0}^{\phi} 1 / \sqrt{1-m\sin^2(\theta)} d\theta
 //
 // Legendre's elliptic integrals can be expressed as symmetric elliptic integrals, in this case:
-//  F(\phi|m) = \sin\phi R_F(\cos^2\phi,1-m\sin^2\phi,1)
+//  F(\phi,m) = \sin\phi R_F(\cos^2\phi,1-m\sin^2\phi,1)
 //
-// The definition of F(\phi,k) where k=\sqrt{m} can be found in NIST Digital Library of Mathematical
+// The definition of F(phi,k) where k=sqrt(m) can be found in NIST Digital Library of Mathematical
 // Functions (http://dlmf.nist.gov/19.2.E4).
 func EllipticF(phi, m float64) float64 {
 	s, c := math.Sincos(phi)
 	return s * EllipticRF(c*c, 1-m*s*s, 1)
 }
 
-// EllipticE computes the Legendre's elliptic integral of the 2nd kind E(\phi|m), 0≤m<1:
-//  E(\phi|m) = \int_{0}^{\phi} \sqrt{1-m\sin^2(\theta)} d\theta
+// EllipticE computes the Legendre's elliptic integral of the 2nd kind E(phi,m), 0≤m<1:
+//  E(\phi,m) = \int_{0}^{\phi} \sqrt{1-m\sin^2(\theta)} d\theta
 //
 // Legendre's elliptic integrals can be expressed as symmetric elliptic integrals, in this case:
-//  E(\phi|m) = \sin\phi R_F(\cos^2\phi,1-m\sin^2\phi,1)-(m/3)\sin^3\phi R_D(\cos^2\phi,1-m\sin^2\phi,1)
+//  E(\phi,m) = \sin\phi R_F(\cos^2\phi,1-m\sin^2\phi,1)-(m/3)\sin^3\phi R_D(\cos^2\phi,1-m\sin^2\phi,1)
 //
-// The definition of E(\phi,k) where k=\sqrt{m} can be found in NIST Digital Library of Mathematical
+// The definition of E(phi,k) where k=sqrt(m) can be found in NIST Digital Library of Mathematical
 // Functions (http://dlmf.nist.gov/19.2.E5).
 func EllipticE(phi, m float64) float64 {
 	s, c := math.Sincos(phi)

--- a/mathext/ell_carlson.go
+++ b/mathext/ell_carlson.go
@@ -8,19 +8,19 @@ import (
 	"math"
 )
 
-// CarlsonRF computes the symmetric elliptic integral R_F(x,y,z):
+// EllipticRF computes the symmetric elliptic integral R_F(x,y,z):
 //
-//	R_F(x,y,z) = (1/2)\int_{0}^{\infty}{s^{-1}(t)} dt,
-//	s(t) = \sqrt{t+x}\sqrt{t+y}\sqrt{t+z}.
+//	R_F(x,y,z) = (1/2)\int_{0}^{\infty}{1/s(t)} dt,
+//	s(t) = \sqrt{(t+x)(t+y)(t+z)}.
 //
 // See: http://dlmf.nist.gov/19.16.E1 for the definition.
 //
 // See: http://doi.org/10.1145/355958.355970 for the original Fortran code.
 //
 // See: http://dx.doi.org/10.1007/BF02198293 for the modified method of computation.
-func CarlsonRF(x, y, z float64) float64 {
+func EllipticRF(x, y, z float64) float64 {
 	const (
-		lower = 1.1125369292536006915451163586662020321096079902312e-307 // 5*2^-1022
+		lower = 5.0 / (1 << 256) / (1 << 256) / (1 << 256) / (1 << 254) // 5*2^-1022
 		upper = 1 / lower
 		tol   = 1.2674918778210762260320167734407048051023273568443e-02 // (3ε)^(1/8)
 	)
@@ -60,17 +60,17 @@ func CarlsonRF(x, y, z float64) float64 {
 	return (E3*(6930*E3+E2*(15015*E2-16380)+17160) + E2*((10010-5775*E2)*E2-24024) + 240240) / (240240 * math.Sqrt(An))
 }
 
-// CarlsonRD computes the symmetric elliptic integral R_D(x,y,z):
+// EllipticRD computes the symmetric elliptic integral R_D(x,y,z):
 //
-//	R_D(x,y,z) = (1/2)\int_{0}^{\infty}{s^{-1}(t)}{(t+z)^{-1}} dt,
-//	s(t) = \sqrt{t+x}\sqrt{t+y}\sqrt{t+z}.
+//	R_D(x,y,z) = (1/2)\int_{0}^{\infty}{1/(s(t)(t+z))} dt,
+//	s(t) = \sqrt{(t+x)(t+y)(t+z)}.
 //
 // See: http://dlmf.nist.gov/19.16.E5 for the definition.
 //
 // See: http://doi.org/10.1145/355958.355970 for the original Fortran code.
 //
 // See: http://dx.doi.org/10.1007/BF02198293 for the modified method of computation.
-func CarlsonRD(x, y, z float64) float64 {
+func EllipticRD(x, y, z float64) float64 {
 	const (
 		lower = 4.8095540743116787026618007863123676393525016818363e-103 // (5*2^-1022)^(1/3)
 		upper = 1 / lower
@@ -126,7 +126,7 @@ func CarlsonRD(x, y, z float64) float64 {
 // See http://dlmf.nist.gov/19.2.E4 for the definition.
 func EllipticF(phi, m float64) float64 {
 	s, c := math.Sincos(phi)
-	return s * CarlsonRF(c*c, 1-m*s*s, 1)
+	return s * EllipticRF(c*c, 1-m*s*s, 1)
 }
 
 // EllipticE computes the Legendre's elliptic integral of the 2nd kind E(\phi|m):
@@ -141,5 +141,5 @@ func EllipticF(phi, m float64) float64 {
 func EllipticE(phi, m float64) float64 {
 	s, c := math.Sincos(phi)
 	x, y := c*c, 1-m*s*s
-	return s * (CarlsonRF(x, y, 1) - (m/3)*s*s*CarlsonRD(x, y, 1))
+	return s * (EllipticRF(x, y, 1) - (m/3)*s*s*EllipticRD(x, y, 1))
 }

--- a/mathext/ell_carlson.go
+++ b/mathext/ell_carlson.go
@@ -19,8 +19,11 @@ import (
 //
 // See: http://dx.doi.org/10.1007/BF02198293 for the modified method of computation.
 func CarlsonRF(x, y, z float64) float64 {
-	const lower = 1.1125369292536006915451163586662020321096079902312e-307 // 5*2^-1022
-	const upper = 1 / lower
+	const (
+		lower = 1.1125369292536006915451163586662020321096079902312e-307 // 5*2^-1022
+		upper = 1 / lower
+		tol   = 1.2674918778210762260320167734407048051023273568443e-02 // (3ε)^(1/8)
+	)
 	if x < 0 || y < 0 || z < 0 || math.IsNaN(x) || math.IsNaN(y) || math.IsNaN(z) {
 		return math.NaN()
 	}
@@ -31,7 +34,6 @@ func CarlsonRF(x, y, z float64) float64 {
 		return math.NaN()
 	}
 
-	const tol = 1.2674918778210762260320167734407048051023273568443e-02 // (3ε)^(1/8)
 	A0 := (x + y + z) / 3
 	An := A0
 	Q := math.Max(math.Max(math.Abs(A0-x), math.Abs(A0-y)), math.Abs(A0-z)) / tol
@@ -69,8 +71,11 @@ func CarlsonRF(x, y, z float64) float64 {
 //
 // See: http://dx.doi.org/10.1007/BF02198293 for the modified method of computation.
 func CarlsonRD(x, y, z float64) float64 {
-	const lower = 4.8095540743116787026618007863123676393525016818363e-103 // (5*2^-1022)^(1/3)
-	const upper = 1 / lower
+	const (
+		lower = 4.8095540743116787026618007863123676393525016818363e-103 // (5*2^-1022)^(1/3)
+		upper = 1 / lower
+		tol   = 9.0351169339315770474760122547068324993857488849382e-03 // (ε/5)^(1/8)
+	)
 	if x < 0 || y < 0 || math.IsNaN(x) || math.IsNaN(y) || math.IsNaN(z) {
 		return math.NaN()
 	}
@@ -81,7 +86,6 @@ func CarlsonRD(x, y, z float64) float64 {
 		return math.NaN()
 	}
 
-	const tol = 9.03511693393157704747601225470683249938574888493817e-03 // (ε/5)^(1/8)
 	A0 := (x + y + 3*z) / 5
 	An := A0
 	Q := math.Max(math.Max(math.Abs(A0-x), math.Abs(A0-y)), math.Abs(A0-z)) / tol

--- a/mathext/ell_carlson_test.go
+++ b/mathext/ell_carlson_test.go
@@ -13,7 +13,7 @@ import (
 // Testing EllipticF (and CarlsonRF) using the addition theorems from http://dlmf.nist.gov/19.11.i
 func TestEllipticF(t *testing.T) {
 	const tol = 1.0e-14
-	rng := rand.New(rand.NewSource(271829))
+	rng := rand.New(rand.NewSource(1))
 
 	for test := 0; test < 100; test++ {
 		alpha := rng.Float64() * math.Pi / 4
@@ -38,7 +38,7 @@ func TestEllipticF(t *testing.T) {
 // Testing EllipticE (and CarlsonRF, CarlsonRD) using the addition theorems from http://dlmf.nist.gov/19.11.i
 func TestEllipticE(t *testing.T) {
 	const tol = 1.0e-14
-	rng := rand.New(rand.NewSource(271829))
+	rng := rand.New(rand.NewSource(1))
 
 	for test := 0; test < 100; test++ {
 		alpha := rng.Float64() * math.Pi / 4

--- a/mathext/ell_carlson_test.go
+++ b/mathext/ell_carlson_test.go
@@ -13,11 +13,32 @@ import (
 // Testing EllipticF (and EllipticRF) using the addition theorems from http://dlmf.nist.gov/19.11.i
 func TestEllipticF(t *testing.T) {
 	const tol = 1.0e-14
-	rng := rand.New(rand.NewSource(1))
+	rnd := rand.New(rand.NewSource(1))
+
+	// The following EllipticF(pi/3,m), m=0.1(0.1)0.9 was computed in Maxima 5.38.0 using Bigfloat arithmetic.
+	vF := [...]float64{
+		1.0631390181954904767742338285104637431858016483079,
+		1.0803778062523490005579242592072579594037132891908,
+		1.0991352230920430074586978843452269008747645822123,
+		1.1196949183404746257742176145632376703505764745654,
+		1.1424290580457772555013955266260457822322036529624,
+		1.1678400583161860445148860686430780757517286094732,
+		1.1966306515644649360767197589467723191317720122309,
+		1.2298294422249382706933871574135731278765534034979,
+		1.2690359140762658660446752406901433173504503955036,
+	}
+	phi := math.Pi / 3
+	for m := 1; m <= 9; m++ {
+		mf := float64(m) / 10
+		delta := math.Abs(EllipticF(phi, mf) - vF[m-1])
+		if delta > tol {
+			t.Fatalf("EllipticF(pi/3,m) test fail for m=%v", mf)
+		}
+	}
 
 	for test := 0; test < 100; test++ {
-		alpha := rng.Float64() * math.Pi / 4
-		beta := rng.Float64() * math.Pi / 4
+		alpha := rnd.Float64() * math.Pi / 4
+		beta := rnd.Float64() * math.Pi / 4
 		for mi := 0; mi < 9999; mi++ {
 			m := float64(mi) / 10000
 			Fa := EllipticF(alpha, m)
@@ -38,11 +59,32 @@ func TestEllipticF(t *testing.T) {
 // Testing EllipticE (and EllipticRF, EllipticRD) using the addition theorems from http://dlmf.nist.gov/19.11.i
 func TestEllipticE(t *testing.T) {
 	const tol = 1.0e-14
-	rng := rand.New(rand.NewSource(1))
+	rnd := rand.New(rand.NewSource(1))
+
+	// The following EllipticE(pi/3,m), m=0.1(0.1)0.9 was computed in Maxima 5.38.0 using Bigfloat arithmetic.
+	vE := [...]float64{
+		1.0316510822817691068014397636905610074934300946730,
+		1.0156973658341766636288643556414001451527597364432,
+		9.9929636467826398814855428365155224243586391115108e-1,
+		9.8240033979859736941287149003648737502960015189033e-1,
+		9.6495145764299257550956863602992167490195750321518e-1,
+		9.4687829659158090935158610908054896203271861698355e-1,
+		9.2809053417715769009517654522979827392794124845027e-1,
+		9.0847044378047233264777277954768245721857017157916e-1,
+		8.8785835036531301307661603341327881634688308777383e-1,
+	}
+	phi := math.Pi / 3
+	for m := 1; m <= 9; m++ {
+		mf := float64(m) / 10
+		delta := math.Abs(EllipticE(phi, mf) - vE[m-1])
+		if delta > tol {
+			t.Fatalf("EllipticE(pi/3,m) test fail for m=%v", mf)
+		}
+	}
 
 	for test := 0; test < 100; test++ {
-		alpha := rng.Float64() * math.Pi / 4
-		beta := rng.Float64() * math.Pi / 4
+		alpha := rnd.Float64() * math.Pi / 4
+		beta := rnd.Float64() * math.Pi / 4
 		for mi := 0; mi < 9999; mi++ {
 			m := float64(mi) / 10000
 			Ea := EllipticE(alpha, m)

--- a/mathext/ell_carlson_test.go
+++ b/mathext/ell_carlson_test.go
@@ -1,0 +1,61 @@
+// Copyright ©2017 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mathext
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// Testing EllipticF (and CarlsonRF) using the addition theorems from http://dlmf.nist.gov/19.11.i
+func TestEllipticF(t *testing.T) {
+	const tol = 1.0e-14
+	rng := rand.New(rand.NewSource(271829))
+
+	for test := 0; test < 100; test++ {
+		alpha := rng.Float64() * math.Pi / 4
+		beta := rng.Float64() * math.Pi / 4
+		for mi := 0; mi < 9999; mi++ {
+			m := float64(mi) / 10000
+			Fa := EllipticF(alpha, m)
+			Fb := EllipticF(beta, m)
+			sina, cosa := math.Sincos(alpha)
+			sinb, cosb := math.Sincos(beta)
+			tan := (sina*math.Sqrt(1-m*sinb*sinb) + sinb*math.Sqrt(1-m*sina*sina)) / (cosa + cosb)
+			gamma := 2 * math.Atan(tan)
+			Fg := EllipticF(gamma, m)
+			delta := math.Abs(Fa + Fb - Fg)
+			if delta > tol {
+				t.Fatalf("EllipticF test fail for m=%v, alpha=%v, beta=%v", m, alpha, beta)
+			}
+		}
+	}
+}
+
+// Testing EllipticE (and CarlsonRF, CarlsonRD) using the addition theorems from http://dlmf.nist.gov/19.11.i
+func TestEllipticE(t *testing.T) {
+	const tol = 1.0e-14
+	rng := rand.New(rand.NewSource(271829))
+
+	for test := 0; test < 100; test++ {
+		alpha := rng.Float64() * math.Pi / 4
+		beta := rng.Float64() * math.Pi / 4
+		for mi := 0; mi < 9999; mi++ {
+			m := float64(mi) / 10000
+			Ea := EllipticE(alpha, m)
+			Eb := EllipticE(beta, m)
+			sina, cosa := math.Sincos(alpha)
+			sinb, cosb := math.Sincos(beta)
+			tan := (sina*math.Sqrt(1-m*sinb*sinb) + sinb*math.Sqrt(1-m*sina*sina)) / (cosa + cosb)
+			gamma := 2 * math.Atan(tan)
+			Eg := EllipticE(gamma, m)
+			delta := math.Abs(Ea + Eb - Eg - m*sina*sinb*math.Sin(gamma))
+			if delta > tol {
+				t.Fatalf("EllipticE test fail for m=%v, alpha=%v, beta=%v", m, alpha, beta)
+			}
+		}
+	}
+}

--- a/mathext/ell_carlson_test.go
+++ b/mathext/ell_carlson_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-// Testing EllipticF (and CarlsonRF) using the addition theorems from http://dlmf.nist.gov/19.11.i
+// Testing EllipticF (and EllipticRF) using the addition theorems from http://dlmf.nist.gov/19.11.i
 func TestEllipticF(t *testing.T) {
 	const tol = 1.0e-14
 	rng := rand.New(rand.NewSource(1))
@@ -35,7 +35,7 @@ func TestEllipticF(t *testing.T) {
 	}
 }
 
-// Testing EllipticE (and CarlsonRF, CarlsonRD) using the addition theorems from http://dlmf.nist.gov/19.11.i
+// Testing EllipticE (and EllipticRF, EllipticRD) using the addition theorems from http://dlmf.nist.gov/19.11.i
 func TestEllipticE(t *testing.T) {
 	const tol = 1.0e-14
 	rng := rand.New(rand.NewSource(1))


### PR DESCRIPTION
Added Carlson's symmetric elliptic integrals RF and RD. Added Legendre's elliptic integrals of the 1st and 2nd kinds.