### PR TITLE
graph/{topo,community}: add clique graph and k-clique community finding

### DIFF
--- a/graph/community/k_communities.go
+++ b/graph/community/k_communities.go
@@ -1,0 +1,98 @@
+// Copyright ©2017 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package community
+
+import (
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/internal/set"
+	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/graph/topo"
+	"gonum.org/v1/gonum/graph/traverse"
+)
+
+// KCliqueCommunities returns the k-clique communties of the undirected graph g for
+// k greater than zero. The returned communities are identified by linkage via k-clique
+// adjacency, where adjacency is defined as having k-1 common nodes. KCliqueCommunities
+// returns a single component including the full set of nodes of g when k is 1,
+// and the classical connected components of g when k is 2. Note that k-clique
+// communities may contain common nodes from g.
+//
+// k-clique communities are described in Palla et al. doi:10.1038/nature03607.
+func KCliqueCommunities(k int, g graph.Undirected) [][]graph.Node {
+	if k < 1 {
+		panic("community: invalid k for k-clique communities")
+	}
+	switch k {
+	case 1:
+		return [][]graph.Node{g.Nodes()}
+	case 2:
+		return topo.ConnectedComponents(g)
+	default:
+		cg := simple.NewUndirectedGraph()
+		topo.CliqueGraph(cg, g)
+		cc := kConnectedComponents(k, cg)
+
+		// Extract the nodes in g from cg,
+		// removing duplicates and separating
+		// cliques smaller than k into separate
+		// single nodes.
+		var kcc [][]graph.Node
+		single := make(set.Nodes)
+		inCommunity := make(set.Nodes)
+		for _, c := range cc {
+			nodes := make(set.Nodes, len(c))
+			for _, cn := range c {
+				for _, n := range cn.(topo.Clique).Nodes() {
+					nodes.Add(n)
+				}
+			}
+			if len(nodes) < k {
+				for _, n := range nodes {
+					single.Add(n)
+				}
+				continue
+			}
+			var kc []graph.Node
+			for _, n := range nodes {
+				inCommunity.Add(n)
+				kc = append(kc, n)
+			}
+			kcc = append(kcc, kc)
+		}
+		for _, n := range single {
+			if !inCommunity.Has(n) {
+				kcc = append(kcc, []graph.Node{n})
+			}
+		}
+
+		return kcc
+	}
+}
+
+// kConnectedComponents returns the connected components of topo.Clique nodes that
+// are joined by k-1 underlying shared nodes in the graph that created the clique
+// graph cg.
+func kConnectedComponents(k int, cg graph.Undirected) [][]graph.Node {
+	var (
+		c  []graph.Node
+		cc [][]graph.Node
+	)
+	during := func(n graph.Node) {
+		c = append(c, n)
+	}
+	after := func() {
+		cc = append(cc, []graph.Node(nil))
+		cc[len(cc)-1] = append(cc[len(cc)-1], c...)
+		c = c[:0]
+	}
+	w := traverse.DepthFirst{
+		EdgeFilter: func(e graph.Edge) bool {
+			return len(e.(topo.CliqueGraphEdge).Nodes()) >= k-1
+		},
+	}
+	w.WalkAll(cg, nil, after, during)
+
+	return cc
+}

