### PR TITLE
graph/topo: rename VertexOrdering => DegeneracyOrdering

### DIFF
--- a/graph/topo/bron_kerbosch.go
+++ b/graph/topo/bron_kerbosch.go
@@ -10,9 +10,9 @@ import (
 	"gonum.org/v1/gonum/graph/internal/set"
 )
 
-// VertexOrdering returns the vertex ordering and the k-cores of
+// DegeneracyOrdering returns the degeneracy ordering and the k-cores of
 // the undirected graph g.
-func VertexOrdering(g graph.Undirected) (order []graph.Node, cores [][]graph.Node) {
+func DegeneracyOrdering(g graph.Undirected) (order []graph.Node, cores [][]graph.Node) {
 	order, offsets := degeneracyOrdering(g)
 
 	ordered.Reverse(order)
@@ -39,7 +39,7 @@ func KCore(k int, g graph.Undirected) []graph.Node {
 	return core
 }
 
-// degeneracyOrdering is the common code for VertexOrdering and KCore. It
+// degeneracyOrdering is the common code for DegeneracyOrdering and KCore. It
 // returns l, the nodes of g in optimal ordering for coloring number and
 // s, a set of relative offsets into l for each k-core, where k is an index
 // into s.

--- a/graph/topo/bron_kerbosch_test.go
+++ b/graph/topo/bron_kerbosch_test.go
@@ -48,7 +48,7 @@ var vOrderTests = []struct {
 	},
 }
 
-func TestVertexOrdering(t *testing.T) {
+func TestDegeneracyOrdering(t *testing.T) {
 	for i, test := range vOrderTests {
 		g := simple.NewUndirectedGraph()
 		for u, e := range test.g {
@@ -60,7 +60,7 @@ func TestVertexOrdering(t *testing.T) {
 				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 			}
 		}
-		order, core := VertexOrdering(g)
+		order, core := DegeneracyOrdering(g)
 		if len(core)-1 != test.wantK {
 			t.Errorf("unexpected value of k for test %d: got: %d want: %d", i, len(core)-1, test.wantK)
 		}


### PR DESCRIPTION
Please take a look.

Fixes #212.