### PR TITLE
mathext: speed up Digamma for large negative arguments

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ Jeremy Atkinson <jchatkinson@gmail.com>
 Jonathan J Lawlor <jonathan.lawlor@gmail.com>
 Jonathan Schroeder <jd.schroeder@gmail.com>
 Joseph Watson <jtwatson@linux-consulting.us>
+Josh Wilson <josh.craig.wilson@gmail.com>
 Julien Roland <juroland@gmail.com>
 Kent English <kent.english@gmail.com>
 Konstantin Shaposhnikov <k.shaposhnikov@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -41,6 +41,7 @@ Jeremy Atkinson <jchatkinson@gmail.com>
 Jonathan J Lawlor <jonathan.lawlor@gmail.com>
 Jonathan Schroeder <jd.schroeder@gmail.com>
 Joseph Watson <jtwatson@linux-consulting.us>
+Josh Wilson <josh.craig.wilson@gmail.com>
 Julien Roland <juroland@gmail.com>
 Kent English <kent.english@gmail.com>
 Konstantin Shaposhnikov <k.shaposhnikov@gmail.com>

--- a/mathext/digamma.go
+++ b/mathext/digamma.go
@@ -10,19 +10,35 @@ import (
 
 // Digamma returns the logorithmic derivative of the gamma function at x.
 //  ψ(x) = d/dx (Ln (Γ(x)).
-// Note that if x is a negative integer in [-7, 0] this function will return
-// negative Inf.
 func Digamma(x float64) float64 {
 	// This is adapted from
 	// http://web.science.mq.edu.au/~mjohnson/code/digamma.c
 	var result float64
-	for ; x < 7.0; x++ {
+	switch {
+	case math.IsNaN(x), math.IsInf(x, 1):
+		return x
+	case math.IsInf(x, -1):
+		return math.NaN()
+	case x == 0:
+		return math.Copysign(math.Inf(1), -x)
+	case x < 0:
+		if x == math.Floor(x) {
+			return math.NaN()
+		}
+		// Reflection formula, http://dlmf.nist.gov/5.5#E4
+		_, r := math.Modf(x)
+		result = -math.Pi / math.Tan(math.Pi * r)
+		x = 1 - x
+	}
+	for ; x < 7; x++ {
+		// Recurrence relation, http://dlmf.nist.gov/5.5#E2
 		result -= 1 / x
 	}
-	x -= 1.0 / 2.0
-	xx := 1.0 / x
+	x -= 0.5
+	xx := 1 / x
 	xx2 := xx * xx
 	xx4 := xx2 * xx2
-	result += math.Log(x) + (1./24.)*xx2 - (7.0/960.0)*xx4 + (31.0/8064.0)*xx4*xx2 - (127.0/30720.0)*xx4*xx4
+	// Asymptotic expansion, http://dlmf.nist.gov/5.11#E2
+	result += math.Log(x) + (1.0/24.0)*xx2 - (7.0/960.0)*xx4 + (31.0/8064.0)*xx4*xx2 - (127.0/30720.0)*xx4*xx4
 	return result
 }

--- a/mathext/digamma_test.go
+++ b/mathext/digamma_test.go
@@ -9,19 +9,36 @@ import (
 	"testing"
 )
 
+var result float64
+
 func TestDigamma(t *testing.T) {
 	for i, test := range []struct {
 		x, want float64
 	}{
 		// Results computed using WolframAlpha.
+		{0.0, math.Inf(-1)},
+		{math.Copysign(0.0, -1.0), math.Inf(1)},
+		{math.Inf(1), math.Inf(1)},
+		{math.Inf(-1), math.NaN()},
+		{math.NaN(), math.NaN()},
+		{-1.0, math.NaN()},
 		{-100.5, 4.615124601338064117341315601525112558522917517910505881343},
 		{.5, -1.96351002602142347944097633299875556719315960466043},
 		{10, 2.251752589066721107647456163885851537211808918028330369448},
 		{math.Pow10(20), 46.05170185988091368035482909368728415202202143924212618733},
+		{-1.111111111e9, 30.497454343508262861},
 	} {
 
 		if got := Digamma(test.x); math.Abs(got-test.want) > 1e-10 {
 			t.Errorf("test %d Digamma(%g) failed: got %g want %g", i, test.x, got, test.want)
 		}
 	}
+}
+
+func BenchmarkDigamma(b *testing.B) {
+	var r float64
+	for i := 0; i < b.N; i++ {
+		r = Digamma(-1.111111111e9)
+	}
+	result = r
 }


### PR DESCRIPTION
Before the Digamma function could be quite slow for large negative
arguments because it had to do use the recurrence relation thousands
of times. This avoids that by instead using the reflection formula. It
also adds some explicit checks for special cases (Inf, NaN, poles).

For example, running the following code:

```go
package main

import (
	"fmt"
	"time"
	"gonum.org/v1/gonum/mathext"
)

func main () {
	start := time.Now()
	for i := 0; i < 10; i++ {
		mathext.Digamma(-1.1111111111e9)
	}
	fmt.Printf("%s elapsed\n", time.Since(start))
}
```
gives me `40.625090145s elapsed` on master and `8.615µs elapsed` on this branch.