### PR TITLE
graph: revert NewNodeID -> NewNode

### DIFF
--- a/graph/encoding/dot/decode.go
+++ b/graph/encoding/dot/decode.go
@@ -17,8 +17,6 @@ import (
 type Builder interface {
 	graph.Graph
 	graph.Builder
-	// NewNode adds a new node with a unique node ID to the graph.
-	NewNode() graph.Node
 	// NewEdge adds a new edge from the source to the destination node to the
 	// graph, or returns the existing edge if already present.
 	NewEdge(from, to graph.Node) graph.Edge

--- a/graph/encoding/dot/decode_test.go
+++ b/graph/encoding/dot/decode_test.go
@@ -114,7 +114,7 @@ func newDotDirectedGraph() *dotDirectedGraph {
 
 // NewNode adds a new node with a unique node ID to the graph.
 func (g *dotDirectedGraph) NewNode() graph.Node {
-	n := &dotNode{Node: simple.Node(g.NewNodeID())}
+	n := &dotNode{Node: g.DirectedGraph.NewNode()}
 	g.AddNode(n)
 	return n
 }
@@ -157,7 +157,7 @@ func newDotUndirectedGraph() *dotUndirectedGraph {
 
 // NewNode adds a new node with a unique node ID to the graph.
 func (g *dotUndirectedGraph) NewNode() graph.Node {
-	n := &dotNode{Node: simple.Node(g.NewNodeID())}
+	n := &dotNode{Node: g.UndirectedGraph.NewNode()}
 	g.AddNode(n)
 	return n
 }
@@ -186,7 +186,7 @@ func (g *dotUndirectedGraph) DOTUnmarshalerAttrs() (graph, node, edge Unmarshale
 // dotNode extends simple.Node with a label field to test round-trip encoding
 // and decoding of node DOT label attributes.
 type dotNode struct {
-	simple.Node
+	graph.Node
 	dotID string
 	// Node label.
 	Label string

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -76,8 +76,9 @@ type Weighter interface {
 
 // NodeAdder is an interface for adding arbitrary nodes to a graph.
 type NodeAdder interface {
-	// NewNodeID returns a new unique arbitrary ID.
-	NewNodeID() int64
+	// NewNode returns a new Node with a unique
+	// arbitrary ID.
+	NewNode() Node
 
 	// Adds a node to the graph. AddNode panics if
 	// the added node ID matches an existing node ID.

--- a/graph/graphs/gen/duplication.go
+++ b/graph/graphs/gen/duplication.go
@@ -59,13 +59,13 @@ func Duplication(dst UndirectedMutator, n int, delta, alpha, sigma float64, src 
 	sort.Sort(ordered.ByID(nodes))
 	if len(nodes) == 0 {
 		n--
-		u := simple.Node(dst.NewNodeID())
+		u := dst.NewNode()
 		dst.AddNode(u)
 		nodes = append(nodes, u)
 	}
 	for i := 0; i < n; i++ {
 		u := nodes[rndN(len(nodes))]
-		d := simple.Node(dst.NewNodeID())
+		d := dst.NewNode()
 
 		// Add the duplicate node.
 		dst.AddNode(d)

--- a/graph/simple/directed.go
+++ b/graph/simple/directed.go
@@ -36,16 +36,16 @@ func NewDirectedGraph(self, absent float64) *DirectedGraph {
 	}
 }
 
-// NewNodeID returns a new unique ID for a node to be added to g. The returned ID does
-// not become a valid ID in g until it is added to g.
-func (g *DirectedGraph) NewNodeID() int64 {
+// NewNode returns a new unique Node to be added to g. The Node's ID does
+// not become valid in g until the Node is added to g.
+func (g *DirectedGraph) NewNode() graph.Node {
 	if len(g.nodes) == 0 {
-		return 0
+		return Node(0)
 	}
 	if int64(len(g.nodes)) == maxInt {
 		panic("simple: cannot allocate node: no slot")
 	}
-	return g.nodeIDs.newID()
+	return Node(g.nodeIDs.newID())
 }
 
 // AddNode adds n to the graph. It panics if the added node ID matches an existing node ID.

--- a/graph/simple/directed_test.go
+++ b/graph/simple/directed_test.go
@@ -50,14 +50,14 @@ func TestIssue123DirectedGraph(t *testing.T) {
 	}()
 	g := NewDirectedGraph(0, math.Inf(1))
 
-	n0 := Node(g.NewNodeID())
+	n0 := g.NewNode()
 	g.AddNode(n0)
 
-	n1 := Node(g.NewNodeID())
+	n1 := g.NewNode()
 	g.AddNode(n1)
 
 	g.RemoveNode(n0)
 
-	n2 := Node(g.NewNodeID())
+	n2 := g.NewNode()
 	g.AddNode(n2)
 }

--- a/graph/simple/undirected.go
+++ b/graph/simple/undirected.go
@@ -34,16 +34,16 @@ func NewUndirectedGraph(self, absent float64) *UndirectedGraph {
 	}
 }
 
-// NewNodeID returns a new unique ID for a node to be added to g. The returned ID does
-// not become a valid ID in g until it is added to g.
-func (g *UndirectedGraph) NewNodeID() int64 {
+// NewNode returns a new unique Node to be added to g. The Node's ID does
+// not become valid in g until the Node is added to g.
+func (g *UndirectedGraph) NewNode() graph.Node {
 	if len(g.nodes) == 0 {
-		return 0
+		return Node(0)
 	}
 	if int64(len(g.nodes)) == maxInt {
 		panic("simple: cannot allocate node: no slot")
 	}
-	return g.nodeIDs.newID()
+	return Node(g.nodeIDs.newID())
 }
 
 // AddNode adds n to the graph. It panics if the added node ID matches an existing node ID.

--- a/graph/simple/undirected_test.go
+++ b/graph/simple/undirected_test.go
@@ -31,7 +31,7 @@ func TestMaxID(t *testing.T) {
 	delete(nodes, Node(0))
 	g.RemoveNode(Node(2))
 	delete(nodes, Node(2))
-	n := Node(g.NewNodeID())
+	n := g.NewNode()
 	g.AddNode(n)
 	if !g.Has(n) {
 		t.Error("added node does not exist in graph")
@@ -50,14 +50,14 @@ func TestIssue123UndirectedGraph(t *testing.T) {
 	}()
 	g := NewUndirectedGraph(0, math.Inf(1))
 
-	n0 := Node(g.NewNodeID())
+	n0 := g.NewNode()
 	g.AddNode(n0)
 
-	n1 := Node(g.NewNodeID())
+	n1 := g.NewNode()
 	g.AddNode(n1)
 
 	g.RemoveNode(n0)
 
-	n2 := Node(g.NewNodeID())
+	n2 := g.NewNode()
 	g.AddNode(n2)
 }


### PR DESCRIPTION
@mewmew @vladimir-ch @btracey Please take a look.

This is a minimal change. The rationale is explained in the issue, but briefly, by returning a `graph.Node` rather than an `int64`, the destination graph can decide what type of node is added, where previously this was hard coded into the filling function. A good example is in the duplication.go file which generates random duplication graphs.

Fixes #59.