### PR TITLE
Fixed documentation for blas/gonum where old documentation referred to package as `native`

### DIFF
--- a/blas/gonum/doc.go
+++ b/blas/gonum/doc.go
@@ -5,7 +5,7 @@
 // Ensure changes made to blas/native are reflected in blas/cgo where relevant.
 
 /*
-Package native is a Go implementation of the BLAS API. This implementation
+Package gonum is a Go implementation of the BLAS API. This implementation
 panics when the input arguments are invalid as per the standard, for example
 if a vector increment is zero. Please note that the treatment of NaN values
 is not specified, and differs among the BLAS implementations.


### PR DESCRIPTION
Doc still referred to this package as `native`. It's now fixed