### PR TITLE
graph: change Edge interface to include ID method

### DIFF
--- a/graph/community/louvain_common.go
+++ b/graph/community/louvain_common.go
@@ -259,6 +259,7 @@ type edge struct {
 
 func (e edge) From() graph.Node { return e.from }
 func (e edge) To() graph.Node   { return e.to }
+func (e edge) ID() int64        { return 0 }
 func (e edge) Weight() float64  { return e.weight }
 
 // multiplexCommunity is a reduced multiplex graph node describing its membership.
@@ -282,6 +283,7 @@ type multiplexEdge struct {
 
 func (e multiplexEdge) From() graph.Node { return e.from }
 func (e multiplexEdge) To() graph.Node   { return e.to }
+func (e multiplexEdge) ID() int64        { return 0 }
 func (e multiplexEdge) Weight() float64  { return e.weight }
 
 // commIdx is an index of a node in a community held by a localMover.

--- a/graph/encoding/dot/encode_test.go
+++ b/graph/encoding/dot/encode_test.go
@@ -216,6 +216,7 @@ type attrEdge struct {
 
 func (e attrEdge) From() graph.Node                 { return e.from }
 func (e attrEdge) To() graph.Node                   { return e.to }
+func (e attrEdge) ID() int64                        { return 0 }
 func (e attrEdge) Weight() float64                  { return 0 }
 func (e attrEdge) Attributes() []encoding.Attribute { return e.attr }
 
@@ -254,6 +255,7 @@ type portedEdge struct {
 
 func (e portedEdge) From() graph.Node { return e.from }
 func (e portedEdge) To() graph.Node   { return e.to }
+func (e portedEdge) ID() int64        { return 0 }
 func (e portedEdge) Weight() float64  { return 0 }
 
 // TODO(kortschak): Figure out a better way to handle the fact that

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -4,15 +4,18 @@
 
 package graph
 
-// Node is a graph node. It returns a graph-unique integer ID.
+// Node is a graph node. It returns a graph-unique integer node ID.
 type Node interface {
 	ID() int64
 }
 
 // Edge is a graph edge. In directed graphs, the direction of the
 // edge is given from -> to, otherwise the edge is semantically
-// unordered.
+// unordered. An Edge returns an ID which must be graph-unique
+// integer edge ID if the containing graph is a multigraph, otherwise
+// no constraint exists on ID values.
 type Edge interface {
+	ID() int64
 	From() Node
 	To() Node
 }

--- a/graph/path/a_star_test.go
+++ b/graph/path/a_star_test.go
@@ -224,6 +224,7 @@ type weightedEdge struct {
 
 func (e weightedEdge) From() graph.Node { return e.from }
 func (e weightedEdge) To() graph.Node   { return e.to }
+func (e weightedEdge) ID() int64        { return 0 }
 func (e weightedEdge) Weight() float64  { return e.cost }
 
 func isMonotonic(g UndirectedWeightLister, h Heuristic) (ok bool, at graph.Edge, goal graph.Node) {

--- a/graph/simple/simple.go
+++ b/graph/simple/simple.go
@@ -30,6 +30,9 @@ func (e Edge) From() graph.Node { return e.F }
 // To returns the to-node of the edge.
 func (e Edge) To() graph.Node { return e.T }
 
+// ID returns zero.
+func (e Edge) ID() int64 { return 0 }
+
 // WeightedEdge is a simple weighted graph edge.
 type WeightedEdge struct {
 	F, T graph.Node
@@ -41,6 +44,9 @@ func (e WeightedEdge) From() graph.Node { return e.F }
 
 // To returns the to-node of the edge.
 func (e WeightedEdge) To() graph.Node { return e.T }
+
+// ID returns zero.
+func (e WeightedEdge) ID() int64 { return 0 }
 
 // Weight returns the weight of the edge.
 func (e WeightedEdge) Weight() float64 { return e.W }

--- a/graph/topo/clique_graph.go
+++ b/graph/topo/clique_graph.go
@@ -101,6 +101,9 @@ func (e CliqueGraphEdge) From() graph.Node { return e.from }
 // To returns the to node of the edge.
 func (e CliqueGraphEdge) To() graph.Node { return e.to }
 
+// ID returns zero.
+func (e CliqueGraphEdge) ID() int64 { return 0 }
+
 // Nodes returns the common nodes in the cliques of the underlying graph
 // corresponding to the from and to nodes in the clique graph.
 func (e CliqueGraphEdge) Nodes() []graph.Node { return e.nodes }

--- a/graph/undirect.go
+++ b/graph/undirect.go
@@ -214,6 +214,16 @@ func (e EdgePair) To() Node {
 	return nil
 }
 
+// ID returns the ID of the first non-nil edge, or 0.
+func (e EdgePair) ID() int64 {
+	if e[0] != nil {
+		return e[0].ID()
+	} else if e[1] != nil {
+		return e[1].ID()
+	}
+	return 0
+}
+
 // WeightedEdgePair is an opposed pair of directed edges.
 type WeightedEdgePair struct {
 	EdgePair


### PR DESCRIPTION
This is a major breaking change in the graph packages.

Updates gonum/graph#109.

Please take a look.