### PR TITLE
floats: Fix Argsort documentation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,6 +24,7 @@ Iakov Davydov <iakov.davydov@unil.ch>
 Jalem Raj Rohit <jrajrohit33@gmail.com>
 James Bell <james@stellentus.com>
 James Bowman <james.edward.bowman@gmail.com>
+Janne Snabb <snabb@epipe.com>
 Jeff Juozapaitis <jjjuozap@email.arizona.edu>
 Jonathan J Lawlor <jonathan.lawlor@gmail.com>
 Jonathan Schroeder <jd.schroeder@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -31,6 +31,7 @@ Iakov Davydov <iakov.davydov@unil.ch>
 Jalem Raj Rohit <jrajrohit33@gmail.com>
 James Bell <james@stellentus.com>
 James Bowman <james.edward.bowman@gmail.com>
+Janne Snabb <snabb@epipe.com>
 Jeff Juozapaitis <jjjuozap@email.arizona.edu>
 Jonathan J Lawlor <jonathan.lawlor@gmail.com>
 Jonathan Schroeder <jd.schroeder@gmail.com>

--- a/floats/floats.go
+++ b/floats/floats.go
@@ -84,8 +84,8 @@ func (a argsort) Swap(i, j int) {
 	a.inds[i], a.inds[j] = a.inds[j], a.inds[i]
 }
 
-// Argsort sorts the elements of s while tracking their original order.
-// At the conclusion of Argsort, s will contain the original elements of s
+// Argsort sorts the elements of dst while tracking their original order.
+// At the conclusion of Argsort, dst will contain the original elements of dst
 // but sorted in increasing order, and inds will contain the original position
 // of the elements in the slice such that dst[i] = origDst[inds[i]].
 // It panics if the lengths of dst and inds do not match.


### PR DESCRIPTION
Commit a60bb67 changed Argsort argument name from "s" to "dst" but forgot to update documentation to reflect that.