### PR TITLE
mat: use generalised rectangular shadow check

### DIFF
--- a/mat/doc.go
+++ b/mat/doc.go
@@ -154,8 +154,6 @@
 // mat will use the following rules to detect overlap between the receiver and one
 // of the inputs:
 //  - the input implements one of the Raw methods, and
-//  - the Raw type matches that of the receiver or
-//    one is a RawMatrixer and the other is a RawVectorer, and
 //  - the address ranges of the backing data slices overlap, and
 //  - the strides differ or there is an overlap in the used data elements.
 // If such an overlap is detected, the method will panic.

--- a/mat/doc.go
+++ b/mat/doc.go
@@ -164,8 +164,6 @@
 //    the value has been untransposed if necessary.
 //
 // mat will not attempt to detect element overlap if the input does not implement a
-// Raw method, or if the Raw method differs from that of the receiver except when a
-// conversion has occurred through a mat API function. Method behavior is undefined
-// if there is undetected overlap.
+// Raw method. Method behavior is undefined if there is undetected overlap.
 //
 package mat // import "gonum.org/v1/gonum/mat"

--- a/mat/shadow.go
+++ b/mat/shadow.go
@@ -70,8 +70,8 @@ func (m *Dense) checkOverlap(a blas64.General) bool {
 	return checkOverlap(m.RawMatrix(), a)
 }
 
-func (s *SymDense) checkOverlap(a blas64.Symmetric) bool {
-	return checkOverlap(generalFromSymmetric(s.RawSymmetric()), generalFromSymmetric(a))
+func (s *SymDense) checkOverlap(a blas64.General) bool {
+	return checkOverlap(generalFromSymmetric(s.RawSymmetric()), a)
 }
 
 // generalFromSymmetric returns a blas64.General with the backing
@@ -85,8 +85,8 @@ func generalFromSymmetric(a blas64.Symmetric) blas64.General {
 	}
 }
 
