### PR TITLE
stat/all: reduce random size and test tolerance to decrease testing t…

### DIFF
--- a/stat/distmat/wishart_test.go
+++ b/stat/distmat/wishart_test.go
@@ -94,7 +94,7 @@ func TestWishartRand(t *testing.T) {
 		{
 			v:       mat.NewSymDense(3, []float64{0.8, 0.3, 0.1, 0.3, 0.7, -0.1, 0.1, -0.1, 7}),
 			nu:      5,
-			samples: 300000,
+			samples: 30000,
 			tol:     3e-2,
 		},
 		{
@@ -104,8 +104,8 @@ func TestWishartRand(t *testing.T) {
 				0.1, -0.1, 7, 1,
 				-0.2, -0.1, 1, 6}),
 			nu:      6,
-			samples: 300000,
-			tol:     3e-2,
+			samples: 30000,
+			tol:     1e-1,
 		},
 	} {
 		rnd := rand.New(rand.NewSource(1))

--- a/stat/distmv/dirichlet_test.go
+++ b/stat/distmv/dirichlet_test.go
@@ -39,34 +39,29 @@ func TestDirichlet(t *testing.T) {
 	rnd := rand.New(rand.NewSource(1))
 	for cas, test := range []struct {
 		Dir *Dirichlet
-		N   int
 	}{
 		{
 			NewDirichlet([]float64{1, 1, 1}, rnd),
-			1e6,
 		},
 		{
 			NewDirichlet([]float64{2, 3}, rnd),
-			1e6,
 		},
 		{
 			NewDirichlet([]float64{0.2, 0.3}, rnd),
-			1e6,
 		},
 		{
 			NewDirichlet([]float64{0.2, 4}, rnd),
-			1e6,
 		},
 		{
 			NewDirichlet([]float64{0.1, 4, 20}, rnd),
-			1e6,
 		},
 	} {
+		const n = 1e5
 		d := test.Dir
 		dim := d.Dim()
-		x := mat.NewDense(test.N, dim, nil)
+		x := mat.NewDense(n, dim, nil)
 		generateSamples(x, d)
-		checkMean(t, cas, x, d, 1e-3)
-		checkCov(t, cas, x, d, 1e-3)
+		checkMean(t, cas, x, d, 1e-2)
+		checkCov(t, cas, x, d, 1e-2)
 	}
 }

--- a/stat/distmv/studentst_test.go
+++ b/stat/distmv/studentst_test.go
@@ -85,7 +85,7 @@ func TestStudentTProbs(t *testing.T) {
 
 func TestStudentsTRand(t *testing.T) {
 	src := rand.New(rand.NewSource(1))
-	for _, test := range []struct {
+	for cas, test := range []struct {
 		mean   []float64
 		cov    *mat.SymDense
 		nu     float64
@@ -94,7 +94,7 @@ func TestStudentsTRand(t *testing.T) {
 		{
 			mean:   []float64{0, 0},
 			cov:    mat.NewSymDense(2, []float64{1, 0, 0, 1}),
-			nu:     3,
+			nu:     4,
 			tolcov: 1e-2,
 		},
 		{
@@ -114,7 +114,7 @@ func TestStudentsTRand(t *testing.T) {
 		if !ok {
 			t.Fatal("bad test")
 		}
-		nSamples := 10000000
+		const nSamples = 1e6
 		dim := len(test.mean)
 		samps := mat.NewDense(nSamples, dim, nil)
 		for i := 0; i < nSamples; i++ {
@@ -131,7 +131,7 @@ func TestStudentsTRand(t *testing.T) {
 		cov := s.CovarianceMatrix(nil)
 		estCov := stat.CovarianceMatrix(nil, samps, nil)
 		if !mat.EqualApprox(estCov, cov, test.tolcov) {
-			t.Errorf("Cov mismatch: want: %v, got %v", cov, estCov)
+			t.Errorf("Case %d: Cov mismatch: want: %v, got %v", cas, cov, estCov)
 		}
 	}
 }

--- a/stat/distuv/beta_test.go
+++ b/stat/distuv/beta_test.go
@@ -45,7 +45,7 @@ func TestBetaRand(t *testing.T) {
 
 func testBeta(t *testing.T, b Beta, i int) {
 	tol := 1e-2
-	const n = 1e6
+	const n = 5e4
 	const bins = 10
 	x := make([]float64, n)
 	generateSamples(x, b)

--- a/stat/distuv/chisquared_test.go
+++ b/stat/distuv/chisquared_test.go
@@ -63,7 +63,7 @@ func TestChiSquared(t *testing.T) {
 
 func testChiSquared(t *testing.T, c ChiSquared, i int) {
 	tol := 1e-2
-	const n = 2e6
+	const n = 1e5
 	const bins = 50
 	x := make([]float64, n)
 	generateSamples(x, c)
@@ -72,7 +72,7 @@ func testChiSquared(t *testing.T, c ChiSquared, i int) {
 	testRandLogProbContinuous(t, i, 0, x, c, tol, bins)
 	checkMean(t, i, x, c, tol)
 	checkVarAndStd(t, i, x, c, tol)
-	checkExKurtosis(t, i, x, c, 5e-2)
+	checkExKurtosis(t, i, x, c, 7e-2)
 	checkProbContinuous(t, i, x, c, 1e-3)
-	checkQuantileCDFSurvival(t, i, x, c, 1e-3)
+	checkQuantileCDFSurvival(t, i, x, c, 1e-2)
 }

--- a/stat/distuv/f_test.go
+++ b/stat/distuv/f_test.go
@@ -72,7 +72,7 @@ func TestF(t *testing.T) {
 func testF(t *testing.T, f F, i int) {
 	const (
 		tol  = 1e-2
-		n    = 2e6
+		n    = 1e5
 		bins = 50
 	)
 	x := make([]float64, n)
@@ -83,7 +83,7 @@ func testF(t *testing.T, f F, i int) {
 	checkProbContinuous(t, i, x, f, 1e-3)
 	checkMean(t, i, x, f, tol)
 	checkVarAndStd(t, i, x, f, tol)
-	checkExKurtosis(t, i, x, f, 5e-2)
-	checkSkewness(t, i, x, f, tol)
-	checkQuantileCDFSurvival(t, i, x, f, 1e-3)
+	checkExKurtosis(t, i, x, f, 1e-1)
+	checkSkewness(t, i, x, f, 5e-2)
+	checkQuantileCDFSurvival(t, i, x, f, 5e-3)
 }

--- a/stat/distuv/gamma_test.go
+++ b/stat/distuv/gamma_test.go
@@ -47,8 +47,8 @@ func TestGamma(t *testing.T) {
 
 func testGamma(t *testing.T, f Gamma, i int) {
 	// TODO(btracey): Replace this when Gamma implements FullDist.
-	tol := 2e-3
-	const n = 1e6
+	tol := 1e-2
+	const n = 1e5
 	const bins = 50
 	x := make([]float64, n)
 	generateSamples(x, f)
@@ -57,7 +57,7 @@ func testGamma(t *testing.T, f Gamma, i int) {
 	testRandLogProbContinuous(t, i, 0, x, f, tol, bins)
 	checkMean(t, i, x, f, tol)
 	checkVarAndStd(t, i, x, f, 2e-2)
-	checkExKurtosis(t, i, x, f, 5e-2)
+	checkExKurtosis(t, i, x, f, 2e-1)
 	checkProbContinuous(t, i, x, f, 1e-3)
-	checkQuantileCDFSurvival(t, i, x, f, 1e-2)
+	checkQuantileCDFSurvival(t, i, x, f, 5e-2)
 }

--- a/stat/distuv/lognormal_test.go
+++ b/stat/distuv/lognormal_test.go
@@ -4,7 +4,10 @@
 
 package distuv
 
-import "testing"
+import (
+	"sort"
+	"testing"
+)
 
 func TestLognormal(t *testing.T) {
 	for i, dist := range []LogNormal{
@@ -21,6 +24,21 @@ func TestLognormal(t *testing.T) {
 			Sigma: 0.01,
 		},
 	} {
-		testFullDist(t, dist, i, true)
+		f := dist
+		tol := 1e-2
+		const n = 1e5
+		x := make([]float64, n)
+		generateSamples(x, f)
+		sort.Float64s(x)
+
+		checkMean(t, i, x, f, tol)
+		checkVarAndStd(t, i, x, f, tol)
+		checkEntropy(t, i, x, f, tol)
+		checkExKurtosis(t, i, x, f, 2e-1)
+		checkSkewness(t, i, x, f, 5e-2)
+		checkMedian(t, i, x, f, tol)
+		checkQuantileCDFSurvival(t, i, x, f, tol)
+		checkProbContinuous(t, i, x, f, 1e-10)
+		checkProbQuantContinuous(t, i, x, f, tol)
 	}
 }

--- a/stat/distuv/studentst_test.go
+++ b/stat/distuv/studentst_test.go
@@ -45,7 +45,7 @@ func TestStudentsT(t *testing.T) {
 
 func testStudentsT(t *testing.T, c StudentsT, i int) {
 	tol := 1e-2
-	const n = 1e6
+	const n = 1e5
 	const bins = 50
 	x := make([]float64, n)
 	generateSamples(x, c)
@@ -54,7 +54,7 @@ func testStudentsT(t *testing.T, c StudentsT, i int) {
 	testRandLogProbContinuous(t, i, math.Inf(-1), x, c, tol, bins)
 	checkMean(t, i, x, c, tol)
 	if c.Nu > 2 {
-		checkVarAndStd(t, i, x, c, tol)
+		checkVarAndStd(t, i, x, c, 5e-2)
 	}
 	checkProbContinuous(t, i, x, c, 1e-3)
 	checkQuantileCDFSurvival(t, i, x, c, tol)

--- a/stat/distuv/triangle.go
+++ b/stat/distuv/triangle.go
@@ -18,9 +18,9 @@ type Triangle struct {
 // NewTriangle constructs a new triangle distribution with lower limit a, upper limit b, and mode c.
 // Constraints are a < b and a ≤ c ≤ b.
 // This distribution is uncommon in nature, but may be useful for simulation.
-func NewTriangle(a, b, c float64) Triangle {
+func NewTriangle(a, b, c float64, src *rand.Rand) Triangle {
 	checkTriangleParameters(a, b, c)
-	return Triangle{a, b, c, nil}
+	return Triangle{a, b, c, src}
 }
 
 func checkTriangleParameters(a, b, c float64) {

--- a/stat/distuv/triangle.go
+++ b/stat/distuv/triangle.go
@@ -18,9 +18,9 @@ type Triangle struct {
 // NewTriangle constructs a new triangle distribution with lower limit a, upper limit b, and mode c.
 // Constraints are a < b and a ≤ c ≤ b.
 // This distribution is uncommon in nature, but may be useful for simulation.
-func NewTriangle(a, b, c float64, src *rand.Rand) Triangle {
+func NewTriangle(a, b, c float64) Triangle {
 	checkTriangleParameters(a, b, c)
-	return Triangle{a, b, c, src}
+	return Triangle{a, b, c, nil}
 }
 
 func checkTriangleParameters(a, b, c float64) {

--- a/stat/distuv/triangle_test.go
+++ b/stat/distuv/triangle_test.go
@@ -6,6 +6,8 @@ package distuv
 
 import (
 	"math"
+	"math/rand"
+	"sort"
 	"testing"
 )
 
@@ -17,12 +19,13 @@ func TestTriangleConstraint(t *testing.T) {
 	}()
 
 	// test b < a
-	NewTriangle(3, 1, 2)
+	NewTriangle(3, 1, 2, nil)
 	// test c > b
-	NewTriangle(1, 2, 3)
+	NewTriangle(1, 2, 3, nil)
 }
 
 func TestTriangle(t *testing.T) {
+	src := rand.New(rand.NewSource(1))
 	for i, test := range []struct {
 		a, b, c float64
 	}{
@@ -47,8 +50,22 @@ func TestTriangle(t *testing.T) {
 			c: 0.0,
 		},
 	} {
-		dist := NewTriangle(test.a, test.b, test.c)
-		testFullDist(t, dist, i, true)
+		f := NewTriangle(test.a, test.b, test.c, src)
+		tol := 1e-2
+		const n = 1e5
+		x := make([]float64, n)
+		generateSamples(x, f)
+		sort.Float64s(x)
+
+		checkMean(t, i, x, f, tol)
+		checkVarAndStd(t, i, x, f, tol)
+		checkEntropy(t, i, x, f, tol)
+		checkExKurtosis(t, i, x, f, tol)
+		checkSkewness(t, i, x, f, 5e-2)
+		checkMedian(t, i, x, f, tol)
+		checkQuantileCDFSurvival(t, i, x, f, tol)
+		checkProbContinuous(t, i, x, f, 1e-10)
+		checkProbQuantContinuous(t, i, x, f, tol)
 	}
 }
 
@@ -79,5 +96,5 @@ func TestTriangleProb(t *testing.T) {
 			logProb: math.Inf(-1),
 		},
 	}
-	testDistributionProbs(t, NewTriangle(1, 3, 2), "Standard 1,2,3 Triangle", pts)
+	testDistributionProbs(t, NewTriangle(1, 3, 2, nil), "Standard 1,2,3 Triangle", pts)
 }

--- a/stat/distuv/triangle_test.go
+++ b/stat/distuv/triangle_test.go
@@ -19,9 +19,9 @@ func TestTriangleConstraint(t *testing.T) {
 	}()
 
 	// test b < a
-	NewTriangle(3, 1, 2, nil)
+	NewTriangle(3, 1, 2)
 	// test c > b
-	NewTriangle(1, 2, 3, nil)
+	NewTriangle(1, 2, 3)
 }
 
 func TestTriangle(t *testing.T) {
@@ -50,7 +50,8 @@ func TestTriangle(t *testing.T) {
 			c: 0.0,
 		},
 	} {
-		f := NewTriangle(test.a, test.b, test.c, src)
+		f := NewTriangle(test.a, test.b, test.c)
+		f.Source = src
 		tol := 1e-2
 		const n = 1e5
 		x := make([]float64, n)
@@ -96,5 +97,5 @@ func TestTriangleProb(t *testing.T) {
 			logProb: math.Inf(-1),
 		},
 	}
-	testDistributionProbs(t, NewTriangle(1, 3, 2, nil), "Standard 1,2,3 Triangle", pts)
+	testDistributionProbs(t, NewTriangle(1, 3, 2), "Standard 1,2,3 Triangle", pts)
 }

--- a/stat/sampleuv/sample_test.go
+++ b/stat/sampleuv/sample_test.go
@@ -59,11 +59,11 @@ func TestRejection(t *testing.T) {
 	target := distuv.Normal{Mu: trueMean, Sigma: 2}
 	proposal := distuv.Normal{Mu: 0, Sigma: 5}
 
-	nSamples := 100000
+	nSamples := 20000
 	x := make([]float64, nSamples)
 	Rejection(x, target, proposal, 100, nil)
 	ev := stat.Mean(x, nil)
-	if math.Abs(ev-trueMean) > 1e-2 {
+	if math.Abs(ev-trueMean) > 2e-2 {
 		t.Errorf("Mean mismatch: Want %v, got %v", trueMean, ev)
 	}
 }


### PR DESCRIPTION
…ime.

We were generating a lot of random numbers, which is slow. Decrease the size of those random numbers, and in some cases increase the tolerance to compensate. In a couple cases, pull out code from testFullDist to allow for more fine-grained testing. This decrases:
distmat from 4.5s to 0.5s
distmv from 24.8s to 9s
distuv from 65.2s to 13s
samplemv from 2.8s to 1.2s
sampleuv from 3.5s to 2.1s