--- a/graph/community/k_communities_test.go
+++ b/graph/community/k_communities_test.go
@@ -1,0 +1,132 @@
+// Copyright ©2017 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package community
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/internal/ordered"
+	"gonum.org/v1/gonum/graph/simple"
+)
+
+// batageljZaversnikGraph is the example graph from
+// figure 1 of http://arxiv.org/abs/cs/0310049v1
+var batageljZaversnikGraph = []intset{
+	0: nil,
+
+	1: linksTo(2, 3),
+	2: linksTo(4),
+	3: linksTo(4),
+	4: linksTo(5),
+	5: nil,
+
+	6:  linksTo(7, 8, 14),
+	7:  linksTo(8, 11, 12, 14),
+	8:  linksTo(14),
+	9:  linksTo(11),
+	10: linksTo(11),
+	11: linksTo(12),
+	12: linksTo(18),
+	13: linksTo(14, 15),
+	14: linksTo(15, 17),
+	15: linksTo(16, 17),
+	16: nil,
+	17: linksTo(18, 19, 20),
+	18: linksTo(19, 20),
+	19: linksTo(20),
+	20: nil,
+}
+
+var kCliqueCommunitiesTests = []struct {
+	g    []intset
+	k    int
+	want [][]graph.Node
+}{
+	{
+		g: []intset{
+			0: linksTo(1, 2, 4, 6),
+			1: linksTo(2, 4, 6),
+			2: linksTo(3, 6),
+			3: linksTo(4, 5),
+			4: linksTo(6),
+			5: nil,
+			6: nil,
+		},
+		k: 3,
+		want: [][]graph.Node{
+			{simple.Node(0), simple.Node(1), simple.Node(2), simple.Node(4), simple.Node(6)},
+			{simple.Node(3)},
+			{simple.Node(5)},
+		},
+	},
+	{
+		g: batageljZaversnikGraph,
+		k: 3,
+		want: [][]graph.Node{
+			{simple.Node(0)},
+			{simple.Node(1)},
+			{simple.Node(2)},
+			{simple.Node(3)},
+			{simple.Node(4)},
+			{simple.Node(5)},
+			{simple.Node(6), simple.Node(7), simple.Node(8), simple.Node(14)},
+			{simple.Node(7), simple.Node(11), simple.Node(12)},
+			{simple.Node(9)},
+			{simple.Node(10)},
+			{simple.Node(13), simple.Node(14), simple.Node(15), simple.Node(17)},
+			{simple.Node(16)},
+			{simple.Node(17), simple.Node(18), simple.Node(19), simple.Node(20)},
+		},
+	},
+	{
+		g: batageljZaversnikGraph,
+		k: 4,
+		want: [][]graph.Node{
+			{simple.Node(0)},
+			{simple.Node(1)},
+			{simple.Node(2)},
+			{simple.Node(3)},
+			{simple.Node(4)},
+			{simple.Node(5)},
+			{simple.Node(6), simple.Node(7), simple.Node(8), simple.Node(14)},
+			{simple.Node(9)},
+			{simple.Node(10)},
+			{simple.Node(11)},
+			{simple.Node(12)},
+			{simple.Node(13)},
+			{simple.Node(15)},
+			{simple.Node(16)},
+			{simple.Node(17), simple.Node(18), simple.Node(19), simple.Node(20)},
+		},
+	},
+}
+
+func TestKCliqueCommunities(t *testing.T) {
+	for _, test := range kCliqueCommunitiesTests {
+		g := simple.NewUndirectedGraph()
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
+			}
+			for v := range e {
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
+			}
+		}
+		got := KCliqueCommunities(test.k, g)
+
+		for _, c := range got {
+			sort.Sort(ordered.ByID(c))
+		}
+		sort.Sort(ordered.BySliceIDs(got))
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("unexpected k-connected components:\ngot: %v\nwant:%v", got, test.want)
+		}
+	}
+}