-func (t *TriDense) checkOverlap(a blas64.Triangular) bool {
-	return checkOverlap(generalFromTriangular(t.RawTriangular()), generalFromTriangular(a))
+func (t *TriDense) checkOverlap(a blas64.General) bool {
+	return checkOverlap(generalFromTriangular(t.RawTriangular()), a)
 }
 
 // generalFromTriangular returns a blas64.General with the backing

--- a/mat/shadow.go
+++ b/mat/shadow.go
@@ -5,7 +5,6 @@
 package mat
 
 import (
-	"gonum.org/v1/gonum/blas"
 	"gonum.org/v1/gonum/blas/blas64"
 )
 
@@ -28,130 +27,77 @@ const (
 //
 // checkOverlap methods return a boolean to allow the check call to be added to a
 // boolean expression, making use of short-circuit operators.
-
-func (m *Dense) checkOverlap(a blas64.General) bool {
-	mat := m.RawMatrix()
-	if cap(mat.Data) == 0 || cap(a.Data) == 0 {
+func checkOverlap(a, b blas64.General) bool {
+	if cap(a.Data) == 0 || cap(b.Data) == 0 {
 		return false
 	}
 
-	off := offset(mat.Data[:1], a.Data[:1])
+	off := offset(a.Data[:1], b.Data[:1])
 
 	if off == 0 {
 		// At least one element overlaps.
-		if mat.Cols == a.Cols && mat.Rows == a.Rows && mat.Stride == a.Stride {
+		if a.Cols == b.Cols && a.Rows == b.Rows && a.Stride == b.Stride {
 			panic(regionIdentity)
 		}
 		panic(regionOverlap)
 	}
 
-	if off > 0 && len(mat.Data) <= off {
-		// We know m is completely before a.
+	if off > 0 && len(a.Data) <= off {
+		// We know a is completely before b.
 		return false
 	}
-	if off < 0 && len(a.Data) <= -off {
-		// We know m is completely after a.
+	if off < 0 && len(b.Data) <= -off {
+		// We know a is completely after b.
 		return false
 	}
 
-	if mat.Stride != a.Stride {
+	if a.Stride != b.Stride {
 		// Too hard, so assume the worst.
 		panic(mismatchedStrides)
 	}
 
 	if off < 0 {
 		off = -off
-		mat.Cols, a.Cols = a.Cols, mat.Cols
+		a.Cols, b.Cols = b.Cols, a.Cols
 	}
-	if rectanglesOverlap(off, mat.Cols, a.Cols, mat.Stride) {
+	if rectanglesOverlap(off, a.Cols, b.Cols, a.Stride) {
 		panic(regionOverlap)
 	}
 	return false
+}
+
+func (m *Dense) checkOverlap(a blas64.General) bool {
+	return checkOverlap(m.RawMatrix(), a)
 }
 
 func (s *SymDense) checkOverlap(a blas64.Symmetric) bool {
-	mat := s.RawSymmetric()
-	if cap(mat.Data) == 0 || cap(a.Data) == 0 {
-		return false
-	}
+	return checkOverlap(generalFromSymmetric(s.RawSymmetric()), generalFromSymmetric(a))
+}
 
-	off := offset(mat.Data[:1], a.Data[:1])
-
-	if off == 0 {
-		// At least one element overlaps.
-		if mat.N == a.N && mat.Stride == a.Stride {
-			panic(regionIdentity)
-		}
-		panic(regionOverlap)
+// generalFromSymmetric returns a blas64.General with the backing
+// data and dimensions of a.
+func generalFromSymmetric(a blas64.Symmetric) blas64.General {
+	return blas64.General{
+		Rows:   a.N,
+		Cols:   a.N,
+		Stride: a.Stride,
+		Data:   a.Data,
 	}
-
-	if off > 0 && len(mat.Data) <= off {
-		// We know s is completely before a.
-		return false
-	}
-	if off < 0 && len(a.Data) <= -off {
-		// We know s is completely after a.
-		return false
-	}
-
-	if mat.Stride != a.Stride {
-		// Too hard, so assume the worst.
-		panic(mismatchedStrides)
-	}
-
-	if off < 0 {
-		off = -off
-		mat.N, a.N = a.N, mat.N
-		// If we created the matrix it will always
-		// be in the upper triangle, but don't trust
-		// that this is the case.
-		mat.Uplo, a.Uplo = a.Uplo, mat.Uplo
-	}
-	if trianglesOverlap(off, mat.N, a.N, mat.Stride, mat.Uplo == blas.Upper, a.Uplo == blas.Upper) {
-		panic(regionOverlap)
-	}
-	return false
 }
 
 func (t *TriDense) checkOverlap(a blas64.Triangular) bool {
-	mat := t.RawTriangular()
-	if cap(mat.Data) == 0 || cap(a.Data) == 0 {
-		return false
-	}
+	return checkOverlap(generalFromTriangular(t.RawTriangular()), generalFromTriangular(a))
+}
 
-	off := offset(mat.Data[:1], a.Data[:1])
-
-	if off == 0 {
-		// At least one element overlaps.
-		if mat.N == a.N && mat.Stride == a.Stride {
-			panic(regionIdentity)
-		}
-		panic(regionOverlap)
+// generalFromTriangular returns a blas64.General with the backing
+// data and dimensions of a.
+func generalFromTriangular(a blas64.Triangular) blas64.General {
+	return blas64.General{
+		Rows:   a.N,
+		Cols:   a.N,
+		Stride: a.Stride,
+		Data:   a.Data,
 	}
-
-	if off > 0 && len(mat.Data) <= off {
-		// We know t is completely before a.
-		return false
-	}
-	if off < 0 && len(a.Data) <= -off {
-		// We know t is completely after a.
-		return false
-	}
-
-	if mat.Stride != a.Stride {
-		// Too hard, so assume the worst.
-		panic(mismatchedStrides)
-	}
-
-	if off < 0 {
-		off = -off
-		mat.N, a.N = a.N, mat.N
-		mat.Uplo, a.Uplo = a.Uplo, mat.Uplo
-	}
-	if trianglesOverlap(off, mat.N, a.N, mat.Stride, mat.Uplo == blas.Upper, a.Uplo == blas.Upper) {
-		panic(regionOverlap)
-	}
-	return false
 }
 
 func (v *VecDense) checkOverlap(a blas64.Vector) bool {
@@ -223,58 +169,4 @@ func rectanglesOverlap(off, aCols, bCols, stride int) bool {
 
 	// b strictly wraps and so must overlap with a.
 	return true
-}
-
-// trianglesOverlap returns whether the strided triangles a and b overlap
-// when b is offset by off elements after a but has at least one element before
-// the end of a. off must be positive. a and b are aSize×aSize and bSize×bSize
-// respectively.
-func trianglesOverlap(off, aSize, bSize, stride int, aUpper, bUpper bool) bool {
-	if !rectanglesOverlap(off, aSize, bSize, stride) {
-		// Fast return if bounding rectangles do not overlap.
-		return false
-	}
-
-	// Find location of b relative to a.
-	rowOffset := off / stride
-	colOffset := off % stride
-	if (off+bSize)%stride < colOffset {
-		// We have wrapped, so readjust offsets.
-		rowOffset++
-		colOffset -= stride
-	}
-
-	if aUpper {
-		// Check whether the upper left of b
-		// is in the triangle of a
-		if rowOffset >= 0 && rowOffset <= colOffset {
-			return true
-		}
-		// Check whether the upper right of b
-		// is in the triangle of a.
-		return bUpper && rowOffset < colOffset+bSize
-	}
-
-	// Check whether the upper left of b
-	// is in the triangle of a
-	if colOffset >= 0 && rowOffset >= colOffset {
-		return true
-	}
-	if bUpper {
-		// Check whether the upper right corner of b
-		// is in a or the upper row of b spans a row
-		// of a.
-		return rowOffset > colOffset+bSize || colOffset < 0
-	}
-	if colOffset < 0 {
-		// Check whether the lower left of a
-		// is in the triangle of b or below
-		// the diagonal of a. This requires a
-		// swap of reference origin.
-		return -rowOffset+aSize > -colOffset
-	}
-	// Check whether the lower left of b
-	// is in the triangle of a or below
-	// the diagonal of a.
-	return rowOffset+bSize > colOffset
 }

--- a/mat/shadow_test.go
+++ b/mat/shadow_test.go
@@ -8,9 +8,6 @@ import (
 	"testing"
 
 	"golang.org/x/exp/rand"
-
-	"gonum.org/v1/gonum/blas"
-	"gonum.org/v1/gonum/blas/blas64"
 )
 
 func TestDenseOverlaps(t *testing.T) {
@@ -86,86 +83,6 @@ func TestDenseOverlaps(t *testing.T) {
 	}
 }
 
-func TestTriDenseOverlaps(t *testing.T) {
-	type view struct {
-		i, j, n int
-		*TriDense
-	}
-
-	rnd := rand.New(rand.NewSource(1))
-
-	for _, parentKind := range []TriKind{Upper, Lower} {
-		for n := 1; n < 20; n++ {
-			data := make([]float64, n*n)
-			for i := range data {
-				data[i] = float64(i + 1)
-			}
-			m := NewDense(n, n, data)
-			mt := denseAsTriDense(m, parentKind)
-			panicked, message := panics(func() { mt.checkOverlap(mt.RawTriangular()) })
-			if !panicked {
-				t.Error("expected matrix overlap with self")
-			}
-			if message != regionIdentity {
-				t.Errorf("unexpected panic message for self overlap: got: %q want: %q", message, regionIdentity)
-			}
-
-			for i := 0; i < 1000; i++ {
-				var views [2]view
-				for k := range views {
-					if n > 1 {
-						views[k].i = rnd.Intn(n - 1)
-						views[k].j = rnd.Intn(n - 1)
-						views[k].n = rnd.Intn(n-max(views[k].i, views[k].j)-1) + 1
-					} else {
-						views[k].n = 1
-					}
-					viewKind := []TriKind{Upper, Lower}[rnd.Intn(2)]
-					views[k].TriDense = denseAsTriDense(
-						m.Slice(views[k].i, views[k].i+views[k].n, views[k].j, views[k].j+views[k].n).(*Dense),
-						viewKind)
-
-					wantPanick := overlapsParentTriangle(views[k].i, views[k].j, views[k].n, parentKind, viewKind)
-
-					panicked, _ = panics(func() { mt.checkOverlap(views[k].RawTriangular()) })
-					if panicked != wantPanick {
-						t.Errorf("unexpected (%d×%d)%s overlap with view {rows=%d:%d, cols=%d:%d}%s got:%t want:%t\n% v\n\n% v\n",
-							n, n, kindString(parentKind),
-							views[k].i, views[k].i+views[k].n, views[k].j, views[k].j+views[k].n, kindString(viewKind),
-							panicked, wantPanick,
-							Formatted(mt), Formatted(views[k].TriDense))
-					}
-					panicked, _ = panics(func() { views[k].checkOverlap(mt.RawTriangular()) })
-					if panicked != wantPanick {
-						t.Errorf("unexpected {rows=%d:%d, cols=%d:%d}%s overlap with parent (%d×%d)%s got:%t want:%t\n% v\n\n% v\n",
-							views[k].i, views[k].i+views[k].n, views[k].j, views[k].j+views[k].n, kindString(viewKind),
-							n, n, kindString(parentKind),
-							panicked, wantPanick,
-							Formatted(views[k].TriDense), Formatted(mt))
-					}
-				}
-
-				want := overlapSiblingTriangles(
-					views[0].i, views[0].j, views[0].n, views[0].mat.Uplo == blas.Upper,
-					views[1].i, views[1].j, views[1].n, views[1].mat.Uplo == blas.Upper,
-				)
-
-				for k, v := range views {
-					w := views[1-k]
-					got, _ := panics(func() { v.checkOverlap(w.RawTriangular()) })
-					if got != want {
-						t.Errorf("unexpected result for overlap test for {rows=%d:%d, cols=%d:%d}%s with {rows=%d:%d, cols=%d:%d}%s: got:%t want:%t\n% v\n\n% v\n",
-							v.i, v.i+v.n, v.j, v.j+v.n, kindString(v.mat.Uplo == blas.Upper),
-							w.i, w.i+w.n, w.j, w.j+w.n, kindString(w.mat.Uplo == blas.Upper),
-							got, want,
-							Formatted(v.TriDense), Formatted(w.TriDense))
-					}
-				}
-			}
-		}
-	}
-}
-
 type interval struct{ from, to int }
 
 func intervalsOverlap(a, b interval) bool {
@@ -217,13 +134,6 @@ func overlapSiblingTriangles(ai, aj, an int, aKind TriKind, bi, bj, bn int, bKin
 	return false
 }
 
-func kindString(k TriKind) string {
-	if k == Upper {
-		return "U"
-	}
-	return "L"
-}
-
 // See https://github.com/gonum/matrix/issues/359 for details.
 func TestIssue359(t *testing.T) {
 	for xi := 0; xi < 2; xi++ {
@@ -247,29 +157,5 @@ func TestIssue359(t *testing.T) {
 				}
 			}
 		}
-	}
-}
-
-// denseAsTriDense returns a triangular matrix derived from the
-// square matrix m, with the orientation specified by kind.
-func denseAsTriDense(m *Dense, kind TriKind) *TriDense {
-	r, c := m.Dims()
-	if r != c {
-		panic(ErrShape)
-	}
-	n := r
-	uplo := blas.Lower
-	if kind == Upper {
-		uplo = blas.Upper
-	}
-	return &TriDense{
-		mat: blas64.Triangular{
-			N:      n,
-			Stride: m.mat.Stride,
-			Data:   m.mat.Data,
-			Uplo:   uplo,
-			Diag:   blas.NonUnit,
-		},
-		cap: n,
 	}
 }

--- a/mat/triangular.go
+++ b/mat/triangular.go
@@ -344,7 +344,7 @@ func (t *TriDense) Copy(a Matrix) (r, c int) {
 // avoided where possible, for example by using the Solve routines.
 func (t *TriDense) InverseTri(a Triangular) error {
 	if rt, ok := a.(RawTriangular); ok {
-		t.checkOverlap(rt.RawTriangular())
+		t.checkOverlap(generalFromTriangular(rt.RawTriangular()))
 	}
 	n, _ := a.Triangle()
 	t.reuseAs(a.Triangle())


### PR DESCRIPTION
This is eases shadow detection between the complete set of BLAS backing matrix types without combinatoric explosion. The second commit changes the `checkOverlap` method signatures to have all take `blas64.General` and then have conversion calls at the method call sites.

Using the changes here allows shadow detection for all BLAS types, including packed matrices.

Please take a look.

Updates #310.