### PR TITLE
mat: Add RawU method to the Cholesky decomposition to directly expose…

### DIFF
--- a/mat/cholesky.go
+++ b/mat/cholesky.go
@@ -232,6 +232,14 @@ func (c *Cholesky) SolveVec(v, b *VecDense) error {
 
 }
 
+// RawU returns the Triangular matrix used to store the Cholesky decomposition of
+// the original matrix A. The returned matrix should not be modified. If it is
+// modified, the decomposition is invalid and should
+// not be used.
+func (c *Cholesky) RawU() Triangular {
+	return c.chol
+}
+
 // UTo extracts the n×n upper triangular matrix U from a Cholesky
 // decomposition into dst and returns the result. If dst is nil a new
 // TriDense is allocated.

--- a/mat/cholesky.go
+++ b/mat/cholesky.go
@@ -234,8 +234,7 @@ func (c *Cholesky) SolveVec(v, b *VecDense) error {
 
 // RawU returns the Triangular matrix used to store the Cholesky decomposition of
 // the original matrix A. The returned matrix should not be modified. If it is
-// modified, the decomposition is invalid and should
-// not be used.
+// modified, the decomposition is invalid and should not be used.
 func (c *Cholesky) RawU() Triangular {
 	return c.chol
 }


### PR DESCRIPTION
… the storage matrix

This is returned as Triangular rather than TriDense for two reasons
1) In the future, we may be able to optimize Cholesky, for instance by storing the decomposition as a banded matrix if the factorized matrix was banded. Returning as Triangular allows this to be robust to future modifications of Cholesky.
2) Normally one wants to return concrete types to allow maximum flexibility is using them, for example avoiding interface assertions. However, the opposite is true here. The user should not modify the returned data, and by returning a Triangular rather than a TriDense, this forces tricky code in order to be able to modify the returned matrix.

Fixes #270.