--- a/graph/topo/clique_graph.go
+++ b/graph/topo/clique_graph.go
@@ -1,0 +1,106 @@
+// Copyright ©2017 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package topo
+
+import (
+	"sort"
+
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/internal/ordered"
+	"gonum.org/v1/gonum/graph/internal/set"
+)
+
+// Builder is a pure topological graph construction type.
+type Builder interface {
+	AddNode(graph.Node)
+	SetEdge(graph.Edge)
+}
+
+// CliqueGraph builds the clique graph of g in dst using Clique and CliqueGraphEdge
+// nodes and edges. The nodes returned by calls to Nodes on the nodes and edges of
+// the constructed graph are the cliques and the common nodes between cliques
+// respectively. The dst graph is not cleared.
+func CliqueGraph(dst Builder, g graph.Undirected) {
+	cliques := BronKerbosch(g)
+
+	// Construct a consistent view of cliques in g. Sorting costs
+	// us a little, but not as much as the cliques themselves.
+	for _, c := range cliques {
+		sort.Sort(ordered.ByID(c))
+	}
+	sort.Sort(ordered.BySliceIDs(cliques))
+
+	cliqueNodes := make(cliqueNodeSets, len(cliques))
+	for id, c := range cliques {
+		s := make(set.Nodes, len(c))
+		for _, n := range c {
+			s.Add(n)
+		}
+		ns := &nodeSet{Clique: Clique{id: int64(id), nodes: c}, nodes: s}
+		dst.AddNode(ns.Clique)
+		for _, n := range c {
+			nid := n.ID()
+			cliqueNodes[nid] = append(cliqueNodes[nid], ns)
+		}
+	}
+
+	for _, cliques := range cliqueNodes {
+		for i, uc := range cliques {
+			for _, vc := range cliques[i+1:] {
+				// Retain the nodes that contribute to the
+				// edge between the cliques.
+				var edgeNodes []graph.Node
+				switch 1 {
+				case len(uc.Clique.nodes):
+					edgeNodes = []graph.Node{uc.Clique.nodes[0]}
+				case len(vc.Clique.nodes):
+					edgeNodes = []graph.Node{vc.Clique.nodes[0]}
+				default:
+					for _, n := range make(set.Nodes).Intersect(uc.nodes, vc.nodes) {
+						edgeNodes = append(edgeNodes, n)
+					}
+					sort.Sort(ordered.ByID(edgeNodes))
+				}
+
+				dst.SetEdge(CliqueGraphEdge{from: uc.Clique, to: vc.Clique, nodes: edgeNodes})
+			}
+		}
+	}
+}
+
+type cliqueNodeSets map[int64][]*nodeSet
+
+type nodeSet struct {
+	Clique
+	nodes set.Nodes
+}
+
+// Clique is a node in a clique graph.
+type Clique struct {
+	id    int64
+	nodes []graph.Node
+}
+
+// ID returns the node ID.
+func (n Clique) ID() int64 { return n.id }
+
+// Nodes returns the nodes in the clique.
+func (n Clique) Nodes() []graph.Node { return n.nodes }
+
+// CliqueGraphEdge is an edge in a clique graph.
+type CliqueGraphEdge struct {
+	from, to Clique
+	nodes    []graph.Node
+}
+
+// From returns the from node of the edge.
+func (e CliqueGraphEdge) From() graph.Node { return e.from }
+
+// To returns the to node of the edge.
+func (e CliqueGraphEdge) To() graph.Node { return e.to }
+
+// Nodes returns the common nodes in the cliques of the underlying graph
+// corresponding to the from and to nodes in the clique graph.
+func (e CliqueGraphEdge) Nodes() []graph.Node { return e.nodes }

