### PR TITLE
mat: tidy up example formatting

### DIFF
--- a/mat/dense_example_test.go
+++ b/mat/dense_example_test.go
@@ -12,81 +12,109 @@ import (
 
 func ExampleDense_Add() {
 	// Initialize two matrices, a and b.
-	a := mat.NewDense(2, 2, []float64{1, 0, 1, 0})
-	b := mat.NewDense(2, 2, []float64{0, 1, 0, 1})
+	a := mat.NewDense(2, 2, []float64{
+		1, 0,
+		1, 0,
+	})
+	b := mat.NewDense(2, 2, []float64{
+		0, 1,
+		0, 1,
+	})
 
 	// Add a and b, placing the result into c.
-	// ...Notice that the size is automatically adjusted when the receiver has zero size.
+	// Notice that the size is automatically adjusted
+	// when the receiver has zero size.
 	var c mat.Dense
 	c.Add(a, b)
 
 	// Print the result using the formatter.
 	fc := mat.Formatted(&c, mat.Prefix("    "), mat.Squeeze())
-	fmt.Printf("Result:\nc = %v\n\n", fc)
+	fmt.Printf("c = %v", fc)
+
 	// Output:
-	// Result:
+	//
 	// c = ⎡1  1⎤
 	//     ⎣1  1⎦
-	//
 }
 
 func ExampleDense_Sub() {
 	// Initialize two matrices, a and b.
-	a := mat.NewDense(2, 2, []float64{1, 1, 1, 1})
-	b := mat.NewDense(2, 2, []float64{1, 0, 0, 1})
+	a := mat.NewDense(2, 2, []float64{
+		1, 1,
+		1, 1,
+	})
+	b := mat.NewDense(2, 2, []float64{
+		1, 0,
+		0, 1,
+	})
 
 	// Subtract b from a, placing the result into a.
 	a.Sub(a, b)
 
 	// Print the result using the formatter.
 	fa := mat.Formatted(a, mat.Prefix("    "), mat.Squeeze())
-	fmt.Printf("Result:\na = %v\n\n", fa)
+	fmt.Printf("a = %v", fa)
+
 	// Output:
-	// Result:
+	//
 	// a = ⎡0  1⎤
 	//     ⎣1  0⎦
-	//
 }
 
 func ExampleDense_MulElem() {
 	// Initialize two matrices, a and b.
-	a := mat.NewDense(2, 2, []float64{1, 2, 3, 4})
-	b := mat.NewDense(2, 2, []float64{1, 2, 3, 4})
+	a := mat.NewDense(2, 2, []float64{
+		1, 2,
+		3, 4,
+	})
+	b := mat.NewDense(2, 2, []float64{
+		1, 2,
+		3, 4,
+	})
 
 	// Multiply the elements of a and b, placing the result into a.
 	a.MulElem(a, b)
 
 	// Print the result using the formatter.
 	fa := mat.Formatted(a, mat.Prefix("    "), mat.Squeeze())
-	fmt.Printf("Result:\na = %v\n\n", fa)
+	fmt.Printf("a = %v", fa)
+
 	// Output:
-	// Result:
+	//
 	// a = ⎡1   4⎤
 	//     ⎣9  16⎦
-	//
 }
 
 func ExampleDense_DivElem() {
 	// Initialize two matrices, a and b.
-	a := mat.NewDense(2, 2, []float64{5, 10, 15, 20})
-	b := mat.NewDense(2, 2, []float64{5, 5, 5, 5})
+	a := mat.NewDense(2, 2, []float64{
+		5, 10,
+		15, 20,
+	})
+	b := mat.NewDense(2, 2, []float64{
+		5, 5,
+		5, 5,
+	})
 
 	// Divide the elements of a by b, placing the result into a.
 	a.DivElem(a, b)
 
 	// Print the result using the formatter.
 	fa := mat.Formatted(a, mat.Prefix("    "), mat.Squeeze())
-	fmt.Printf("Result:\na = %v\n\n", fa)
+	fmt.Printf("a = %v", fa)
+
 	// Output:
-	// Result:
+	//
 	// a = ⎡1  2⎤
 	//     ⎣3  4⎦
-	//
 }
 
 func ExampleDense_Inverse() {
 	// Initialize two matrices, a and ia.
-	a := mat.NewDense(2, 2, []float64{4, 0, 0, 4})
+	a := mat.NewDense(2, 2, []float64{
+		4, 0,
+		0, 4,
+	})
 	var ia mat.Dense
 
 	// Take the inverse of a and place the result in ia.
@@ -94,45 +122,53 @@ func ExampleDense_Inverse() {
 
 	// Print the result using the formatter.
 	fa := mat.Formatted(&ia, mat.Prefix("     "), mat.Squeeze())
-	fmt.Printf("Result:\nia = %.2g\n\n", fa)
+	fmt.Printf("ia = %.2g\n\n", fa)
 
 	// Confirm that A * A^-1 = I
 	var r mat.Dense
 	r.Mul(a, &ia)
 	fr := mat.Formatted(&r, mat.Prefix("    "), mat.Squeeze())
-	fmt.Printf("Result:\nr = %v\n\n", fr)
+	fmt.Printf("r = %v\n\n", fr)
 
-	// The Inverse operation, however, is numerically unstable, and should typically be avoided.
-	// For example, a common need is to find x = A^-1 * b. In this case, the SolveVec method of VecDense
-	// (if b is a Vector) or Solve method of Dense (if b is a matrix) should used instead of computing
-	// the Inverse of A.
-	b := mat.NewDense(2, 2, []float64{2, 0, 0, 2})
+	// The Inverse operation, however, is numerically unstable,
+	// and should typically be avoided.
+	// For example, a common need is to find x = A^-1 * b.
+	// In this case, the SolveVec method of VecDense
+	// (if b is a Vector) or Solve method of Dense (if b is a
+	// matrix) should used instead of computing the Inverse of A.
+	b := mat.NewDense(2, 2, []float64{
+		2, 0,
+		0, 2,
+	})
 	var x mat.Dense
 	x.Solve(a, b)
 
 	// Print the result using the formatter.
 	fx := mat.Formatted(&x, mat.Prefix("    "), mat.Squeeze())
-	fmt.Printf("Result:\nx = %v\n\n", fx)
+	fmt.Printf("x = %v", fx)
 
 	// Output:
-	// Result:
+	//
 	// ia = ⎡0.25    -0⎤
 	//      ⎣   0  0.25⎦
 	//
-	// Result:
 	// r = ⎡1  0⎤
 	//     ⎣0  1⎦
 	//
-	// Result:
 	// x = ⎡0.5    0⎤
 	//     ⎣  0  0.5⎦
-	//
 }
 
 func ExampleDense_Mul() {
 	// Initialize two matrices, a and b.
-	a := mat.NewDense(2, 2, []float64{4, 0, 0, 4})
-	b := mat.NewDense(2, 3, []float64{4, 0, 0, 0, 0, 4})
+	a := mat.NewDense(2, 2, []float64{
+		4, 0,
+		0, 4,
+	})
+	b := mat.NewDense(2, 3, []float64{
+		4, 0, 0,
+		0, 0, 4,
+	})
 
 	// Take the matrix product of a and b and place the result in c.
 	var c mat.Dense
@@ -140,17 +176,20 @@ func ExampleDense_Mul() {
 
 	// Print the result using the formatter.
 	fc := mat.Formatted(&c, mat.Prefix("    "), mat.Squeeze())
-	fmt.Printf("Result:\nc = %v\n\n", fc)
+	fmt.Printf("c = %v", fc)
+
 	// Output:
-	// Result:
+	//
 	// c = ⎡16  0   0⎤
 	//     ⎣ 0  0  16⎦
-	//
 }
 
 func ExampleDense_Exp() {
 	// Initialize a matrix a with some data.
-	a := mat.NewDense(2, 2, []float64{1, 0, 0, 1})
+	a := mat.NewDense(2, 2, []float64{
+		1, 0,
+		0, 1,
+	})
 
 	// Take the exponential of the matrix and place the result in m.
 	var m mat.Dense
@@ -158,17 +197,20 @@ func ExampleDense_Exp() {
 
 	// Print the result using the formatter.
 	fm := mat.Formatted(&m, mat.Prefix("    "), mat.Squeeze())
-	fmt.Printf("Result:\nm = %4.2f\n\n", fm)
+	fmt.Printf("m = %4.2f", fm)
+
 	// Output:
-	// Result:
+	//
 	// m = ⎡2.72  0.00⎤
 	//     ⎣0.00  2.72⎦
-	//
 }
 
 func ExampleDense_Pow() {
 	// Initialize a matrix with some data.
-	a := mat.NewDense(2, 2, []float64{4, 4, 4, 4})
+	a := mat.NewDense(2, 2, []float64{
+		4, 4,
+		4, 4,
+	})
 
 	// Take the second power of matrix a and place the result in m.
 	var m mat.Dense
@@ -176,7 +218,7 @@ func ExampleDense_Pow() {
 
 	// Print the result using the formatter.
 	fm := mat.Formatted(&m, mat.Prefix("    "), mat.Squeeze())
-	fmt.Printf("Result:\nm = %v\n\n", fm)
+	fmt.Printf("m = %v\n\n", fm)
 
 	// Take the zeroth power of matrix a and place the result in n.
 	// We expect an identity matrix of the same size as matrix a.
@@ -185,21 +227,23 @@ func ExampleDense_Pow() {
 
 	// Print the result using the formatter.
 	fn := mat.Formatted(&n, mat.Prefix("    "), mat.Squeeze())
-	fmt.Printf("Result:\nn = %v\n\n", fn)
+	fmt.Printf("n = %v", fn)
+
 	// Output:
-	// Result:
+	//
 	// m = ⎡32  32⎤
 	//     ⎣32  32⎦
 	//
-	// Result:
 	// n = ⎡1  0⎤
 	//     ⎣0  1⎦
-	//
 }
 
 func ExampleDense_Scale() {
 	// Initialize a matrix with some data.
-	a := mat.NewDense(2, 2, []float64{4, 4, 4, 4})
+	a := mat.NewDense(2, 2, []float64{
+		4, 4,
+		4, 4,
+	})
 
 	// Scale the matrix by a factor of 0.25 and place the result in m.
 	var m mat.Dense
@@ -207,10 +251,10 @@ func ExampleDense_Scale() {
 
 	// Print the result using the formatter.
 	fm := mat.Formatted(&m, mat.Prefix("    "), mat.Squeeze())
-	fmt.Printf("Result:\nm = %4.3f\n\n", fm)
+	fmt.Printf("m = %4.3f", fm)
+
 	// Output:
-	// Result:
+	//
 	// m = ⎡1.000  1.000⎤
 	//     ⎣1.000  1.000⎦
-	//
 }


### PR DESCRIPTION
@btracey @jchatkinson Please take a look.

This makes matrix elements appear as they would if written down, removes superfluous verbiage, and breaks lines so godoc.org does not present a need to scroll horizontally to read comments.

As a note, example test output is trimmed of trailing whitespace, so the final newline is not needed.