### PR TITLE
stat/distuv: implement Poisson with inversion method

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Jonathan Schroeder <jd.schroeder@gmail.com>
 Joseph Watson <jtwatson@linux-consulting.us>
 Julien Roland <juroland@gmail.com>
 Kent English <kent.english@gmail.com>
+Kevin C. Zimmerman <kevinczimmerman@gmail.com>
 Konstantin Shaposhnikov <k.shaposhnikov@gmail.com>
 Leonid Kneller <recondite.matter@gmail.com>
 Lyron Winderbaum <lyron.winderbaum@student.adelaide.edu.au>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -42,6 +42,7 @@ Jonathan Schroeder <jd.schroeder@gmail.com>
 Joseph Watson <jtwatson@linux-consulting.us>
 Julien Roland <juroland@gmail.com>
 Kent English <kent.english@gmail.com>
+Kevin C. Zimmerman <kevinczimmerman@gmail.com>
 Konstantin Shaposhnikov <k.shaposhnikov@gmail.com>
 Leonid Kneller <recondite.matter@gmail.com>
 Lyron Winderbaum <lyron.winderbaum@student.adelaide.edu.au>

--- a/stat/distuv/poisson.go
+++ b/stat/distuv/poisson.go
@@ -1,0 +1,109 @@
+// Copyright ©2017 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package distuv
+
+import (
+	"math"
+	"math/rand"
+
+	"gonum.org/v1/gonum/mathext"
+)
+
+// Poisson implements the Poisson distribution, a discrete probability distribution
+// that expresses the probability of a given number of events occurring in a fixed
+// interval of time and/or space.
+// The poisson distribution has density function:
+//  f(k) = λ^k / k! e^(-λ)
+// For more information, see https://en.wikipedia.org/wiki/Poisson_distribution.
+type Poisson struct {
+	// Lambda is the average number of events in an interval.
+	// Lambda must be greater than 0.
+	Lambda float64
+
+	Source *rand.Rand
+}
+
+// CDF computes the value of the cumulative distribution function at x.
+func (p Poisson) CDF(x float64) float64 {
+	if x < 0 {
+		return 0
+	}
+	return mathext.GammaInc(math.Floor(x+1), p.Lambda) / math.Gamma(x+1)
+}
+
+// ExKurtosis returns the excess kurtosis of the distribution.
+func (p Poisson) ExKurtosis() float64 {
+	return 1 / p.Lambda
+}
+
+// LogProb computes the natural logarithm of the value of the probability
+// density function at x.
+func (p Poisson) LogProb(x float64) float64 {
+	if x < 0 {
+		return math.Inf(-1)
+	}
+	lg, _ := math.Lgamma(math.Floor(x) + 1)
+	return x*math.Log(p.Lambda) - p.Lambda - lg
+}
+
+// Mean returns the mean of the probability distribution.
+func (p Poisson) Mean() float64 {
+	return p.Lambda
+}
+
+// NumParameters returns the number of parameters in the distribution.
+func (Poisson) NumParameters() int {
+	return 1
+}
+
+// Prob computes the value of the probability density function at x.
+func (p Poisson) Prob(x float64) float64 {
+	return math.Exp(p.LogProb(x))
+}
+
+// Rand returns a random sample drawn from the distribution.
+func (p Poisson) Rand() float64 {
+	// poisson generator based upon the multiplication of
+	// uniform random variates.
+	// see:
+	//  Non-Uniform Random Variate Generation,
+	//  Luc Devroye (p504)
+	//  http://www.eirene.de/Devroye.pdf
+	x := 0.0
+	prod := 1.0
+	exp := math.Exp(-p.Lambda)
+	rnd := rand.Float64
+	if p.Source != nil {
+		rnd = p.Source.Float64
+	}
+
+	for {
+		prod *= rnd()
+		if prod <= exp {
+			return x
+		}
+		x++
+	}
+}
+
+// Skewness returns the skewness of the distribution.
+func (p Poisson) Skewness() float64 {
+	return 1 / math.Sqrt(p.Lambda)
+}
+
+// StdDev returns the standard deviation of the probability distribution.
+func (p Poisson) StdDev() float64 {
+	return math.Sqrt(p.Variance())
+}
+
+// Survival returns the survival function (complementary CDF) at x.
+func (p Poisson) Survival(x float64) float64 {
+	return 1 - p.CDF(x)
+}
+
+// Variance returns the variance of the probability distribution.
+func (p Poisson) Variance() float64 {
+	return p.Lambda
+}

--- a/stat/distuv/poisson_test.go
+++ b/stat/distuv/poisson_test.go
@@ -1,0 +1,48 @@
+// Copyright ©2017 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package distuv
+
+import (
+	"testing"
+
+	"gonum.org/v1/gonum/floats"
+)
+
+func TestPoisson(t *testing.T) {
+	const tol = 1e-16
+	for i, tt := range []struct {
+		k    int
+		l    float64
+		want float64
+	}{
+		{0, 1, 3.678794411714423e-01},
+		{1, 1, 3.678794411714423e-01},
+		{2, 1, 1.839397205857211e-01},
+		{3, 1, 6.131324019524039e-02},
+		{4, 1, 1.532831004881010e-02},
+		{5, 1, 3.065662009762020e-03},
+		{6, 1, 5.109436682936698e-04},
+		{7, 1, 7.299195261338139e-05},
+		{8, 1, 9.123994076672672e-06},
+		{9, 1, 1.013777119630298e-06},
+
+		{0, 2.5, 8.208499862389880e-02},
+		{1, 2.5, 2.052124965597470e-01},
+		{2, 2.5, 2.565156206996838e-01},
+		{3, 2.5, 2.137630172497365e-01},
+		{4, 2.5, 1.336018857810853e-01},
+		{5, 2.5, 6.680094289054267e-02},
+		{6, 2.5, 2.783372620439277e-02},
+		{7, 2.5, 9.940616501568845e-03},
+		{8, 2.5, 3.106442656740263e-03},
+		{9, 2.5, 8.629007379834082e-04},
+	} {
+		p := Poisson{Lambda: tt.l}
+		got := p.Prob(float64(tt.k))
+		if !floats.EqualWithinAbs(got, tt.want, tol) {
+			t.Errorf("test-%d: got=%e. want=%e\n", i, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
This is just an update of @sbinet PR of the Poisson implementation. I updated the Rand method to use the inversion method based on Lambda. The implementation was ported from the Root TRandom. I don't know the standard for giving attribution to the original algorithm implementation.