--- a/graph/topo/clique_graph_test.go
+++ b/graph/topo/clique_graph_test.go
@@ -1,0 +1,120 @@
+// Copyright ©2017 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package topo
+
+import (
+	"fmt"
+	"testing"
+
+	"gonum.org/v1/gonum/graph/encoding"
+	"gonum.org/v1/gonum/graph/encoding/dot"
+	"gonum.org/v1/gonum/graph/simple"
+)
+
+var cliqueGraphTests = []struct {
+	g    []intset
+	want string
+}{
+	{
+		g: []intset{
+			0: linksTo(1, 2, 4, 6),
+			1: linksTo(2, 4, 6),
+			2: linksTo(3, 6),
+			3: linksTo(4, 5),
+			4: linksTo(6),
+			5: nil,
+			6: nil,
+		},
+		want: `graph {
+  // Node definitions.
+  0 [nodes="[0 1 2 6]"];
+  1 [nodes="[0 1 4 6]"];
+  2 [nodes="[2 3]"];
+  3 [nodes="[3 4]"];
+  4 [nodes="[3 5]"];
+
+  // Edge definitions.
+  0 -- 1 [nodes="[0 1 6]"];
+  0 -- 2 [nodes="[2]"];
+  1 -- 3 [nodes="[4]"];
+  2 -- 3 [nodes="[3]"];
+  2 -- 4 [nodes="[3]"];
+  3 -- 4 [nodes="[3]"];
+}`,
+	},
+	{
+		g: batageljZaversnikGraph,
+		want: `graph {
+  // Node definitions.
+  0 [nodes="[0]"];
+  1 [nodes="[1 2]"];
+  2 [nodes="[1 3]"];
+  3 [nodes="[2 4]"];
+  4 [nodes="[3 4]"];
+  5 [nodes="[4 5]"];
+  6 [nodes="[6 7 8 14]"];
+  7 [nodes="[7 11 12]"];
+  8 [nodes="[9 11]"];
+  9 [nodes="[10 11]"];
+  10 [nodes="[12 18]"];
+  11 [nodes="[13 14 15]"];
+  12 [nodes="[14 15 17]"];
+  13 [nodes="[15 16]"];
+  14 [nodes="[17 18 19 20]"];
+
+  // Edge definitions.
+  1 -- 2 [nodes="[1]"];
+  1 -- 3 [nodes="[2]"];
+  2 -- 4 [nodes="[3]"];
+  3 -- 4 [nodes="[4]"];
+  3 -- 5 [nodes="[4]"];
+  4 -- 5 [nodes="[4]"];
+  6 -- 7 [nodes="[7]"];
+  6 -- 11 [nodes="[14]"];
+  6 -- 12 [nodes="[14]"];
+  7 -- 8 [nodes="[11]"];
+  7 -- 9 [nodes="[11]"];
+  7 -- 10 [nodes="[12]"];
+  8 -- 9 [nodes="[11]"];
+  10 -- 14 [nodes="[18]"];
+  11 -- 12 [nodes="[14 15]"];
+  11 -- 13 [nodes="[15]"];
+  12 -- 13 [nodes="[15]"];
+  12 -- 14 [nodes="[17]"];
+}`,
+	},
+}
+
+func TestCliqueGraph(t *testing.T) {
+	for _, test := range cliqueGraphTests {
+		g := simple.NewUndirectedGraph()
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(simple.Node(u)) {
+				g.AddNode(simple.Node(u))
+			}
+			for v := range e {
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
+			}
+		}
+		dst := simple.NewUndirectedGraph()
+		CliqueGraph(dst, g)
+
+		b, _ := dot.Marshal(dst, "", "", "  ", false)
+		got := string(b)
+
+		if got != test.want {
+			t.Errorf("unexpected clique graph result: got:\n%s\nwant:\n%s", got, test.want)
+		}
+	}
+}
+
+func (n Clique) Attributes() []encoding.Attribute {
+	return []encoding.Attribute{{Key: "nodes", Value: fmt.Sprintf(`"%v"`, n.Nodes())}}
+}
+
+func (e CliqueGraphEdge) Attributes() []encoding.Attribute {
+	return []encoding.Attribute{{Key: "nodes", Value: fmt.Sprintf(`"%v"`, e.Nodes())}}
+}


### PR DESCRIPTION
@mewmew @vladimir-ch Please take a look.

There are likely optimisations in `community.KCliqueCommunities` since we are using `topo.CliqueGraph` which does more work than is absolutely required, but at least for the moment the clarity in the code is worth that additional cost, which is probably significantly less than the unavoidable costs of doing the maximal clique finding in the first place. If it becomes an issue for someone, we can re-address it then.