### PR TITLE
Add a badge for Go Report Card

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Konstantin Shaposhnikov <k.shaposhnikov@gmail.com>
 Leonid Kneller <recondite.matter@gmail.com>
 Lyron Winderbaum <lyron.winderbaum@student.adelaide.edu.au>
 Matthieu Di Mercurio <matthieu.dimercurio@gmail.com>
+MinJae Kwon <k239507@gmail.com>
 Or Rikon <rikonor@gmail.com>
 Pontus Melke <pontusmelke@gmail.com>
 Renée French

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -38,6 +38,7 @@ Konstantin Shaposhnikov <k.shaposhnikov@gmail.com>
 Leonid Kneller <recondite.matter@gmail.com>
 Lyron Winderbaum <lyron.winderbaum@student.adelaide.edu.au>
 Matthieu Di Mercurio <matthieu.dimercurio@gmail.com>
+MinJae Kwon <k239507@gmail.com>
 Or Rikon <rikonor@gmail.com>
 Pontus Melke <pontusmelke@gmail.com>
 Renée French

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gonum [![Build Status](https://travis-ci.org/gonum/gonum.svg?branch=master)](https://travis-ci.org/gonum/gonum) [![Coverage Status](https://coveralls.io/repos/gonum/gonum/badge.svg?branch=master&service=github)](https://coveralls.io/github/gonum/gonum?branch=master) [![GoDoc](https://godoc.org/gonum.org/v1/gonum?status.svg)](https://godoc.org/gonum.org/v1/gonum)
+# Gonum [![Build Status](https://travis-ci.org/gonum/gonum.svg?branch=master)](https://travis-ci.org/gonum/gonum) [![Coverage Status](https://coveralls.io/repos/gonum/gonum/badge.svg?branch=master&service=github)](https://coveralls.io/github/gonum/gonum?branch=master) [![GoDoc](https://godoc.org/gonum.org/v1/gonum?status.svg)](https://godoc.org/gonum.org/v1/gonum) [![Go Report Card](https://goreportcard.com/badge/github.com/gonum/gonum)](https://goreportcard.com/report/github.com/gonum/gonum)
 
 ## Issues
 


### PR DESCRIPTION
I've added a badge for [Go Report Card](https://goreportcard.com/) which reports the quality of an open source go project using `gofmt`, `go vet` and so on. 

This allows users to see at a glance how well the source code is formatted.