### PR TITLE
graph: change documentation to allow self edges

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -99,8 +99,9 @@ type EdgeSetter interface {
 	// If the graph supports node addition the nodes
 	// will be added if they do not exist, otherwise
 	// SetEdge will panic.
-	// If the IDs returned by e.From and e.To are
-	// equal, SetEdge will panic.
+	// The behavior of an EdgeSetter when the IDs
+	// returned by e.From and e.To are equal is
+	// implementation-dependent.
 	SetEdge(e Edge)
 }
 


### PR DESCRIPTION
No behaviour change; package simple graphs still panic for addition of self
edges, as noted in their existing documentation.