### PR TITLE
travis: Print git diff when check-generate fails.

### DIFF
--- a/.travis/check-generate.sh
+++ b/.travis/check-generate.sh
@@ -5,5 +5,6 @@ go generate gonum.org/v1/gonum/blas/gonum
 go generate gonum.org/v1/gonum/unit
 go generate gonum.org/v1/gonum/graph/formats/dot
 if [ -n "$(git diff)" ]; then
+	git diff
 	exit 1
 fi


### PR DESCRIPTION
Noticed in #225 that check-generate failures in travis don't show the offending lines.  

