### PR TITLE
blas/gonum: add Ztrsv

### DIFF
--- a/blas/gonum/cmplx.go
+++ b/blas/gonum/cmplx.go
@@ -144,9 +144,6 @@ func (Implementation) Ztbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 func (Implementation) Ztpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, ap []complex128, x []complex128, incX int) {
 	panic(noComplex)
 }
-func (Implementation) Ztrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []complex128, lda int, x []complex128, incX int) {
-	panic(noComplex)
-}
 func (Implementation) Ztbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []complex128, lda int, x []complex128, incX int) {
 	panic(noComplex)
 }

--- a/blas/gonum/level2cmplx128_test.go
+++ b/blas/gonum/level2cmplx128_test.go
@@ -37,3 +37,7 @@ func TestZher2(t *testing.T) {
 func TestZtrmv(t *testing.T) {
 	testblas.ZtrmvTest(t, impl)
 }
+
+func TestZtrsv(t *testing.T) {
+	testblas.ZtrsvTest(t, impl)
+}

--- a/blas/testblas/common.go
+++ b/blas/testblas/common.go
@@ -254,22 +254,46 @@ func allPairs(x, y []int) [][2]int {
 	return p
 }
 
+func sameFloat64(a, b float64) bool {
+	return a == b || math.IsNaN(a) && math.IsNaN(b)
+}
+
+func sameComplex128(x, y complex128) bool {
+	return sameFloat64(real(x), real(y)) && sameFloat64(imag(x), imag(y))
+}
+
 func zsame(x, y []complex128) bool {
 	if len(x) != len(y) {
 		return false
 	}
 	for i, v := range x {
 		w := y[i]
-		if math.IsNaN(real(v)) && math.IsNaN(imag(v)) && math.IsNaN(real(w)) && math.IsNaN(imag(w)) {
+		if !sameComplex128(v, w) {
+			return false
+		}
+	}
+	return true
+}
+
+// zEqualApprox returns whether vectors x and y with stride inc
+// are approximately equal within tol. Elements at non-strided
+// positions must be same in both x and y.
+func zEqualApprox(x, y []complex128, inc int, tol float64) bool {
+	if len(x) != len(y) {
+		return false
+	}
+	if inc < 0 {
+		inc = -inc
+	}
+	for i, v := range x {
+		w := y[i]
+		if i%inc == 0 {
+			if cmplx.Abs(v-w) > tol {
+				return false
+			}
 			continue
 		}
-		if math.IsNaN(real(v)) && math.IsNaN(real(w)) && imag(v) == imag(w) {
-			continue
-		}
-		if math.IsNaN(imag(v)) && math.IsNaN(imag(w)) && real(v) == real(w) {
-			continue
-		}
-		if v != w {
+		if !sameComplex128(v, w) {
 			return false
 		}
 	}

--- a/blas/testblas/common.go
+++ b/blas/testblas/common.go
@@ -260,7 +260,16 @@ func zsame(x, y []complex128) bool {
 	}
 	for i, v := range x {
 		w := y[i]
-		if v != w && !math.IsNaN(real(v)) && !math.IsNaN(imag(v)) && !math.IsNaN(real(w)) && !math.IsNaN(imag(w)) {
+		if math.IsNaN(real(v)) && math.IsNaN(imag(v)) && math.IsNaN(real(w)) && math.IsNaN(imag(w)) {
+			continue
+		}
+		if math.IsNaN(real(v)) && math.IsNaN(real(w)) && imag(v) == imag(w) {
+			continue
+		}
+		if math.IsNaN(imag(v)) && math.IsNaN(imag(w)) && real(v) == real(w) {
+			continue
+		}
+		if v != w {
 			return false
 		}
 	}

--- a/blas/testblas/common.go
+++ b/blas/testblas/common.go
@@ -298,21 +298,23 @@ func makeZGeneral(data []complex128, m, n int, ld int) []complex128 {
 	if m < 0 || n < 0 {
 		panic("bad test")
 	}
-	if len(data) != m*n {
+	if data != nil && len(data) != m*n {
 		panic("bad test")
 	}
 	if ld < max(1, n) {
 		panic("bad test")
 	}
-	if len(data) == 0 {
+	if m == 0 || n == 0 {
 		return nil
 	}
 	a := make([]complex128, (m-1)*ld+n)
 	for i := range a {
 		a[i] = cmplx.NaN()
 	}
-	for i := 0; i < m; i++ {
-		copy(a[i*ld:i*ld+n], data[i*n:i*n+n])
+	if data != nil {
+		for i := 0; i < m; i++ {
+			copy(a[i*ld:i*ld+n], data[i*n:i*n+n])
+		}
 	}
 	return a
 }

--- a/blas/testblas/zcopy.go
+++ b/blas/testblas/zcopy.go
@@ -7,6 +7,7 @@ package testblas
 import (
 	"fmt"
 	"math"
+	"math/cmplx"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -47,6 +48,9 @@ func ZcopyTest(t *testing.T, impl Zcopyer) {
 			}
 
 			want := make([]complex128, len(y))
+			for i := range want {
+				want[i] = cmplx.NaN()
+			}
 			if incX*incY > 0 {
 				for i := 0; i < n; i++ {
 					want[i*aincY] = x[i*aincX]

--- a/blas/testblas/zher.go
+++ b/blas/testblas/zher.go
@@ -5,7 +5,6 @@
 package testblas
 
 import (
-	"math"
 	"math/cmplx"
 	"testing"
 
@@ -128,7 +127,6 @@ func ZherTest(t *testing.T, impl Zherer) {
 								a[i*lda+j] = cmplx.NaN()
 								want[i*lda+j] = cmplx.NaN()
 							}
-							a[i*lda+i] = complex(real(a[i*lda+i]), math.NaN())
 						}
 					} else {
 						for i := 0; i < n; i++ {
@@ -136,17 +134,16 @@ func ZherTest(t *testing.T, impl Zherer) {
 								a[i*lda+j] = cmplx.NaN()
 								want[i*lda+j] = cmplx.NaN()
 							}
-							a[i*lda+i] = complex(real(a[i*lda+i]), math.NaN())
 						}
 					}
 
 					impl.Zher(uplo, n, test.alpha, x, incX, a, lda)
 
 					if !zsame(x, xCopy) {
-						t.Errorf("Case %v (uplo=%v,incX=%v,lda=%v: unexpected modification of x", tc, uplo, incX, lda)
+						t.Errorf("Case %v (uplo=%v,incX=%v,lda=%v,alpha=%v): unexpected modification of x", tc, uplo, incX, test.alpha, lda)
 					}
 					if !zsame(want, a) {
-						t.Errorf("Case %v (uplo=%v,incX=%v,lda=%v: unexpected result\nwant: %v\ngot:  %v", tc, uplo, incX, lda, want, a)
+						t.Errorf("Case %v (uplo=%v,incX=%v,lda=%v,alpha=%v): unexpected result\nwant: %v\ngot:  %v", tc, uplo, incX, lda, test.alpha, want, a)
 					}
 				}
 			}

--- a/blas/testblas/zher2.go
+++ b/blas/testblas/zher2.go
@@ -5,7 +5,6 @@
 package testblas
 
 import (
-	"math"
 	"math/cmplx"
 	"testing"
 
@@ -228,7 +227,6 @@ func Zher2Test(t *testing.T, impl Zher2er) {
 							a[i*lda+j] = cmplx.NaN()
 							want[i*lda+j] = cmplx.NaN()
 						}
-						a[i*lda+i] = complex(real(a[i*lda+i]), math.NaN())
 					}
 				} else {
 					for i := 0; i < n; i++ {
@@ -236,7 +234,6 @@ func Zher2Test(t *testing.T, impl Zher2er) {
 							a[i*lda+j] = cmplx.NaN()
 							want[i*lda+j] = cmplx.NaN()
 						}
-						a[i*lda+i] = complex(real(a[i*lda+i]), math.NaN())
 					}
 				}
 

--- a/blas/testblas/zswap.go
+++ b/blas/testblas/zswap.go
@@ -42,7 +42,13 @@ func ZswapTest(t *testing.T, impl Zswaper) {
 			}
 
 			xWant := make([]complex128, len(x))
+			for i := range xWant {
+				xWant[i] = cmplx.NaN()
+			}
 			yWant := make([]complex128, len(y))
+			for i := range yWant {
+				yWant[i] = cmplx.NaN()
+			}
 			if incX*incY > 0 {
 				for i := 0; i < n; i++ {
 					xWant[i*aincX] = y[i*aincY]

--- a/blas/testblas/ztrsv.go
+++ b/blas/testblas/ztrsv.go
@@ -1,0 +1,86 @@
+// Copyright ©2017 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testblas
+
+import (
+	"math/cmplx"
+	"testing"
+
+	"golang.org/x/exp/rand"
+	"gonum.org/v1/gonum/blas"
+)
+
+type Ztrsver interface {
+	Ztrsv(uplo blas.Uplo, trans blas.Transpose, diag blas.Diag, n int, a []complex128, lda int, x []complex128, incX int)
+
+	Ztrmver
+}
+
+func ZtrsvTest(t *testing.T, impl Ztrsver) {
+	rnd := rand.New(rand.NewSource(1))
+	for _, uplo := range []blas.Uplo{blas.Upper, blas.Lower} {
+		for _, trans := range []blas.Transpose{blas.NoTrans, blas.Trans, blas.ConjTrans} {
+			for _, diag := range []blas.Diag{blas.NonUnit, blas.Unit} {
+				for _, n := range []int{0, 1, 2, 3, 4, 10} {
+					for _, lda := range []int{max(1, n), n + 11} {
+						for _, incX := range []int{-11, -3, -2, -1, 1, 2, 3, 7} {
+							ztrsvTest(t, impl, uplo, trans, diag, n, lda, incX, rnd)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func ztrsvTest(t *testing.T, impl Ztrsver, uplo blas.Uplo, trans blas.Transpose, diag blas.Diag, n, lda, incX int, rnd *rand.Rand) {
+	const tol = 1e-10
+
+	a := makeZGeneral(nil, n, n, lda)
+	if uplo == blas.Upper {
+		for i := 0; i < n; i++ {
+			for j := i; j < n; j++ {
+				re := rnd.NormFloat64()
+				im := rnd.NormFloat64()
+				a[i*lda+j] = complex(re, im)
+			}
+		}
+	} else {
+		for i := 0; i < n; i++ {
+			for j := 0; j <= i; j++ {
+				re := rnd.NormFloat64()
+				im := rnd.NormFloat64()
+				a[i*lda+j] = complex(re, im)
+			}
+		}
+	}
+	if diag == blas.Unit {
+		for i := 0; i < n; i++ {
+			a[i*lda+i] = cmplx.NaN()
+		}
+	}
+	aCopy := make([]complex128, len(a))
+	copy(aCopy, a)
+
+	xtest := make([]complex128, n)
+	for i := range xtest {
+		re := rnd.NormFloat64()
+		im := rnd.NormFloat64()
+		xtest[i] = complex(re, im)
+	}
+	x := makeZVector(xtest, incX)
+	want := make([]complex128, len(x))
+	copy(want, x)
+
+	impl.Ztrmv(uplo, trans, diag, n, a, lda, x, incX)
+	impl.Ztrsv(uplo, trans, diag, n, a, lda, x, incX)
+
+	if !zsame(a, aCopy) {
+		t.Errorf("Case uplo=%v,trans=%v,diag=%v,n=%v,lda=%v,incX=%v: unexpected modification of A", uplo, trans, diag, n, lda, incX)
+	}
+	if !zEqualApprox(x, want, incX, tol) {
+		t.Errorf("Case uplo=%v,trans=%v,diag=%v,n=%v,lda=%v,incX=%v: unexpected result\nwant %v\ngot  %v", uplo, trans, diag, n, lda, incX, want, x)
+	}
+}


### PR DESCRIPTION
I had to fix `zsame` which in turn required modifying tests for `Zher` and `Zher2`. This in turn revealed that their behavior is not as documented when `alpha == 0`. I postpone that to another PR. If you wish I can cut out the commits to a prequel PR.