### PR TITLE
graph: redesign weight handling

### DIFF
--- a/graph/community/bisect_test.go
+++ b/graph/community/bisect_test.go
@@ -66,7 +66,7 @@ func init() {
 			friends.AddNode(simple.Node(u))
 		}
 		for v := range e {
-			friends.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+			friends.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: 1})
 		}
 	}
 	enemies = simple.NewWeightedUndirectedGraph(0, 0)
@@ -76,7 +76,7 @@ func init() {
 			enemies.AddNode(simple.Node(u))
 		}
 		for v := range e {
-			enemies.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: -1})
+			enemies.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: -1})
 		}
 	}
 }
@@ -148,7 +148,7 @@ func TestProfileWeightedUndirected(t *testing.T) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 
@@ -207,7 +207,7 @@ func TestProfileWeightedDirected(t *testing.T) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 

--- a/graph/community/louvain_common.go
+++ b/graph/community/louvain_common.go
@@ -356,7 +356,8 @@ const (
 )
 
 // positiveWeightFuncFor returns a constructed weight function for the
-// positively weighted g.
+// positively weighted g. Unweighted graphs have unit weight for existing
+// edges.
 func positiveWeightFuncFor(g graph.Graph) func(x, y graph.Node) float64 {
 	if wg, ok := g.(graph.Weighted); ok {
 		return func(x, y graph.Node) float64 {
@@ -375,16 +376,13 @@ func positiveWeightFuncFor(g graph.Graph) func(x, y graph.Node) float64 {
 		if e == nil {
 			return 0
 		}
-		w := e.Weight()
-		if w < 0 {
-			panic(negativeWeight)
-		}
-		return w
+		return 1
 	}
 }
 
 // negativeWeightFuncFor returns a constructed weight function for the
-// negatively weighted g.
+// negatively weighted g. Unweighted graphs have unit weight for existing
+// edges.
 func negativeWeightFuncFor(g graph.Graph) func(x, y graph.Node) float64 {
 	if wg, ok := g.(graph.Weighted); ok {
 		return func(x, y graph.Node) float64 {
@@ -403,11 +401,7 @@ func negativeWeightFuncFor(g graph.Graph) func(x, y graph.Node) float64 {
 		if e == nil {
 			return 0
 		}
-		w := e.Weight()
-		if w > 0 {
-			panic(positiveWeight)
-		}
-		return -w
+		return 1
 	}
 }
 

--- a/graph/community/louvain_common.go
+++ b/graph/community/louvain_common.go
@@ -358,7 +358,7 @@ const (
 // positiveWeightFuncFor returns a constructed weight function for the
 // positively weighted g.
 func positiveWeightFuncFor(g graph.Graph) func(x, y graph.Node) float64 {
-	if wg, ok := g.(graph.WeightedGraph); ok {
+	if wg, ok := g.(graph.Weighted); ok {
 		return func(x, y graph.Node) float64 {
 			w, ok := wg.Weight(x, y)
 			if !ok {
@@ -386,7 +386,7 @@ func positiveWeightFuncFor(g graph.Graph) func(x, y graph.Node) float64 {
 // negativeWeightFuncFor returns a constructed weight function for the
 // negatively weighted g.
 func negativeWeightFuncFor(g graph.Graph) func(x, y graph.Node) float64 {
-	if wg, ok := g.(graph.WeightedGraph); ok {
+	if wg, ok := g.(graph.Weighted); ok {
 		return func(x, y graph.Node) float64 {
 			w, ok := wg.Weight(x, y)
 			if !ok {

--- a/graph/community/louvain_common.go
+++ b/graph/community/louvain_common.go
@@ -358,7 +358,7 @@ const (
 // positiveWeightFuncFor returns a constructed weight function for the
 // positively weighted g.
 func positiveWeightFuncFor(g graph.Graph) func(x, y graph.Node) float64 {
-	if wg, ok := g.(graph.Weighter); ok {
+	if wg, ok := g.(graph.WeightedGraph); ok {
 		return func(x, y graph.Node) float64 {
 			w, ok := wg.Weight(x, y)
 			if !ok {
@@ -386,7 +386,7 @@ func positiveWeightFuncFor(g graph.Graph) func(x, y graph.Node) float64 {
 // negativeWeightFuncFor returns a constructed weight function for the
 // negatively weighted g.
 func negativeWeightFuncFor(g graph.Graph) func(x, y graph.Node) float64 {
-	if wg, ok := g.(graph.Weighter); ok {
+	if wg, ok := g.(graph.WeightedGraph); ok {
 		return func(x, y graph.Node) float64 {
 			w, ok := wg.Weight(x, y)
 			if !ok {

--- a/graph/community/louvain_directed.go
+++ b/graph/community/louvain_directed.go
@@ -111,9 +111,10 @@ type ReducedDirected struct {
 }
 
 var (
-	_ graph.Directed = (*ReducedDirected)(nil)
-	_ graph.Weighter = (*ReducedDirected)(nil)
-	_ ReducedGraph   = (*ReducedUndirected)(nil)
+	reducedDirected = (*ReducedDirected)(nil)
+
+	_ graph.WeightedDirected = reducedDirected
+	_ ReducedGraph           = reducedDirected
 )
 
 // Communities returns the community memberships of the nodes in the
@@ -377,6 +378,12 @@ func (g *ReducedDirected) HasEdgeFromTo(u, v graph.Node) bool {
 // Edge returns the edge from u to v if such an edge exists and nil otherwise.
 // The node v must be directly reachable from u as defined by the From method.
 func (g *ReducedDirected) Edge(u, v graph.Node) graph.Edge {
+	return g.WeightedEdge(u, v)
+}
+
+// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+func (g *ReducedDirected) WeightedEdge(u, v graph.Node) graph.WeightedEdge {
 	uid := u.ID()
 	vid := v.ID()
 	if uid == vid || !isValidID(uid) || !isValidID(vid) {

--- a/graph/community/louvain_directed_multiplex.go
+++ b/graph/community/louvain_directed_multiplex.go
@@ -207,9 +207,8 @@ type ReducedDirectedMultiplex struct {
 }
 
 var (
-	_ DirectedMultiplex = (*ReducedDirectedMultiplex)(nil)
-	_ graph.Directed    = (*directedLayerHandle)(nil)
-	_ graph.Weighter    = (*directedLayerHandle)(nil)
+	_ DirectedMultiplex      = (*ReducedDirectedMultiplex)(nil)
+	_ graph.WeightedDirected = (*directedLayerHandle)(nil)
 )
 
 // Nodes returns all the nodes in the graph.
@@ -544,6 +543,12 @@ func (g directedLayerHandle) HasEdgeFromTo(u, v graph.Node) bool {
 // Edge returns the edge from u to v if such an edge exists and nil otherwise.
 // The node v must be directly reachable from u as defined by the From method.
 func (g directedLayerHandle) Edge(u, v graph.Node) graph.Edge {
+	return g.WeightedEdge(u, v)
+}
+
+// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+func (g directedLayerHandle) WeightedEdge(u, v graph.Node) graph.WeightedEdge {
 	uid := u.ID()
 	vid := v.ID()
 	if uid == vid || !isValidID(uid) || !isValidID(vid) {
@@ -554,11 +559,6 @@ func (g directedLayerHandle) Edge(u, v graph.Node) graph.Edge {
 		return nil
 	}
 	return multiplexEdge{from: g.multiplex.nodes[u.ID()], to: g.multiplex.nodes[v.ID()], weight: w}
-}
-
-// EdgeBetween returns the edge between nodes x and y.
-func (g directedLayerHandle) EdgeBetween(x, y graph.Node) graph.Edge {
-	return g.Edge(x, y)
 }
 
 // Weight returns the weight for the edge between x and y if Edge(x, y) returns a non-nil Edge.

--- a/graph/community/louvain_directed_multiplex_test.go
+++ b/graph/community/louvain_directed_multiplex_test.go
@@ -647,12 +647,32 @@ func TestLouvainDirectedMultiplex(t *testing.T) {
 }
 
 func TestNonContiguousDirectedMultiplex(t *testing.T) {
-	g := simple.NewDirectedGraph(0, 0)
+	g := simple.NewDirectedGraph()
+	for _, e := range []simple.Edge{
+		{F: simple.Node(0), T: simple.Node(1)},
+		{F: simple.Node(4), T: simple.Node(5)},
+	} {
+		g.SetEdge(e)
+	}
+
+	func() {
+		defer func() {
+			r := recover()
+			if r != nil {
+				t.Error("unexpected panic with non-contiguous ID range")
+			}
+		}()
+		ModularizeMultiplex(DirectedLayers{g}, nil, nil, true, nil)
+	}()
+}
+
+func TestNonContiguousWeightedDirectedMultiplex(t *testing.T) {
+	g := simple.NewWeightedDirectedGraph(0, 0)
 	for _, e := range []simple.Edge{
 		{F: simple.Node(0), T: simple.Node(1), W: 1},
 		{F: simple.Node(4), T: simple.Node(5), W: 1},
 	} {
-		g.SetEdge(e)
+		g.SetWeightedEdge(e)
 	}
 
 	func() {
@@ -677,7 +697,7 @@ func directedMultiplexFrom(raw []layer) (DirectedLayers, []float64, error) {
 	var layers []graph.Directed
 	var weights []float64
 	for _, l := range raw {
-		g := simple.NewDirectedGraph(0, 0)
+		g := simple.NewWeightedDirectedGraph(0, 0)
 		for u, e := range l.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
@@ -688,7 +708,7 @@ func directedMultiplexFrom(raw []layer) (DirectedLayers, []float64, error) {
 				if l.edgeWeight != 0 {
 					w = l.edgeWeight
 				}
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: w})
+				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: w})
 			}
 		}
 		layers = append(layers, g)

--- a/graph/community/louvain_directed_multiplex_test.go
+++ b/graph/community/louvain_directed_multiplex_test.go
@@ -668,7 +668,7 @@ func TestNonContiguousDirectedMultiplex(t *testing.T) {
 
 func TestNonContiguousWeightedDirectedMultiplex(t *testing.T) {
 	g := simple.NewWeightedDirectedGraph(0, 0)
-	for _, e := range []simple.Edge{
+	for _, e := range []simple.WeightedEdge{
 		{F: simple.Node(0), T: simple.Node(1), W: 1},
 		{F: simple.Node(4), T: simple.Node(5), W: 1},
 	} {
@@ -708,7 +708,7 @@ func directedMultiplexFrom(raw []layer) (DirectedLayers, []float64, error) {
 				if l.edgeWeight != 0 {
 					w = l.edgeWeight
 				}
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: w})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: w})
 			}
 		}
 		layers = append(layers, g)

--- a/graph/community/louvain_directed_test.go
+++ b/graph/community/louvain_directed_test.go
@@ -225,7 +225,7 @@ func TestCommunityQWeightedDirected(t *testing.T) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 
@@ -278,7 +278,7 @@ func TestCommunityDeltaQWeightedDirected(t *testing.T) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 
@@ -403,7 +403,7 @@ func TestReduceQConsistencyWeightedDirected(t *testing.T) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 
@@ -521,7 +521,7 @@ func TestMoveLocalWeightedDirected(t *testing.T) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 
@@ -583,7 +583,7 @@ func TestModularizeWeightedDirected(t *testing.T) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 
@@ -693,7 +693,7 @@ func TestNonContiguousDirected(t *testing.T) {
 
 func TestNonContiguousWeightedDirected(t *testing.T) {
 	g := simple.NewWeightedDirectedGraph(0, 0)
-	for _, e := range []simple.Edge{
+	for _, e := range []simple.WeightedEdge{
 		{F: simple.Node(0), T: simple.Node(1), W: 1},
 		{F: simple.Node(4), T: simple.Node(5), W: 1},
 	} {

--- a/graph/community/louvain_directed_test.go
+++ b/graph/community/louvain_directed_test.go
@@ -17,13 +17,15 @@ import (
 	"gonum.org/v1/gonum/graph/simple"
 )
 
-var communityDirectedQTests = []struct {
+type communityDirectedQTest struct {
 	name       string
 	g          []intset
 	structures []structure
 
 	wantLevels []level
-}{
+}
+
+var communityDirectedQTests = []communityDirectedQTest{
 	{
 		name: "simple_directed",
 		g:    simpleDirected,
@@ -199,194 +201,258 @@ var communityDirectedQTests = []struct {
 
 func TestCommunityQDirected(t *testing.T) {
 	for _, test := range communityDirectedQTests {
-		g := simple.NewDirectedGraph(0, 0)
+		g := simple.NewDirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 			}
 		}
-		for _, structure := range test.structures {
-			communities := make([][]graph.Node, len(structure.memberships))
-			for i, c := range structure.memberships {
-				for n := range c {
-					communities[i] = append(communities[i], simple.Node(n))
-				}
+
+		testCommunityQDirected(t, test, g)
+	}
+}
+
+func TestCommunityQWeightedDirected(t *testing.T) {
+	for _, test := range communityDirectedQTests {
+		g := simple.NewWeightedDirectedGraph(0, 0)
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
 			}
-			got := Q(g, communities, structure.resolution)
-			if !floats.EqualWithinAbsOrRel(got, structure.want, structure.tol, structure.tol) && !math.IsNaN(structure.want) {
-				for _, c := range communities {
-					sort.Sort(ordered.ByID(c))
-				}
-				t.Errorf("unexpected Q value for %q %v: got: %v want: %v",
-					test.name, communities, got, structure.want)
+			for v := range e {
+				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
+		}
+
+		testCommunityQDirected(t, test, g)
+	}
+}
+
+func testCommunityQDirected(t *testing.T, test communityDirectedQTest, g graph.Directed) {
+	for _, structure := range test.structures {
+		communities := make([][]graph.Node, len(structure.memberships))
+		for i, c := range structure.memberships {
+			for n := range c {
+				communities[i] = append(communities[i], simple.Node(n))
+			}
+		}
+		got := Q(g, communities, structure.resolution)
+		if !floats.EqualWithinAbsOrRel(got, structure.want, structure.tol, structure.tol) && !math.IsNaN(structure.want) {
+			for _, c := range communities {
+				sort.Sort(ordered.ByID(c))
+			}
+			t.Errorf("unexpected Q value for %q %v: got: %v want: %v",
+				test.name, communities, got, structure.want)
 		}
 	}
 }
 
 func TestCommunityDeltaQDirected(t *testing.T) {
-tests:
 	for _, test := range communityDirectedQTests {
-		g := simple.NewDirectedGraph(0, 0)
+		g := simple.NewDirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 			}
 		}
 
-		rnd := rand.New(rand.NewSource(1)).Intn
-		for _, structure := range test.structures {
-			communityOf := make(map[int64]int)
-			communities := make([][]graph.Node, len(structure.memberships))
+		testCommunityDeltaQDirected(t, test, g)
+	}
+}
+
+func TestCommunityDeltaQWeightedDirected(t *testing.T) {
+	for _, test := range communityDirectedQTests {
+		g := simple.NewWeightedDirectedGraph(0, 0)
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
+			}
+			for v := range e {
+				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+			}
+		}
+
+		testCommunityDeltaQDirected(t, test, g)
+	}
+}
+
+func testCommunityDeltaQDirected(t *testing.T, test communityDirectedQTest, g graph.Directed) {
+	rnd := rand.New(rand.NewSource(1)).Intn
+	for _, structure := range test.structures {
+		communityOf := make(map[int64]int)
+		communities := make([][]graph.Node, len(structure.memberships))
+		for i, c := range structure.memberships {
+			for n := range c {
+				n := int64(n)
+				communityOf[n] = i
+				communities[i] = append(communities[i], simple.Node(n))
+			}
+			sort.Sort(ordered.ByID(communities[i]))
+		}
+
+		before := Q(g, communities, structure.resolution)
+
+		l := newDirectedLocalMover(reduceDirected(g, nil), communities, structure.resolution)
+		if l == nil {
+			if !math.IsNaN(before) {
+				t.Errorf("unexpected nil localMover with non-NaN Q graph: Q=%.4v", before)
+			}
+			return
+		}
+
+		// This is done to avoid run-to-run
+		// variation due to map iteration order.
+		sort.Sort(ordered.ByID(l.nodes))
+
+		l.shuffle(rnd)
+
+		for _, target := range l.nodes {
+			got, gotDst, gotSrc := l.deltaQ(target)
+
+			want, wantDst := math.Inf(-1), -1
+			migrated := make([][]graph.Node, len(structure.memberships))
 			for i, c := range structure.memberships {
 				for n := range c {
 					n := int64(n)
-					communityOf[n] = i
-					communities[i] = append(communities[i], simple.Node(n))
-				}
-				sort.Sort(ordered.ByID(communities[i]))
-			}
-
-			before := Q(g, communities, structure.resolution)
-
-			l := newDirectedLocalMover(reduceDirected(g, nil), communities, structure.resolution)
-			if l == nil {
-				if !math.IsNaN(before) {
-					t.Errorf("unexpected nil localMover with non-NaN Q graph: Q=%.4v", before)
-				}
-				continue tests
-			}
-
-			// This is done to avoid run-to-run
-			// variation due to map iteration order.
-			sort.Sort(ordered.ByID(l.nodes))
-
-			l.shuffle(rnd)
-
-			for _, target := range l.nodes {
-				got, gotDst, gotSrc := l.deltaQ(target)
-
-				want, wantDst := math.Inf(-1), -1
-				migrated := make([][]graph.Node, len(structure.memberships))
-				for i, c := range structure.memberships {
-					for n := range c {
-						n := int64(n)
-						if n == target.ID() {
-							continue
-						}
-						migrated[i] = append(migrated[i], simple.Node(n))
-					}
-					sort.Sort(ordered.ByID(migrated[i]))
-				}
-
-				for i, c := range structure.memberships {
-					if i == communityOf[target.ID()] {
+					if n == target.ID() {
 						continue
 					}
-					connected := false
-					for n := range c {
-						if g.HasEdgeBetween(simple.Node(n), target) {
-							connected = true
-							break
-						}
-					}
-					if !connected {
-						continue
-					}
-					migrated[i] = append(migrated[i], target)
-					after := Q(g, migrated, structure.resolution)
-					migrated[i] = migrated[i][:len(migrated[i])-1]
-					if after-before > want {
-						want = after - before
-						wantDst = i
-					}
+					migrated[i] = append(migrated[i], simple.Node(n))
 				}
+				sort.Sort(ordered.ByID(migrated[i]))
+			}
 
-				if !floats.EqualWithinAbsOrRel(got, want, structure.tol, structure.tol) || gotDst != wantDst {
-					t.Errorf("unexpected result moving n=%d in c=%d of %s/%.4v: got: %.4v,%d want: %.4v,%d"+
-						"\n\t%v\n\t%v",
-						target.ID(), communityOf[target.ID()], test.name, structure.resolution, got, gotDst, want, wantDst,
-						communities, migrated)
+			for i, c := range structure.memberships {
+				if i == communityOf[target.ID()] {
+					continue
 				}
-				if gotSrc.community != communityOf[target.ID()] {
-					t.Errorf("unexpected source community index: got: %d want: %d", gotSrc, communityOf[target.ID()])
-				} else if communities[gotSrc.community][gotSrc.node].ID() != target.ID() {
-					wantNodeIdx := -1
-					for i, n := range communities[gotSrc.community] {
-						if n.ID() == target.ID() {
-							wantNodeIdx = i
-							break
-						}
+				connected := false
+				for n := range c {
+					if g.HasEdgeBetween(simple.Node(n), target) {
+						connected = true
+						break
 					}
-					t.Errorf("unexpected source node index: got: %d want: %d", gotSrc.node, wantNodeIdx)
 				}
+				if !connected {
+					continue
+				}
+				migrated[i] = append(migrated[i], target)
+				after := Q(g, migrated, structure.resolution)
+				migrated[i] = migrated[i][:len(migrated[i])-1]
+				if after-before > want {
+					want = after - before
+					wantDst = i
+				}
+			}
+
+			if !floats.EqualWithinAbsOrRel(got, want, structure.tol, structure.tol) || gotDst != wantDst {
+				t.Errorf("unexpected result moving n=%d in c=%d of %s/%.4v: got: %.4v,%d want: %.4v,%d"+
+					"\n\t%v\n\t%v",
+					target.ID(), communityOf[target.ID()], test.name, structure.resolution, got, gotDst, want, wantDst,
+					communities, migrated)
+			}
+			if gotSrc.community != communityOf[target.ID()] {
+				t.Errorf("unexpected source community index: got: %d want: %d", gotSrc, communityOf[target.ID()])
+			} else if communities[gotSrc.community][gotSrc.node].ID() != target.ID() {
+				wantNodeIdx := -1
+				for i, n := range communities[gotSrc.community] {
+					if n.ID() == target.ID() {
+						wantNodeIdx = i
+						break
+					}
+				}
+				t.Errorf("unexpected source node index: got: %d want: %d", gotSrc.node, wantNodeIdx)
 			}
 		}
 	}
 }
 
 func TestReduceQConsistencyDirected(t *testing.T) {
-tests:
 	for _, test := range communityDirectedQTests {
-		g := simple.NewDirectedGraph(0, 0)
+		g := simple.NewDirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 			}
 		}
 
-		for _, structure := range test.structures {
-			if math.IsNaN(structure.want) {
-				continue tests
-			}
+		testReduceQConsistencyDirected(t, test, g)
+	}
+}
 
-			communities := make([][]graph.Node, len(structure.memberships))
-			for i, c := range structure.memberships {
-				for n := range c {
-					communities[i] = append(communities[i], simple.Node(n))
-				}
-				sort.Sort(ordered.ByID(communities[i]))
+func TestReduceQConsistencyWeightedDirected(t *testing.T) {
+	for _, test := range communityDirectedQTests {
+		g := simple.NewWeightedDirectedGraph(0, 0)
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
 			}
+			for v := range e {
+				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+			}
+		}
 
-			gQ := Q(g, communities, structure.resolution)
-			gQnull := Q(g, nil, 1)
+		testReduceQConsistencyDirected(t, test, g)
+	}
+}
 
-			cg0 := reduceDirected(g, nil)
-			cg0Qnull := Q(cg0, cg0.Structure(), 1)
-			if !floats.EqualWithinAbsOrRel(gQnull, cg0Qnull, structure.tol, structure.tol) {
-				t.Errorf("disagreement between null Q from method: %v and function: %v", cg0Qnull, gQnull)
-			}
-			cg0Q := Q(cg0, communities, structure.resolution)
-			if !floats.EqualWithinAbsOrRel(gQ, cg0Q, structure.tol, structure.tol) {
-				t.Errorf("unexpected Q result after initial reduction: got: %v want :%v", cg0Q, gQ)
-			}
+func testReduceQConsistencyDirected(t *testing.T, test communityDirectedQTest, g graph.Directed) {
+	for _, structure := range test.structures {
+		if math.IsNaN(structure.want) {
+			return
+		}
 
-			cg1 := reduceDirected(cg0, communities)
-			cg1Q := Q(cg1, cg1.Structure(), structure.resolution)
-			if !floats.EqualWithinAbsOrRel(gQ, cg1Q, structure.tol, structure.tol) {
-				t.Errorf("unexpected Q result after second reduction: got: %v want :%v", cg1Q, gQ)
+		communities := make([][]graph.Node, len(structure.memberships))
+		for i, c := range structure.memberships {
+			for n := range c {
+				communities[i] = append(communities[i], simple.Node(n))
 			}
+			sort.Sort(ordered.ByID(communities[i]))
+		}
+
+		gQ := Q(g, communities, structure.resolution)
+		gQnull := Q(g, nil, 1)
+
+		cg0 := reduceDirected(g, nil)
+		cg0Qnull := Q(cg0, cg0.Structure(), 1)
+		if !floats.EqualWithinAbsOrRel(gQnull, cg0Qnull, structure.tol, structure.tol) {
+			t.Errorf("disagreement between null Q from method: %v and function: %v", cg0Qnull, gQnull)
+		}
+		cg0Q := Q(cg0, communities, structure.resolution)
+		if !floats.EqualWithinAbsOrRel(gQ, cg0Q, structure.tol, structure.tol) {
+			t.Errorf("unexpected Q result after initial reduction: got: %v want :%v", cg0Q, gQ)
+		}
+
+		cg1 := reduceDirected(cg0, communities)
+		cg1Q := Q(cg1, cg1.Structure(), structure.resolution)
+		if !floats.EqualWithinAbsOrRel(gQ, cg1Q, structure.tol, structure.tol) {
+			t.Errorf("unexpected Q result after second reduction: got: %v want :%v", cg1Q, gQ)
 		}
 	}
 }
 
-var localDirectedMoveTests = []struct {
+type localDirectedMoveTest struct {
 	name       string
 	g          []intset
 	structures []moveStructures
-}{
+}
+
+var localDirectedMoveTests = []localDirectedMoveTest{
 	{
 		name: "blondel",
 		g:    blondel,
@@ -431,39 +497,60 @@ var localDirectedMoveTests = []struct {
 
 func TestMoveLocalDirected(t *testing.T) {
 	for _, test := range localDirectedMoveTests {
-		g := simple.NewDirectedGraph(0, 0)
+		g := simple.NewDirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 			}
 		}
 
-		for _, structure := range test.structures {
-			communities := make([][]graph.Node, len(structure.memberships))
-			for i, c := range structure.memberships {
-				for n := range c {
-					communities[i] = append(communities[i], simple.Node(n))
-				}
-				sort.Sort(ordered.ByID(communities[i]))
+		testMoveLocalDirected(t, test, g)
+	}
+}
+
+func TestMoveLocalWeightedDirected(t *testing.T) {
+	for _, test := range localDirectedMoveTests {
+		g := simple.NewWeightedDirectedGraph(0, 0)
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
 			}
+			for v := range e {
+				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+			}
+		}
 
-			r := reduceDirected(reduceDirected(g, nil), communities)
+		testMoveLocalDirected(t, test, g)
+	}
+}
 
-			l := newDirectedLocalMover(r, r.communities, structure.resolution)
-			for _, n := range structure.targetNodes {
-				dQ, dst, src := l.deltaQ(n)
-				if dQ > 0 {
-					before := Q(r, l.communities, structure.resolution)
-					l.move(dst, src)
-					after := Q(r, l.communities, structure.resolution)
-					want := after - before
-					if !floats.EqualWithinAbsOrRel(dQ, want, structure.tol, structure.tol) {
-						t.Errorf("unexpected deltaQ: got: %v want: %v", dQ, want)
-					}
+func testMoveLocalDirected(t *testing.T, test localDirectedMoveTest, g graph.Directed) {
+	for _, structure := range test.structures {
+		communities := make([][]graph.Node, len(structure.memberships))
+		for i, c := range structure.memberships {
+			for n := range c {
+				communities[i] = append(communities[i], simple.Node(n))
+			}
+			sort.Sort(ordered.ByID(communities[i]))
+		}
+
+		r := reduceDirected(reduceDirected(g, nil), communities)
+
+		l := newDirectedLocalMover(r, r.communities, structure.resolution)
+		for _, n := range structure.targetNodes {
+			dQ, dst, src := l.deltaQ(n)
+			if dQ > 0 {
+				before := Q(r, l.communities, structure.resolution)
+				l.move(dst, src)
+				after := Q(r, l.communities, structure.resolution)
+				want := after - before
+				if !floats.EqualWithinAbsOrRel(dQ, want, structure.tol, structure.tol) {
+					t.Errorf("unexpected deltaQ: got: %v want: %v", dQ, want)
 				}
 			}
 		}
@@ -471,105 +558,146 @@ func TestMoveLocalDirected(t *testing.T) {
 }
 
 func TestModularizeDirected(t *testing.T) {
-	const louvainIterations = 20
-
 	for _, test := range communityDirectedQTests {
-		g := simple.NewDirectedGraph(0, 0)
+		g := simple.NewDirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 			}
 		}
 
-		if test.structures[0].resolution != 1 {
-			panic("bad test: expect resolution=1")
-		}
-		want := make([][]graph.Node, len(test.structures[0].memberships))
-		for i, c := range test.structures[0].memberships {
-			for n := range c {
-				want[i] = append(want[i], simple.Node(n))
+		testModularizeDirected(t, test, g)
+	}
+}
+
+func TestModularizeWeightedDirected(t *testing.T) {
+	for _, test := range communityDirectedQTests {
+		g := simple.NewWeightedDirectedGraph(0, 0)
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
 			}
-			sort.Sort(ordered.ByID(want[i]))
-		}
-		sort.Sort(ordered.BySliceIDs(want))
-
-		var (
-			got   *ReducedDirected
-			bestQ = math.Inf(-1)
-		)
-		// Modularize is randomised so we do this to
-		// ensure the level tests are consistent.
-		src := rand.New(rand.NewSource(1))
-		for i := 0; i < louvainIterations; i++ {
-			r := Modularize(g, 1, src).(*ReducedDirected)
-			if q := Q(r, nil, 1); q > bestQ || math.IsNaN(q) {
-				bestQ = q
-				got = r
-
-				if math.IsNaN(q) {
-					// Don't try again for non-connected case.
-					break
-				}
-			}
-
-			var qs []float64
-			for p := r; p != nil; p = p.Expanded().(*ReducedDirected) {
-				qs = append(qs, Q(p, nil, 1))
-			}
-
-			// Recovery of Q values is reversed.
-			if reverse(qs); !sort.Float64sAreSorted(qs) {
-				t.Errorf("Q values not monotonically increasing: %.5v", qs)
+			for v := range e {
+				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 
-		gotCommunities := got.Communities()
-		for _, c := range gotCommunities {
-			sort.Sort(ordered.ByID(c))
-		}
-		sort.Sort(ordered.BySliceIDs(gotCommunities))
-		if !reflect.DeepEqual(gotCommunities, want) {
-			t.Errorf("unexpected community membership for %s Q=%.4v:\n\tgot: %v\n\twant:%v",
-				test.name, bestQ, gotCommunities, want)
-			continue
-		}
+		testModularizeDirected(t, test, g)
+	}
+}
 
-		var levels []level
-		for p := got; p != nil; p = p.Expanded().(*ReducedDirected) {
-			var communities [][]graph.Node
-			if p.parent != nil {
-				communities = p.parent.Communities()
-				for _, c := range communities {
-					sort.Sort(ordered.ByID(c))
-				}
-				sort.Sort(ordered.BySliceIDs(communities))
-			} else {
-				communities = reduceDirected(g, nil).Communities()
-			}
-			q := Q(p, nil, 1)
+func testModularizeDirected(t *testing.T, test communityDirectedQTest, g graph.Directed) {
+	const louvainIterations = 20
+
+	if test.structures[0].resolution != 1 {
+		panic("bad test: expect resolution=1")
+	}
+	want := make([][]graph.Node, len(test.structures[0].memberships))
+	for i, c := range test.structures[0].memberships {
+		for n := range c {
+			want[i] = append(want[i], simple.Node(n))
+		}
+		sort.Sort(ordered.ByID(want[i]))
+	}
+	sort.Sort(ordered.BySliceIDs(want))
+
+	var (
+		got   *ReducedDirected
+		bestQ = math.Inf(-1)
+	)
+	// Modularize is randomised so we do this to
+	// ensure the level tests are consistent.
+	src := rand.New(rand.NewSource(1))
+	for i := 0; i < louvainIterations; i++ {
+		r := Modularize(g, 1, src).(*ReducedDirected)
+		if q := Q(r, nil, 1); q > bestQ || math.IsNaN(q) {
+			bestQ = q
+			got = r
+
 			if math.IsNaN(q) {
-				// Use an equalable flag value in place of NaN.
-				q = math.Inf(-1)
+				// Don't try again for non-connected case.
+				break
 			}
-			levels = append(levels, level{q: q, communities: communities})
 		}
-		if !reflect.DeepEqual(levels, test.wantLevels) {
-			t.Errorf("unexpected level structure:\n\tgot: %v\n\twant:%v", levels, test.wantLevels)
+
+		var qs []float64
+		for p := r; p != nil; p = p.Expanded().(*ReducedDirected) {
+			qs = append(qs, Q(p, nil, 1))
 		}
+
+		// Recovery of Q values is reversed.
+		if reverse(qs); !sort.Float64sAreSorted(qs) {
+			t.Errorf("Q values not monotonically increasing: %.5v", qs)
+		}
+	}
+
+	gotCommunities := got.Communities()
+	for _, c := range gotCommunities {
+		sort.Sort(ordered.ByID(c))
+	}
+	sort.Sort(ordered.BySliceIDs(gotCommunities))
+	if !reflect.DeepEqual(gotCommunities, want) {
+		t.Errorf("unexpected community membership for %s Q=%.4v:\n\tgot: %v\n\twant:%v",
+			test.name, bestQ, gotCommunities, want)
+		return
+	}
+
+	var levels []level
+	for p := got; p != nil; p = p.Expanded().(*ReducedDirected) {
+		var communities [][]graph.Node
+		if p.parent != nil {
+			communities = p.parent.Communities()
+			for _, c := range communities {
+				sort.Sort(ordered.ByID(c))
+			}
+			sort.Sort(ordered.BySliceIDs(communities))
+		} else {
+			communities = reduceDirected(g, nil).Communities()
+		}
+		q := Q(p, nil, 1)
+		if math.IsNaN(q) {
+			// Use an equalable flag value in place of NaN.
+			q = math.Inf(-1)
+		}
+		levels = append(levels, level{q: q, communities: communities})
+	}
+	if !reflect.DeepEqual(levels, test.wantLevels) {
+		t.Errorf("unexpected level structure:\n\tgot: %v\n\twant:%v", levels, test.wantLevels)
 	}
 }
 
 func TestNonContiguousDirected(t *testing.T) {
-	g := simple.NewDirectedGraph(0, 0)
+	g := simple.NewDirectedGraph()
+	for _, e := range []simple.Edge{
+		{F: simple.Node(0), T: simple.Node(1)},
+		{F: simple.Node(4), T: simple.Node(5)},
+	} {
+		g.SetEdge(e)
+	}
+
+	func() {
+		defer func() {
+			r := recover()
+			if r != nil {
+				t.Error("unexpected panic with non-contiguous ID range")
+			}
+		}()
+		Modularize(g, 1, nil)
+	}()
+}
+
+func TestNonContiguousWeightedDirected(t *testing.T) {
+	g := simple.NewWeightedDirectedGraph(0, 0)
 	for _, e := range []simple.Edge{
 		{F: simple.Node(0), T: simple.Node(1), W: 1},
 		{F: simple.Node(4), T: simple.Node(5), W: 1},
 	} {
-		g.SetEdge(e)
+		g.SetWeightedEdge(e)
 	}
 
 	func() {

--- a/graph/community/louvain_test.go
+++ b/graph/community/louvain_test.go
@@ -229,8 +229,8 @@ func hasNegative(f []float64) bool {
 }
 
 var (
-	dupGraph         = simple.NewUndirectedGraph(0, 0)
-	dupGraphDirected = simple.NewDirectedGraph(0, 0)
+	dupGraph         = simple.NewUndirectedGraph()
+	dupGraphDirected = simple.NewDirectedGraph()
 )
 
 func init() {

--- a/graph/community/louvain_undirected.go
+++ b/graph/community/louvain_undirected.go
@@ -111,9 +111,10 @@ type ReducedUndirected struct {
 }
 
 var (
-	_ graph.Undirected = (*ReducedUndirected)(nil)
-	_ graph.Weighter   = (*ReducedUndirected)(nil)
-	_ ReducedGraph     = (*ReducedUndirected)(nil)
+	reducedUndirected = (*ReducedUndirected)(nil)
+
+	_ graph.WeightedUndirected = reducedUndirected
+	_ ReducedGraph             = reducedUndirected
 )
 
 // Communities returns the community memberships of the nodes in the
@@ -324,24 +325,35 @@ func (g *ReducedUndirected) HasEdgeBetween(x, y graph.Node) bool {
 // Edge returns the edge from u to v if such an edge exists and nil otherwise.
 // The node v must be directly reachable from u as defined by the From method.
 func (g *ReducedUndirected) Edge(u, v graph.Node) graph.Edge {
-	uid := u.ID()
-	vid := v.ID()
-	if uid == vid || !isValidID(uid) || !isValidID(vid) {
-		return nil
-	}
-	if vid < uid {
-		uid, vid = vid, uid
-	}
-	w, ok := g.weights[[2]int{int(uid), int(vid)}]
-	if !ok {
-		return nil
-	}
-	return edge{from: g.nodes[u.ID()], to: g.nodes[v.ID()], weight: w}
+	return g.WeightedEdgeBetween(u, v)
+}
+
+// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+func (g *ReducedUndirected) WeightedEdge(u, v graph.Node) graph.WeightedEdge {
+	return g.WeightedEdgeBetween(u, v)
 }
 
 // EdgeBetween returns the edge between nodes x and y.
 func (g *ReducedUndirected) EdgeBetween(x, y graph.Node) graph.Edge {
-	return g.Edge(x, y)
+	return g.WeightedEdgeBetween(x, y)
+}
+
+// WeightedEdgeBetween returns the weighted edge between nodes x and y.
+func (g *ReducedUndirected) WeightedEdgeBetween(x, y graph.Node) graph.WeightedEdge {
+	xid := x.ID()
+	yid := y.ID()
+	if xid == yid || !isValidID(xid) || !isValidID(yid) {
+		return nil
+	}
+	if yid < xid {
+		xid, yid = yid, xid
+	}
+	w, ok := g.weights[[2]int{int(xid), int(yid)}]
+	if !ok {
+		return nil
+	}
+	return edge{from: g.nodes[x.ID()], to: g.nodes[y.ID()], weight: w}
 }
 
 // Weight returns the weight for the edge between x and y if Edge(x, y) returns a non-nil Edge.

--- a/graph/community/louvain_undirected_multiplex.go
+++ b/graph/community/louvain_undirected_multiplex.go
@@ -206,9 +206,8 @@ type ReducedUndirectedMultiplex struct {
 }
 
 var (
-	_ UndirectedMultiplex = (*ReducedUndirectedMultiplex)(nil)
-	_ graph.Undirected    = (*undirectedLayerHandle)(nil)
-	_ graph.Weighter      = (*undirectedLayerHandle)(nil)
+	_ UndirectedMultiplex      = (*ReducedUndirectedMultiplex)(nil)
+	_ graph.WeightedUndirected = (*undirectedLayerHandle)(nil)
 )
 
 // Nodes returns all the nodes in the graph.
@@ -486,24 +485,35 @@ func (g undirectedLayerHandle) HasEdgeBetween(x, y graph.Node) bool {
 // Edge returns the edge from u to v if such an edge exists and nil otherwise.
 // The node v must be directly reachable from u as defined by the From method.
 func (g undirectedLayerHandle) Edge(u, v graph.Node) graph.Edge {
-	uid := u.ID()
-	vid := v.ID()
-	if uid == vid || !isValidID(uid) || !isValidID(vid) {
-		return nil
-	}
-	if vid < uid {
-		uid, vid = vid, uid
-	}
-	w, ok := g.multiplex.layers[g.layer].weights[[2]int{int(uid), int(vid)}]
-	if !ok {
-		return nil
-	}
-	return multiplexEdge{from: g.multiplex.nodes[u.ID()], to: g.multiplex.nodes[v.ID()], weight: w}
+	return g.WeightedEdgeBetween(u, v)
+}
+
+// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+func (g undirectedLayerHandle) WeightedEdge(u, v graph.Node) graph.WeightedEdge {
+	return g.WeightedEdgeBetween(u, v)
 }
 
 // EdgeBetween returns the edge between nodes x and y.
 func (g undirectedLayerHandle) EdgeBetween(x, y graph.Node) graph.Edge {
-	return g.Edge(x, y)
+	return g.WeightedEdgeBetween(x, y)
+}
+
+// WeightedEdgeBetween returns the weighted edge between nodes x and y.
+func (g undirectedLayerHandle) WeightedEdgeBetween(x, y graph.Node) graph.WeightedEdge {
+	xid := x.ID()
+	yid := y.ID()
+	if xid == yid || !isValidID(xid) || !isValidID(yid) {
+		return nil
+	}
+	if yid < xid {
+		xid, yid = yid, xid
+	}
+	w, ok := g.multiplex.layers[g.layer].weights[[2]int{int(xid), int(yid)}]
+	if !ok {
+		return nil
+	}
+	return multiplexEdge{from: g.multiplex.nodes[x.ID()], to: g.multiplex.nodes[y.ID()], weight: w}
 }
 
 // Weight returns the weight for the edge between x and y if Edge(x, y) returns a non-nil Edge.

--- a/graph/community/louvain_undirected_multiplex_test.go
+++ b/graph/community/louvain_undirected_multiplex_test.go
@@ -616,12 +616,32 @@ func TestLouvainMultiplex(t *testing.T) {
 }
 
 func TestNonContiguousUndirectedMultiplex(t *testing.T) {
-	g := simple.NewUndirectedGraph(0, 0)
+	g := simple.NewUndirectedGraph()
+	for _, e := range []simple.Edge{
+		{F: simple.Node(0), T: simple.Node(1)},
+		{F: simple.Node(4), T: simple.Node(5)},
+	} {
+		g.SetEdge(e)
+	}
+
+	func() {
+		defer func() {
+			r := recover()
+			if r != nil {
+				t.Error("unexpected panic with non-contiguous ID range")
+			}
+		}()
+		ModularizeMultiplex(UndirectedLayers{g}, nil, nil, true, nil)
+	}()
+}
+
+func TestNonContiguousWeightedUndirectedMultiplex(t *testing.T) {
+	g := simple.NewWeightedUndirectedGraph(0, 0)
 	for _, e := range []simple.Edge{
 		{F: simple.Node(0), T: simple.Node(1), W: 1},
 		{F: simple.Node(4), T: simple.Node(5), W: 1},
 	} {
-		g.SetEdge(e)
+		g.SetWeightedEdge(e)
 	}
 
 	func() {
@@ -646,7 +666,7 @@ func undirectedMultiplexFrom(raw []layer) (UndirectedLayers, []float64, error) {
 	var layers []graph.Undirected
 	var weights []float64
 	for _, l := range raw {
-		g := simple.NewUndirectedGraph(0, 0)
+		g := simple.NewWeightedUndirectedGraph(0, 0)
 		for u, e := range l.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
@@ -657,7 +677,7 @@ func undirectedMultiplexFrom(raw []layer) (UndirectedLayers, []float64, error) {
 				if l.edgeWeight != 0 {
 					w = l.edgeWeight
 				}
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: w})
+				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: w})
 			}
 		}
 		layers = append(layers, g)

--- a/graph/community/louvain_undirected_multiplex_test.go
+++ b/graph/community/louvain_undirected_multiplex_test.go
@@ -637,7 +637,7 @@ func TestNonContiguousUndirectedMultiplex(t *testing.T) {
 
 func TestNonContiguousWeightedUndirectedMultiplex(t *testing.T) {
 	g := simple.NewWeightedUndirectedGraph(0, 0)
-	for _, e := range []simple.Edge{
+	for _, e := range []simple.WeightedEdge{
 		{F: simple.Node(0), T: simple.Node(1), W: 1},
 		{F: simple.Node(4), T: simple.Node(5), W: 1},
 	} {
@@ -677,7 +677,7 @@ func undirectedMultiplexFrom(raw []layer) (UndirectedLayers, []float64, error) {
 				if l.edgeWeight != 0 {
 					w = l.edgeWeight
 				}
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: w})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: w})
 			}
 		}
 		layers = append(layers, g)

--- a/graph/community/louvain_undirected_test.go
+++ b/graph/community/louvain_undirected_test.go
@@ -284,7 +284,7 @@ func TestCommunityQWeightedUndirected(t *testing.T) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 
@@ -337,7 +337,7 @@ func TestCommunityDeltaQWeightedUndirected(t *testing.T) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 
@@ -462,7 +462,7 @@ func TestReduceQConsistencyWeightedUndirected(t *testing.T) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 
@@ -580,7 +580,7 @@ func TestMoveLocalWeightedUndirected(t *testing.T) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 
@@ -642,7 +642,7 @@ func TestModularizeWeightedUndirected(t *testing.T) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 
@@ -752,7 +752,7 @@ func TestNonContiguousUndirected(t *testing.T) {
 
 func TestNonContiguousWeightedUndirected(t *testing.T) {
 	g := simple.NewWeightedUndirectedGraph(0, 0)
-	for _, e := range []simple.Edge{
+	for _, e := range []simple.WeightedEdge{
 		{F: simple.Node(0), T: simple.Node(1), W: 1},
 		{F: simple.Node(4), T: simple.Node(5), W: 1},
 	} {

--- a/graph/community/louvain_undirected_test.go
+++ b/graph/community/louvain_undirected_test.go
@@ -17,13 +17,15 @@ import (
 	"gonum.org/v1/gonum/graph/simple"
 )
 
-var communityUndirectedQTests = []struct {
+type communityUndirectedQTest struct {
 	name       string
 	g          []intset
 	structures []structure
 
 	wantLevels []level
-}{
+}
+
+var communityUndirectedQTests = []communityUndirectedQTest{
 	// The java reference implementation is available from http://www.ludowaltman.nl/slm/.
 	{
 		name: "unconnected",
@@ -258,194 +260,258 @@ var communityUndirectedQTests = []struct {
 
 func TestCommunityQUndirected(t *testing.T) {
 	for _, test := range communityUndirectedQTests {
-		g := simple.NewUndirectedGraph(0, 0)
+		g := simple.NewUndirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 			}
 		}
-		for _, structure := range test.structures {
-			communities := make([][]graph.Node, len(structure.memberships))
-			for i, c := range structure.memberships {
-				for n := range c {
-					communities[i] = append(communities[i], simple.Node(n))
-				}
+
+		testCommunityQUndirected(t, test, g)
+	}
+}
+
+func TestCommunityQWeightedUndirected(t *testing.T) {
+	for _, test := range communityUndirectedQTests {
+		g := simple.NewWeightedUndirectedGraph(0, 0)
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
 			}
-			got := Q(g, communities, structure.resolution)
-			if !floats.EqualWithinAbsOrRel(got, structure.want, structure.tol, structure.tol) && !math.IsNaN(structure.want) {
-				for _, c := range communities {
-					sort.Sort(ordered.ByID(c))
-				}
-				t.Errorf("unexpected Q value for %q %v: got: %v want: %v",
-					test.name, communities, got, structure.want)
+			for v := range e {
+				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
+		}
+
+		testCommunityQUndirected(t, test, g)
+	}
+}
+
+func testCommunityQUndirected(t *testing.T, test communityUndirectedQTest, g graph.Undirected) {
+	for _, structure := range test.structures {
+		communities := make([][]graph.Node, len(structure.memberships))
+		for i, c := range structure.memberships {
+			for n := range c {
+				communities[i] = append(communities[i], simple.Node(n))
+			}
+		}
+		got := Q(g, communities, structure.resolution)
+		if !floats.EqualWithinAbsOrRel(got, structure.want, structure.tol, structure.tol) && !math.IsNaN(structure.want) {
+			for _, c := range communities {
+				sort.Sort(ordered.ByID(c))
+			}
+			t.Errorf("unexpected Q value for %q %v: got: %v want: %v",
+				test.name, communities, got, structure.want)
 		}
 	}
 }
 
 func TestCommunityDeltaQUndirected(t *testing.T) {
-tests:
 	for _, test := range communityUndirectedQTests {
-		g := simple.NewUndirectedGraph(0, 0)
+		g := simple.NewUndirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 			}
 		}
 
-		rnd := rand.New(rand.NewSource(1)).Intn
-		for _, structure := range test.structures {
-			communityOf := make(map[int64]int)
-			communities := make([][]graph.Node, len(structure.memberships))
+		testCommunityDeltaQUndirected(t, test, g)
+	}
+}
+
+func TestCommunityDeltaQWeightedUndirected(t *testing.T) {
+	for _, test := range communityUndirectedQTests {
+		g := simple.NewWeightedUndirectedGraph(0, 0)
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
+			}
+			for v := range e {
+				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+			}
+		}
+
+		testCommunityDeltaQUndirected(t, test, g)
+	}
+}
+
+func testCommunityDeltaQUndirected(t *testing.T, test communityUndirectedQTest, g graph.Undirected) {
+	rnd := rand.New(rand.NewSource(1)).Intn
+	for _, structure := range test.structures {
+		communityOf := make(map[int64]int)
+		communities := make([][]graph.Node, len(structure.memberships))
+		for i, c := range structure.memberships {
+			for n := range c {
+				n := int64(n)
+				communityOf[n] = i
+				communities[i] = append(communities[i], simple.Node(n))
+			}
+			sort.Sort(ordered.ByID(communities[i]))
+		}
+
+		before := Q(g, communities, structure.resolution)
+
+		l := newUndirectedLocalMover(reduceUndirected(g, nil), communities, structure.resolution)
+		if l == nil {
+			if !math.IsNaN(before) {
+				t.Errorf("unexpected nil localMover with non-NaN Q graph: Q=%.4v", before)
+			}
+			return
+		}
+
+		// This is done to avoid run-to-run
+		// variation due to map iteration order.
+		sort.Sort(ordered.ByID(l.nodes))
+
+		l.shuffle(rnd)
+
+		for _, target := range l.nodes {
+			got, gotDst, gotSrc := l.deltaQ(target)
+
+			want, wantDst := math.Inf(-1), -1
+			migrated := make([][]graph.Node, len(structure.memberships))
 			for i, c := range structure.memberships {
 				for n := range c {
 					n := int64(n)
-					communityOf[n] = i
-					communities[i] = append(communities[i], simple.Node(n))
-				}
-				sort.Sort(ordered.ByID(communities[i]))
-			}
-
-			before := Q(g, communities, structure.resolution)
-
-			l := newUndirectedLocalMover(reduceUndirected(g, nil), communities, structure.resolution)
-			if l == nil {
-				if !math.IsNaN(before) {
-					t.Errorf("unexpected nil localMover with non-NaN Q graph: Q=%.4v", before)
-				}
-				continue tests
-			}
-
-			// This is done to avoid run-to-run
-			// variation due to map iteration order.
-			sort.Sort(ordered.ByID(l.nodes))
-
-			l.shuffle(rnd)
-
-			for _, target := range l.nodes {
-				got, gotDst, gotSrc := l.deltaQ(target)
-
-				want, wantDst := math.Inf(-1), -1
-				migrated := make([][]graph.Node, len(structure.memberships))
-				for i, c := range structure.memberships {
-					for n := range c {
-						n := int64(n)
-						if n == target.ID() {
-							continue
-						}
-						migrated[i] = append(migrated[i], simple.Node(n))
-					}
-					sort.Sort(ordered.ByID(migrated[i]))
-				}
-
-				for i, c := range structure.memberships {
-					if i == communityOf[target.ID()] {
+					if n == target.ID() {
 						continue
 					}
-					connected := false
-					for n := range c {
-						if g.HasEdgeBetween(simple.Node(n), target) {
-							connected = true
-							break
-						}
-					}
-					if !connected {
-						continue
-					}
-					migrated[i] = append(migrated[i], target)
-					after := Q(g, migrated, structure.resolution)
-					migrated[i] = migrated[i][:len(migrated[i])-1]
-					if after-before > want {
-						want = after - before
-						wantDst = i
-					}
+					migrated[i] = append(migrated[i], simple.Node(n))
 				}
+				sort.Sort(ordered.ByID(migrated[i]))
+			}
 
-				if !floats.EqualWithinAbsOrRel(got, want, structure.tol, structure.tol) || gotDst != wantDst {
-					t.Errorf("unexpected result moving n=%d in c=%d of %s/%.4v: got: %.4v,%d want: %.4v,%d"+
-						"\n\t%v\n\t%v",
-						target.ID(), communityOf[target.ID()], test.name, structure.resolution, got, gotDst, want, wantDst,
-						communities, migrated)
+			for i, c := range structure.memberships {
+				if i == communityOf[target.ID()] {
+					continue
 				}
-				if gotSrc.community != communityOf[target.ID()] {
-					t.Errorf("unexpected source community index: got: %d want: %d", gotSrc, communityOf[target.ID()])
-				} else if communities[gotSrc.community][gotSrc.node].ID() != target.ID() {
-					wantNodeIdx := -1
-					for i, n := range communities[gotSrc.community] {
-						if n.ID() == target.ID() {
-							wantNodeIdx = i
-							break
-						}
+				connected := false
+				for n := range c {
+					if g.HasEdgeBetween(simple.Node(n), target) {
+						connected = true
+						break
 					}
-					t.Errorf("unexpected source node index: got: %d want: %d", gotSrc.node, wantNodeIdx)
 				}
+				if !connected {
+					continue
+				}
+				migrated[i] = append(migrated[i], target)
+				after := Q(g, migrated, structure.resolution)
+				migrated[i] = migrated[i][:len(migrated[i])-1]
+				if after-before > want {
+					want = after - before
+					wantDst = i
+				}
+			}
+
+			if !floats.EqualWithinAbsOrRel(got, want, structure.tol, structure.tol) || gotDst != wantDst {
+				t.Errorf("unexpected result moving n=%d in c=%d of %s/%.4v: got: %.4v,%d want: %.4v,%d"+
+					"\n\t%v\n\t%v",
+					target.ID(), communityOf[target.ID()], test.name, structure.resolution, got, gotDst, want, wantDst,
+					communities, migrated)
+			}
+			if gotSrc.community != communityOf[target.ID()] {
+				t.Errorf("unexpected source community index: got: %d want: %d", gotSrc, communityOf[target.ID()])
+			} else if communities[gotSrc.community][gotSrc.node].ID() != target.ID() {
+				wantNodeIdx := -1
+				for i, n := range communities[gotSrc.community] {
+					if n.ID() == target.ID() {
+						wantNodeIdx = i
+						break
+					}
+				}
+				t.Errorf("unexpected source node index: got: %d want: %d", gotSrc.node, wantNodeIdx)
 			}
 		}
 	}
 }
 
 func TestReduceQConsistencyUndirected(t *testing.T) {
-tests:
 	for _, test := range communityUndirectedQTests {
-		g := simple.NewUndirectedGraph(0, 0)
+		g := simple.NewUndirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 			}
 		}
 
-		for _, structure := range test.structures {
-			if math.IsNaN(structure.want) {
-				continue tests
-			}
+		testReduceQConsistencyUndirected(t, test, g)
+	}
+}
 
-			communities := make([][]graph.Node, len(structure.memberships))
-			for i, c := range structure.memberships {
-				for n := range c {
-					communities[i] = append(communities[i], simple.Node(n))
-				}
-				sort.Sort(ordered.ByID(communities[i]))
+func TestReduceQConsistencyWeightedUndirected(t *testing.T) {
+	for _, test := range communityUndirectedQTests {
+		g := simple.NewWeightedUndirectedGraph(0, 0)
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
 			}
+			for v := range e {
+				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+			}
+		}
 
-			gQ := Q(g, communities, structure.resolution)
-			gQnull := Q(g, nil, 1)
+		testReduceQConsistencyUndirected(t, test, g)
+	}
+}
 
-			cg0 := reduceUndirected(g, nil)
-			cg0Qnull := Q(cg0, cg0.Structure(), 1)
-			if !floats.EqualWithinAbsOrRel(gQnull, cg0Qnull, structure.tol, structure.tol) {
-				t.Errorf("disagreement between null Q from method: %v and function: %v", cg0Qnull, gQnull)
-			}
-			cg0Q := Q(cg0, communities, structure.resolution)
-			if !floats.EqualWithinAbsOrRel(gQ, cg0Q, structure.tol, structure.tol) {
-				t.Errorf("unexpected Q result after initial reduction: got: %v want :%v", cg0Q, gQ)
-			}
+func testReduceQConsistencyUndirected(t *testing.T, test communityUndirectedQTest, g graph.Undirected) {
+	for _, structure := range test.structures {
+		if math.IsNaN(structure.want) {
+			return
+		}
 
-			cg1 := reduceUndirected(cg0, communities)
-			cg1Q := Q(cg1, cg1.Structure(), structure.resolution)
-			if !floats.EqualWithinAbsOrRel(gQ, cg1Q, structure.tol, structure.tol) {
-				t.Errorf("unexpected Q result after second reduction: got: %v want :%v", cg1Q, gQ)
+		communities := make([][]graph.Node, len(structure.memberships))
+		for i, c := range structure.memberships {
+			for n := range c {
+				communities[i] = append(communities[i], simple.Node(n))
 			}
+			sort.Sort(ordered.ByID(communities[i]))
+		}
+
+		gQ := Q(g, communities, structure.resolution)
+		gQnull := Q(g, nil, 1)
+
+		cg0 := reduceUndirected(g, nil)
+		cg0Qnull := Q(cg0, cg0.Structure(), 1)
+		if !floats.EqualWithinAbsOrRel(gQnull, cg0Qnull, structure.tol, structure.tol) {
+			t.Errorf("disagreement between null Q from method: %v and function: %v", cg0Qnull, gQnull)
+		}
+		cg0Q := Q(cg0, communities, structure.resolution)
+		if !floats.EqualWithinAbsOrRel(gQ, cg0Q, structure.tol, structure.tol) {
+			t.Errorf("unexpected Q result after initial reduction: got: %v want :%v", cg0Q, gQ)
+		}
+
+		cg1 := reduceUndirected(cg0, communities)
+		cg1Q := Q(cg1, cg1.Structure(), structure.resolution)
+		if !floats.EqualWithinAbsOrRel(gQ, cg1Q, structure.tol, structure.tol) {
+			t.Errorf("unexpected Q result after second reduction: got: %v want :%v", cg1Q, gQ)
 		}
 	}
 }
 
-var localUndirectedMoveTests = []struct {
+type localUndirectedMoveTest struct {
 	name       string
 	g          []intset
 	structures []moveStructures
-}{
+}
+
+var localUndirectedMoveTests = []localUndirectedMoveTest{
 	{
 		name: "blondel",
 		g:    blondel,
@@ -490,39 +556,60 @@ var localUndirectedMoveTests = []struct {
 
 func TestMoveLocalUndirected(t *testing.T) {
 	for _, test := range localUndirectedMoveTests {
-		g := simple.NewUndirectedGraph(0, 0)
+		g := simple.NewUndirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 			}
 		}
 
-		for _, structure := range test.structures {
-			communities := make([][]graph.Node, len(structure.memberships))
-			for i, c := range structure.memberships {
-				for n := range c {
-					communities[i] = append(communities[i], simple.Node(n))
-				}
-				sort.Sort(ordered.ByID(communities[i]))
+		testMoveLocalUndirected(t, test, g)
+	}
+}
+
+func TestMoveLocalWeightedUndirected(t *testing.T) {
+	for _, test := range localUndirectedMoveTests {
+		g := simple.NewWeightedUndirectedGraph(0, 0)
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
 			}
+			for v := range e {
+				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+			}
+		}
 
-			r := reduceUndirected(reduceUndirected(g, nil), communities)
+		testMoveLocalUndirected(t, test, g)
+	}
+}
 
-			l := newUndirectedLocalMover(r, r.communities, structure.resolution)
-			for _, n := range structure.targetNodes {
-				dQ, dst, src := l.deltaQ(n)
-				if dQ > 0 {
-					before := Q(r, l.communities, structure.resolution)
-					l.move(dst, src)
-					after := Q(r, l.communities, structure.resolution)
-					want := after - before
-					if !floats.EqualWithinAbsOrRel(dQ, want, structure.tol, structure.tol) {
-						t.Errorf("unexpected deltaQ: got: %v want: %v", dQ, want)
-					}
+func testMoveLocalUndirected(t *testing.T, test localUndirectedMoveTest, g graph.Undirected) {
+	for _, structure := range test.structures {
+		communities := make([][]graph.Node, len(structure.memberships))
+		for i, c := range structure.memberships {
+			for n := range c {
+				communities[i] = append(communities[i], simple.Node(n))
+			}
+			sort.Sort(ordered.ByID(communities[i]))
+		}
+
+		r := reduceUndirected(reduceUndirected(g, nil), communities)
+
+		l := newUndirectedLocalMover(r, r.communities, structure.resolution)
+		for _, n := range structure.targetNodes {
+			dQ, dst, src := l.deltaQ(n)
+			if dQ > 0 {
+				before := Q(r, l.communities, structure.resolution)
+				l.move(dst, src)
+				after := Q(r, l.communities, structure.resolution)
+				want := after - before
+				if !floats.EqualWithinAbsOrRel(dQ, want, structure.tol, structure.tol) {
+					t.Errorf("unexpected deltaQ: got: %v want: %v", dQ, want)
 				}
 			}
 		}
@@ -530,105 +617,146 @@ func TestMoveLocalUndirected(t *testing.T) {
 }
 
 func TestModularizeUndirected(t *testing.T) {
-	const louvainIterations = 20
-
 	for _, test := range communityUndirectedQTests {
-		g := simple.NewUndirectedGraph(0, 0)
+		g := simple.NewUndirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 			}
 		}
 
-		if test.structures[0].resolution != 1 {
-			panic("bad test: expect resolution=1")
-		}
-		want := make([][]graph.Node, len(test.structures[0].memberships))
-		for i, c := range test.structures[0].memberships {
-			for n := range c {
-				want[i] = append(want[i], simple.Node(n))
+		testModularizeUndirected(t, test, g)
+	}
+}
+
+func TestModularizeWeightedUndirected(t *testing.T) {
+	for _, test := range communityUndirectedQTests {
+		g := simple.NewWeightedUndirectedGraph(0, 0)
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
 			}
-			sort.Sort(ordered.ByID(want[i]))
-		}
-		sort.Sort(ordered.BySliceIDs(want))
-
-		var (
-			got   *ReducedUndirected
-			bestQ = math.Inf(-1)
-		)
-		// Modularize is randomised so we do this to
-		// ensure the level tests are consistent.
-		src := rand.New(rand.NewSource(1))
-		for i := 0; i < louvainIterations; i++ {
-			r := Modularize(g, 1, src).(*ReducedUndirected)
-			if q := Q(r, nil, 1); q > bestQ || math.IsNaN(q) {
-				bestQ = q
-				got = r
-
-				if math.IsNaN(q) {
-					// Don't try again for non-connected case.
-					break
-				}
-			}
-
-			var qs []float64
-			for p := r; p != nil; p = p.Expanded().(*ReducedUndirected) {
-				qs = append(qs, Q(p, nil, 1))
-			}
-
-			// Recovery of Q values is reversed.
-			if reverse(qs); !sort.Float64sAreSorted(qs) {
-				t.Errorf("Q values not monotonically increasing: %.5v", qs)
+			for v := range e {
+				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 
-		gotCommunities := got.Communities()
-		for _, c := range gotCommunities {
-			sort.Sort(ordered.ByID(c))
-		}
-		sort.Sort(ordered.BySliceIDs(gotCommunities))
-		if !reflect.DeepEqual(gotCommunities, want) {
-			t.Errorf("unexpected community membership for %s Q=%.4v:\n\tgot: %v\n\twant:%v",
-				test.name, bestQ, gotCommunities, want)
-			continue
-		}
+		testModularizeUndirected(t, test, g)
+	}
+}
 
-		var levels []level
-		for p := got; p != nil; p = p.Expanded().(*ReducedUndirected) {
-			var communities [][]graph.Node
-			if p.parent != nil {
-				communities = p.parent.Communities()
-				for _, c := range communities {
-					sort.Sort(ordered.ByID(c))
-				}
-				sort.Sort(ordered.BySliceIDs(communities))
-			} else {
-				communities = reduceUndirected(g, nil).Communities()
-			}
-			q := Q(p, nil, 1)
+func testModularizeUndirected(t *testing.T, test communityUndirectedQTest, g graph.Undirected) {
+	const louvainIterations = 20
+
+	if test.structures[0].resolution != 1 {
+		panic("bad test: expect resolution=1")
+	}
+	want := make([][]graph.Node, len(test.structures[0].memberships))
+	for i, c := range test.structures[0].memberships {
+		for n := range c {
+			want[i] = append(want[i], simple.Node(n))
+		}
+		sort.Sort(ordered.ByID(want[i]))
+	}
+	sort.Sort(ordered.BySliceIDs(want))
+
+	var (
+		got   *ReducedUndirected
+		bestQ = math.Inf(-1)
+	)
+	// Modularize is randomised so we do this to
+	// ensure the level tests are consistent.
+	src := rand.New(rand.NewSource(1))
+	for i := 0; i < louvainIterations; i++ {
+		r := Modularize(g, 1, src).(*ReducedUndirected)
+		if q := Q(r, nil, 1); q > bestQ || math.IsNaN(q) {
+			bestQ = q
+			got = r
+
 			if math.IsNaN(q) {
-				// Use an equalable flag value in place of NaN.
-				q = math.Inf(-1)
+				// Don't try again for non-connected case.
+				break
 			}
-			levels = append(levels, level{q: q, communities: communities})
 		}
-		if !reflect.DeepEqual(levels, test.wantLevels) {
-			t.Errorf("unexpected level structure:\n\tgot: %v\n\twant:%v", levels, test.wantLevels)
+
+		var qs []float64
+		for p := r; p != nil; p = p.Expanded().(*ReducedUndirected) {
+			qs = append(qs, Q(p, nil, 1))
 		}
+
+		// Recovery of Q values is reversed.
+		if reverse(qs); !sort.Float64sAreSorted(qs) {
+			t.Errorf("Q values not monotonically increasing: %.5v", qs)
+		}
+	}
+
+	gotCommunities := got.Communities()
+	for _, c := range gotCommunities {
+		sort.Sort(ordered.ByID(c))
+	}
+	sort.Sort(ordered.BySliceIDs(gotCommunities))
+	if !reflect.DeepEqual(gotCommunities, want) {
+		t.Errorf("unexpected community membership for %s Q=%.4v:\n\tgot: %v\n\twant:%v",
+			test.name, bestQ, gotCommunities, want)
+		return
+	}
+
+	var levels []level
+	for p := got; p != nil; p = p.Expanded().(*ReducedUndirected) {
+		var communities [][]graph.Node
+		if p.parent != nil {
+			communities = p.parent.Communities()
+			for _, c := range communities {
+				sort.Sort(ordered.ByID(c))
+			}
+			sort.Sort(ordered.BySliceIDs(communities))
+		} else {
+			communities = reduceUndirected(g, nil).Communities()
+		}
+		q := Q(p, nil, 1)
+		if math.IsNaN(q) {
+			// Use an equalable flag value in place of NaN.
+			q = math.Inf(-1)
+		}
+		levels = append(levels, level{q: q, communities: communities})
+	}
+	if !reflect.DeepEqual(levels, test.wantLevels) {
+		t.Errorf("unexpected level structure:\n\tgot: %v\n\twant:%v", levels, test.wantLevels)
 	}
 }
 
 func TestNonContiguousUndirected(t *testing.T) {
-	g := simple.NewUndirectedGraph(0, 0)
+	g := simple.NewUndirectedGraph()
+	for _, e := range []simple.Edge{
+		{F: simple.Node(0), T: simple.Node(1)},
+		{F: simple.Node(4), T: simple.Node(5)},
+	} {
+		g.SetEdge(e)
+	}
+
+	func() {
+		defer func() {
+			r := recover()
+			if r != nil {
+				t.Error("unexpected panic with non-contiguous ID range")
+			}
+		}()
+		Modularize(g, 1, nil)
+	}()
+}
+
+func TestNonContiguousWeightedUndirected(t *testing.T) {
+	g := simple.NewWeightedUndirectedGraph(0, 0)
 	for _, e := range []simple.Edge{
 		{F: simple.Node(0), T: simple.Node(1), W: 1},
 		{F: simple.Node(4), T: simple.Node(5), W: 1},
 	} {
-		g.SetEdge(e)
+		g.SetWeightedEdge(e)
 	}
 
 	func() {

--- a/graph/encoding/dot/decode_test.go
+++ b/graph/encoding/dot/decode_test.go
@@ -110,7 +110,7 @@ type dotDirectedGraph struct {
 // newDotDirectedGraph returns a new directed capable of creating user-defined
 // nodes and edges.
 func newDotDirectedGraph() *dotDirectedGraph {
-	return &dotDirectedGraph{DirectedGraph: simple.NewDirectedGraph(0, 0)}
+	return &dotDirectedGraph{DirectedGraph: simple.NewDirectedGraph()}
 }
 
 // NewNode returns a new node with a unique node ID for the graph.
@@ -145,7 +145,7 @@ type dotUndirectedGraph struct {
 // newDotUndirectedGraph returns a new undirected capable of creating user-
 // defined nodes and edges.
 func newDotUndirectedGraph() *dotUndirectedGraph {
-	return &dotUndirectedGraph{UndirectedGraph: simple.NewUndirectedGraph(0, 0)}
+	return &dotUndirectedGraph{UndirectedGraph: simple.NewUndirectedGraph()}
 }
 
 // NewNode adds a new node with a unique node ID to the graph.

--- a/graph/encoding/dot/encode_test.go
+++ b/graph/encoding/dot/encode_test.go
@@ -5,7 +5,6 @@
 package dot
 
 import (
-	"math"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -55,7 +54,7 @@ var (
 )
 
 func directedGraphFrom(g []intset) graph.Directed {
-	dg := simple.NewDirectedGraph(0, math.Inf(1))
+	dg := simple.NewDirectedGraph()
 	for u, e := range g {
 		for v := range e {
 			dg.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
@@ -65,7 +64,7 @@ func directedGraphFrom(g []intset) graph.Directed {
 }
 
 func undirectedGraphFrom(g []intset) graph.Graph {
-	dg := simple.NewUndirectedGraph(0, math.Inf(1))
+	dg := simple.NewUndirectedGraph()
 	for u, e := range g {
 		for v := range e {
 			dg.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
@@ -85,7 +84,7 @@ func (n namedNode) ID() int64     { return n.id }
 func (n namedNode) DOTID() string { return n.name }
 
 func directedNamedIDGraphFrom(g []intset) graph.Directed {
-	dg := simple.NewDirectedGraph(0, math.Inf(1))
+	dg := simple.NewDirectedGraph()
 	for u, e := range g {
 		u := int64(u)
 		nu := namedNode{id: u, name: alpha[u : u+1]}
@@ -98,7 +97,7 @@ func directedNamedIDGraphFrom(g []intset) graph.Directed {
 }
 
 func undirectedNamedIDGraphFrom(g []intset) graph.Graph {
-	dg := simple.NewUndirectedGraph(0, math.Inf(1))
+	dg := simple.NewUndirectedGraph()
 	for u, e := range g {
 		u := int64(u)
 		nu := namedNode{id: u, name: alpha[u : u+1]}
@@ -120,7 +119,7 @@ func (n attrNode) ID() int64                        { return n.id }
 func (n attrNode) Attributes() []encoding.Attribute { return n.attr }
 
 func directedNodeAttrGraphFrom(g []intset, attr [][]encoding.Attribute) graph.Directed {
-	dg := simple.NewDirectedGraph(0, math.Inf(1))
+	dg := simple.NewDirectedGraph()
 	for u, e := range g {
 		u := int64(u)
 		var at []encoding.Attribute
@@ -140,7 +139,7 @@ func directedNodeAttrGraphFrom(g []intset, attr [][]encoding.Attribute) graph.Di
 }
 
 func undirectedNodeAttrGraphFrom(g []intset, attr [][]encoding.Attribute) graph.Graph {
-	dg := simple.NewUndirectedGraph(0, math.Inf(1))
+	dg := simple.NewUndirectedGraph()
 	for u, e := range g {
 		u := int64(u)
 		var at []encoding.Attribute
@@ -170,7 +169,7 @@ func (n namedAttrNode) DOTID() string                    { return n.name }
 func (n namedAttrNode) Attributes() []encoding.Attribute { return n.attr }
 
 func directedNamedIDNodeAttrGraphFrom(g []intset, attr [][]encoding.Attribute) graph.Directed {
-	dg := simple.NewDirectedGraph(0, math.Inf(1))
+	dg := simple.NewDirectedGraph()
 	for u, e := range g {
 		u := int64(u)
 		var at []encoding.Attribute
@@ -190,7 +189,7 @@ func directedNamedIDNodeAttrGraphFrom(g []intset, attr [][]encoding.Attribute) g
 }
 
 func undirectedNamedIDNodeAttrGraphFrom(g []intset, attr [][]encoding.Attribute) graph.Graph {
-	dg := simple.NewUndirectedGraph(0, math.Inf(1))
+	dg := simple.NewUndirectedGraph()
 	for u, e := range g {
 		u := int64(u)
 		var at []encoding.Attribute
@@ -221,7 +220,7 @@ func (e attrEdge) Weight() float64                  { return 0 }
 func (e attrEdge) Attributes() []encoding.Attribute { return e.attr }
 
 func directedEdgeAttrGraphFrom(g []intset, attr map[edge][]encoding.Attribute) graph.Directed {
-	dg := simple.NewDirectedGraph(0, math.Inf(1))
+	dg := simple.NewDirectedGraph()
 	for u, e := range g {
 		u := int64(u)
 		for v := range e {
@@ -232,7 +231,7 @@ func directedEdgeAttrGraphFrom(g []intset, attr map[edge][]encoding.Attribute) g
 }
 
 func undirectedEdgeAttrGraphFrom(g []intset, attr map[edge][]encoding.Attribute) graph.Graph {
-	dg := simple.NewUndirectedGraph(0, math.Inf(1))
+	dg := simple.NewUndirectedGraph()
 	for u, e := range g {
 		u := int64(u)
 		for v := range e {
@@ -273,7 +272,7 @@ func (e portedEdge) ToPort() (port, compass string) {
 }
 
 func directedPortedAttrGraphFrom(g []intset, attr [][]encoding.Attribute, ports map[edge]portedEdge) graph.Directed {
-	dg := simple.NewDirectedGraph(0, math.Inf(1))
+	dg := simple.NewDirectedGraph()
 	for u, e := range g {
 		u := int64(u)
 		var at []encoding.Attribute
@@ -295,7 +294,7 @@ func directedPortedAttrGraphFrom(g []intset, attr [][]encoding.Attribute, ports 
 }
 
 func undirectedPortedAttrGraphFrom(g []intset, attr [][]encoding.Attribute, ports map[edge]portedEdge) graph.Graph {
-	dg := simple.NewUndirectedGraph(0, math.Inf(1))
+	dg := simple.NewUndirectedGraph()
 	for u, e := range g {
 		u := int64(u)
 		var at []encoding.Attribute
@@ -337,10 +336,10 @@ type structuredGraph struct {
 }
 
 func undirectedStructuredGraphFrom(c []edge, g ...[]intset) graph.Graph {
-	s := &structuredGraph{UndirectedGraph: simple.NewUndirectedGraph(0, math.Inf(1))}
+	s := &structuredGraph{UndirectedGraph: simple.NewUndirectedGraph()}
 	var base int64
 	for i, sg := range g {
-		sub := simple.NewUndirectedGraph(0, math.Inf(1))
+		sub := simple.NewUndirectedGraph()
 		for u, e := range sg {
 			u := int64(u)
 			for v := range e {
@@ -382,7 +381,7 @@ func undirectedSubGraphFrom(g []intset, s map[int64][]intset) graph.Graph {
 	var base int64
 	subs := make(map[int64]subGraph)
 	for i, sg := range s {
-		sub := simple.NewUndirectedGraph(0, math.Inf(1))
+		sub := simple.NewUndirectedGraph()
 		for u, e := range sg {
 			u := int64(u)
 			for v := range e {
@@ -394,7 +393,7 @@ func undirectedSubGraphFrom(g []intset, s map[int64][]intset) graph.Graph {
 		base += int64(len(sg))
 	}
 
-	dg := simple.NewUndirectedGraph(0, math.Inf(1))
+	dg := simple.NewUndirectedGraph()
 	for u, e := range g {
 		u := int64(u)
 		var nu graph.Node

--- a/graph/encoding/graphql/decode_test.go
+++ b/graph/encoding/graphql/decode_test.go
@@ -155,7 +155,7 @@ type directedGraph struct {
 }
 
 func newDirectedGraph() *directedGraph {
-	return &directedGraph{DirectedGraph: simple.NewDirectedGraph(0, 0)}
+	return &directedGraph{DirectedGraph: simple.NewDirectedGraph()}
 }
 
 func (g *directedGraph) NewNode() graph.Node {

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -48,13 +48,22 @@ type Graph interface {
 // WeightedGraph is a weighted graph.
 type WeightedGraph interface {
 	Graph
-	Weighter
 
 	// WeightedEdge returns the weighted edge from u to v if
 	// such an edge exists and nil otherwise. The node v must
 	// be directly reachable from u as defined by the
 	// From method.
 	WeightedEdge(u, v Node) WeightedEdge
+
+	// Weight returns the weight for the edge between
+	// x and y if Edge(x, y) returns a non-nil Edge.
+	// If x and y are the same node or there is no
+	// joining edge between the two nodes the weight
+	// value returned is implementation dependent.
+	// Weight returns true if an edge exists between
+	// x and y or if x and y have the same ID, false
+	// otherwise.
+	Weight(x, y Node) (w float64, ok bool)
 }
 
 // Undirected is an undirected graph.
@@ -98,19 +107,6 @@ type WeightedDirected interface {
 	// To returns all nodes that can reach directly
 	// to the given node.
 	To(Node) []Node
-}
-
-// Weighter defines graphs that can report edge weights.
-type Weighter interface {
-	// Weight returns the weight for the edge between
-	// x and y if Edge(x, y) returns a non-nil Edge.
-	// If x and y are the same node or there is no
-	// joining edge between the two nodes the weight
-	// value returned is implementation dependent.
-	// Weight returns true if an edge exists between
-	// x and y or if x and y have the same ID, false
-	// otherwise.
-	Weight(x, y Node) (w float64, ok bool)
 }
 
 // NodeAdder is an interface for adding arbitrary nodes to a graph.

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -18,6 +18,11 @@ type Edge interface {
 	Weight() float64
 }
 
+// WeightedEdge is a graph edge. In directed graphs, the direction
+// of the edge is given from -> to, otherwise the edge is semantically
+// unordered.
+type WeightedEdge Edge
+
 // Graph is a generalized graph.
 type Graph interface {
 	// Has returns whether the node exists within the graph.
@@ -40,6 +45,17 @@ type Graph interface {
 	Edge(u, v Node) Edge
 }
 
+// WeightedGraph is a weighted graph.
+type WeightedGraph interface {
+	Graph
+
+	// WeightedEdge returns the weighted edge from u to v if
+	// such an edge exists and nil otherwise. The node v must
+	// be directly reachable from u as defined by the
+	// From method.
+	WeightedEdge(u, v Node) WeightedEdge
+}
+
 // Undirected is an undirected graph.
 type Undirected interface {
 	Graph
@@ -48,9 +64,31 @@ type Undirected interface {
 	EdgeBetween(x, y Node) Edge
 }
 
+// WeightedUndirected is a weighted undirected graph.
+type WeightedUndirected interface {
+	WeightedGraph
+
+	// WeightedEdgeBetween returns the edge between nodes
+	// x and y.
+	WeightedEdgeBetween(x, y Node) WeightedEdge
+}
+
 // Directed is a directed graph.
 type Directed interface {
 	Graph
+
+	// HasEdgeFromTo returns whether an edge exists
+	// in the graph from u to v.
+	HasEdgeFromTo(u, v Node) bool
+
+	// To returns all nodes that can reach directly
+	// to the given node.
+	To(Node) []Node
+}
+
+// WeightedDirected is a weighted directed graph.
+type WeightedDirected interface {
+	WeightedGraph
 
 	// HasEdgeFromTo returns whether an edge exists
 	// in the graph from u to v.

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -48,6 +48,7 @@ type Graph interface {
 // WeightedGraph is a weighted graph.
 type WeightedGraph interface {
 	Graph
+	Weighter
 
 	// WeightedEdge returns the weighted edge from u to v if
 	// such an edge exists and nil otherwise. The node v must

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -45,8 +45,8 @@ type Graph interface {
 	Edge(u, v Node) Edge
 }
 
-// WeightedGraph is a weighted graph.
-type WeightedGraph interface {
+// Weighted is a weighted graph.
+type Weighted interface {
 	Graph
 
 	// WeightedEdge returns the weighted edge from u to v if
@@ -76,7 +76,7 @@ type Undirected interface {
 
 // WeightedUndirected is a weighted undirected graph.
 type WeightedUndirected interface {
-	WeightedGraph
+	Weighted
 
 	// WeightedEdgeBetween returns the edge between nodes
 	// x and y.
@@ -98,7 +98,7 @@ type Directed interface {
 
 // WeightedDirected is a weighted directed graph.
 type WeightedDirected interface {
-	WeightedGraph
+	Weighted
 
 	// HasEdgeFromTo returns whether an edge exists
 	// in the graph from u to v.

--- a/graph/graphs/gen/batagelj_brandes.go
+++ b/graph/graphs/gen/batagelj_brandes.go
@@ -50,7 +50,7 @@ func Gnp(dst GraphBuilder, n int, p float64, src *rand.Rand) error {
 			v++
 		}
 		if v < n {
-			dst.SetEdge(simple.Edge{F: simple.Node(w), T: simple.Node(v), W: 1})
+			dst.SetEdge(simple.Edge{F: simple.Node(w), T: simple.Node(v)})
 		}
 	}
 
@@ -65,7 +65,7 @@ func Gnp(dst GraphBuilder, n int, p float64, src *rand.Rand) error {
 			v++
 		}
 		if v < n {
-			dst.SetEdge(simple.Edge{F: simple.Node(v), T: simple.Node(w), W: 1})
+			dst.SetEdge(simple.Edge{F: simple.Node(v), T: simple.Node(w)})
 		}
 	}
 
@@ -120,7 +120,7 @@ func Gnm(dst GraphBuilder, n, m int, src *rand.Rand) error {
 	for i := 0; i < m; i++ {
 		for {
 			v, w := edgeNodesFor(rnd(nChoose2))
-			e := simple.Edge{F: w, T: v, W: 1}
+			e := simple.Edge{F: w, T: v}
 			if !hasEdge(e.F, e.T) {
 				dst.SetEdge(e)
 				break
@@ -135,7 +135,7 @@ func Gnm(dst GraphBuilder, n, m int, src *rand.Rand) error {
 	for i := 0; i < m; i++ {
 		for {
 			v, w := edgeNodesFor(rnd(nChoose2))
-			e := simple.Edge{F: v, T: w, W: 1}
+			e := simple.Edge{F: v, T: w}
 			if !hasEdge(e.F, e.T) {
 				dst.SetEdge(e)
 				break
@@ -198,14 +198,14 @@ func SmallWorldsBB(dst GraphBuilder, n, d int, p float64, src *rand.Rand) error 
 		for i := 1; i <= d; i++ {
 			if k > 0 {
 				j := v*(v-1)/2 + (v+i)%n
-				ej := simple.Edge{W: 1}
+				var ej simple.Edge
 				ej.T, ej.F = edgeNodesFor(j)
 				if !hasEdge(ej.From(), ej.To()) {
 					dst.SetEdge(ej)
 				}
 				k--
 				m++
-				em := simple.Edge{W: 1}
+				var em simple.Edge
 				em.T, em.F = edgeNodesFor(m)
 				if !hasEdge(em.From(), em.To()) {
 					replace[j] = m
@@ -219,7 +219,7 @@ func SmallWorldsBB(dst GraphBuilder, n, d int, p float64, src *rand.Rand) error 
 	}
 	for i := m + 1; i <= n*d && i < nChoose2; i++ {
 		r := rndN(nChoose2-i) + i
-		er := simple.Edge{W: 1}
+		var er simple.Edge
 		er.T, er.F = edgeNodesFor(r)
 		if !hasEdge(er.From(), er.To()) {
 			dst.SetEdge(er)
@@ -229,7 +229,7 @@ func SmallWorldsBB(dst GraphBuilder, n, d int, p float64, src *rand.Rand) error 
 				dst.SetEdge(er)
 			}
 		}
-		ei := simple.Edge{W: 1}
+		var ei simple.Edge
 		ei.T, ei.F = edgeNodesFor(i)
 		if !hasEdge(ei.From(), ei.To()) {
 			replace[r] = i
@@ -249,7 +249,7 @@ func SmallWorldsBB(dst GraphBuilder, n, d int, p float64, src *rand.Rand) error 
 		for i := 1; i <= d; i++ {
 			if k > 0 {
 				j := v*(v-1)/2 + (v+i)%n
-				ej := simple.Edge{W: 1}
+				var ej simple.Edge
 				ej.F, ej.T = edgeNodesFor(j)
 				if !hasEdge(ej.From(), ej.To()) {
 					dst.SetEdge(ej)
@@ -268,7 +268,7 @@ func SmallWorldsBB(dst GraphBuilder, n, d int, p float64, src *rand.Rand) error 
 	}
 	for i := m + 1; i <= n*d && i < nChoose2; i++ {
 		r := rndN(nChoose2-i) + i
-		er := simple.Edge{W: 1}
+		var er simple.Edge
 		er.F, er.T = edgeNodesFor(r)
 		if !hasEdge(er.From(), er.To()) {
 			dst.SetEdge(er)

--- a/graph/graphs/gen/batagelj_brandes_test.go
+++ b/graph/graphs/gen/batagelj_brandes_test.go
@@ -5,7 +5,6 @@
 package gen
 
 import (
-	"math"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -54,7 +53,7 @@ func (g *gnDirected) SetEdge(e graph.Edge) {
 func TestGnpUndirected(t *testing.T) {
 	for n := 2; n <= 20; n++ {
 		for p := 0.; p <= 1; p += 0.1 {
-			g := &gnUndirected{UndirectedBuilder: simple.NewUndirectedGraph(0, math.Inf(1))}
+			g := &gnUndirected{UndirectedBuilder: simple.NewUndirectedGraph()}
 			err := Gnp(g, n, p, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: n=%d, p=%v: %v", n, p, err)
@@ -75,7 +74,7 @@ func TestGnpUndirected(t *testing.T) {
 func TestGnpDirected(t *testing.T) {
 	for n := 2; n <= 20; n++ {
 		for p := 0.; p <= 1; p += 0.1 {
-			g := &gnDirected{DirectedBuilder: simple.NewDirectedGraph(0, math.Inf(1))}
+			g := &gnDirected{DirectedBuilder: simple.NewDirectedGraph()}
 			err := Gnp(g, n, p, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: n=%d, p=%v: %v", n, p, err)
@@ -94,7 +93,7 @@ func TestGnmUndirected(t *testing.T) {
 	for n := 2; n <= 20; n++ {
 		nChoose2 := (n - 1) * n / 2
 		for m := 0; m <= nChoose2; m++ {
-			g := &gnUndirected{UndirectedBuilder: simple.NewUndirectedGraph(0, math.Inf(1))}
+			g := &gnUndirected{UndirectedBuilder: simple.NewUndirectedGraph()}
 			err := Gnm(g, n, m, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: n=%d, m=%d: %v", n, m, err)
@@ -116,7 +115,7 @@ func TestGnmDirected(t *testing.T) {
 	for n := 2; n <= 20; n++ {
 		nChoose2 := (n - 1) * n / 2
 		for m := 0; m <= nChoose2*2; m++ {
-			g := &gnDirected{DirectedBuilder: simple.NewDirectedGraph(0, math.Inf(1))}
+			g := &gnDirected{DirectedBuilder: simple.NewDirectedGraph()}
 			err := Gnm(g, n, m, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: n=%d, m=%d: %v", n, m, err)
@@ -135,7 +134,7 @@ func TestSmallWorldsBBUndirected(t *testing.T) {
 	for n := 2; n <= 20; n++ {
 		for d := 1; d <= (n-1)/2; d++ {
 			for p := 0.; p < 1; p += 0.1 {
-				g := &gnUndirected{UndirectedBuilder: simple.NewUndirectedGraph(0, math.Inf(1))}
+				g := &gnUndirected{UndirectedBuilder: simple.NewUndirectedGraph()}
 				err := SmallWorldsBB(g, n, d, p, nil)
 				if err != nil {
 					t.Fatalf("unexpected error: n=%d, d=%d, p=%v: %v", n, d, p, err)
@@ -158,7 +157,7 @@ func TestSmallWorldsBBDirected(t *testing.T) {
 	for n := 2; n <= 20; n++ {
 		for d := 1; d <= (n-1)/2; d++ {
 			for p := 0.; p < 1; p += 0.1 {
-				g := &gnDirected{DirectedBuilder: simple.NewDirectedGraph(0, math.Inf(1))}
+				g := &gnDirected{DirectedBuilder: simple.NewDirectedGraph()}
 				err := SmallWorldsBB(g, n, d, p, nil)
 				if err != nil {
 					t.Fatalf("unexpected error: n=%d, d=%d, p=%v: %v", n, d, p, err)

--- a/graph/graphs/gen/duplication_test.go
+++ b/graph/graphs/gen/duplication_test.go
@@ -5,7 +5,6 @@
 package gen
 
 import (
-	"math"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -38,7 +37,7 @@ func TestDuplication(t *testing.T) {
 		for alpha := 0.1; alpha <= 1; alpha += 0.1 {
 			for delta := 0.; delta <= 1; delta += 0.2 {
 				for sigma := 0.; sigma <= 1; sigma += 0.2 {
-					g := &duplication{UndirectedMutator: simple.NewUndirectedGraph(0, math.Inf(1))}
+					g := &duplication{UndirectedMutator: simple.NewUndirectedGraph()}
 					err := Duplication(g, n, delta, alpha, sigma, nil)
 					if err != nil {
 						t.Fatalf("unexpected error: n=%d, alpha=%v, delta=%v sigma=%v: %v", n, alpha, delta, sigma, err)

--- a/graph/graphs/gen/holme_kim.go
+++ b/graph/graphs/gen/holme_kim.go
@@ -72,7 +72,7 @@ func TunableClusteringScaleFree(dst graph.UndirectedBuilder, n, m int, p float64
 					if wid == int64(v) || dst.HasEdgeBetween(w, simple.Node(v)) {
 						continue
 					}
-					dst.SetEdge(simple.Edge{F: w, T: simple.Node(v), W: 1})
+					dst.SetEdge(simple.Edge{F: w, T: simple.Node(v)})
 					wt[wid]++
 					wt[v]++
 					continue pa
@@ -89,7 +89,7 @@ func TunableClusteringScaleFree(dst graph.UndirectedBuilder, n, m int, p float64
 				if u == v || dst.HasEdgeBetween(simple.Node(u), simple.Node(v)) {
 					continue
 				}
-				dst.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				dst.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 				wt[u]++
 				wt[v]++
 				break
@@ -149,7 +149,7 @@ func PreferentialAttachment(dst graph.UndirectedBuilder, n, m int, src *rand.Ran
 			if !ok {
 				return errors.New("gen: depleted distribution")
 			}
-			dst.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+			dst.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 			wt[u]++
 			wt[v]++
 		}

--- a/graph/graphs/gen/holme_kim_test.go
+++ b/graph/graphs/gen/holme_kim_test.go
@@ -5,7 +5,6 @@
 package gen
 
 import (
-	"math"
 	"testing"
 
 	"gonum.org/v1/gonum/graph/simple"
@@ -15,7 +14,7 @@ func TestTunableClusteringScaleFree(t *testing.T) {
 	for n := 2; n <= 20; n++ {
 		for m := 0; m < n; m++ {
 			for p := 0.; p <= 1; p += 0.1 {
-				g := &gnUndirected{UndirectedBuilder: simple.NewUndirectedGraph(0, math.Inf(1))}
+				g := &gnUndirected{UndirectedBuilder: simple.NewUndirectedGraph()}
 				err := TunableClusteringScaleFree(g, n, m, p, nil)
 				if err != nil {
 					t.Fatalf("unexpected error: n=%d, m=%d, p=%v: %v", n, m, p, err)
@@ -37,7 +36,7 @@ func TestTunableClusteringScaleFree(t *testing.T) {
 func TestPreferentialAttachment(t *testing.T) {
 	for n := 2; n <= 20; n++ {
 		for m := 0; m < n; m++ {
-			g := &gnUndirected{UndirectedBuilder: simple.NewUndirectedGraph(0, math.Inf(1))}
+			g := &gnUndirected{UndirectedBuilder: simple.NewUndirectedGraph()}
 			err := PreferentialAttachment(g, n, m, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: n=%d, m=%d: %v", n, m, err)

--- a/graph/graphs/gen/small_world.go
+++ b/graph/graphs/gen/small_world.go
@@ -62,7 +62,7 @@ func NavigableSmallWorld(dst GraphBuilder, dims []int, p, q int, r float64, src 
 				return
 			}
 			vid := idFromDelta(u, delta, dims, -p)
-			e := simple.Edge{F: simple.Node(uid), T: simple.Node(vid), W: 1}
+			e := simple.Edge{F: simple.Node(uid), T: simple.Node(vid)}
 			if uid > vid {
 				e.F, e.T = e.T, e.F
 			}
@@ -105,7 +105,7 @@ func NavigableSmallWorld(dst GraphBuilder, dims []int, p, q int, r float64, src 
 			if !ok {
 				panic("depleted distribution")
 			}
-			e := simple.Edge{F: simple.Node(uid), T: simple.Node(vid), W: 1}
+			e := simple.Edge{F: simple.Node(uid), T: simple.Node(vid)}
 			if !isDirected && uid > vid {
 				e.F, e.T = e.T, e.F
 			}

--- a/graph/graphs/gen/small_world_test.go
+++ b/graph/graphs/gen/small_world_test.go
@@ -5,7 +5,6 @@
 package gen
 
 import (
-	"math"
 	"testing"
 
 	"gonum.org/v1/gonum/graph/simple"
@@ -22,7 +21,7 @@ func TestNavigableSmallWorldUndirected(t *testing.T) {
 		for q := 0; q < 10; q++ {
 			for r := 0.5; r < 10; r++ {
 				for _, dims := range smallWorldDimensionParameters {
-					g := &gnUndirected{UndirectedBuilder: simple.NewUndirectedGraph(0, math.Inf(1))}
+					g := &gnUndirected{UndirectedBuilder: simple.NewUndirectedGraph()}
 					err := NavigableSmallWorld(g, dims, p, q, r, nil)
 					n := 1
 					for _, d := range dims {
@@ -51,7 +50,7 @@ func TestNavigableSmallWorldDirected(t *testing.T) {
 		for q := 0; q < 10; q++ {
 			for r := 0.5; r < 10; r++ {
 				for _, dims := range smallWorldDimensionParameters {
-					g := &gnDirected{DirectedBuilder: simple.NewDirectedGraph(0, math.Inf(1))}
+					g := &gnDirected{DirectedBuilder: simple.NewDirectedGraph()}
 					err := NavigableSmallWorld(g, dims, p, q, r, nil)
 					n := 1
 					for _, d := range dims {

--- a/graph/network/betweenness.go
+++ b/graph/network/betweenness.go
@@ -146,7 +146,7 @@ func brandes(g graph.Graph, accumulate func(s graph.Node, stack linear.NodeStack
 //
 // where \sigma_{st} and \sigma_{st}(v) are the number of shortest paths from s to t,
 // and the subset of those paths containing v respectively.
-func BetweennessWeighted(g graph.WeightedGraph, p path.AllShortest) map[int64]float64 {
+func BetweennessWeighted(g graph.Weighted, p path.AllShortest) map[int64]float64 {
 	cb := make(map[int64]float64)
 
 	nodes := g.Nodes()
@@ -197,7 +197,7 @@ func BetweennessWeighted(g graph.WeightedGraph, p path.AllShortest) map[int64]fl
 //
 // If g is undirected, edges are retained such that u.ID < v.ID where u and v are
 // the nodes of e.
-func EdgeBetweennessWeighted(g graph.WeightedGraph, p path.AllShortest) map[[2]int64]float64 {
+func EdgeBetweennessWeighted(g graph.Weighted, p path.AllShortest) map[[2]int64]float64 {
 	cb := make(map[[2]int64]float64)
 
 	_, isUndirected := g.(graph.Undirected)

--- a/graph/network/betweenness.go
+++ b/graph/network/betweenness.go
@@ -139,12 +139,6 @@ func brandes(g graph.Graph, accumulate func(s graph.Node, stack linear.NodeStack
 	}
 }
 
-// WeightedGraph is a graph with edge weights.
-type WeightedGraph interface {
-	graph.Graph
-	graph.Weighter
-}
-
 // BetweennessWeighted returns the non-zero betweenness centrality for nodes in the weighted
 // graph g used to construct the given shortest paths.
 //
@@ -152,7 +146,7 @@ type WeightedGraph interface {
 //
 // where \sigma_{st} and \sigma_{st}(v) are the number of shortest paths from s to t,
 // and the subset of those paths containing v respectively.
-func BetweennessWeighted(g WeightedGraph, p path.AllShortest) map[int64]float64 {
+func BetweennessWeighted(g graph.WeightedGraph, p path.AllShortest) map[int64]float64 {
 	cb := make(map[int64]float64)
 
 	nodes := g.Nodes()
@@ -203,7 +197,7 @@ func BetweennessWeighted(g WeightedGraph, p path.AllShortest) map[int64]float64 
 //
 // If g is undirected, edges are retained such that u.ID < v.ID where u and v are
 // the nodes of e.
-func EdgeBetweennessWeighted(g WeightedGraph, p path.AllShortest) map[[2]int64]float64 {
+func EdgeBetweennessWeighted(g graph.WeightedGraph, p path.AllShortest) map[[2]int64]float64 {
 	cb := make(map[[2]int64]float64)
 
 	_, isUndirected := g.(graph.Undirected)

--- a/graph/network/betweenness_test.go
+++ b/graph/network/betweenness_test.go
@@ -244,7 +244,7 @@ func TestBetweennessWeighted(t *testing.T) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 
@@ -280,7 +280,7 @@ func TestEdgeBetweennessWeighted(t *testing.T) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 

--- a/graph/network/betweenness_test.go
+++ b/graph/network/betweenness_test.go
@@ -176,15 +176,14 @@ var betweennessTests = []struct {
 
 func TestBetweenness(t *testing.T) {
 	for i, test := range betweennessTests {
-		g := simple.NewUndirectedGraph(0, math.Inf(1))
+		g := simple.NewUndirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				// Weight omitted to show weight-independence.
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 0})
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 			}
 		}
 		got := Betweenness(g)
@@ -206,15 +205,14 @@ func TestBetweenness(t *testing.T) {
 
 func TestEdgeBetweenness(t *testing.T) {
 	for i, test := range betweennessTests {
-		g := simple.NewUndirectedGraph(0, math.Inf(1))
+		g := simple.NewUndirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				// Weight omitted to show weight-independence.
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 0})
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 			}
 		}
 		got := EdgeBetweenness(g)
@@ -239,14 +237,14 @@ func TestEdgeBetweenness(t *testing.T) {
 
 func TestBetweennessWeighted(t *testing.T) {
 	for i, test := range betweennessTests {
-		g := simple.NewUndirectedGraph(0, math.Inf(1))
+		g := simple.NewWeightedUndirectedGraph(0, math.Inf(1))
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 
@@ -275,14 +273,14 @@ func TestBetweennessWeighted(t *testing.T) {
 
 func TestEdgeBetweennessWeighted(t *testing.T) {
 	for i, test := range betweennessTests {
-		g := simple.NewUndirectedGraph(0, math.Inf(1))
+		g := simple.NewWeightedUndirectedGraph(0, math.Inf(1))
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 

--- a/graph/network/distance_test.go
+++ b/graph/network/distance_test.go
@@ -150,7 +150,7 @@ func TestDistanceCentralityUndirected(t *testing.T) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 		p, ok := path.FloydWarshall(g)
@@ -340,7 +340,7 @@ func TestDistanceCentralityDirected(t *testing.T) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.WeightedEdge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 		p, ok := path.FloydWarshall(g)

--- a/graph/network/distance_test.go
+++ b/graph/network/distance_test.go
@@ -143,14 +143,14 @@ func TestDistanceCentralityUndirected(t *testing.T) {
 	prec := 1 - int(math.Log10(tol))
 
 	for i, test := range undirectedCentralityTests {
-		g := simple.NewUndirectedGraph(0, math.Inf(1))
+		g := simple.NewWeightedUndirectedGraph(0, math.Inf(1))
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 		p, ok := path.FloydWarshall(g)
@@ -333,14 +333,14 @@ func TestDistanceCentralityDirected(t *testing.T) {
 	prec := 1 - int(math.Log10(tol))
 
 	for i, test := range directedCentralityTests {
-		g := simple.NewDirectedGraph(0, math.Inf(1))
+		g := simple.NewWeightedDirectedGraph(0, math.Inf(1))
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
 				g.AddNode(simple.Node(u))
 			}
 			for v := range e {
-				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
+				g.SetWeightedEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v), W: 1})
 			}
 		}
 		p, ok := path.FloydWarshall(g)

--- a/graph/network/hits_test.go
+++ b/graph/network/hits_test.go
@@ -43,7 +43,7 @@ var hitsTests = []struct {
 
 func TestHITS(t *testing.T) {
 	for i, test := range hitsTests {
-		g := simple.NewDirectedGraph(0, math.Inf(1))
+		g := simple.NewDirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {

--- a/graph/network/page_test.go
+++ b/graph/network/page_test.go
@@ -81,7 +81,7 @@ var pageRankTests = []struct {
 
 func TestPageRank(t *testing.T) {
 	for i, test := range pageRankTests {
-		g := simple.NewDirectedGraph(0, math.Inf(1))
+		g := simple.NewDirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
@@ -105,7 +105,7 @@ func TestPageRank(t *testing.T) {
 
 func TestPageRankSparse(t *testing.T) {
 	for i, test := range pageRankTests {
-		g := simple.NewDirectedGraph(0, math.Inf(1))
+		g := simple.NewDirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {

--- a/graph/path/a_star.go
+++ b/graph/path/a_star.go
@@ -28,7 +28,7 @@ func AStar(s, t graph.Node, g graph.Graph, h Heuristic) (path Shortest, expanded
 		return Shortest{from: s}, 0
 	}
 	var weight Weighting
-	if wg, ok := g.(graph.Weighter); ok {
+	if wg, ok := g.(graph.WeightedGraph); ok {
 		weight = wg.Weight
 	} else {
 		weight = UniformCost(g)

--- a/graph/path/a_star.go
+++ b/graph/path/a_star.go
@@ -28,7 +28,7 @@ func AStar(s, t graph.Node, g graph.Graph, h Heuristic) (path Shortest, expanded
 		return Shortest{from: s}, 0
 	}
 	var weight Weighting
-	if wg, ok := g.(graph.WeightedGraph); ok {
+	if wg, ok := g.(graph.Weighted); ok {
 		weight = wg.Weight
 	} else {
 		weight = UniformCost(g)

--- a/graph/path/a_star_test.go
+++ b/graph/path/a_star_test.go
@@ -228,7 +228,7 @@ func (e weightedEdge) Weight() float64  { return e.cost }
 
 func isMonotonic(g UndirectedWeightLister, h Heuristic) (ok bool, at graph.Edge, goal graph.Node) {
 	for _, goal := range g.Nodes() {
-		for _, edge := range g.Edges() {
+		for _, edge := range g.WeightedEdges() {
 			from := edge.From()
 			to := edge.To()
 			w, ok := g.Weight(from, to)

--- a/graph/path/a_star_test.go
+++ b/graph/path/a_star_test.go
@@ -154,7 +154,7 @@ func TestAStar(t *testing.T) {
 }
 
 func TestExhaustiveAStar(t *testing.T) {
-	g := simple.NewUndirectedGraph(0, math.Inf(1))
+	g := simple.NewWeightedUndirectedGraph(0, math.Inf(1))
 	nodes := []locatedNode{
 		{id: 1, x: 0, y: 6},
 		{id: 2, x: 1, y: 0},
@@ -179,7 +179,7 @@ func TestExhaustiveAStar(t *testing.T) {
 		{from: g.Node(5), to: g.Node(6), cost: 9},
 	}
 	for _, e := range edges {
-		g.SetEdge(e)
+		g.SetWeightedEdge(e)
 	}
 
 	heuristic := func(u, v graph.Node) float64 {
@@ -247,7 +247,7 @@ func TestAStarNullHeuristic(t *testing.T) {
 	for _, test := range testgraphs.ShortestPathTests {
 		g := test.Graph()
 		for _, e := range test.Edges {
-			g.SetEdge(e)
+			g.SetWeightedEdge(e)
 		}
 
 		var (

--- a/graph/path/bellman_ford_moore.go
+++ b/graph/path/bellman_ford_moore.go
@@ -16,7 +16,7 @@ func BellmanFordFrom(u graph.Node, g graph.Graph) (path Shortest, ok bool) {
 		return Shortest{from: u}, true
 	}
 	var weight Weighting
-	if wg, ok := g.(graph.WeightedGraph); ok {
+	if wg, ok := g.(graph.Weighted); ok {
 		weight = wg.Weight
 	} else {
 		weight = UniformCost(g)

--- a/graph/path/bellman_ford_moore.go
+++ b/graph/path/bellman_ford_moore.go
@@ -16,7 +16,7 @@ func BellmanFordFrom(u graph.Node, g graph.Graph) (path Shortest, ok bool) {
 		return Shortest{from: u}, true
 	}
 	var weight Weighting
-	if wg, ok := g.(graph.Weighter); ok {
+	if wg, ok := g.(graph.WeightedGraph); ok {
 		weight = wg.Weight
 	} else {
 		weight = UniformCost(g)

--- a/graph/path/bellman_ford_moore_test.go
+++ b/graph/path/bellman_ford_moore_test.go
@@ -17,7 +17,7 @@ func TestBellmanFordFrom(t *testing.T) {
 	for _, test := range testgraphs.ShortestPathTests {
 		g := test.Graph()
 		for _, e := range test.Edges {
-			g.SetEdge(e)
+			g.SetWeightedEdge(e)
 		}
 
 		pt, ok := BellmanFordFrom(test.Query.From(), g.(graph.Graph))

--- a/graph/path/bench_test.go
+++ b/graph/path/bench_test.go
@@ -5,7 +5,6 @@
 package path
 
 import (
-	"math"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -23,7 +22,7 @@ var (
 )
 
 func gnpUndirected(n int, p float64) graph.Undirected {
-	g := simple.NewUndirectedGraph(0, math.Inf(1))
+	g := simple.NewUndirectedGraph()
 	gen.Gnp(g, n, p, nil)
 	return g
 }
@@ -65,7 +64,7 @@ var (
 )
 
 func navigableSmallWorldUndirected(n, p, q int, r float64) graph.Undirected {
-	g := simple.NewUndirectedGraph(0, math.Inf(1))
+	g := simple.NewUndirectedGraph()
 	gen.NavigableSmallWorld(g, []int{n, n}, p, q, r, nil)
 	return g
 }

--- a/graph/path/dijkstra.go
+++ b/graph/path/dijkstra.go
@@ -20,7 +20,7 @@ func DijkstraFrom(u graph.Node, g graph.Graph) Shortest {
 		return Shortest{from: u}
 	}
 	var weight Weighting
-	if wg, ok := g.(graph.WeightedGraph); ok {
+	if wg, ok := g.(graph.Weighted); ok {
 		weight = wg.Weight
 	} else {
 		weight = UniformCost(g)
@@ -83,7 +83,7 @@ func DijkstraAllPaths(g graph.Graph) (paths AllShortest) {
 // result of the work in the paths parameter which is a reference type.
 func dijkstraAllPaths(g graph.Graph, paths AllShortest) {
 	var weight Weighting
-	if wg, ok := g.(graph.WeightedGraph); ok {
+	if wg, ok := g.(graph.Weighted); ok {
 		weight = wg.Weight
 	} else {
 		weight = UniformCost(g)

--- a/graph/path/dijkstra.go
+++ b/graph/path/dijkstra.go
@@ -20,7 +20,7 @@ func DijkstraFrom(u graph.Node, g graph.Graph) Shortest {
 		return Shortest{from: u}
 	}
 	var weight Weighting
-	if wg, ok := g.(graph.Weighter); ok {
+	if wg, ok := g.(graph.WeightedGraph); ok {
 		weight = wg.Weight
 	} else {
 		weight = UniformCost(g)
@@ -83,7 +83,7 @@ func DijkstraAllPaths(g graph.Graph) (paths AllShortest) {
 // result of the work in the paths parameter which is a reference type.
 func dijkstraAllPaths(g graph.Graph, paths AllShortest) {
 	var weight Weighting
-	if wg, ok := g.(graph.Weighter); ok {
+	if wg, ok := g.(graph.WeightedGraph); ok {
 		weight = wg.Weight
 	} else {
 		weight = UniformCost(g)

--- a/graph/path/dijkstra_test.go
+++ b/graph/path/dijkstra_test.go
@@ -19,7 +19,7 @@ func TestDijkstraFrom(t *testing.T) {
 	for _, test := range testgraphs.ShortestPathTests {
 		g := test.Graph()
 		for _, e := range test.Edges {
-			g.SetEdge(e)
+			g.SetWeightedEdge(e)
 		}
 
 		var (
@@ -85,7 +85,7 @@ func TestDijkstraAllPaths(t *testing.T) {
 	for _, test := range testgraphs.ShortestPathTests {
 		g := test.Graph()
 		for _, e := range test.Edges {
-			g.SetEdge(e)
+			g.SetWeightedEdge(e)
 		}
 
 		var (

--- a/graph/path/dynamic/dstarlite.go
+++ b/graph/path/dynamic/dstarlite.go
@@ -104,7 +104,7 @@ func NewDStarLite(s, t graph.Node, g graph.Graph, h path.Heuristic, m WorldModel
 			if w < 0 {
 				panic("D* Lite: negative edge weight")
 			}
-			d.model.SetWeightedEdge(simple.Edge{F: u, T: d.model.Node(v.ID()), W: w})
+			d.model.SetWeightedEdge(simple.WeightedEdge{F: u, T: d.model.Node(v.ID()), W: w})
 		}
 	}
 
@@ -302,7 +302,7 @@ func (d *DStarLite) UpdateWorld(changes []graph.Edge) {
 		cOld, _ := d.model.Weight(from, to)
 		u := d.worldNodeFor(from)
 		v := d.worldNodeFor(to)
-		d.model.SetWeightedEdge(simple.Edge{F: u, T: v, W: c})
+		d.model.SetWeightedEdge(simple.WeightedEdge{F: u, T: v, W: c})
 		if cOld > c {
 			if u.ID() != d.t.ID() {
 				u.rhs = math.Min(u.rhs, c+v.g)

--- a/graph/path/dynamic/dstarlite.go
+++ b/graph/path/dynamic/dstarlite.go
@@ -73,7 +73,7 @@ func NewDStarLite(s, t graph.Node, g graph.Graph, h path.Heuristic, m WorldModel
 	*/
 	d.last = d.s
 
-	if wg, ok := g.(graph.WeightedGraph); ok {
+	if wg, ok := g.(graph.Weighted); ok {
 		d.weight = wg.Weight
 	} else {
 		d.weight = path.UniformCost(g)

--- a/graph/path/dynamic/dstarlite.go
+++ b/graph/path/dynamic/dstarlite.go
@@ -33,7 +33,7 @@ type DStarLite struct {
 // WorldModel is a mutable weighted directed graph that returns nodes identified
 // by id number.
 type WorldModel interface {
-	graph.Builder
+	graph.WeightedBuilder
 	graph.WeightedDirected
 	Node(id int64) graph.Node
 }
@@ -104,7 +104,7 @@ func NewDStarLite(s, t graph.Node, g graph.Graph, h path.Heuristic, m WorldModel
 			if w < 0 {
 				panic("D* Lite: negative edge weight")
 			}
-			d.model.SetEdge(simple.Edge{F: u, T: d.model.Node(v.ID()), W: w})
+			d.model.SetWeightedEdge(simple.Edge{F: u, T: d.model.Node(v.ID()), W: w})
 		}
 	}
 
@@ -302,7 +302,7 @@ func (d *DStarLite) UpdateWorld(changes []graph.Edge) {
 		cOld, _ := d.model.Weight(from, to)
 		u := d.worldNodeFor(from)
 		v := d.worldNodeFor(to)
-		d.model.SetEdge(simple.Edge{F: u, T: v, W: c})
+		d.model.SetWeightedEdge(simple.Edge{F: u, T: v, W: c})
 		if cOld > c {
 			if u.ID() != d.t.ID() {
 				u.rhs = math.Min(u.rhs, c+v.g)

--- a/graph/path/dynamic/dstarlite.go
+++ b/graph/path/dynamic/dstarlite.go
@@ -33,8 +33,8 @@ type DStarLite struct {
 // WorldModel is a mutable weighted directed graph that returns nodes identified
 // by id number.
 type WorldModel interface {
-	graph.DirectedBuilder
-	graph.Weighter
+	graph.Builder
+	graph.WeightedDirected
 	Node(id int64) graph.Node
 }
 
@@ -73,7 +73,7 @@ func NewDStarLite(s, t graph.Node, g graph.Graph, h path.Heuristic, m WorldModel
 	*/
 	d.last = d.s
 
-	if wg, ok := g.(graph.Weighter); ok {
+	if wg, ok := g.(graph.WeightedGraph); ok {
 		d.weight = wg.Weight
 	} else {
 		d.weight = path.UniformCost(g)

--- a/graph/path/dynamic/dstarlite_test.go
+++ b/graph/path/dynamic/dstarlite_test.go
@@ -653,7 +653,7 @@ func samePath(a, b []graph.Node) bool {
 }
 
 // weightOf return the weight of the path in g.
-func weightOf(path []graph.Node, g graph.WeightedGraph) float64 {
+func weightOf(path []graph.Node, g graph.Weighted) float64 {
 	var w float64
 	if len(path) > 1 {
 		for p, n := range path[1:] {
@@ -668,7 +668,7 @@ func weightOf(path []graph.Node, g graph.WeightedGraph) float64 {
 }
 
 // simpleEdgesOf returns the weighted edges in g corresponding to the given edges.
-func simpleEdgesOf(g graph.WeightedGraph, edges []graph.Edge) []simple.Edge {
+func simpleEdgesOf(g graph.Weighted, edges []graph.Edge) []simple.Edge {
 	w := make([]simple.Edge, len(edges))
 	for i, e := range edges {
 		w[i].F = e.From()

--- a/graph/path/dynamic/dstarlite_test.go
+++ b/graph/path/dynamic/dstarlite_test.go
@@ -35,7 +35,7 @@ func TestDStarLiteNullHeuristic(t *testing.T) {
 
 		g := test.Graph()
 		for _, e := range test.Edges {
-			g.SetEdge(e)
+			g.SetWeightedEdge(e)
 		}
 
 		var (
@@ -47,7 +47,7 @@ func TestDStarLiteNullHeuristic(t *testing.T) {
 			defer func() {
 				panicked = recover() != nil
 			}()
-			d = NewDStarLite(test.Query.From(), test.Query.To(), g.(graph.Graph), path.NullHeuristic, simple.NewDirectedGraph(0, math.Inf(1)))
+			d = NewDStarLite(test.Query.From(), test.Query.To(), g.(graph.Graph), path.NullHeuristic, simple.NewWeightedDirectedGraph(0, math.Inf(1)))
 		}()
 		if panicked || test.HasNegativeWeight {
 			if !test.HasNegativeWeight {
@@ -579,7 +579,7 @@ func TestDStarLiteDynamic(t *testing.T) {
 				return test.heuristic(ax-bx, ay-by)
 			}
 
-			world := simple.NewDirectedGraph(0, math.Inf(1))
+			world := simple.NewWeightedDirectedGraph(0, math.Inf(1))
 			d := NewDStarLite(test.s, test.t, l, heuristic, world)
 			var (
 				dp  *dumper

--- a/graph/path/dynamic/dstarlite_test.go
+++ b/graph/path/dynamic/dstarlite_test.go
@@ -596,7 +596,7 @@ func TestDStarLiteDynamic(t *testing.T) {
 			}
 
 			dp.dump(true)
-			dp.printEdges("Initial world knowledge: %s\n\n", simpleEdgesOf(l, world.Edges()))
+			dp.printEdges("Initial world knowledge: %s\n\n", simpleWeightedEdgesOf(l, world.Edges()))
 			for d.Step() {
 				changes, _ := l.MoveTo(d.Here())
 				got = append(got, l.Location)
@@ -609,7 +609,7 @@ func TestDStarLiteDynamic(t *testing.T) {
 							i, memory(remember), gotPath, wantedPath)
 					}
 				}
-				dp.printEdges("Edges changing after last step:\n%s\n\n", simpleEdgesOf(l, changes))
+				dp.printEdges("Edges changing after last step:\n%s\n\n", simpleWeightedEdgesOf(l, changes))
 			}
 
 			if weight := weightOf(got, l.Grid); !samePath(got, test.want) || weight != test.weight {
@@ -667,9 +667,9 @@ func weightOf(path []graph.Node, g graph.Weighted) float64 {
 	return w
 }
 
-// simpleEdgesOf returns the weighted edges in g corresponding to the given edges.
-func simpleEdgesOf(g graph.Weighted, edges []graph.Edge) []simple.Edge {
-	w := make([]simple.Edge, len(edges))
+// simpleWeightedEdgesOf returns the weighted edges in g corresponding to the given edges.
+func simpleWeightedEdgesOf(g graph.Weighted, edges []graph.Edge) []simple.WeightedEdge {
+	w := make([]simple.WeightedEdge, len(edges))
 	for i, e := range edges {
 		w[i].F = e.From()
 		w[i].T = e.To()

--- a/graph/path/dynamic/dstarlite_test.go
+++ b/graph/path/dynamic/dstarlite_test.go
@@ -652,13 +652,8 @@ func samePath(a, b []graph.Node) bool {
 	return true
 }
 
-type weightedGraph interface {
-	graph.Graph
-	graph.Weighter
-}
-
 // weightOf return the weight of the path in g.
-func weightOf(path []graph.Node, g weightedGraph) float64 {
+func weightOf(path []graph.Node, g graph.WeightedGraph) float64 {
 	var w float64
 	if len(path) > 1 {
 		for p, n := range path[1:] {
@@ -673,7 +668,7 @@ func weightOf(path []graph.Node, g weightedGraph) float64 {
 }
 
 // simpleEdgesOf returns the weighted edges in g corresponding to the given edges.
-func simpleEdgesOf(g weightedGraph, edges []graph.Edge) []simple.Edge {
+func simpleEdgesOf(g graph.WeightedGraph, edges []graph.Edge) []simple.Edge {
 	w := make([]simple.Edge, len(edges))
 	for i, e := range edges {
 		w[i].F = e.From()

--- a/graph/path/dynamic/dumper_test.go
+++ b/graph/path/dynamic/dumper_test.go
@@ -126,7 +126,7 @@ func (d *dumper) dump(withpath bool) {
 // printEdges pretty prints the given edges to the dumper's io.Writer using the provided
 // format string. The edges are first formated to a string, so the format string must use
 // the %s verb to indicate where the edges are to be printed.
-func (d *dumper) printEdges(format string, edges []simple.Edge) {
+func (d *dumper) printEdges(format string, edges []simple.WeightedEdge) {
 	if d == nil {
 		return
 	}
@@ -144,7 +144,7 @@ func (d *dumper) printEdges(format string, edges []simple.Edge) {
 	fmt.Fprintf(d.w, format, buf.Bytes())
 }
 
-type lexically []simple.Edge
+type lexically []simple.WeightedEdge
 
 func (l lexically) Len() int { return len(l) }
 func (l lexically) Less(i, j int) bool {

--- a/graph/path/floydwarshall.go
+++ b/graph/path/floydwarshall.go
@@ -13,7 +13,7 @@ import "gonum.org/v1/gonum/graph"
 // The time complexity of FloydWarshall is O(|V|^3).
 func FloydWarshall(g graph.Graph) (paths AllShortest, ok bool) {
 	var weight Weighting
-	if wg, ok := g.(graph.Weighter); ok {
+	if wg, ok := g.(graph.WeightedGraph); ok {
 		weight = wg.Weight
 	} else {
 		weight = UniformCost(g)

--- a/graph/path/floydwarshall.go
+++ b/graph/path/floydwarshall.go
@@ -13,7 +13,7 @@ import "gonum.org/v1/gonum/graph"
 // The time complexity of FloydWarshall is O(|V|^3).
 func FloydWarshall(g graph.Graph) (paths AllShortest, ok bool) {
 	var weight Weighting
-	if wg, ok := g.(graph.WeightedGraph); ok {
+	if wg, ok := g.(graph.Weighted); ok {
 		weight = wg.Weight
 	} else {
 		weight = UniformCost(g)

--- a/graph/path/floydwarshall_test.go
+++ b/graph/path/floydwarshall_test.go
@@ -19,7 +19,7 @@ func TestFloydWarshall(t *testing.T) {
 	for _, test := range testgraphs.ShortestPathTests {
 		g := test.Graph()
 		for _, e := range test.Edges {
-			g.SetEdge(e)
+			g.SetWeightedEdge(e)
 		}
 
 		pt, ok := FloydWarshall(g.(graph.Graph))

--- a/graph/path/internal/grid.go
+++ b/graph/path/internal/grid.go
@@ -218,11 +218,11 @@ func (g *Grid) EdgeBetween(u, v graph.Node) graph.Edge {
 func (g *Grid) WeightedEdgeBetween(u, v graph.Node) graph.WeightedEdge {
 	if g.HasEdgeBetween(u, v) {
 		if !g.AllowDiagonal || g.UnitEdgeWeight {
-			return simple.Edge{F: u, T: v, W: 1}
+			return simple.WeightedEdge{F: u, T: v, W: 1}
 		}
 		ux, uy := g.XY(u)
 		vx, vy := g.XY(v)
-		return simple.Edge{F: u, T: v, W: math.Hypot(ux-vx, uy-vy)}
+		return simple.WeightedEdge{F: u, T: v, W: math.Hypot(ux-vx, uy-vy)}
 	}
 	return nil
 }

--- a/graph/path/internal/grid.go
+++ b/graph/path/internal/grid.go
@@ -201,11 +201,21 @@ func abs(i int) int {
 
 // Edge returns the edge between u and v.
 func (g *Grid) Edge(u, v graph.Node) graph.Edge {
-	return g.EdgeBetween(u, v)
+	return g.WeightedEdgeBetween(u, v)
+}
+
+// WeightedEdge returns the weighted edge between u and v.
+func (g *Grid) WeightedEdge(u, v graph.Node) graph.WeightedEdge {
+	return g.WeightedEdgeBetween(u, v)
 }
 
 // EdgeBetween returns the edge between u and v.
 func (g *Grid) EdgeBetween(u, v graph.Node) graph.Edge {
+	return g.WeightedEdgeBetween(u, v)
+}
+
+// WeightedEdgeBetween returns the weighted edge between u and v.
+func (g *Grid) WeightedEdgeBetween(u, v graph.Node) graph.WeightedEdge {
 	if g.HasEdgeBetween(u, v) {
 		if !g.AllowDiagonal || g.UnitEdgeWeight {
 			return simple.Edge{F: u, T: v, W: 1}

--- a/graph/path/internal/limited.go
+++ b/graph/path/internal/limited.go
@@ -234,11 +234,11 @@ func (l *LimitedVisionGrid) EdgeBetween(u, v graph.Node) graph.Edge {
 func (l *LimitedVisionGrid) WeightedEdgeBetween(u, v graph.Node) graph.WeightedEdge {
 	if l.HasEdgeBetween(u, v) {
 		if !l.Grid.AllowDiagonal || l.Grid.UnitEdgeWeight {
-			return simple.Edge{F: u, T: v, W: 1}
+			return simple.WeightedEdge{F: u, T: v, W: 1}
 		}
 		ux, uy := l.XY(u)
 		vx, vy := l.XY(v)
-		return simple.Edge{F: u, T: v, W: math.Hypot(ux-vx, uy-vy)}
+		return simple.WeightedEdge{F: u, T: v, W: math.Hypot(ux-vx, uy-vy)}
 	}
 	return nil
 }

--- a/graph/path/internal/limited.go
+++ b/graph/path/internal/limited.go
@@ -217,11 +217,21 @@ func (l *LimitedVisionGrid) HasEdgeBetween(u, v graph.Node) bool {
 
 // Edge optimistically returns the edge from u to v.
 func (l *LimitedVisionGrid) Edge(u, v graph.Node) graph.Edge {
-	return l.EdgeBetween(u, v)
+	return l.WeightedEdgeBetween(u, v)
 }
 
-// EdgeBetween optimistically returns the edge between u and v.
+// Edge optimistically returns the weighted edge from u to v.
+func (l *LimitedVisionGrid) WeightedEdge(u, v graph.Node) graph.WeightedEdge {
+	return l.WeightedEdgeBetween(u, v)
+}
+
+// WeightedEdgeBetween optimistically returns the edge between u and v.
 func (l *LimitedVisionGrid) EdgeBetween(u, v graph.Node) graph.Edge {
+	return l.WeightedEdgeBetween(u, v)
+}
+
+// WeightedEdgeBetween optimistically returns the weighted edge between u and v.
+func (l *LimitedVisionGrid) WeightedEdgeBetween(u, v graph.Node) graph.WeightedEdge {
 	if l.HasEdgeBetween(u, v) {
 		if !l.Grid.AllowDiagonal || l.Grid.UnitEdgeWeight {
 			return simple.Edge{F: u, T: v, W: 1}

--- a/graph/path/internal/limited_test.go
+++ b/graph/path/internal/limited_test.go
@@ -16,7 +16,7 @@ import (
 type changes struct {
 	n graph.Node
 
-	new, old []simple.Edge
+	new, old []simple.WeightedEdge
 }
 
 var limitedVisionTests = []struct {
@@ -44,7 +44,7 @@ var limitedVisionTests = []struct {
 		want: []changes{
 			{
 				n: node(1),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(0), T: simple.Node(1), W: math.Inf(1)},
 					{F: simple.Node(1), T: simple.Node(0), W: math.Inf(1)},
 					{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -56,7 +56,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(2),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(1), T: simple.Node(2), W: 1},
 					{F: simple.Node(2), T: simple.Node(1), W: 1},
 					{F: simple.Node(2), T: simple.Node(3), W: math.Inf(1)},
@@ -68,7 +68,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(6),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(2), T: simple.Node(6), W: 1},
 					{F: simple.Node(5), T: simple.Node(6), W: math.Inf(1)},
 					{F: simple.Node(6), T: simple.Node(2), W: 1},
@@ -82,7 +82,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(10),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(6), T: simple.Node(10), W: 1},
 					{F: simple.Node(9), T: simple.Node(10), W: math.Inf(1)},
 					{F: simple.Node(10), T: simple.Node(6), W: 1},
@@ -96,7 +96,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(14),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(10), T: simple.Node(14), W: 1},
 					{F: simple.Node(13), T: simple.Node(14), W: math.Inf(1)},
 					{F: simple.Node(14), T: simple.Node(10), W: 1},
@@ -123,7 +123,7 @@ var limitedVisionTests = []struct {
 		want: []changes{
 			{
 				n: node(1),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(0), T: simple.Node(1), W: math.Inf(1)},
 					{F: simple.Node(0), T: simple.Node(4), W: math.Inf(1)},
 					{F: simple.Node(1), T: simple.Node(0), W: math.Inf(1)},
@@ -143,7 +143,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(2),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(1), T: simple.Node(2), W: 1},
 					{F: simple.Node(1), T: simple.Node(5), W: math.Inf(1)},
 					{F: simple.Node(2), T: simple.Node(1), W: 1},
@@ -163,7 +163,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(6),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(1), T: simple.Node(2), W: 1},
 					{F: simple.Node(1), T: simple.Node(5), W: math.Inf(1)},
 					{F: simple.Node(2), T: simple.Node(1), W: 1},
@@ -193,7 +193,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(10),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(5), T: simple.Node(6), W: math.Inf(1)},
 					{F: simple.Node(5), T: simple.Node(9), W: math.Inf(1)},
 					{F: simple.Node(6), T: simple.Node(5), W: math.Inf(1)},
@@ -223,7 +223,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(14),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(9), T: simple.Node(10), W: math.Inf(1)},
 					{F: simple.Node(9), T: simple.Node(13), W: math.Inf(1)},
 					{F: simple.Node(10), T: simple.Node(9), W: math.Inf(1)},
@@ -258,7 +258,7 @@ var limitedVisionTests = []struct {
 		want: []changes{
 			{
 				n: node(1),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(0), T: simple.Node(1), W: math.Inf(1)},
 					{F: simple.Node(1), T: simple.Node(0), W: math.Inf(1)},
 					{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -270,14 +270,14 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(2),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(2), T: simple.Node(3), W: math.Inf(1)},
 					{F: simple.Node(2), T: simple.Node(6), W: 1},
 					{F: simple.Node(3), T: simple.Node(2), W: math.Inf(1)},
 					{F: simple.Node(6), T: simple.Node(2), W: 1},
 					{F: simple.Node(6), T: simple.Node(5), W: math.Inf(1)},
 				},
-				old: []simple.Edge{
+				old: []simple.WeightedEdge{
 					{F: simple.Node(1), T: simple.Node(0), W: math.Inf(1)},
 					{F: simple.Node(1), T: simple.Node(2), W: 1},
 					{F: simple.Node(1), T: simple.Node(5), W: math.Inf(1)},
@@ -286,14 +286,14 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(6),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(6), T: simple.Node(7), W: math.Inf(1)},
 					{F: simple.Node(6), T: simple.Node(10), W: 1},
 					{F: simple.Node(7), T: simple.Node(3), W: math.Inf(1)},
 					{F: simple.Node(7), T: simple.Node(6), W: math.Inf(1)},
 					{F: simple.Node(10), T: simple.Node(6), W: 1},
 				},
-				old: []simple.Edge{
+				old: []simple.WeightedEdge{
 					{F: simple.Node(2), T: simple.Node(1), W: 1},
 					{F: simple.Node(2), T: simple.Node(3), W: math.Inf(1)},
 					{F: simple.Node(2), T: simple.Node(6), W: 1},
@@ -305,7 +305,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(10),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(9), T: simple.Node(5), W: math.Inf(1)},
 					{F: simple.Node(9), T: simple.Node(10), W: math.Inf(1)},
 					{F: simple.Node(10), T: simple.Node(9), W: math.Inf(1)},
@@ -315,7 +315,7 @@ var limitedVisionTests = []struct {
 					{F: simple.Node(11), T: simple.Node(10), W: math.Inf(1)},
 					{F: simple.Node(14), T: simple.Node(10), W: 1},
 				},
-				old: []simple.Edge{
+				old: []simple.WeightedEdge{
 					{F: simple.Node(6), T: simple.Node(2), W: 1},
 					{F: simple.Node(6), T: simple.Node(5), W: math.Inf(1)},
 					{F: simple.Node(6), T: simple.Node(7), W: math.Inf(1)},
@@ -325,7 +325,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(14),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(13), T: simple.Node(9), W: math.Inf(1)},
 					{F: simple.Node(13), T: simple.Node(14), W: math.Inf(1)},
 					{F: simple.Node(14), T: simple.Node(13), W: math.Inf(1)},
@@ -333,7 +333,7 @@ var limitedVisionTests = []struct {
 					{F: simple.Node(15), T: simple.Node(11), W: math.Inf(1)},
 					{F: simple.Node(15), T: simple.Node(14), W: math.Inf(1)},
 				},
-				old: []simple.Edge{
+				old: []simple.WeightedEdge{
 					{F: simple.Node(10), T: simple.Node(6), W: 1},
 					{F: simple.Node(10), T: simple.Node(9), W: math.Inf(1)},
 					{F: simple.Node(10), T: simple.Node(11), W: math.Inf(1)},
@@ -358,7 +358,7 @@ var limitedVisionTests = []struct {
 		want: []changes{
 			{
 				n: node(1),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(0), T: simple.Node(1), W: math.Inf(1)},
 					{F: simple.Node(0), T: simple.Node(4), W: math.Inf(1)},
 					{F: simple.Node(1), T: simple.Node(0), W: math.Inf(1)},
@@ -378,7 +378,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(2),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(2), T: simple.Node(3), W: math.Inf(1)},
 					{F: simple.Node(3), T: simple.Node(2), W: math.Inf(1)},
 					{F: simple.Node(3), T: simple.Node(7), W: math.Inf(1)},
@@ -386,7 +386,7 @@ var limitedVisionTests = []struct {
 					{F: simple.Node(7), T: simple.Node(3), W: math.Inf(1)},
 					{F: simple.Node(7), T: simple.Node(6), W: math.Inf(1)},
 				},
-				old: []simple.Edge{
+				old: []simple.WeightedEdge{
 					{F: simple.Node(1), T: simple.Node(0), W: math.Inf(1)},
 					{F: simple.Node(1), T: simple.Node(2), W: 1},
 					{F: simple.Node(1), T: simple.Node(5), W: math.Inf(1)},
@@ -401,7 +401,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(6),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(5), T: simple.Node(9), W: math.Inf(1)},
 					{F: simple.Node(6), T: simple.Node(10), W: 1},
 					{F: simple.Node(7), T: simple.Node(11), W: math.Inf(1)},
@@ -413,7 +413,7 @@ var limitedVisionTests = []struct {
 					{F: simple.Node(11), T: simple.Node(7), W: math.Inf(1)},
 					{F: simple.Node(11), T: simple.Node(10), W: math.Inf(1)},
 				},
-				old: []simple.Edge{
+				old: []simple.WeightedEdge{
 					{F: simple.Node(1), T: simple.Node(0), W: math.Inf(1)},
 					{F: simple.Node(1), T: simple.Node(2), W: 1},
 					{F: simple.Node(1), T: simple.Node(5), W: math.Inf(1)},
@@ -434,7 +434,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(10),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(9), T: simple.Node(13), W: math.Inf(1)},
 					{F: simple.Node(10), T: simple.Node(14), W: 1},
 					{F: simple.Node(11), T: simple.Node(15), W: math.Inf(1)},
@@ -446,7 +446,7 @@ var limitedVisionTests = []struct {
 					{F: simple.Node(15), T: simple.Node(11), W: math.Inf(1)},
 					{F: simple.Node(15), T: simple.Node(14), W: math.Inf(1)},
 				},
-				old: []simple.Edge{
+				old: []simple.WeightedEdge{
 					{F: simple.Node(5), T: simple.Node(1), W: math.Inf(1)},
 					{F: simple.Node(5), T: simple.Node(4), W: math.Inf(1)},
 					{F: simple.Node(5), T: simple.Node(6), W: math.Inf(1)},
@@ -470,7 +470,7 @@ var limitedVisionTests = []struct {
 			{
 				n:   node(14),
 				new: nil,
-				old: []simple.Edge{
+				old: []simple.WeightedEdge{
 					{F: simple.Node(9), T: simple.Node(5), W: math.Inf(1)},
 					{F: simple.Node(9), T: simple.Node(10), W: math.Inf(1)},
 					{F: simple.Node(9), T: simple.Node(13), W: math.Inf(1)},
@@ -507,7 +507,7 @@ var limitedVisionTests = []struct {
 		want: []changes{
 			{
 				n: node(1),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(0), T: simple.Node(1), W: math.Inf(1)},
 					{F: simple.Node(0), T: simple.Node(5), W: math.Inf(1)},
 					{F: simple.Node(1), T: simple.Node(0), W: math.Inf(1)},
@@ -523,7 +523,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(2),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(1), T: simple.Node(2), W: 1},
 					{F: simple.Node(1), T: simple.Node(6), W: math.Sqrt2},
 					{F: simple.Node(2), T: simple.Node(1), W: 1},
@@ -539,7 +539,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(6),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(2), T: simple.Node(5), W: math.Inf(1)},
 					{F: simple.Node(2), T: simple.Node(6), W: 1},
 					{F: simple.Node(2), T: simple.Node(7), W: math.Inf(1)},
@@ -561,7 +561,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(10),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(6), T: simple.Node(9), W: math.Inf(1)},
 					{F: simple.Node(6), T: simple.Node(10), W: 1},
 					{F: simple.Node(6), T: simple.Node(11), W: math.Inf(1)},
@@ -583,7 +583,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(14),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(10), T: simple.Node(13), W: math.Inf(1)},
 					{F: simple.Node(10), T: simple.Node(14), W: 1},
 					{F: simple.Node(10), T: simple.Node(15), W: math.Inf(1)},
@@ -614,7 +614,7 @@ var limitedVisionTests = []struct {
 		want: []changes{
 			{
 				n: node(1),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(0), T: simple.Node(1), W: math.Inf(1)},
 					{F: simple.Node(0), T: simple.Node(4), W: math.Inf(1)},
 					{F: simple.Node(0), T: simple.Node(5), W: math.Inf(1)},
@@ -642,7 +642,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(2),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(1), T: simple.Node(2), W: 1},
 					{F: simple.Node(1), T: simple.Node(5), W: math.Inf(1)},
 					{F: simple.Node(1), T: simple.Node(6), W: math.Sqrt2},
@@ -670,7 +670,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(6),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(1), T: simple.Node(2), W: 1},
 					{F: simple.Node(1), T: simple.Node(5), W: math.Inf(1)},
 					{F: simple.Node(1), T: simple.Node(6), W: math.Sqrt2},
@@ -716,7 +716,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(10),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(5), T: simple.Node(6), W: math.Inf(1)},
 					{F: simple.Node(5), T: simple.Node(9), W: math.Inf(1)},
 					{F: simple.Node(5), T: simple.Node(10), W: math.Inf(1)},
@@ -762,7 +762,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(14),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(9), T: simple.Node(10), W: math.Inf(1)},
 					{F: simple.Node(9), T: simple.Node(13), W: math.Inf(1)},
 					{F: simple.Node(9), T: simple.Node(14), W: math.Inf(1)},
@@ -805,7 +805,7 @@ var limitedVisionTests = []struct {
 		want: []changes{
 			{
 				n: node(1),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(0), T: simple.Node(1), W: math.Inf(1)},
 					{F: simple.Node(0), T: simple.Node(5), W: math.Inf(1)},
 					{F: simple.Node(1), T: simple.Node(0), W: math.Inf(1)},
@@ -821,7 +821,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(2),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(1), T: simple.Node(6), W: math.Sqrt2},
 					{F: simple.Node(2), T: simple.Node(3), W: math.Inf(1)},
 					{F: simple.Node(2), T: simple.Node(6), W: 1},
@@ -832,7 +832,7 @@ var limitedVisionTests = []struct {
 					{F: simple.Node(6), T: simple.Node(3), W: math.Inf(1)},
 					{F: simple.Node(6), T: simple.Node(5), W: math.Inf(1)},
 				},
-				old: []simple.Edge{
+				old: []simple.WeightedEdge{
 					{F: simple.Node(1), T: simple.Node(0), W: math.Inf(1)},
 					{F: simple.Node(1), T: simple.Node(2), W: 1},
 					{F: simple.Node(1), T: simple.Node(5), W: math.Inf(1)},
@@ -842,7 +842,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(6),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(2), T: simple.Node(7), W: math.Inf(1)},
 					{F: simple.Node(5), T: simple.Node(10), W: math.Inf(1)},
 					{F: simple.Node(6), T: simple.Node(7), W: math.Inf(1)},
@@ -855,7 +855,7 @@ var limitedVisionTests = []struct {
 					{F: simple.Node(10), T: simple.Node(6), W: 1},
 					{F: simple.Node(10), T: simple.Node(7), W: math.Inf(1)},
 				},
-				old: []simple.Edge{
+				old: []simple.WeightedEdge{
 					{F: simple.Node(2), T: simple.Node(1), W: 1},
 					{F: simple.Node(2), T: simple.Node(3), W: math.Inf(1)},
 					{F: simple.Node(2), T: simple.Node(5), W: math.Inf(1)},
@@ -872,7 +872,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(10),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(6), T: simple.Node(9), W: math.Inf(1)},
 					{F: simple.Node(6), T: simple.Node(11), W: math.Inf(1)},
 					{F: simple.Node(9), T: simple.Node(5), W: math.Inf(1)},
@@ -890,7 +890,7 @@ var limitedVisionTests = []struct {
 					{F: simple.Node(14), T: simple.Node(10), W: 1},
 					{F: simple.Node(14), T: simple.Node(11), W: math.Inf(1)},
 				},
-				old: []simple.Edge{
+				old: []simple.WeightedEdge{
 					{F: simple.Node(6), T: simple.Node(1), W: math.Sqrt2},
 					{F: simple.Node(6), T: simple.Node(2), W: 1},
 					{F: simple.Node(6), T: simple.Node(3), W: math.Inf(1)},
@@ -904,7 +904,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(14),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(10), T: simple.Node(13), W: math.Inf(1)},
 					{F: simple.Node(10), T: simple.Node(15), W: math.Inf(1)},
 					{F: simple.Node(13), T: simple.Node(9), W: math.Inf(1)},
@@ -916,7 +916,7 @@ var limitedVisionTests = []struct {
 					{F: simple.Node(15), T: simple.Node(11), W: math.Inf(1)},
 					{F: simple.Node(15), T: simple.Node(14), W: math.Inf(1)},
 				},
-				old: []simple.Edge{
+				old: []simple.WeightedEdge{
 					{F: simple.Node(10), T: simple.Node(5), W: math.Inf(1)},
 					{F: simple.Node(10), T: simple.Node(6), W: 1},
 					{F: simple.Node(10), T: simple.Node(7), W: math.Inf(1)},
@@ -945,7 +945,7 @@ var limitedVisionTests = []struct {
 		want: []changes{
 			{
 				n: node(1),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(0), T: simple.Node(1), W: math.Inf(1)},
 					{F: simple.Node(0), T: simple.Node(4), W: math.Inf(1)},
 					{F: simple.Node(0), T: simple.Node(5), W: math.Inf(1)},
@@ -973,7 +973,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(2),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(2), T: simple.Node(3), W: math.Inf(1)},
 					{F: simple.Node(2), T: simple.Node(7), W: math.Inf(1)},
 					{F: simple.Node(3), T: simple.Node(2), W: math.Inf(1)},
@@ -985,7 +985,7 @@ var limitedVisionTests = []struct {
 					{F: simple.Node(7), T: simple.Node(3), W: math.Inf(1)},
 					{F: simple.Node(7), T: simple.Node(6), W: math.Inf(1)},
 				},
-				old: []simple.Edge{
+				old: []simple.WeightedEdge{
 					{F: simple.Node(1), T: simple.Node(0), W: math.Inf(1)},
 					{F: simple.Node(1), T: simple.Node(2), W: 1},
 					{F: simple.Node(1), T: simple.Node(4), W: math.Inf(1)},
@@ -1006,7 +1006,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(6),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(5), T: simple.Node(9), W: math.Inf(1)},
 					{F: simple.Node(5), T: simple.Node(10), W: math.Inf(1)},
 					{F: simple.Node(6), T: simple.Node(9), W: math.Inf(1)},
@@ -1027,7 +1027,7 @@ var limitedVisionTests = []struct {
 					{F: simple.Node(11), T: simple.Node(7), W: math.Inf(1)},
 					{F: simple.Node(11), T: simple.Node(10), W: math.Inf(1)},
 				},
-				old: []simple.Edge{
+				old: []simple.WeightedEdge{
 					{F: simple.Node(1), T: simple.Node(0), W: math.Inf(1)},
 					{F: simple.Node(1), T: simple.Node(2), W: 1},
 					{F: simple.Node(1), T: simple.Node(4), W: math.Inf(1)},
@@ -1058,7 +1058,7 @@ var limitedVisionTests = []struct {
 			},
 			{
 				n: node(10),
-				new: []simple.Edge{
+				new: []simple.WeightedEdge{
 					{F: simple.Node(9), T: simple.Node(13), W: math.Inf(1)},
 					{F: simple.Node(9), T: simple.Node(14), W: math.Inf(1)},
 					{F: simple.Node(10), T: simple.Node(13), W: math.Inf(1)},
@@ -1078,7 +1078,7 @@ var limitedVisionTests = []struct {
 					{F: simple.Node(15), T: simple.Node(11), W: math.Inf(1)},
 					{F: simple.Node(15), T: simple.Node(14), W: math.Inf(1)},
 				},
-				old: []simple.Edge{
+				old: []simple.WeightedEdge{
 					{F: simple.Node(5), T: simple.Node(0), W: math.Inf(1)},
 					{F: simple.Node(5), T: simple.Node(1), W: math.Inf(1)},
 					{F: simple.Node(5), T: simple.Node(2), W: math.Inf(1)},
@@ -1116,7 +1116,7 @@ var limitedVisionTests = []struct {
 			{
 				n:   node(14),
 				new: nil,
-				old: []simple.Edge{
+				old: []simple.WeightedEdge{
 					{F: simple.Node(9), T: simple.Node(4), W: math.Inf(1)},
 					{F: simple.Node(9), T: simple.Node(5), W: math.Inf(1)},
 					{F: simple.Node(9), T: simple.Node(6), W: math.Inf(1)},
@@ -1197,11 +1197,11 @@ func TestLimitedVisionGrid(t *testing.T) {
 	}
 }
 
-func asConcreteEdges(changes []graph.Edge, in graph.Weighted) []simple.Edge {
+func asConcreteEdges(changes []graph.Edge, in graph.Weighted) []simple.WeightedEdge {
 	if changes == nil {
 		return nil
 	}
-	we := make([]simple.Edge, len(changes))
+	we := make([]simple.WeightedEdge, len(changes))
 	for i, e := range changes {
 		we[i].F = e.From()
 		we[i].T = e.To()

--- a/graph/path/internal/limited_test.go
+++ b/graph/path/internal/limited_test.go
@@ -1197,7 +1197,7 @@ func TestLimitedVisionGrid(t *testing.T) {
 	}
 }
 
-func asConcreteEdges(changes []graph.Edge, in graph.Weighter) []simple.Edge {
+func asConcreteEdges(changes []graph.Edge, in graph.WeightedGraph) []simple.Edge {
 	if changes == nil {
 		return nil
 	}

--- a/graph/path/internal/limited_test.go
+++ b/graph/path/internal/limited_test.go
@@ -1197,7 +1197,7 @@ func TestLimitedVisionGrid(t *testing.T) {
 	}
 }
 
-func asConcreteEdges(changes []graph.Edge, in graph.WeightedGraph) []simple.Edge {
+func asConcreteEdges(changes []graph.Edge, in graph.Weighted) []simple.Edge {
 	if changes == nil {
 		return nil
 	}

--- a/graph/path/internal/testgraphs/shortest.go
+++ b/graph/path/internal/testgraphs/shortest.go
@@ -26,7 +26,7 @@ func init() {
 var ShortestPathTests = []struct {
 	Name              string
 	Graph             func() graph.WeightedEdgeAdder
-	Edges             []simple.Edge
+	Edges             []simple.WeightedEdge
 	HasNegativeWeight bool
 	HasNegativeCycle  bool
 
@@ -59,7 +59,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "one edge directed",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 		},
 
@@ -75,7 +75,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "one edge self directed",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 		},
 
@@ -91,7 +91,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "one edge undirected",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 		},
 
@@ -107,7 +107,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "two paths directed",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			{F: simple.Node(0), T: simple.Node(2), W: 2},
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 			{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -126,7 +126,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "two paths undirected",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			{F: simple.Node(0), T: simple.Node(2), W: 2},
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 			{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -145,7 +145,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "confounding paths directed",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			// Add a path from 0->5 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 			{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -179,7 +179,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "confounding paths undirected",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			// Add a path from 0->5 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 			{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -213,7 +213,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "confounding paths directed 2-step",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			// Add a path from 0->5 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 			{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -248,7 +248,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "confounding paths undirected 2-step",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			// Add a path from 0->5 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 			{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -283,7 +283,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "zero-weight cycle directed",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 			{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -307,7 +307,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "zero-weight cycle^2 directed",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 			{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -334,7 +334,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "zero-weight cycle^2 confounding directed",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 			{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -364,7 +364,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "zero-weight cycle^3 directed",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 			{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -394,7 +394,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "zero-weight 3·cycle^2 confounding directed",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 			{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -430,7 +430,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "zero-weight reversed 3·cycle^2 confounding directed",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 			{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -466,8 +466,8 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "zero-weight |V|·cycle^(n/|V|) directed",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
-		Edges: func() []simple.Edge {
-			e := []simple.Edge{
+		Edges: func() []simple.WeightedEdge {
+			e := []simple.WeightedEdge{
 				// Add a path from 0->4 of weight 4
 				{F: simple.Node(0), T: simple.Node(1), W: 1},
 				{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -480,8 +480,8 @@ var ShortestPathTests = []struct {
 			const n = 100
 			for i := 0; i < n; i++ {
 				e = append(e,
-					simple.Edge{F: simple.Node(next + i), T: simple.Node(i), W: 0},
-					simple.Edge{F: simple.Node(i), T: simple.Node(next + i), W: 0},
+					simple.WeightedEdge{F: simple.Node(next + i), T: simple.Node(i), W: 0},
+					simple.WeightedEdge{F: simple.Node(i), T: simple.Node(next + i), W: 0},
 				)
 			}
 			return e
@@ -499,8 +499,8 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "zero-weight n·cycle directed",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
-		Edges: func() []simple.Edge {
-			e := []simple.Edge{
+		Edges: func() []simple.WeightedEdge {
+			e := []simple.WeightedEdge{
 				// Add a path from 0->4 of weight 4
 				{F: simple.Node(0), T: simple.Node(1), W: 1},
 				{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -513,8 +513,8 @@ var ShortestPathTests = []struct {
 			const n = 100
 			for i := 0; i < n; i++ {
 				e = append(e,
-					simple.Edge{F: simple.Node(next + i), T: simple.Node(1), W: 0},
-					simple.Edge{F: simple.Node(1), T: simple.Node(next + i), W: 0},
+					simple.WeightedEdge{F: simple.Node(next + i), T: simple.Node(1), W: 0},
+					simple.WeightedEdge{F: simple.Node(1), T: simple.Node(next + i), W: 0},
 				)
 			}
 			return e
@@ -532,8 +532,8 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "zero-weight bi-directional tree with single exit directed",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
-		Edges: func() []simple.Edge {
-			e := []simple.Edge{
+		Edges: func() []simple.WeightedEdge {
+			e := []simple.WeightedEdge{
 				// Add a path from 0->4 of weight 4
 				{F: simple.Node(0), T: simple.Node(1), W: 1},
 				{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -555,13 +555,13 @@ var ShortestPathTests = []struct {
 			for l := 0; l < depth; l++ {
 				for i = 0; i < branching; i++ {
 					last = next + i
-					e = append(e, simple.Edge{F: simple.Node(src), T: simple.Node(last), W: 0})
-					e = append(e, simple.Edge{F: simple.Node(last), T: simple.Node(src), W: 0})
+					e = append(e, simple.WeightedEdge{F: simple.Node(src), T: simple.Node(last), W: 0})
+					e = append(e, simple.WeightedEdge{F: simple.Node(last), T: simple.Node(src), W: 0})
 				}
 				src = next + 1
 				next += branching
 			}
-			e = append(e, simple.Edge{F: simple.Node(last), T: simple.Node(4), W: 2})
+			e = append(e, simple.WeightedEdge{F: simple.Node(last), T: simple.Node(4), W: 2})
 			return e
 		}(),
 
@@ -580,7 +580,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "one edge directed negative",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			{F: simple.Node(0), T: simple.Node(1), W: -1},
 		},
 		HasNegativeWeight: true,
@@ -597,7 +597,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "one edge undirected negative",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			{F: simple.Node(0), T: simple.Node(1), W: -1},
 		},
 		HasNegativeWeight: true,
@@ -608,7 +608,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "wp graph negative", // http://en.wikipedia.org/w/index.php?title=Johnson%27s_algorithm&oldid=564595231
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			{F: simple.Node('w'), T: simple.Node('z'), W: 2},
 			{F: simple.Node('x'), T: simple.Node('w'), W: 6},
 			{F: simple.Node('x'), T: simple.Node('y'), W: 3},
@@ -631,7 +631,7 @@ var ShortestPathTests = []struct {
 	{
 		Name:  "roughgarden negative",
 		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
-		Edges: []simple.Edge{
+		Edges: []simple.WeightedEdge{
 			{F: simple.Node('a'), T: simple.Node('b'), W: -2},
 			{F: simple.Node('b'), T: simple.Node('c'), W: -1},
 			{F: simple.Node('c'), T: simple.Node('a'), W: 4},

--- a/graph/path/internal/testgraphs/shortest.go
+++ b/graph/path/internal/testgraphs/shortest.go
@@ -25,7 +25,7 @@ func init() {
 // dynamic shortest path routine in path/dynamic: DStarLite.
 var ShortestPathTests = []struct {
 	Name              string
-	Graph             func() graph.EdgeAdder
+	Graph             func() graph.WeightedEdgeAdder
 	Edges             []simple.Edge
 	HasNegativeWeight bool
 	HasNegativeCycle  bool
@@ -40,7 +40,7 @@ var ShortestPathTests = []struct {
 	// Positive weighted graphs.
 	{
 		Name:  "empty directed",
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(1)},
 		Weight: math.Inf(1),
@@ -49,7 +49,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "empty undirected",
-		Graph: func() graph.EdgeAdder { return simple.NewUndirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
 
 		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(1)},
 		Weight: math.Inf(1),
@@ -58,7 +58,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "one edge directed",
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 		},
@@ -74,7 +74,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "one edge self directed",
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 		},
@@ -90,7 +90,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "one edge undirected",
-		Graph: func() graph.EdgeAdder { return simple.NewUndirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
 		},
@@ -106,7 +106,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "two paths directed",
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(2), W: 2},
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -125,7 +125,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "two paths undirected",
-		Graph: func() graph.EdgeAdder { return simple.NewUndirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(2), W: 2},
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -144,7 +144,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "confounding paths directed",
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->5 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -178,7 +178,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "confounding paths undirected",
-		Graph: func() graph.EdgeAdder { return simple.NewUndirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->5 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -212,7 +212,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "confounding paths directed 2-step",
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->5 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -247,7 +247,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "confounding paths undirected 2-step",
-		Graph: func() graph.EdgeAdder { return simple.NewUndirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->5 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -282,7 +282,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight cycle directed",
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -306,7 +306,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight cycle^2 directed",
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -333,7 +333,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight cycle^2 confounding directed",
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -363,7 +363,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight cycle^3 directed",
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -393,7 +393,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight 3·cycle^2 confounding directed",
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -429,7 +429,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight reversed 3·cycle^2 confounding directed",
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			// Add a path from 0->4 of weight 4
 			{F: simple.Node(0), T: simple.Node(1), W: 1},
@@ -465,7 +465,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight |V|·cycle^(n/|V|) directed",
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 		Edges: func() []simple.Edge {
 			e := []simple.Edge{
 				// Add a path from 0->4 of weight 4
@@ -498,7 +498,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight n·cycle directed",
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 		Edges: func() []simple.Edge {
 			e := []simple.Edge{
 				// Add a path from 0->4 of weight 4
@@ -531,7 +531,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "zero-weight bi-directional tree with single exit directed",
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 		Edges: func() []simple.Edge {
 			e := []simple.Edge{
 				// Add a path from 0->4 of weight 4
@@ -579,7 +579,7 @@ var ShortestPathTests = []struct {
 	// Negative weighted graphs.
 	{
 		Name:  "one edge directed negative",
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(1), W: -1},
 		},
@@ -596,7 +596,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "one edge undirected negative",
-		Graph: func() graph.EdgeAdder { return simple.NewUndirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(1), W: -1},
 		},
@@ -607,7 +607,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "wp graph negative", // http://en.wikipedia.org/w/index.php?title=Johnson%27s_algorithm&oldid=564595231
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node('w'), T: simple.Node('z'), W: 2},
 			{F: simple.Node('x'), T: simple.Node('w'), W: 6},
@@ -630,7 +630,7 @@ var ShortestPathTests = []struct {
 	},
 	{
 		Name:  "roughgarden negative",
-		Graph: func() graph.EdgeAdder { return simple.NewDirectedGraph(0, math.Inf(1)) },
+		Graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedDirectedGraph(0, math.Inf(1)) },
 		Edges: []simple.Edge{
 			{F: simple.Node('a'), T: simple.Node('b'), W: -2},
 			{F: simple.Node('b'), T: simple.Node('c'), W: -1},

--- a/graph/path/johnson_apsp.go
+++ b/graph/path/johnson_apsp.go
@@ -22,7 +22,7 @@ func JohnsonAllPaths(g graph.Graph) (paths AllShortest, ok bool) {
 		from:   g.From,
 		edgeTo: g.Edge,
 	}
-	if wg, ok := g.(graph.WeightedGraph); ok {
+	if wg, ok := g.(graph.Weighted); ok {
 		jg.weight = wg.Weight
 	} else {
 		jg.weight = UniformCost(g)
@@ -81,8 +81,8 @@ var (
 	// of a directed graph, but we don't need
 	// to be explicit with the type since it
 	// is not exported.
-	_ graph.Graph         = johnsonWeightAdjuster{}
-	_ graph.WeightedGraph = johnsonWeightAdjuster{}
+	_ graph.Graph    = johnsonWeightAdjuster{}
+	_ graph.Weighted = johnsonWeightAdjuster{}
 )
 
 func (g johnsonWeightAdjuster) Has(n graph.Node) bool {

--- a/graph/path/johnson_apsp.go
+++ b/graph/path/johnson_apsp.go
@@ -22,7 +22,7 @@ func JohnsonAllPaths(g graph.Graph) (paths AllShortest, ok bool) {
 		from:   g.From,
 		edgeTo: g.Edge,
 	}
-	if wg, ok := g.(graph.Weighter); ok {
+	if wg, ok := g.(graph.WeightedGraph); ok {
 		jg.weight = wg.Weight
 	} else {
 		jg.weight = UniformCost(g)
@@ -81,8 +81,8 @@ var (
 	// of a directed graph, but we don't need
 	// to be explicit with the type since it
 	// is not exported.
-	_ graph.Graph    = johnsonWeightAdjuster{}
-	_ graph.Weighter = johnsonWeightAdjuster{}
+	_ graph.Graph         = johnsonWeightAdjuster{}
+	_ graph.WeightedGraph = johnsonWeightAdjuster{}
 )
 
 func (g johnsonWeightAdjuster) Has(n graph.Node) bool {
@@ -105,6 +105,10 @@ func (g johnsonWeightAdjuster) From(n graph.Node) []graph.Node {
 		return g.g.Nodes()
 	}
 	return g.from(n)
+}
+
+func (g johnsonWeightAdjuster) WeightedEdge(u, v graph.Node) graph.WeightedEdge {
+	panic("path: unintended use of johnsonWeightAdjuster")
 }
 
 func (g johnsonWeightAdjuster) Edge(u, v graph.Node) graph.Edge {

--- a/graph/path/johnson_apsp_test.go
+++ b/graph/path/johnson_apsp_test.go
@@ -19,7 +19,7 @@ func TestJohnsonAllPaths(t *testing.T) {
 	for _, test := range testgraphs.ShortestPathTests {
 		g := test.Graph()
 		for _, e := range test.Edges {
-			g.SetEdge(e)
+			g.SetWeightedEdge(e)
 		}
 
 		pt, ok := JohnsonAllPaths(g.(graph.Graph))

--- a/graph/path/spanning_tree.go
+++ b/graph/path/spanning_tree.go
@@ -13,19 +13,13 @@ import (
 	"gonum.org/v1/gonum/graph/simple"
 )
 
-// UndirectedWeighter is an undirected graph that returns edge weights.
-type UndirectedWeighter interface {
-	graph.Undirected
-	graph.Weighter
-}
-
 // Prim generates a minimum spanning tree of g by greedy tree extension, placing
 // the result in the destination, dst. If the edge weights of g are distinct
 // it will be the unique minimum spanning tree of g. The destination is not cleared
 // first. The weight of the minimum spanning tree is returned. If g is not connected,
 // a minimum spanning forest will be constructed in dst and the sum of minimum
 // spanning tree weights will be returned.
-func Prim(dst graph.UndirectedBuilder, g UndirectedWeighter) float64 {
+func Prim(dst graph.UndirectedBuilder, g graph.WeightedUndirected) float64 {
 	nodes := g.Nodes()
 	if len(nodes) == 0 {
 		return 0
@@ -135,7 +129,7 @@ func (q *primQueue) update(u, v graph.Node, key float64) {
 // UndirectedWeightLister is an undirected graph that returns edge weights and
 // the set of edges in the graph.
 type UndirectedWeightLister interface {
-	UndirectedWeighter
+	graph.WeightedUndirected
 	Edges() []graph.Edge
 }
 

--- a/graph/path/spanning_tree.go
+++ b/graph/path/spanning_tree.go
@@ -27,10 +27,10 @@ func Prim(dst graph.UndirectedBuilder, g graph.WeightedUndirected) float64 {
 
 	q := &primQueue{
 		indexOf: make(map[int64]int, len(nodes)-1),
-		nodes:   make([]simple.Edge, 0, len(nodes)-1),
+		nodes:   make([]simple.WeightedEdge, 0, len(nodes)-1),
 	}
 	for _, u := range nodes[1:] {
-		heap.Push(q, simple.Edge{F: u, W: math.Inf(1)})
+		heap.Push(q, simple.WeightedEdge{F: u, W: math.Inf(1)})
 	}
 
 	u := nodes[0]
@@ -44,7 +44,7 @@ func Prim(dst graph.UndirectedBuilder, g graph.WeightedUndirected) float64 {
 
 	var w float64
 	for q.Len() > 0 {
-		e := heap.Pop(q).(simple.Edge)
+		e := heap.Pop(q).(simple.WeightedEdge)
 		if e.To() != nil && g.HasEdgeBetween(e.From(), e.To()) {
 			dst.SetEdge(e)
 			w += e.Weight()
@@ -72,7 +72,7 @@ func Prim(dst graph.UndirectedBuilder, g graph.WeightedUndirected) float64 {
 // spanning forest.
 type primQueue struct {
 	indexOf map[int64]int
-	nodes   []simple.Edge
+	nodes   []simple.WeightedEdge
 }
 
 func (q *primQueue) Less(i, j int) bool {
@@ -90,7 +90,7 @@ func (q *primQueue) Len() int {
 }
 
 func (q *primQueue) Push(x interface{}) {
-	n := x.(simple.Edge)
+	n := x.(simple.WeightedEdge)
 	q.indexOf[n.From().ID()] = len(q.nodes)
 	q.nodes = append(q.nodes, n)
 }
@@ -141,7 +141,7 @@ type UndirectedWeightLister interface {
 // spanning tree weights will be returned.
 func Kruskal(dst graph.UndirectedBuilder, g UndirectedWeightLister) float64 {
 	edges := g.Edges()
-	ascend := make([]simple.Edge, 0, len(edges))
+	ascend := make([]simple.WeightedEdge, 0, len(edges))
 	for _, e := range edges {
 		u := e.From()
 		v := e.To()
@@ -149,7 +149,7 @@ func Kruskal(dst graph.UndirectedBuilder, g UndirectedWeightLister) float64 {
 		if !ok {
 			panic("kruskal: unexpected invalid weight")
 		}
-		ascend = append(ascend, simple.Edge{F: u, T: v, W: w})
+		ascend = append(ascend, simple.WeightedEdge{F: u, T: v, W: w})
 	}
 	sort.Sort(byWeight(ascend))
 
@@ -169,7 +169,7 @@ func Kruskal(dst graph.UndirectedBuilder, g UndirectedWeightLister) float64 {
 	return w
 }
 
-type byWeight []simple.Edge
+type byWeight []simple.WeightedEdge
 
 func (e byWeight) Len() int           { return len(e) }
 func (e byWeight) Less(i, j int) bool { return e[i].Weight() < e[j].Weight() }

--- a/graph/path/spanning_tree.go
+++ b/graph/path/spanning_tree.go
@@ -13,13 +13,25 @@ import (
 	"gonum.org/v1/gonum/graph/simple"
 )
 
+// WeightedBuilder is a type that can add nodes and weighted edges.
+type WeightedBuilder interface {
+	AddNode(graph.Node)
+	SetWeightedEdge(graph.WeightedEdge)
+}
+
 // Prim generates a minimum spanning tree of g by greedy tree extension, placing
 // the result in the destination, dst. If the edge weights of g are distinct
 // it will be the unique minimum spanning tree of g. The destination is not cleared
 // first. The weight of the minimum spanning tree is returned. If g is not connected,
 // a minimum spanning forest will be constructed in dst and the sum of minimum
 // spanning tree weights will be returned.
-func Prim(dst graph.UndirectedBuilder, g graph.WeightedUndirected) float64 {
+//
+// Nodes and Edges from g are used to construct dst, so if the Node and Edge
+// types used in g are pointer or reference-like, then the values will be shared
+// between the graphs.
+//
+// If dst has nodes that exist in g, Prim will panic.
+func Prim(dst WeightedBuilder, g graph.WeightedUndirected) float64 {
 	nodes := g.Nodes()
 	if len(nodes) == 0 {
 		return 0
@@ -29,7 +41,9 @@ func Prim(dst graph.UndirectedBuilder, g graph.WeightedUndirected) float64 {
 		indexOf: make(map[int64]int, len(nodes)-1),
 		nodes:   make([]simple.WeightedEdge, 0, len(nodes)-1),
 	}
+	dst.AddNode(nodes[0])
 	for _, u := range nodes[1:] {
+		dst.AddNode(u)
 		heap.Push(q, simple.WeightedEdge{F: u, W: math.Inf(1)})
 	}
 
@@ -46,7 +60,7 @@ func Prim(dst graph.UndirectedBuilder, g graph.WeightedUndirected) float64 {
 	for q.Len() > 0 {
 		e := heap.Pop(q).(simple.WeightedEdge)
 		if e.To() != nil && g.HasEdgeBetween(e.From(), e.To()) {
-			dst.SetEdge(e)
+			dst.SetWeightedEdge(g.WeightedEdge(e.From(), e.To()))
 			w += e.Weight()
 		}
 
@@ -130,7 +144,7 @@ func (q *primQueue) update(u, v graph.Node, key float64) {
 // the set of edges in the graph.
 type UndirectedWeightLister interface {
 	graph.WeightedUndirected
-	Edges() []graph.Edge
+	WeightedEdges() []graph.WeightedEdge
 }
 
 // Kruskal generates a minimum spanning tree of g by greedy tree coalescence, placing
@@ -139,37 +153,34 @@ type UndirectedWeightLister interface {
 // first. The weight of the minimum spanning tree is returned. If g is not connected,
 // a minimum spanning forest will be constructed in dst and the sum of minimum
 // spanning tree weights will be returned.
-func Kruskal(dst graph.UndirectedBuilder, g UndirectedWeightLister) float64 {
-	edges := g.Edges()
-	ascend := make([]simple.WeightedEdge, 0, len(edges))
-	for _, e := range edges {
-		u := e.From()
-		v := e.To()
-		w, ok := g.Weight(u, v)
-		if !ok {
-			panic("kruskal: unexpected invalid weight")
-		}
-		ascend = append(ascend, simple.WeightedEdge{F: u, T: v, W: w})
-	}
-	sort.Sort(byWeight(ascend))
+//
+// Nodes and Edges from g are used to construct dst, so if the Node and Edge
+// types used in g are pointer or reference-like, then the values will be shared
+// between the graphs.
+//
+// If dst has nodes that exist in g, Kruskal will panic.
+func Kruskal(dst WeightedBuilder, g UndirectedWeightLister) float64 {
+	edges := g.WeightedEdges()
+	sort.Sort(byWeight(edges))
 
 	ds := newDisjointSet()
 	for _, node := range g.Nodes() {
+		dst.AddNode(node)
 		ds.makeSet(node.ID())
 	}
 
 	var w float64
-	for _, e := range ascend {
+	for _, e := range edges {
 		if s1, s2 := ds.find(e.From().ID()), ds.find(e.To().ID()); s1 != s2 {
 			ds.union(s1, s2)
-			dst.SetEdge(e)
+			dst.SetWeightedEdge(g.WeightedEdge(e.From(), e.To()))
 			w += e.Weight()
 		}
 	}
 	return w
 }
 
-type byWeight []simple.WeightedEdge
+type byWeight []graph.WeightedEdge
 
 func (e byWeight) Len() int           { return len(e) }
 func (e byWeight) Less(i, j int) bool { return e[i].Weight() < e[j].Weight() }

--- a/graph/path/spanning_tree_test.go
+++ b/graph/path/spanning_tree_test.go
@@ -28,7 +28,7 @@ func init() {
 type spanningGraph interface {
 	graph.WeightedBuilder
 	graph.WeightedUndirected
-	Edges() []graph.Edge
+	WeightedEdges() []graph.WeightedEdge
 }
 
 var spanningTreeTests = []struct {
@@ -240,14 +240,14 @@ var spanningTreeTests = []struct {
 	},
 }
 
-func testMinumumSpanning(mst func(dst graph.UndirectedBuilder, g spanningGraph) float64, t *testing.T) {
+func testMinumumSpanning(mst func(dst WeightedBuilder, g spanningGraph) float64, t *testing.T) {
 	for _, test := range spanningTreeTests {
 		g := test.graph()
 		for _, e := range test.edges {
 			g.SetWeightedEdge(e)
 		}
 
-		dst := edgeAdder{simple.NewWeightedUndirectedGraph(0, math.Inf(1))}
+		dst := simple.NewWeightedUndirectedGraph(0, math.Inf(1))
 		w := mst(dst, g)
 		if w != test.want {
 			t.Errorf("unexpected minimum spanning tree weight for %q: got: %f want: %f",
@@ -281,26 +281,14 @@ func testMinumumSpanning(mst func(dst graph.UndirectedBuilder, g spanningGraph) 
 	}
 }
 
-type edgeAdder struct {
-	*simple.WeightedUndirectedGraph
-}
-
-func (g edgeAdder) NewEdge(x, y graph.Node) graph.Edge {
-	return g.WeightedUndirectedGraph.NewWeightedEdge(x, y, 1)
-}
-
-func (g edgeAdder) SetEdge(e graph.Edge) {
-	g.WeightedUndirectedGraph.SetWeightedEdge(e.(graph.WeightedEdge))
-}
-
 func TestKruskal(t *testing.T) {
-	testMinumumSpanning(func(dst graph.UndirectedBuilder, g spanningGraph) float64 {
+	testMinumumSpanning(func(dst WeightedBuilder, g spanningGraph) float64 {
 		return Kruskal(dst, g)
 	}, t)
 }
 
 func TestPrim(t *testing.T) {
-	testMinumumSpanning(func(dst graph.UndirectedBuilder, g spanningGraph) float64 {
+	testMinumumSpanning(func(dst WeightedBuilder, g spanningGraph) float64 {
 		return Prim(dst, g)
 	}, t)
 }

--- a/graph/path/spanning_tree_test.go
+++ b/graph/path/spanning_tree_test.go
@@ -34,9 +34,9 @@ type spanningGraph interface {
 var spanningTreeTests = []struct {
 	name      string
 	graph     func() spanningGraph
-	edges     []simple.Edge
+	edges     []simple.WeightedEdge
 	want      float64
-	treeEdges []simple.Edge
+	treeEdges []simple.WeightedEdge
 }{
 	{
 		name:  "Empty",
@@ -49,7 +49,7 @@ var spanningTreeTests = []struct {
 		// to prevent the alternative solution being found.
 		name:  "Prim WP figure 1",
 		graph: func() spanningGraph { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
-		edges: []simple.Edge{
+		edges: []simple.WeightedEdge{
 			{F: simple.Node('A'), T: simple.Node('B'), W: 2.5},
 			{F: simple.Node('A'), T: simple.Node('D'), W: 1},
 			{F: simple.Node('B'), T: simple.Node('D'), W: 2},
@@ -57,7 +57,7 @@ var spanningTreeTests = []struct {
 		},
 
 		want: 6,
-		treeEdges: []simple.Edge{
+		treeEdges: []simple.WeightedEdge{
 			{F: simple.Node('A'), T: simple.Node('D'), W: 1},
 			{F: simple.Node('B'), T: simple.Node('D'), W: 2},
 			{F: simple.Node('C'), T: simple.Node('D'), W: 3},
@@ -67,7 +67,7 @@ var spanningTreeTests = []struct {
 		// https://upload.wikimedia.org/wikipedia/commons/5/5c/MST_kruskal_en.gif
 		name:  "Kruskal WP figure 1",
 		graph: func() spanningGraph { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
-		edges: []simple.Edge{
+		edges: []simple.WeightedEdge{
 			{F: simple.Node('a'), T: simple.Node('b'), W: 3},
 			{F: simple.Node('a'), T: simple.Node('e'), W: 1},
 			{F: simple.Node('b'), T: simple.Node('c'), W: 5},
@@ -78,7 +78,7 @@ var spanningTreeTests = []struct {
 		},
 
 		want: 11,
-		treeEdges: []simple.Edge{
+		treeEdges: []simple.WeightedEdge{
 			{F: simple.Node('a'), T: simple.Node('b'), W: 3},
 			{F: simple.Node('a'), T: simple.Node('e'), W: 1},
 			{F: simple.Node('b'), T: simple.Node('c'), W: 5},
@@ -89,7 +89,7 @@ var spanningTreeTests = []struct {
 		// https://upload.wikimedia.org/wikipedia/commons/8/87/Kruskal_Algorithm_6.svg
 		name:  "Kruskal WP example",
 		graph: func() spanningGraph { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
-		edges: []simple.Edge{
+		edges: []simple.WeightedEdge{
 			{F: simple.Node('A'), T: simple.Node('B'), W: 7},
 			{F: simple.Node('A'), T: simple.Node('D'), W: 5},
 			{F: simple.Node('B'), T: simple.Node('C'), W: 8},
@@ -104,7 +104,7 @@ var spanningTreeTests = []struct {
 		},
 
 		want: 39,
-		treeEdges: []simple.Edge{
+		treeEdges: []simple.WeightedEdge{
 			{F: simple.Node('A'), T: simple.Node('B'), W: 7},
 			{F: simple.Node('A'), T: simple.Node('D'), W: 5},
 			{F: simple.Node('B'), T: simple.Node('E'), W: 7},
@@ -117,7 +117,7 @@ var spanningTreeTests = []struct {
 		// https://upload.wikimedia.org/wikipedia/commons/2/2e/Boruvka%27s_algorithm_%28Sollin%27s_algorithm%29_Anim.gif
 		name:  "Borůvka WP example",
 		graph: func() spanningGraph { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
-		edges: []simple.Edge{
+		edges: []simple.WeightedEdge{
 			{F: simple.Node('A'), T: simple.Node('B'), W: 13},
 			{F: simple.Node('A'), T: simple.Node('C'), W: 6},
 			{F: simple.Node('B'), T: simple.Node('C'), W: 7},
@@ -141,7 +141,7 @@ var spanningTreeTests = []struct {
 		},
 
 		want: 83,
-		treeEdges: []simple.Edge{
+		treeEdges: []simple.WeightedEdge{
 			{F: simple.Node('A'), T: simple.Node('C'), W: 6},
 			{F: simple.Node('B'), T: simple.Node('C'), W: 7},
 			{F: simple.Node('B'), T: simple.Node('D'), W: 1},
@@ -160,7 +160,7 @@ var spanningTreeTests = []struct {
 		// Nodes labelled row major.
 		name:  "Minimum Spanning Tree WP figure 1",
 		graph: func() spanningGraph { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
-		edges: []simple.Edge{
+		edges: []simple.WeightedEdge{
 			{F: simple.Node(1), T: simple.Node(2), W: 4},
 			{F: simple.Node(1), T: simple.Node(3), W: 1},
 			{F: simple.Node(1), T: simple.Node(4), W: 4},
@@ -185,7 +185,7 @@ var spanningTreeTests = []struct {
 		},
 
 		want: 38,
-		treeEdges: []simple.Edge{
+		treeEdges: []simple.WeightedEdge{
 			{F: simple.Node(1), T: simple.Node(2), W: 4},
 			{F: simple.Node(1), T: simple.Node(3), W: 1},
 			{F: simple.Node(2), T: simple.Node(8), W: 7},
@@ -203,7 +203,7 @@ var spanningTreeTests = []struct {
 		// but with C--H and E--J cut.
 		name:  "Borůvka WP example cut",
 		graph: func() spanningGraph { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
-		edges: []simple.Edge{
+		edges: []simple.WeightedEdge{
 			{F: simple.Node('A'), T: simple.Node('B'), W: 13},
 			{F: simple.Node('A'), T: simple.Node('C'), W: 6},
 			{F: simple.Node('B'), T: simple.Node('C'), W: 7},
@@ -225,7 +225,7 @@ var spanningTreeTests = []struct {
 		},
 
 		want: 65,
-		treeEdges: []simple.Edge{
+		treeEdges: []simple.WeightedEdge{
 			{F: simple.Node('A'), T: simple.Node('C'), W: 6},
 			{F: simple.Node('B'), T: simple.Node('C'), W: 7},
 			{F: simple.Node('B'), T: simple.Node('D'), W: 1},

--- a/graph/path/spanning_tree_test.go
+++ b/graph/path/spanning_tree_test.go
@@ -26,8 +26,8 @@ func init() {
 }
 
 type spanningGraph interface {
-	graph.UndirectedBuilder
-	graph.Weighter
+	graph.Builder
+	graph.WeightedUndirected
 	Edges() []graph.Edge
 }
 

--- a/graph/simple/dense_directed_matrix.go
+++ b/graph/simple/dense_directed_matrix.go
@@ -174,6 +174,12 @@ func (g *DirectedMatrix) HasEdgeBetween(x, y graph.Node) bool {
 // Edge returns the edge from u to v if such an edge exists and nil otherwise.
 // The node v must be directly reachable from u as defined by the From method.
 func (g *DirectedMatrix) Edge(u, v graph.Node) graph.Edge {
+	return g.WeightedEdge(u, v)
+}
+
+// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+func (g *DirectedMatrix) WeightedEdge(u, v graph.Node) graph.WeightedEdge {
 	if g.HasEdgeFromTo(u, v) {
 		// x.ID() and y.ID() are not greater than maximum int by this point.
 		return Edge{F: g.Node(u.ID()), T: g.Node(v.ID()), W: g.mat.At(int(u.ID()), int(v.ID()))}

--- a/graph/simple/dense_directed_matrix.go
+++ b/graph/simple/dense_directed_matrix.go
@@ -218,9 +218,19 @@ func (g *DirectedMatrix) Weight(x, y graph.Node) (w float64, ok bool) {
 	return g.absent, false
 }
 
-// SetEdge sets e, an edge from one node to another. If the ends of the edge are not in g
-// or the edge is a self loop, SetEdge panics.
+// SetEdge sets e, an edge from one node to another with unit weight. If the ends of the edge
+// are not in g or the edge is a self loop, SetEdge panics.
 func (g *DirectedMatrix) SetEdge(e graph.Edge) {
+	g.setWeightedEdge(e, 1)
+}
+
+// SetWeightedEdge sets e, an edge from one node to another. If the ends of the edge are not in g
+// or the edge is a self loop, SetWeightedEdge panics.
+func (g *DirectedMatrix) SetWeightedEdge(e graph.WeightedEdge) {
+	g.setWeightedEdge(e, e.Weight())
+}
+
+func (g *DirectedMatrix) setWeightedEdge(e graph.Edge, weight float64) {
 	fid := e.From().ID()
 	tid := e.To().ID()
 	if fid == tid {
@@ -233,7 +243,7 @@ func (g *DirectedMatrix) SetEdge(e graph.Edge) {
 		panic("simple: unavailable to node ID for dense graph")
 	}
 	// fid and tid are not greater than maximum int by this point.
-	g.mat.Set(int(fid), int(tid), e.Weight())
+	g.mat.Set(int(fid), int(tid), weight)
 }
 
 // RemoveEdge removes e from the graph, leaving the terminal nodes. If the edge does not exist

--- a/graph/simple/dense_directed_matrix.go
+++ b/graph/simple/dense_directed_matrix.go
@@ -109,7 +109,7 @@ func (g *DirectedMatrix) Edges() []graph.Edge {
 				continue
 			}
 			if w := g.mat.At(i, j); !isSame(w, g.absent) {
-				edges = append(edges, Edge{F: g.Node(int64(i)), T: g.Node(int64(j)), W: w})
+				edges = append(edges, WeightedEdge{F: g.Node(int64(i)), T: g.Node(int64(j)), W: w})
 			}
 		}
 	}
@@ -182,7 +182,7 @@ func (g *DirectedMatrix) Edge(u, v graph.Node) graph.Edge {
 func (g *DirectedMatrix) WeightedEdge(u, v graph.Node) graph.WeightedEdge {
 	if g.HasEdgeFromTo(u, v) {
 		// x.ID() and y.ID() are not greater than maximum int by this point.
-		return Edge{F: g.Node(u.ID()), T: g.Node(v.ID()), W: g.mat.At(int(u.ID()), int(v.ID()))}
+		return WeightedEdge{F: g.Node(u.ID()), T: g.Node(v.ID()), W: g.mat.At(int(u.ID()), int(v.ID()))}
 	}
 	return nil
 }

--- a/graph/simple/dense_undirected_matrix.go
+++ b/graph/simple/dense_undirected_matrix.go
@@ -190,9 +190,19 @@ func (g *UndirectedMatrix) Weight(x, y graph.Node) (w float64, ok bool) {
 	return g.absent, false
 }
 
-// SetEdge sets e, an edge from one node to another. If the ends of the edge are not in g
-// or the edge is a self loop, SetEdge panics.
+// SetEdge sets e, an edge from one node to another with unit weight. If the ends of the edge are
+// not in g or the edge is a self loop, SetEdge panics.
 func (g *UndirectedMatrix) SetEdge(e graph.Edge) {
+	g.setWeightedEdge(e, 1)
+}
+
+// SetWeightedEdge sets e, an edge from one node to another. If the ends of the edge are not in g
+// or the edge is a self loop, SetWeightedEdge panics.
+func (g *UndirectedMatrix) SetWeightedEdge(e graph.WeightedEdge) {
+	g.setWeightedEdge(e, e.Weight())
+}
+
+func (g *UndirectedMatrix) setWeightedEdge(e graph.Edge, weight float64) {
 	fid := e.From().ID()
 	tid := e.To().ID()
 	if fid == tid {
@@ -205,7 +215,7 @@ func (g *UndirectedMatrix) SetEdge(e graph.Edge) {
 		panic("simple: unavailable to node ID for dense graph")
 	}
 	// fid and tid are not greater than maximum int by this point.
-	g.mat.SetSym(int(fid), int(tid), e.Weight())
+	g.mat.SetSym(int(fid), int(tid), weight)
 }
 
 // RemoveEdge removes e from the graph, leaving the terminal nodes. If the edge does not exist

--- a/graph/simple/dense_undirected_matrix.go
+++ b/graph/simple/dense_undirected_matrix.go
@@ -106,7 +106,7 @@ func (g *UndirectedMatrix) Edges() []graph.Edge {
 	for i := 0; i < r; i++ {
 		for j := i + 1; j < r; j++ {
 			if w := g.mat.At(i, j); !isSame(w, g.absent) {
-				edges = append(edges, Edge{F: g.Node(int64(i)), T: g.Node(int64(j)), W: w})
+				edges = append(edges, WeightedEdge{F: g.Node(int64(i)), T: g.Node(int64(j)), W: w})
 			}
 		}
 	}
@@ -168,7 +168,7 @@ func (g *UndirectedMatrix) EdgeBetween(u, v graph.Node) graph.Edge {
 func (g *UndirectedMatrix) WeightedEdgeBetween(u, v graph.Node) graph.WeightedEdge {
 	if g.HasEdgeBetween(u, v) {
 		// u.ID() and v.ID() are not greater than maximum int by this point.
-		return Edge{F: g.Node(u.ID()), T: g.Node(v.ID()), W: g.mat.At(int(u.ID()), int(v.ID()))}
+		return WeightedEdge{F: g.Node(u.ID()), T: g.Node(v.ID()), W: g.mat.At(int(u.ID()), int(v.ID()))}
 	}
 	return nil
 }

--- a/graph/simple/dense_undirected_matrix.go
+++ b/graph/simple/dense_undirected_matrix.go
@@ -150,11 +150,22 @@ func (g *UndirectedMatrix) HasEdgeBetween(u, v graph.Node) bool {
 // Edge returns the edge from u to v if such an edge exists and nil otherwise.
 // The node v must be directly reachable from u as defined by the From method.
 func (g *UndirectedMatrix) Edge(u, v graph.Node) graph.Edge {
-	return g.EdgeBetween(u, v)
+	return g.WeightedEdgeBetween(u, v)
+}
+
+// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+func (g *UndirectedMatrix) WeightedEdge(u, v graph.Node) graph.WeightedEdge {
+	return g.WeightedEdgeBetween(u, v)
 }
 
 // EdgeBetween returns the edge between nodes x and y.
 func (g *UndirectedMatrix) EdgeBetween(u, v graph.Node) graph.Edge {
+	return g.WeightedEdgeBetween(u, v)
+}
+
+// WeightedEdgeBetween returns the weighted edge between nodes x and y.
+func (g *UndirectedMatrix) WeightedEdgeBetween(u, v graph.Node) graph.WeightedEdge {
 	if g.HasEdgeBetween(u, v) {
 		// u.ID() and v.ID() are not greater than maximum int by this point.
 		return Edge{F: g.Node(u.ID()), T: g.Node(v.ID()), W: g.mat.At(int(u.ID()), int(v.ID()))}

--- a/graph/simple/densegraph_test.go
+++ b/graph/simple/densegraph_test.go
@@ -75,7 +75,7 @@ func TestBasicDensePassable(t *testing.T) {
 
 func TestDirectedDenseAddRemove(t *testing.T) {
 	dg := NewDirectedMatrix(10, math.Inf(1), 0, math.Inf(1))
-	dg.SetEdge(Edge{F: Node(0), T: Node(2), W: 1})
+	dg.SetWeightedEdge(WeightedEdge{F: Node(0), T: Node(2), W: 1})
 
 	if neighbors := dg.From(Node(0)); len(neighbors) != 1 || neighbors[0].ID() != 2 ||
 		dg.Edge(Node(0), Node(2)) == nil {
@@ -92,7 +92,7 @@ func TestDirectedDenseAddRemove(t *testing.T) {
 		t.Errorf("Removing directed edge wrongly kept predecessor")
 	}
 
-	dg.SetEdge(Edge{F: Node(0), T: Node(2), W: 2})
+	dg.SetWeightedEdge(WeightedEdge{F: Node(0), T: Node(2), W: 2})
 	// I figure we've torture tested From/To at this point
 	// so we'll just use the bool functions now
 	if dg.Edge(Node(0), Node(2)) == nil {

--- a/graph/simple/densegraph_test.go
+++ b/graph/simple/densegraph_test.go
@@ -14,8 +14,17 @@ import (
 )
 
 var (
-	_ graph.Graph    = (*UndirectedMatrix)(nil)
-	_ graph.Directed = (*DirectedMatrix)(nil)
+	directedMatrix = (*DirectedMatrix)(nil)
+
+	_ graph.Graph            = directedMatrix
+	_ graph.Directed         = directedMatrix
+	_ graph.WeightedDirected = directedMatrix
+
+	undirectedMatrix = (*UndirectedMatrix)(nil)
+
+	_ graph.Graph              = undirectedMatrix
+	_ graph.Undirected         = undirectedMatrix
+	_ graph.WeightedUndirected = undirectedMatrix
 )
 
 func TestBasicDenseImpassable(t *testing.T) {

--- a/graph/simple/directed.go
+++ b/graph/simple/directed.go
@@ -213,6 +213,12 @@ func (g *DirectedGraph) HasEdgeBetween(x, y graph.Node) bool {
 // Edge returns the edge from u to v if such an edge exists and nil otherwise.
 // The node v must be directly reachable from u as defined by the From method.
 func (g *DirectedGraph) Edge(u, v graph.Node) graph.Edge {
+	return g.WeightedEdge(u, v)
+}
+
+// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+func (g *DirectedGraph) WeightedEdge(u, v graph.Node) graph.WeightedEdge {
 	if _, ok := g.nodes[u.ID()]; !ok {
 		return nil
 	}

--- a/graph/simple/directed_test.go
+++ b/graph/simple/directed_test.go
@@ -11,9 +11,13 @@ import (
 	"gonum.org/v1/gonum/graph"
 )
 
-var _ graph.Graph = &DirectedGraph{}
-var _ graph.Directed = &DirectedGraph{}
-var _ graph.Directed = &DirectedGraph{}
+var (
+	directedGraph = (*DirectedGraph)(nil)
+
+	_ graph.Graph            = directedGraph
+	_ graph.Directed         = directedGraph
+	_ graph.WeightedDirected = directedGraph
+)
 
 // Tests Issue #27
 func TestEdgeOvercounting(t *testing.T) {

--- a/graph/simple/simple.go
+++ b/graph/simple/simple.go
@@ -22,7 +22,6 @@ func (n Node) ID() int64 {
 // Edge is a simple graph edge.
 type Edge struct {
 	F, T graph.Node
-	W    float64
 }
 
 // From returns the from-node of the edge.
@@ -31,8 +30,20 @@ func (e Edge) From() graph.Node { return e.F }
 // To returns the to-node of the edge.
 func (e Edge) To() graph.Node { return e.T }
 
+// WeightedEdge is a simple weighted graph edge.
+type WeightedEdge struct {
+	F, T graph.Node
+	W    float64
+}
+
+// From returns the from-node of the edge.
+func (e WeightedEdge) From() graph.Node { return e.F }
+
+// To returns the to-node of the edge.
+func (e WeightedEdge) To() graph.Node { return e.T }
+
 // Weight returns the weight of the edge.
-func (e Edge) Weight() float64 { return e.W }
+func (e WeightedEdge) Weight() float64 { return e.W }
 
 // isSame returns whether two float64 values are the same where NaN values
 // are equalable.

--- a/graph/simple/undirected.go
+++ b/graph/simple/undirected.go
@@ -186,11 +186,22 @@ func (g *UndirectedGraph) HasEdgeBetween(x, y graph.Node) bool {
 // Edge returns the edge from u to v if such an edge exists and nil otherwise.
 // The node v must be directly reachable from u as defined by the From method.
 func (g *UndirectedGraph) Edge(u, v graph.Node) graph.Edge {
-	return g.EdgeBetween(u, v)
+	return g.WeightedEdgeBetween(u, v)
+}
+
+// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+func (g *UndirectedGraph) WeightedEdge(u, v graph.Node) graph.WeightedEdge {
+	return g.WeightedEdgeBetween(u, v)
 }
 
 // EdgeBetween returns the edge between nodes x and y.
 func (g *UndirectedGraph) EdgeBetween(x, y graph.Node) graph.Edge {
+	return g.WeightedEdgeBetween(x, y)
+}
+
+// WeightedEdgeBetween returns the weighted edge between nodes x and y.
+func (g *UndirectedGraph) WeightedEdgeBetween(x, y graph.Node) graph.WeightedEdge {
 	// We don't need to check if neigh exists because
 	// it's implicit in the edges access.
 	if !g.Has(x) {

--- a/graph/simple/undirected_test.go
+++ b/graph/simple/undirected_test.go
@@ -11,7 +11,13 @@ import (
 	"gonum.org/v1/gonum/graph"
 )
 
-var _ graph.Graph = (*UndirectedGraph)(nil)
+var (
+	undirectedGraph = (*UndirectedGraph)(nil)
+
+	_ graph.Graph              = undirectedGraph
+	_ graph.Undirected         = undirectedGraph
+	_ graph.WeightedUndirected = undirectedGraph
+)
 
 func TestAssertMutableNotDirected(t *testing.T) {
 	var g graph.UndirectedBuilder = NewUndirectedGraph(0, math.Inf(1))

--- a/graph/simple/weighted_directed.go
+++ b/graph/simple/weighted_directed.go
@@ -82,7 +82,7 @@ func (g *WeightedDirectedGraph) RemoveNode(n graph.Node) {
 
 // NewWeightedEdge returns a new weighted edge from the source to the destination node.
 func (g *WeightedDirectedGraph) NewWeightedEdge(from, to graph.Node, weight float64) graph.WeightedEdge {
-	return &Edge{F: from, T: to, W: weight}
+	return &WeightedEdge{F: from, T: to, W: weight}
 }
 
 // SetWeightedEdge adds a weighted edge from one node to another. If the nodes do not exist, they are added.

--- a/graph/simple/weighted_directed.go
+++ b/graph/simple/weighted_directed.go
@@ -10,22 +10,27 @@ import (
 	"gonum.org/v1/gonum/graph"
 )
 
-// DirectedGraph implements a generalized directed graph.
-type DirectedGraph struct {
+// WeightedDirectedGraph implements a generalized weighted directed graph.
+type WeightedDirectedGraph struct {
 	nodes map[int64]graph.Node
-	from  map[int64]map[int64]graph.Edge
-	to    map[int64]map[int64]graph.Edge
+	from  map[int64]map[int64]graph.WeightedEdge
+	to    map[int64]map[int64]graph.WeightedEdge
+
+	self, absent float64
 
 	nodeIDs idSet
 }
 
-// NewDirectedGraph returns a DirectedGraph with the specified self and absent
+// NewWeightedDirectedGraph returns a WeightedDirectedGraph with the specified self and absent
 // edge weight values.
-func NewDirectedGraph() *DirectedGraph {
-	return &DirectedGraph{
+func NewWeightedDirectedGraph(self, absent float64) *WeightedDirectedGraph {
+	return &WeightedDirectedGraph{
 		nodes: make(map[int64]graph.Node),
-		from:  make(map[int64]map[int64]graph.Edge),
-		to:    make(map[int64]map[int64]graph.Edge),
+		from:  make(map[int64]map[int64]graph.WeightedEdge),
+		to:    make(map[int64]map[int64]graph.WeightedEdge),
+
+		self:   self,
+		absent: absent,
 
 		nodeIDs: newIDSet(),
 	}
@@ -33,7 +38,7 @@ func NewDirectedGraph() *DirectedGraph {
 
 // NewNode returns a new unique Node to be added to g. The Node's ID does
 // not become valid in g until the Node is added to g.
-func (g *DirectedGraph) NewNode() graph.Node {
+func (g *WeightedDirectedGraph) NewNode() graph.Node {
 	if len(g.nodes) == 0 {
 		return Node(0)
 	}
@@ -44,19 +49,19 @@ func (g *DirectedGraph) NewNode() graph.Node {
 }
 
 // AddNode adds n to the graph. It panics if the added node ID matches an existing node ID.
-func (g *DirectedGraph) AddNode(n graph.Node) {
+func (g *WeightedDirectedGraph) AddNode(n graph.Node) {
 	if _, exists := g.nodes[n.ID()]; exists {
 		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
 	}
 	g.nodes[n.ID()] = n
-	g.from[n.ID()] = make(map[int64]graph.Edge)
-	g.to[n.ID()] = make(map[int64]graph.Edge)
+	g.from[n.ID()] = make(map[int64]graph.WeightedEdge)
+	g.to[n.ID()] = make(map[int64]graph.WeightedEdge)
 	g.nodeIDs.use(n.ID())
 }
 
 // RemoveNode removes n from the graph, as well as any edges attached to it. If the node
 // is not in the graph it is a no-op.
-func (g *DirectedGraph) RemoveNode(n graph.Node) {
+func (g *WeightedDirectedGraph) RemoveNode(n graph.Node) {
 	if _, ok := g.nodes[n.ID()]; !ok {
 		return
 	}
@@ -75,14 +80,14 @@ func (g *DirectedGraph) RemoveNode(n graph.Node) {
 	g.nodeIDs.release(n.ID())
 }
 
-// NewEdge returns a new Edge from the source to the destination node.
-func (g *DirectedGraph) NewEdge(from, to graph.Node) graph.Edge {
-	return &Edge{F: from, T: to}
+// NewWeightedEdge returns a new weighted edge from the source to the destination node.
+func (g *WeightedDirectedGraph) NewWeightedEdge(from, to graph.Node, weight float64) graph.WeightedEdge {
+	return &Edge{F: from, T: to, W: weight}
 }
 
-// SetEdge adds e, an edge from one node to another. If the nodes do not exist, they are added.
+// SetWeightedEdge adds a weighted edge from one node to another. If the nodes do not exist, they are added.
 // It will panic if the IDs of the e.From and e.To are equal.
-func (g *DirectedGraph) SetEdge(e graph.Edge) {
+func (g *WeightedDirectedGraph) SetWeightedEdge(e graph.WeightedEdge) {
 	var (
 		from = e.From()
 		fid  = from.ID()
@@ -107,7 +112,7 @@ func (g *DirectedGraph) SetEdge(e graph.Edge) {
 
 // RemoveEdge removes e from the graph, leaving the terminal nodes. If the edge does not exist
 // it is a no-op.
-func (g *DirectedGraph) RemoveEdge(e graph.Edge) {
+func (g *WeightedDirectedGraph) RemoveEdge(e graph.Edge) {
 	from, to := e.From(), e.To()
 	if _, ok := g.nodes[from.ID()]; !ok {
 		return
@@ -121,19 +126,19 @@ func (g *DirectedGraph) RemoveEdge(e graph.Edge) {
 }
 
 // Node returns the node in the graph with the given ID.
-func (g *DirectedGraph) Node(id int64) graph.Node {
+func (g *WeightedDirectedGraph) Node(id int64) graph.Node {
 	return g.nodes[id]
 }
 
 // Has returns whether the node exists within the graph.
-func (g *DirectedGraph) Has(n graph.Node) bool {
+func (g *WeightedDirectedGraph) Has(n graph.Node) bool {
 	_, ok := g.nodes[n.ID()]
 
 	return ok
 }
 
 // Nodes returns all the nodes in the graph.
-func (g *DirectedGraph) Nodes() []graph.Node {
+func (g *WeightedDirectedGraph) Nodes() []graph.Node {
 	nodes := make([]graph.Node, len(g.from))
 	i := 0
 	for _, n := range g.nodes {
@@ -145,7 +150,7 @@ func (g *DirectedGraph) Nodes() []graph.Node {
 }
 
 // Edges returns all the edges in the graph.
-func (g *DirectedGraph) Edges() []graph.Edge {
+func (g *WeightedDirectedGraph) Edges() []graph.Edge {
 	var edges []graph.Edge
 	for _, u := range g.nodes {
 		for _, e := range g.from[u.ID()] {
@@ -155,8 +160,19 @@ func (g *DirectedGraph) Edges() []graph.Edge {
 	return edges
 }
 
+// WeightedEdges returns all the weighted edges in the graph.
+func (g *WeightedDirectedGraph) WeightedEdges() []graph.WeightedEdge {
+	var edges []graph.WeightedEdge
+	for _, u := range g.nodes {
+		for _, e := range g.from[u.ID()] {
+			edges = append(edges, e)
+		}
+	}
+	return edges
+}
+
 // From returns all nodes in g that can be reached directly from n.
-func (g *DirectedGraph) From(n graph.Node) []graph.Node {
+func (g *WeightedDirectedGraph) From(n graph.Node) []graph.Node {
 	if _, ok := g.from[n.ID()]; !ok {
 		return nil
 	}
@@ -172,7 +188,7 @@ func (g *DirectedGraph) From(n graph.Node) []graph.Node {
 }
 
 // To returns all nodes in g that can reach directly to n.
-func (g *DirectedGraph) To(n graph.Node) []graph.Node {
+func (g *WeightedDirectedGraph) To(n graph.Node) []graph.Node {
 	if _, ok := g.from[n.ID()]; !ok {
 		return nil
 	}
@@ -189,7 +205,7 @@ func (g *DirectedGraph) To(n graph.Node) []graph.Node {
 
 // HasEdgeBetween returns whether an edge exists between nodes x and y without
 // considering direction.
-func (g *DirectedGraph) HasEdgeBetween(x, y graph.Node) bool {
+func (g *WeightedDirectedGraph) HasEdgeBetween(x, y graph.Node) bool {
 	xid := x.ID()
 	yid := y.ID()
 	if _, ok := g.nodes[xid]; !ok {
@@ -207,7 +223,13 @@ func (g *DirectedGraph) HasEdgeBetween(x, y graph.Node) bool {
 
 // Edge returns the edge from u to v if such an edge exists and nil otherwise.
 // The node v must be directly reachable from u as defined by the From method.
-func (g *DirectedGraph) Edge(u, v graph.Node) graph.Edge {
+func (g *WeightedDirectedGraph) Edge(u, v graph.Node) graph.Edge {
+	return g.WeightedEdge(u, v)
+}
+
+// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+func (g *WeightedDirectedGraph) WeightedEdge(u, v graph.Node) graph.WeightedEdge {
 	if _, ok := g.nodes[u.ID()]; !ok {
 		return nil
 	}
@@ -222,7 +244,7 @@ func (g *DirectedGraph) Edge(u, v graph.Node) graph.Edge {
 }
 
 // HasEdgeFromTo returns whether an edge exists in the graph from u to v.
-func (g *DirectedGraph) HasEdgeFromTo(u, v graph.Node) bool {
+func (g *WeightedDirectedGraph) HasEdgeFromTo(u, v graph.Node) bool {
 	if _, ok := g.nodes[u.ID()]; !ok {
 		return false
 	}
@@ -235,8 +257,26 @@ func (g *DirectedGraph) HasEdgeFromTo(u, v graph.Node) bool {
 	return true
 }
 
+// Weight returns the weight for the edge between x and y if Edge(x, y) returns a non-nil Edge.
+// If x and y are the same node or there is no joining edge between the two nodes the weight
+// value returned is either the graph's absent or self value. Weight returns true if an edge
+// exists between x and y or if x and y have the same ID, false otherwise.
+func (g *WeightedDirectedGraph) Weight(x, y graph.Node) (w float64, ok bool) {
+	xid := x.ID()
+	yid := y.ID()
+	if xid == yid {
+		return g.self, true
+	}
+	if to, ok := g.from[xid]; ok {
+		if e, ok := to[yid]; ok {
+			return e.Weight(), true
+		}
+	}
+	return g.absent, false
+}
+
 // Degree returns the in+out degree of n in g.
-func (g *DirectedGraph) Degree(n graph.Node) int {
+func (g *WeightedDirectedGraph) Degree(n graph.Node) int {
 	if _, ok := g.nodes[n.ID()]; !ok {
 		return 0
 	}

--- a/graph/simple/weighted_directed_test.go
+++ b/graph/simple/weighted_directed_test.go
@@ -5,20 +5,22 @@
 package simple
 
 import (
+	"math"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
 )
 
 var (
-	directedGraph = (*DirectedGraph)(nil)
+	weightedDirectedGraph = (*WeightedDirectedGraph)(nil)
 
-	_ graph.Graph    = directedGraph
-	_ graph.Directed = directedGraph
+	_ graph.Graph            = weightedDirectedGraph
+	_ graph.Directed         = weightedDirectedGraph
+	_ graph.WeightedDirected = weightedDirectedGraph
 )
 
 // Tests Issue #27
-func TestEdgeOvercounting(t *testing.T) {
+func TestWeightedEdgeOvercounting(t *testing.T) {
 	g := generateDummyGraph()
 
 	if neigh := g.From(Node(Node(2))); len(neigh) != 2 {
@@ -26,7 +28,7 @@ func TestEdgeOvercounting(t *testing.T) {
 	}
 }
 
-func generateDummyGraph() *DirectedGraph {
+func generateDummyWeightedGraph() *WeightedDirectedGraph {
 	nodes := [4]struct{ srcID, targetID int }{
 		{2, 1},
 		{1, 0},
@@ -34,23 +36,23 @@ func generateDummyGraph() *DirectedGraph {
 		{0, 2},
 	}
 
-	g := NewDirectedGraph()
+	g := NewWeightedDirectedGraph(0, math.Inf(1))
 
 	for _, n := range nodes {
-		g.SetEdge(Edge{F: Node(n.srcID), T: Node(n.targetID)})
+		g.SetWeightedEdge(Edge{F: Node(n.srcID), T: Node(n.targetID), W: 1})
 	}
 
 	return g
 }
 
 // Test for issue #123 https://github.com/gonum/graph/issues/123
-func TestIssue123DirectedGraph(t *testing.T) {
+func TestIssue123WeightedDirectedGraph(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
 			t.Errorf("unexpected panic: %v", r)
 		}
 	}()
-	g := NewDirectedGraph()
+	g := NewWeightedDirectedGraph(0, math.Inf(1))
 
 	n0 := g.NewNode()
 	g.AddNode(n0)

--- a/graph/simple/weighted_directed_test.go
+++ b/graph/simple/weighted_directed_test.go
@@ -39,7 +39,7 @@ func generateDummyWeightedGraph() *WeightedDirectedGraph {
 	g := NewWeightedDirectedGraph(0, math.Inf(1))
 
 	for _, n := range nodes {
-		g.SetWeightedEdge(Edge{F: Node(n.srcID), T: Node(n.targetID), W: 1})
+		g.SetWeightedEdge(WeightedEdge{F: Node(n.srcID), T: Node(n.targetID), W: 1})
 	}
 
 	return g

--- a/graph/simple/weighted_undirected.go
+++ b/graph/simple/weighted_undirected.go
@@ -74,7 +74,7 @@ func (g *WeightedUndirectedGraph) RemoveNode(n graph.Node) {
 
 // NewWeightedEdge returns a new weighted edge from the source to the destination node.
 func (g *WeightedUndirectedGraph) NewWeightedEdge(from, to graph.Node, weight float64) graph.WeightedEdge {
-	return &Edge{F: from, T: to, W: weight}
+	return &WeightedEdge{F: from, T: to, W: weight}
 }
 
 // SetWeightedEdge adds a weighted edge from one node to another. If the nodes do not exist, they are added.

--- a/graph/simple/weighted_undirected.go
+++ b/graph/simple/weighted_undirected.go
@@ -10,20 +10,25 @@ import (
 	"gonum.org/v1/gonum/graph"
 )
 
-// UndirectedGraph implements a generalized undirected graph.
-type UndirectedGraph struct {
+// WeightedUndirectedGraph implements a generalized weighted undirected graph.
+type WeightedUndirectedGraph struct {
 	nodes map[int64]graph.Node
-	edges map[int64]map[int64]graph.Edge
+	edges map[int64]map[int64]graph.WeightedEdge
+
+	self, absent float64
 
 	nodeIDs idSet
 }
 
-// NewUndirectedGraph returns an UndirectedGraph with the specified self and absent
+// NewWeightedUndirectedGraph returns an WeightedUndirectedGraph with the specified self and absent
 // edge weight values.
-func NewUndirectedGraph() *UndirectedGraph {
-	return &UndirectedGraph{
+func NewWeightedUndirectedGraph(self, absent float64) *WeightedUndirectedGraph {
+	return &WeightedUndirectedGraph{
 		nodes: make(map[int64]graph.Node),
-		edges: make(map[int64]map[int64]graph.Edge),
+		edges: make(map[int64]map[int64]graph.WeightedEdge),
+
+		self:   self,
+		absent: absent,
 
 		nodeIDs: newIDSet(),
 	}
@@ -31,7 +36,7 @@ func NewUndirectedGraph() *UndirectedGraph {
 
 // NewNode returns a new unique Node to be added to g. The Node's ID does
 // not become valid in g until the Node is added to g.
-func (g *UndirectedGraph) NewNode() graph.Node {
+func (g *WeightedUndirectedGraph) NewNode() graph.Node {
 	if len(g.nodes) == 0 {
 		return Node(0)
 	}
@@ -42,18 +47,18 @@ func (g *UndirectedGraph) NewNode() graph.Node {
 }
 
 // AddNode adds n to the graph. It panics if the added node ID matches an existing node ID.
-func (g *UndirectedGraph) AddNode(n graph.Node) {
+func (g *WeightedUndirectedGraph) AddNode(n graph.Node) {
 	if _, exists := g.nodes[n.ID()]; exists {
 		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
 	}
 	g.nodes[n.ID()] = n
-	g.edges[n.ID()] = make(map[int64]graph.Edge)
+	g.edges[n.ID()] = make(map[int64]graph.WeightedEdge)
 	g.nodeIDs.use(n.ID())
 }
 
 // RemoveNode removes n from the graph, as well as any edges attached to it. If the node
 // is not in the graph it is a no-op.
-func (g *UndirectedGraph) RemoveNode(n graph.Node) {
+func (g *WeightedUndirectedGraph) RemoveNode(n graph.Node) {
 	if _, ok := g.nodes[n.ID()]; !ok {
 		return
 	}
@@ -67,14 +72,14 @@ func (g *UndirectedGraph) RemoveNode(n graph.Node) {
 	g.nodeIDs.release(n.ID())
 }
 
-// NewEdge returns a new Edge from the source to the destination node.
-func (g *UndirectedGraph) NewEdge(from, to graph.Node) graph.Edge {
-	return &Edge{F: from, T: to}
+// NewWeightedEdge returns a new weighted edge from the source to the destination node.
+func (g *WeightedUndirectedGraph) NewWeightedEdge(from, to graph.Node, weight float64) graph.WeightedEdge {
+	return &Edge{F: from, T: to, W: weight}
 }
 
-// SetEdge adds e, an edge from one node to another. If the nodes do not exist, they are added.
+// SetWeightedEdge adds a weighted edge from one node to another. If the nodes do not exist, they are added.
 // It will panic if the IDs of the e.From and e.To are equal.
-func (g *UndirectedGraph) SetEdge(e graph.Edge) {
+func (g *WeightedUndirectedGraph) SetWeightedEdge(e graph.WeightedEdge) {
 	var (
 		from = e.From()
 		fid  = from.ID()
@@ -99,7 +104,7 @@ func (g *UndirectedGraph) SetEdge(e graph.Edge) {
 
 // RemoveEdge removes e from the graph, leaving the terminal nodes. If the edge does not exist
 // it is a no-op.
-func (g *UndirectedGraph) RemoveEdge(e graph.Edge) {
+func (g *WeightedUndirectedGraph) RemoveEdge(e graph.Edge) {
 	from, to := e.From(), e.To()
 	if _, ok := g.nodes[from.ID()]; !ok {
 		return
@@ -113,18 +118,18 @@ func (g *UndirectedGraph) RemoveEdge(e graph.Edge) {
 }
 
 // Node returns the node in the graph with the given ID.
-func (g *UndirectedGraph) Node(id int64) graph.Node {
+func (g *WeightedUndirectedGraph) Node(id int64) graph.Node {
 	return g.nodes[id]
 }
 
 // Has returns whether the node exists within the graph.
-func (g *UndirectedGraph) Has(n graph.Node) bool {
+func (g *WeightedUndirectedGraph) Has(n graph.Node) bool {
 	_, ok := g.nodes[n.ID()]
 	return ok
 }
 
 // Nodes returns all the nodes in the graph.
-func (g *UndirectedGraph) Nodes() []graph.Node {
+func (g *WeightedUndirectedGraph) Nodes() []graph.Node {
 	nodes := make([]graph.Node, len(g.nodes))
 	i := 0
 	for _, n := range g.nodes {
@@ -136,7 +141,7 @@ func (g *UndirectedGraph) Nodes() []graph.Node {
 }
 
 // Edges returns all the edges in the graph.
-func (g *UndirectedGraph) Edges() []graph.Edge {
+func (g *WeightedUndirectedGraph) Edges() []graph.Edge {
 	var edges []graph.Edge
 
 	seen := make(map[[2]int64]struct{})
@@ -156,8 +161,29 @@ func (g *UndirectedGraph) Edges() []graph.Edge {
 	return edges
 }
 
+// WeightedEdges returns all the weighted edges in the graph.
+func (g *WeightedUndirectedGraph) WeightedEdges() []graph.WeightedEdge {
+	var edges []graph.WeightedEdge
+
+	seen := make(map[[2]int64]struct{})
+	for _, u := range g.edges {
+		for _, e := range u {
+			uid := e.From().ID()
+			vid := e.To().ID()
+			if _, ok := seen[[2]int64{uid, vid}]; ok {
+				continue
+			}
+			seen[[2]int64{uid, vid}] = struct{}{}
+			seen[[2]int64{vid, uid}] = struct{}{}
+			edges = append(edges, e)
+		}
+	}
+
+	return edges
+}
+
 // From returns all nodes in g that can be reached directly from n.
-func (g *UndirectedGraph) From(n graph.Node) []graph.Node {
+func (g *WeightedUndirectedGraph) From(n graph.Node) []graph.Node {
 	if !g.Has(n) {
 		return nil
 	}
@@ -173,19 +199,30 @@ func (g *UndirectedGraph) From(n graph.Node) []graph.Node {
 }
 
 // HasEdgeBetween returns whether an edge exists between nodes x and y.
-func (g *UndirectedGraph) HasEdgeBetween(x, y graph.Node) bool {
+func (g *WeightedUndirectedGraph) HasEdgeBetween(x, y graph.Node) bool {
 	_, ok := g.edges[x.ID()][y.ID()]
 	return ok
 }
 
 // Edge returns the edge from u to v if such an edge exists and nil otherwise.
 // The node v must be directly reachable from u as defined by the From method.
-func (g *UndirectedGraph) Edge(u, v graph.Node) graph.Edge {
-	return g.EdgeBetween(u, v)
+func (g *WeightedUndirectedGraph) Edge(u, v graph.Node) graph.Edge {
+	return g.WeightedEdgeBetween(u, v)
+}
+
+// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+func (g *WeightedUndirectedGraph) WeightedEdge(u, v graph.Node) graph.WeightedEdge {
+	return g.WeightedEdgeBetween(u, v)
 }
 
 // EdgeBetween returns the edge between nodes x and y.
-func (g *UndirectedGraph) EdgeBetween(x, y graph.Node) graph.Edge {
+func (g *WeightedUndirectedGraph) EdgeBetween(x, y graph.Node) graph.Edge {
+	return g.WeightedEdgeBetween(x, y)
+}
+
+// WeightedEdgeBetween returns the weighted edge between nodes x and y.
+func (g *WeightedUndirectedGraph) WeightedEdgeBetween(x, y graph.Node) graph.WeightedEdge {
 	// We don't need to check if neigh exists because
 	// it's implicit in the edges access.
 	if !g.Has(x) {
@@ -195,8 +232,26 @@ func (g *UndirectedGraph) EdgeBetween(x, y graph.Node) graph.Edge {
 	return g.edges[x.ID()][y.ID()]
 }
 
+// Weight returns the weight for the edge between x and y if Edge(x, y) returns a non-nil Edge.
+// If x and y are the same node or there is no joining edge between the two nodes the weight
+// value returned is either the graph's absent or self value. Weight returns true if an edge
+// exists between x and y or if x and y have the same ID, false otherwise.
+func (g *WeightedUndirectedGraph) Weight(x, y graph.Node) (w float64, ok bool) {
+	xid := x.ID()
+	yid := y.ID()
+	if xid == yid {
+		return g.self, true
+	}
+	if n, ok := g.edges[xid]; ok {
+		if e, ok := n[yid]; ok {
+			return e.Weight(), true
+		}
+	}
+	return g.absent, false
+}
+
 // Degree returns the degree of n in g.
-func (g *UndirectedGraph) Degree(n graph.Node) int {
+func (g *WeightedUndirectedGraph) Degree(n graph.Node) int {
 	if _, ok := g.nodes[n.ID()]; !ok {
 		return 0
 	}

--- a/graph/simple/weighted_undirected_test.go
+++ b/graph/simple/weighted_undirected_test.go
@@ -5,27 +5,29 @@
 package simple
 
 import (
+	"math"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
 )
 
 var (
-	undirectedGraph = (*UndirectedGraph)(nil)
+	weightedUndirectedGraph = (*WeightedUndirectedGraph)(nil)
 
-	_ graph.Graph      = undirectedGraph
-	_ graph.Undirected = undirectedGraph
+	_ graph.Graph              = weightedUndirectedGraph
+	_ graph.Undirected         = weightedUndirectedGraph
+	_ graph.WeightedUndirected = weightedUndirectedGraph
 )
 
-func TestAssertMutableNotDirected(t *testing.T) {
-	var g graph.UndirectedBuilder = NewUndirectedGraph()
+func TestAssertWeightedMutableNotDirected(t *testing.T) {
+	var g graph.UndirectedWeightedBuilder = NewWeightedUndirectedGraph(0, math.Inf(1))
 	if _, ok := g.(graph.Directed); ok {
 		t.Fatal("Graph is directed, but a MutableGraph cannot safely be directed!")
 	}
 }
 
-func TestMaxID(t *testing.T) {
-	g := NewUndirectedGraph()
+func TestWeightedMaxID(t *testing.T) {
+	g := NewWeightedUndirectedGraph(0, math.Inf(1))
 	nodes := make(map[graph.Node]struct{})
 	for i := Node(0); i < 3; i++ {
 		g.AddNode(i)
@@ -46,13 +48,13 @@ func TestMaxID(t *testing.T) {
 }
 
 // Test for issue #123 https://github.com/gonum/graph/issues/123
-func TestIssue123UndirectedGraph(t *testing.T) {
+func TestIssue123WeightedUndirectedGraph(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
 			t.Errorf("unexpected panic: %v", r)
 		}
 	}()
-	g := NewUndirectedGraph()
+	g := NewWeightedUndirectedGraph(0, math.Inf(1))
 
 	n0 := g.NewNode()
 	g.AddNode(n0)

--- a/graph/topo/bench_test.go
+++ b/graph/topo/bench_test.go
@@ -5,7 +5,6 @@
 package topo
 
 import (
-	"math"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -23,7 +22,7 @@ var (
 )
 
 func gnpDirected(n int, p float64) graph.Directed {
-	g := simple.NewDirectedGraph(0, math.Inf(1))
+	g := simple.NewDirectedGraph()
 	gen.Gnp(g, n, p, nil)
 	return g
 }

--- a/graph/topo/bron_kerbosch_test.go
+++ b/graph/topo/bron_kerbosch_test.go
@@ -5,7 +5,6 @@
 package topo
 
 import (
-	"math"
 	"reflect"
 	"sort"
 	"testing"
@@ -51,7 +50,7 @@ var vOrderTests = []struct {
 
 func TestVertexOrdering(t *testing.T) {
 	for i, test := range vOrderTests {
-		g := simple.NewUndirectedGraph(0, math.Inf(1))
+		g := simple.NewUndirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
@@ -136,7 +135,7 @@ var bronKerboschTests = []struct {
 
 func TestBronKerbosch(t *testing.T) {
 	for i, test := range bronKerboschTests {
-		g := simple.NewUndirectedGraph(0, math.Inf(1))
+		g := simple.NewUndirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {

--- a/graph/topo/johnson_cycles_test.go
+++ b/graph/topo/johnson_cycles_test.go
@@ -5,7 +5,6 @@
 package topo
 
 import (
-	"math"
 	"reflect"
 	"sort"
 	"testing"
@@ -85,7 +84,7 @@ var cyclesInTests = []struct {
 
 func TestDirectedCyclesIn(t *testing.T) {
 	for i, test := range cyclesInTests {
-		g := simple.NewDirectedGraph(0, math.Inf(1))
+		g := simple.NewDirectedGraph()
 		g.AddNode(simple.Node(-10)) // Make sure we test graphs with sparse IDs.
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.

--- a/graph/topo/paton_cycles_test.go
+++ b/graph/topo/paton_cycles_test.go
@@ -5,7 +5,6 @@
 package topo
 
 import (
-	"math"
 	"reflect"
 	"sort"
 	"testing"
@@ -74,7 +73,7 @@ var undirectedCyclesInTests = []struct {
 
 func TestUndirectedCyclesIn(t *testing.T) {
 	for i, test := range undirectedCyclesInTests {
-		g := simple.NewUndirectedGraph(0, math.Inf(1))
+		g := simple.NewUndirectedGraph()
 		g.AddNode(simple.Node(-10)) // Make sure we test graphs with sparse IDs.
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.

--- a/graph/topo/tarjan_test.go
+++ b/graph/topo/tarjan_test.go
@@ -5,7 +5,6 @@
 package topo
 
 import (
-	"math"
 	"reflect"
 	"sort"
 	"testing"
@@ -130,7 +129,7 @@ var tarjanTests = []struct {
 
 func TestSort(t *testing.T) {
 	for i, test := range tarjanTests {
-		g := simple.NewDirectedGraph(0, math.Inf(1))
+		g := simple.NewDirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
@@ -161,7 +160,7 @@ func TestSort(t *testing.T) {
 
 func TestTarjanSCC(t *testing.T) {
 	for i, test := range tarjanTests {
-		g := simple.NewDirectedGraph(0, math.Inf(1))
+		g := simple.NewDirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
@@ -288,7 +287,7 @@ var stabilizedSortTests = []struct {
 
 func TestSortStabilized(t *testing.T) {
 	for i, test := range stabilizedSortTests {
-		g := simple.NewDirectedGraph(0, math.Inf(1))
+		g := simple.NewDirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {

--- a/graph/topo/topo_test.go
+++ b/graph/topo/topo_test.go
@@ -5,7 +5,6 @@
 package topo
 
 import (
-	"math"
 	"reflect"
 	"sort"
 	"testing"
@@ -16,7 +15,7 @@ import (
 )
 
 func TestIsPath(t *testing.T) {
-	dg := simple.NewDirectedGraph(0, math.Inf(1))
+	dg := simple.NewDirectedGraph()
 	if !IsPathIn(dg, nil) {
 		t.Error("IsPath returns false on nil path")
 	}
@@ -33,7 +32,7 @@ func TestIsPath(t *testing.T) {
 	if IsPathIn(dg, p) {
 		t.Error("IsPath returns true on bad path of length 2")
 	}
-	dg.SetEdge(simple.Edge{F: p[0], T: p[1], W: 1})
+	dg.SetEdge(simple.Edge{F: p[0], T: p[1]})
 	if !IsPathIn(dg, p) {
 		t.Error("IsPath returns false on correct path of length 2")
 	}
@@ -42,13 +41,13 @@ func TestIsPath(t *testing.T) {
 		t.Error("IsPath erroneously returns true for a reverse path")
 	}
 	p = []graph.Node{p[1], p[0], simple.Node(2)}
-	dg.SetEdge(simple.Edge{F: p[1], T: p[2], W: 1})
+	dg.SetEdge(simple.Edge{F: p[1], T: p[2]})
 	if !IsPathIn(dg, p) {
 		t.Error("IsPath does not find a correct path for path > 2 nodes")
 	}
-	ug := simple.NewUndirectedGraph(0, math.Inf(1))
-	ug.SetEdge(simple.Edge{F: p[1], T: p[0], W: 1})
-	ug.SetEdge(simple.Edge{F: p[1], T: p[2], W: 1})
+	ug := simple.NewUndirectedGraph()
+	ug.SetEdge(simple.Edge{F: p[1], T: p[0]})
+	ug.SetEdge(simple.Edge{F: p[1], T: p[2]})
 	if !IsPathIn(dg, p) {
 		t.Error("IsPath does not correctly account for undirected behavior")
 	}
@@ -69,7 +68,7 @@ var pathExistsInUndirectedTests = []struct {
 
 func TestPathExistsInUndirected(t *testing.T) {
 	for i, test := range pathExistsInUndirectedTests {
-		g := simple.NewUndirectedGraph(0, math.Inf(1))
+		g := simple.NewUndirectedGraph()
 
 		for u, e := range test.g {
 			if !g.Has(simple.Node(u)) {
@@ -108,7 +107,7 @@ var pathExistsInDirectedTests = []struct {
 
 func TestPathExistsInDirected(t *testing.T) {
 	for i, test := range pathExistsInDirectedTests {
-		g := simple.NewDirectedGraph(0, math.Inf(1))
+		g := simple.NewDirectedGraph()
 
 		for u, e := range test.g {
 			if !g.Has(simple.Node(u)) {
@@ -145,7 +144,7 @@ var connectedComponentTests = []struct {
 
 func TestConnectedComponents(t *testing.T) {
 	for i, test := range connectedComponentTests {
-		g := simple.NewUndirectedGraph(0, math.Inf(1))
+		g := simple.NewUndirectedGraph()
 
 		for u, e := range test.g {
 			if !g.Has(simple.Node(u)) {

--- a/graph/traverse/traverse_test.go
+++ b/graph/traverse/traverse_test.go
@@ -6,7 +6,6 @@ package traverse
 
 import (
 	"fmt"
-	"math"
 	"reflect"
 	"sort"
 	"testing"
@@ -134,7 +133,7 @@ var breadthFirstTests = []struct {
 
 func TestBreadthFirst(t *testing.T) {
 	for i, test := range breadthFirstTests {
-		g := simple.NewUndirectedGraph(0, math.Inf(1))
+		g := simple.NewUndirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
@@ -222,7 +221,7 @@ var depthFirstTests = []struct {
 
 func TestDepthFirst(t *testing.T) {
 	for i, test := range depthFirstTests {
-		g := simple.NewUndirectedGraph(0, math.Inf(1))
+		g := simple.NewUndirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
 			if !g.Has(simple.Node(u)) {
@@ -283,7 +282,7 @@ var walkAllTests = []struct {
 
 func TestWalkAll(t *testing.T) {
 	for i, test := range walkAllTests {
-		g := simple.NewUndirectedGraph(0, math.Inf(1))
+		g := simple.NewUndirectedGraph()
 
 		for u, e := range test.g {
 			if !g.Has(simple.Node(u)) {
@@ -366,7 +365,7 @@ var (
 )
 
 func gnpUndirected(n int, p float64) graph.Undirected {
-	g := simple.NewUndirectedGraph(0, math.Inf(1))
+	g := simple.NewUndirectedGraph()
 	gen.Gnp(g, n, p, nil)
 	return g
 }

--- a/graph/undirect.go
+++ b/graph/undirect.go
@@ -33,7 +33,6 @@ type Undirect struct {
 var (
 	_ Undirected         = Undirect{}
 	_ WeightedUndirected = Undirect{}
-	_ Weighter           = Undirect{}
 )
 
 // Has returns whether the node exists within the graph.
@@ -96,7 +95,7 @@ func (g Undirect) WeightedEdgeBetween(x, y Node) WeightedEdge {
 	}
 
 	var f, r float64
-	if wg, ok := g.G.(Weighter); ok {
+	if wg, ok := g.G.(WeightedDirected); ok {
 		f, ok = wg.Weight(x, y)
 		if !ok {
 			f = g.Absent
@@ -134,7 +133,7 @@ func (g Undirect) Weight(x, y Node) (w float64, ok bool) {
 	re := g.G.Edge(y, x)
 
 	var f, r float64
-	if wg, wOk := g.G.(Weighter); wOk {
+	if wg, wOk := g.G.(WeightedDirected); wOk {
 		var fOk, rOK bool
 		f, fOk = wg.Weight(x, y)
 		if !fOk {

--- a/graph/undirect.go
+++ b/graph/undirect.go
@@ -4,36 +4,12 @@
 
 package graph
 
-// Undirect converts a directed graph to an undirected graph, resolving
-// edge weight conflicts.
+// Undirect converts a directed graph to an undirected graph.
 type Undirect struct {
 	G Directed
-
-	// Absent is the value used to
-	// represent absent edge weights
-	// passed to Merge if the reverse
-	// edge is present.
-	Absent float64
-
-	// Merge defines how discordant edge
-	// weights in G are resolved. A merge
-	// is performed if at least one edge
-	// exists between the nodes being
-	// considered. The edges corresponding
-	// to the two weights are also passed,
-	// in the same order.
-	// The order of weight parameters
-	// passed to Merge is not defined, so
-	// the function should be commutative.
-	// If Merge is nil, the arithmetic
-	// mean is used to merge weights.
-	Merge func(x, y float64, xe, ye Edge) float64
 }
 
-var (
-	_ Undirected         = Undirect{}
-	_ WeightedUndirected = Undirect{}
-)
+var _ Undirected = Undirect{}
 
 // Has returns whether the node exists within the graph.
 func (g Undirect) Has(n Node) bool { return g.G.Has(n) }
@@ -68,51 +44,118 @@ func (g Undirect) HasEdgeBetween(x, y Node) bool { return g.G.HasEdgeBetween(x, 
 // If an edge exists, the Edge returned is an EdgePair. The weight of
 // the edge is determined by applying the Merge func to the weights of the
 // edges between u and v.
-func (g Undirect) Edge(u, v Node) Edge { return g.WeightedEdgeBetween(u, v) }
-
-// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
-// The node v must be directly reachable from u as defined by the From method.
-// If an edge exists, the Edge returned is an EdgePair. The weight of
-// the edge is determined by applying the Merge func to the weights of the
-// edges between u and v.
-func (g Undirect) WeightedEdge(u, v Node) WeightedEdge { return g.WeightedEdgeBetween(u, v) }
+func (g Undirect) Edge(u, v Node) Edge { return g.EdgeBetween(u, v) }
 
 // EdgeBetween returns the edge between nodes x and y. If an edge exists, the
 // Edge returned is an EdgePair. The weight of the edge is determined by
 // applying the Merge func to the weights of edges between x and y.
 func (g Undirect) EdgeBetween(x, y Node) Edge {
-	return g.WeightedEdgeBetween(x, y)
-}
-
-// WeightedEdgeBetween returns the weighted edge between nodes x and y. If an edge exists, the
-// Edge returned is an EdgePair. The weight of the edge is determined by
-// applying the Merge func to the weights of edges between x and y.
-func (g Undirect) WeightedEdgeBetween(x, y Node) WeightedEdge {
 	fe := g.G.Edge(x, y)
 	re := g.G.Edge(y, x)
 	if fe == nil && re == nil {
 		return nil
 	}
 
-	var f, r float64
-	if wg, ok := g.G.(WeightedDirected); ok {
-		f, ok = wg.Weight(x, y)
-		if !ok {
-			f = g.Absent
+	return EdgePair{fe, re}
+}
+
+// UndirectWeighted converts a directed weighted graph to an undirected weighted graph,
+// resolving edge weight conflicts.
+type UndirectWeighted struct {
+	G WeightedDirected
+
+	// Absent is the value used to
+	// represent absent edge weights
+	// passed to Merge if the reverse
+	// edge is present.
+	Absent float64
+
+	// Merge defines how discordant edge
+	// weights in G are resolved. A merge
+	// is performed if at least one edge
+	// exists between the nodes being
+	// considered. The edges corresponding
+	// to the two weights are also passed,
+	// in the same order.
+	// The order of weight parameters
+	// passed to Merge is not defined, so
+	// the function should be commutative.
+	// If Merge is nil, the arithmetic
+	// mean is used to merge weights.
+	Merge func(x, y float64, xe, ye Edge) float64
+}
+
+var (
+	_ Undirected         = UndirectWeighted{}
+	_ WeightedUndirected = UndirectWeighted{}
+)
+
+// Has returns whether the node exists within the graph.
+func (g UndirectWeighted) Has(n Node) bool { return g.G.Has(n) }
+
+// Nodes returns all the nodes in the graph.
+func (g UndirectWeighted) Nodes() []Node { return g.G.Nodes() }
+
+// From returns all nodes in g that can be reached directly from u.
+func (g UndirectWeighted) From(u Node) []Node {
+	var nodes []Node
+	seen := make(map[int64]struct{})
+	for _, n := range g.G.From(u) {
+		seen[n.ID()] = struct{}{}
+		nodes = append(nodes, n)
+	}
+	for _, n := range g.G.To(u) {
+		id := n.ID()
+		if _, ok := seen[id]; ok {
+			continue
 		}
-		r, ok = wg.Weight(y, x)
-		if !ok {
-			r = g.Absent
-		}
-	} else {
+		seen[n.ID()] = struct{}{}
+		nodes = append(nodes, n)
+	}
+	return nodes
+}
+
+// HasEdgeBetween returns whether an edge exists between nodes x and y.
+func (g UndirectWeighted) HasEdgeBetween(x, y Node) bool { return g.G.HasEdgeBetween(x, y) }
+
+// Edge returns the edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+// If an edge exists, the Edge returned is an EdgePair. The weight of
+// the edge is determined by applying the Merge func to the weights of the
+// edges between u and v.
+func (g UndirectWeighted) Edge(u, v Node) Edge { return g.WeightedEdgeBetween(u, v) }
+
+// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+// If an edge exists, the Edge returned is an EdgePair. The weight of
+// the edge is determined by applying the Merge func to the weights of the
+// edges between u and v.
+func (g UndirectWeighted) WeightedEdge(u, v Node) WeightedEdge { return g.WeightedEdgeBetween(u, v) }
+
+// EdgeBetween returns the edge between nodes x and y. If an edge exists, the
+// Edge returned is an EdgePair. The weight of the edge is determined by
+// applying the Merge func to the weights of edges between x and y.
+func (g UndirectWeighted) EdgeBetween(x, y Node) Edge {
+	return g.WeightedEdgeBetween(x, y)
+}
+
+// WeightedEdgeBetween returns the weighted edge between nodes x and y. If an edge exists, the
+// Edge returned is an EdgePair. The weight of the edge is determined by
+// applying the Merge func to the weights of edges between x and y.
+func (g UndirectWeighted) WeightedEdgeBetween(x, y Node) WeightedEdge {
+	fe := g.G.Edge(x, y)
+	re := g.G.Edge(y, x)
+	if fe == nil && re == nil {
+		return nil
+	}
+
+	f, ok := g.G.Weight(x, y)
+	if !ok {
 		f = g.Absent
-		if fe != nil {
-			f = fe.Weight()
-		}
+	}
+	r, ok := g.G.Weight(y, x)
+	if !ok {
 		r = g.Absent
-		if re != nil {
-			r = re.Weight()
-		}
 	}
 
 	var w float64
@@ -121,41 +164,26 @@ func (g Undirect) WeightedEdgeBetween(x, y Node) WeightedEdge {
 	} else {
 		w = g.Merge(f, r, fe, re)
 	}
-	return EdgePair{E: [2]Edge{fe, re}, W: w}
+	return WeightedEdgePair{EdgePair: [2]Edge{fe, re}, W: w}
 }
 
 // Weight returns the weight for the edge between x and y if Edge(x, y) returns a non-nil Edge.
 // If x and y are the same node the internal node weight is returned. If there is no joining
 // edge between the two nodes the weight value returned is zero. Weight returns true if an edge
 // exists between x and y or if x and y have the same ID, false otherwise.
-func (g Undirect) Weight(x, y Node) (w float64, ok bool) {
+func (g UndirectWeighted) Weight(x, y Node) (w float64, ok bool) {
 	fe := g.G.Edge(x, y)
 	re := g.G.Edge(y, x)
 
-	var f, r float64
-	if wg, wOk := g.G.(WeightedDirected); wOk {
-		var fOk, rOK bool
-		f, fOk = wg.Weight(x, y)
-		if !fOk {
-			f = g.Absent
-		}
-		r, rOK = wg.Weight(y, x)
-		if !rOK {
-			r = g.Absent
-		}
-		ok = fOk || rOK
-	} else {
+	f, fOk := g.G.Weight(x, y)
+	if !fOk {
 		f = g.Absent
-		if fe != nil {
-			f = fe.Weight()
-			ok = true
-		}
-		r = g.Absent
-		if re != nil {
-			r = re.Weight()
-			ok = true
-		}
 	}
+	r, rOK := g.G.Weight(y, x)
+	if !rOK {
+		r = g.Absent
+	}
+	ok = fOk || rOK
 
 	if g.Merge == nil {
 		return (f + r) / 2, ok
@@ -164,30 +192,33 @@ func (g Undirect) Weight(x, y Node) (w float64, ok bool) {
 }
 
 // EdgePair is an opposed pair of directed edges.
-type EdgePair struct {
-	E [2]Edge
-	W float64
-}
+type EdgePair [2]Edge
 
 // From returns the from node of the first non-nil edge, or nil.
 func (e EdgePair) From() Node {
-	if e.E[0] != nil {
-		return e.E[0].From()
-	} else if e.E[1] != nil {
-		return e.E[1].From()
+	if e[0] != nil {
+		return e[0].From()
+	} else if e[1] != nil {
+		return e[1].From()
 	}
 	return nil
 }
 
 // To returns the to node of the first non-nil edge, or nil.
 func (e EdgePair) To() Node {
-	if e.E[0] != nil {
-		return e.E[0].To()
-	} else if e.E[1] != nil {
-		return e.E[1].To()
+	if e[0] != nil {
+		return e[0].To()
+	} else if e[1] != nil {
+		return e[1].To()
 	}
 	return nil
 }
 
+// WeightedEdgePair is an opposed pair of directed edges.
+type WeightedEdgePair struct {
+	EdgePair
+	W float64
+}
+
 // Weight returns the merged edge weights of the two edges.
-func (e EdgePair) Weight() float64 { return e.W }
+func (e WeightedEdgePair) Weight() float64 { return e.W }

--- a/graph/undirect.go
+++ b/graph/undirect.go
@@ -31,8 +31,9 @@ type Undirect struct {
 }
 
 var (
-	_ Undirected = Undirect{}
-	_ Weighter   = Undirect{}
+	_ Undirected         = Undirect{}
+	_ WeightedUndirected = Undirect{}
+	_ Weighter           = Undirect{}
 )
 
 // Has returns whether the node exists within the graph.
@@ -68,12 +69,26 @@ func (g Undirect) HasEdgeBetween(x, y Node) bool { return g.G.HasEdgeBetween(x, 
 // If an edge exists, the Edge returned is an EdgePair. The weight of
 // the edge is determined by applying the Merge func to the weights of the
 // edges between u and v.
-func (g Undirect) Edge(u, v Node) Edge { return g.EdgeBetween(u, v) }
+func (g Undirect) Edge(u, v Node) Edge { return g.WeightedEdgeBetween(u, v) }
+
+// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+// If an edge exists, the Edge returned is an EdgePair. The weight of
+// the edge is determined by applying the Merge func to the weights of the
+// edges between u and v.
+func (g Undirect) WeightedEdge(u, v Node) WeightedEdge { return g.WeightedEdgeBetween(u, v) }
 
 // EdgeBetween returns the edge between nodes x and y. If an edge exists, the
 // Edge returned is an EdgePair. The weight of the edge is determined by
 // applying the Merge func to the weights of edges between x and y.
 func (g Undirect) EdgeBetween(x, y Node) Edge {
+	return g.WeightedEdgeBetween(x, y)
+}
+
+// WeightedEdgeBetween returns the weighted edge between nodes x and y. If an edge exists, the
+// Edge returned is an EdgePair. The weight of the edge is determined by
+// applying the Merge func to the weights of edges between x and y.
+func (g Undirect) WeightedEdgeBetween(x, y Node) WeightedEdge {
 	fe := g.G.Edge(x, y)
 	re := g.G.Edge(y, x)
 	if fe == nil && re == nil {

--- a/graph/undirect_test.go
+++ b/graph/undirect_test.go
@@ -22,7 +22,7 @@ var weightedDirectedGraphs = []struct {
 	skipUnweighted bool
 
 	g      func() weightedDirectedBuilder
-	edges  []simple.Edge
+	edges  []simple.WeightedEdge
 	absent float64
 	merge  func(x, y float64, xe, ye graph.Edge) float64
 
@@ -30,7 +30,7 @@ var weightedDirectedGraphs = []struct {
 }{
 	{
 		g: func() weightedDirectedBuilder { return simple.NewWeightedDirectedGraph(0, 0) },
-		edges: []simple.Edge{
+		edges: []simple.WeightedEdge{
 			{F: simple.Node(0), T: simple.Node(1), W: 2},
 			{F: simple.Node(1), T: simple.Node(0), W: 1},
 			{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -43,7 +43,7 @@ var weightedDirectedGraphs = []struct {
 	},
 	{
 		g: func() weightedDirectedBuilder { return simple.NewWeightedDirectedGraph(0, 0) },
-		edges: []simple.Edge{
+		edges: []simple.WeightedEdge{
 			{F: simple.Node(0), T: simple.Node(1), W: 2},
 			{F: simple.Node(1), T: simple.Node(0), W: 1},
 			{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -60,7 +60,7 @@ var weightedDirectedGraphs = []struct {
 		skipUnweighted: true, // The min merge function cannot be used in the unweighted case.
 
 		g: func() weightedDirectedBuilder { return simple.NewWeightedDirectedGraph(0, 0) },
-		edges: []simple.Edge{
+		edges: []simple.WeightedEdge{
 			{F: simple.Node(0), T: simple.Node(1), W: 2},
 			{F: simple.Node(1), T: simple.Node(0), W: 1},
 			{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -74,7 +74,7 @@ var weightedDirectedGraphs = []struct {
 	},
 	{
 		g: func() weightedDirectedBuilder { return simple.NewWeightedDirectedGraph(0, 0) },
-		edges: []simple.Edge{
+		edges: []simple.WeightedEdge{
 			{F: simple.Node(0), T: simple.Node(1), W: 2},
 			{F: simple.Node(1), T: simple.Node(0), W: 1},
 			{F: simple.Node(1), T: simple.Node(2), W: 1},
@@ -96,7 +96,7 @@ var weightedDirectedGraphs = []struct {
 	},
 	{
 		g: func() weightedDirectedBuilder { return simple.NewWeightedDirectedGraph(0, 0) },
-		edges: []simple.Edge{
+		edges: []simple.WeightedEdge{
 			{F: simple.Node(0), T: simple.Node(1), W: 2},
 			{F: simple.Node(1), T: simple.Node(0), W: 1},
 			{F: simple.Node(1), T: simple.Node(2), W: 1},

--- a/graph/undirect_test.go
+++ b/graph/undirect_test.go
@@ -13,8 +13,15 @@ import (
 	"gonum.org/v1/gonum/mat"
 )
 
-var directedGraphs = []struct {
-	g      func() graph.DirectedBuilder
+type weightedDirectedBuilder interface {
+	graph.WeightedBuilder
+	graph.WeightedDirected
+}
+
+var weightedDirectedGraphs = []struct {
+	skipUnweighted bool
+
+	g      func() weightedDirectedBuilder
 	edges  []simple.Edge
 	absent float64
 	merge  func(x, y float64, xe, ye graph.Edge) float64
@@ -22,7 +29,7 @@ var directedGraphs = []struct {
 	want mat.Matrix
 }{
 	{
-		g: func() graph.DirectedBuilder { return simple.NewDirectedGraph(0, 0) },
+		g: func() weightedDirectedBuilder { return simple.NewWeightedDirectedGraph(0, 0) },
 		edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(1), W: 2},
 			{F: simple.Node(1), T: simple.Node(0), W: 1},
@@ -35,7 +42,7 @@ var directedGraphs = []struct {
 		}),
 	},
 	{
-		g: func() graph.DirectedBuilder { return simple.NewDirectedGraph(0, 0) },
+		g: func() weightedDirectedBuilder { return simple.NewWeightedDirectedGraph(0, 0) },
 		edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(1), W: 2},
 			{F: simple.Node(1), T: simple.Node(0), W: 1},
@@ -50,7 +57,9 @@ var directedGraphs = []struct {
 		}),
 	},
 	{
-		g: func() graph.DirectedBuilder { return simple.NewDirectedGraph(0, 0) },
+		skipUnweighted: true, // The min merge function cannot be used in the unweighted case.
+
+		g: func() weightedDirectedBuilder { return simple.NewWeightedDirectedGraph(0, 0) },
 		edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(1), W: 2},
 			{F: simple.Node(1), T: simple.Node(0), W: 1},
@@ -64,7 +73,7 @@ var directedGraphs = []struct {
 		}),
 	},
 	{
-		g: func() graph.DirectedBuilder { return simple.NewDirectedGraph(0, 0) },
+		g: func() weightedDirectedBuilder { return simple.NewWeightedDirectedGraph(0, 0) },
 		edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(1), W: 2},
 			{F: simple.Node(1), T: simple.Node(0), W: 1},
@@ -86,7 +95,7 @@ var directedGraphs = []struct {
 		}),
 	},
 	{
-		g: func() graph.DirectedBuilder { return simple.NewDirectedGraph(0, 0) },
+		g: func() weightedDirectedBuilder { return simple.NewWeightedDirectedGraph(0, 0) },
 		edges: []simple.Edge{
 			{F: simple.Node(0), T: simple.Node(1), W: 2},
 			{F: simple.Node(1), T: simple.Node(0), W: 1},
@@ -102,13 +111,16 @@ var directedGraphs = []struct {
 }
 
 func TestUndirect(t *testing.T) {
-	for _, test := range directedGraphs {
+	for i, test := range weightedDirectedGraphs {
+		if test.skipUnweighted {
+			continue
+		}
 		g := test.g()
 		for _, e := range test.edges {
-			g.SetEdge(e)
+			g.SetWeightedEdge(e)
 		}
 
-		src := graph.Undirect{G: g, Absent: test.absent, Merge: test.merge}
+		src := graph.Undirect{G: g}
 		dst := simple.NewUndirectedMatrixFrom(src.Nodes(), 0, 0, 0)
 		for _, u := range src.Nodes() {
 			for _, v := range src.From(u) {
@@ -116,11 +128,48 @@ func TestUndirect(t *testing.T) {
 			}
 		}
 
+		want := unit{test.want}
+		if !mat.Equal(dst.Matrix(), want) {
+			t.Errorf("unexpected result for case %d:\ngot:\n%.4v\nwant:\n%.4v", i,
+				mat.Formatted(dst.Matrix()),
+				mat.Formatted(want),
+			)
+		}
+	}
+}
+
+func TestUndirectWeighted(t *testing.T) {
+	for i, test := range weightedDirectedGraphs {
+		g := test.g()
+		for _, e := range test.edges {
+			g.SetWeightedEdge(e)
+		}
+
+		src := graph.UndirectWeighted{G: g, Absent: test.absent, Merge: test.merge}
+		dst := simple.NewUndirectedMatrixFrom(src.Nodes(), 0, 0, 0)
+		for _, u := range src.Nodes() {
+			for _, v := range src.From(u) {
+				dst.SetWeightedEdge(src.WeightedEdge(u, v))
+			}
+		}
+
 		if !mat.Equal(dst.Matrix(), test.want) {
-			t.Errorf("unexpected result:\ngot:\n%.4v\nwant:\n%.4v",
+			t.Errorf("unexpected result for case %d:\ngot:\n%.4v\nwant:\n%.4v", i,
 				mat.Formatted(dst.Matrix()),
 				mat.Formatted(test.want),
 			)
 		}
 	}
+}
+
+type unit struct {
+	mat.Matrix
+}
+
+func (m unit) At(i, j int) float64 {
+	v := m.Matrix.At(i, j)
+	if v == 0 {
+		return 0
+	}
+	return 1
 }


### PR DESCRIPTION
@mewmew Please take a look.

This is the first few steps of the redesign. The next is to delete the `Weight` method from `Edge`. This step requires that the simple graphs and the undirect graph need to be duplicated into weighted and unweighted type because we cannot mix edge types without doing sneaky underhanded and difficult to maintain things behind the scenes. I have had a stab at the next step, but I'll pick it up again later. I figured it would be good to get your views on the progress so far.

After that (or in conjunction) the weighted edge addition methods and interfaces will be added.