### PR TITLE
graph/topo: add function to find k-core of undirected graph

### DIFF
--- a/graph/internal/ordered/sort.go
+++ b/graph/internal/ordered/sort.go
@@ -67,3 +67,10 @@ type Int64s []int64
 func (s Int64s) Len() int           { return len(s) }
 func (s Int64s) Less(i, j int) bool { return s[i] < s[j] }
 func (s Int64s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+// Reverse reverses the order of nodes.
+func Reverse(nodes []graph.Node) {
+	for i, j := 0, len(nodes)-1; i < j; i, j = i+1, j-1 {
+		nodes[i], nodes[j] = nodes[j], nodes[i]
+	}
+}

--- a/graph/path/shortest.go
+++ b/graph/path/shortest.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 
 	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/mat"
 )
 
@@ -101,7 +102,7 @@ func (p Shortest) To(v graph.Node) (path []graph.Node, weight float64) {
 		path = append(path, p.nodes[p.next[to]])
 		to = p.next[to]
 	}
-	reverse(path)
+	ordered.Reverse(path)
 	return path, p.dist[p.indexOf[v.ID()]]
 }
 
@@ -248,7 +249,7 @@ func (p AllShortest) Between(u, v graph.Node) (path []graph.Node, weight float64
 		}
 	}
 	if !p.forward {
-		reverse(path)
+		ordered.Reverse(path)
 	}
 
 	return path, weight, unique
@@ -289,7 +290,7 @@ func (p AllShortest) allBetween(from, to int, seen []bool, path []graph.Node, pa
 			return paths
 		}
 		if !p.forward {
-			reverse(path)
+			ordered.Reverse(path)
 		}
 		return append(paths, path)
 	}
@@ -310,10 +311,4 @@ func (p AllShortest) allBetween(from, to int, seen []bool, path []graph.Node, pa
 		paths = p.allBetween(from, to, append([]bool(nil), seen...), append(path, p.nodes[n]), paths)
 	}
 	return paths
-}
-
-func reverse(p []graph.Node) {
-	for i, j := 0, len(p)-1; i < j; i, j = i+1, j-1 {
-		p[i], p[j] = p[j], p[i]
-	}
 }

--- a/graph/topo/bron_kerbosch.go
+++ b/graph/topo/bron_kerbosch.go
@@ -143,7 +143,8 @@ func BronKerbosch(g graph.Undirected) [][]graph.Node {
 	}
 	x := make(set.Nodes)
 	var bk bronKerbosch
-	order, _ := VertexOrdering(g)
+	order, _ := degeneracyOrdering(g)
+	ordered.Reverse(order)
 	for _, v := range order {
 		neighbours := g.From(v)
 		nv := make(set.Nodes, len(neighbours))

--- a/graph/topo/bron_kerbosch_test.go
+++ b/graph/topo/bron_kerbosch_test.go
@@ -73,7 +73,7 @@ func TestVertexOrdering(t *testing.T) {
 			}
 			sort.Sort(ordered.Int64s(got))
 			if !reflect.DeepEqual(got, want) {
-				t.Errorf("unexpected %d-core for test %d:\ngot: %v\nwant:%v", k, i, got, test.wantCore)
+				t.Errorf("unexpected %d-core for test %d:\ngot: %v\nwant:%v", k, i, got, want)
 			}
 
 			for j, n := range core[k] {

--- a/graph/topo/bron_kerbosch_test.go
+++ b/graph/topo/bron_kerbosch_test.go
@@ -81,9 +81,46 @@ func TestVertexOrdering(t *testing.T) {
 			}
 			sort.Sort(ordered.Int64s(got))
 			if !reflect.DeepEqual(got, want) {
-				t.Errorf("unexpected %d-core for test %d:\ngot: %v\nwant:%v", k, i, got, test.wantCore)
+				t.Errorf("unexpected %d-core for test %d:\ngot: %v\nwant:%v", k, i, got, want)
 			}
 			offset += len(want)
+		}
+	}
+}
+
+func TestKCore(t *testing.T) {
+	for i, test := range vOrderTests {
+		g := simple.NewUndirectedGraph()
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
+			}
+			for v := range e {
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
+			}
+		}
+
+		for k := 0; k <= test.wantK+1; k++ {
+			var want []int64
+			for _, c := range test.wantCore[k:] {
+				want = append(want, c...)
+			}
+			core := KCore(k, g)
+			if len(core) != len(want) {
+				t.Errorf("unexpected %d-core length for test %d:\ngot: %v\nwant:%v", k, i, len(core), len(want))
+				continue
+			}
+
+			var got []int64
+			for _, n := range core {
+				got = append(got, n.ID())
+			}
+			sort.Sort(ordered.Int64s(got))
+			sort.Sort(ordered.Int64s(want))
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("unexpected %d-core for test %d:\ngot: %v\nwant:%v", k, i, got, want)
+			}
 		}
 	}
 }

--- a/graph/topo/paton_cycles_test.go
+++ b/graph/topo/paton_cycles_test.go
@@ -134,10 +134,7 @@ func canonicalise(c []graph.Node) []graph.Node {
 		c = append(c[idx:], c[:idx]...)
 	}
 	if c[len(c)-1].ID() < c[1].ID() {
-		s := c[1:]
-		for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
-			s[i], s[j] = s[j], s[i]
-		}
+		ordered.Reverse(c[1:])
 	}
 	return c
 }

--- a/graph/topo/tarjan.go
+++ b/graph/topo/tarjan.go
@@ -76,14 +76,8 @@ func sortedFrom(sccs [][]graph.Node, order func([]graph.Node)) ([]graph.Node, er
 		}
 		err = sc
 	}
-	reverse(sorted)
+	ordered.Reverse(sorted)
 	return sorted, err
-}
-
-func reverse(p []graph.Node) {
-	for i, j := 0, len(p)-1; i < j; i, j = i+1, j-1 {
-		p[i], p[j] = p[j], p[i]
-	}
 }
 
 // TarjanSCC returns the strongly connected components of the graph g using Tarjan's algorithm.
@@ -106,12 +100,12 @@ func tarjanSCCstabilized(g graph.Directed, order func([]graph.Node)) [][]graph.N
 		succ = g.From
 	} else {
 		order(nodes)
-		reverse(nodes)
+		ordered.Reverse(nodes)
 
 		succ = func(n graph.Node) []graph.Node {
 			to := g.From(n)
 			order(to)
-			reverse(to)
+			ordered.Reverse(to)
 			return to
 		}
 	}


### PR DESCRIPTION
This could be done using `VertexOrdering`, but this is marginally more efficient, and probably clearer to read given the naming for its use.

@mewmew Please take a look.
