### PR TITLE
mat: generalize VecDense Copy method and LU SolveVec method; add ApplyVec and ApplySym

### DIFF
--- a/mat/symmetric_test.go
+++ b/mat/symmetric_test.go
@@ -190,6 +190,103 @@ func TestSymAdd(t *testing.T) {
 	testTwoInput(t, "AddSym", &SymDense{}, method, denseComparison, legalTypesSym, legalSizeSameSquare, 1e-14)
 }
 
+func TestApplySym(t *testing.T) {
+	for i, test := range []struct {
+		a, want [][]float64
+		fn      func(r, c int, v float64) float64
+	}{
+		{
+			[][]float64{{0, 0, 0}, {0, 0, 0}, {0, 0, 0}},
+			[][]float64{{0, 0, 0}, {0, 0, 0}, {0, 0, 0}},
+			identity,
+		},
+		{
+			[][]float64{{1, 1, 1}, {1, 1, 1}, {1, 1, 1}},
+			[][]float64{{1, 1, 1}, {1, 1, 1}, {1, 1, 1}},
+			identity,
+		},
+		{
+			[][]float64{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}},
+			[][]float64{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}},
+			identity,
+		},
+		{
+			[][]float64{{-1, 0, 0}, {0, -1, 0}, {0, 0, -1}},
+			[][]float64{{-1, 0, 0}, {0, -1, 0}, {0, 0, -1}},
+			identity,
+		},
+		{
+			[][]float64{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
+			[][]float64{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
+			identity,
+		},
+		{
+			[][]float64{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
+			[][]float64{{2, 4, 6}, {8, 10, 12}, {14, 16, 18}},
+			func(r, c int, v float64) float64 { return v * 2 },
+		},
+		{
+			[][]float64{{1, 2, 3}, {2, 1, 2}, {3, 2, 1}},
+			[][]float64{{0, 2, 0}, {2, 1, 2}, {0, 2, 0}},
+			func(r, c int, v float64) float64 {
+				if r == 1 || c == 1 {
+					return v
+				}
+				return 0
+			},
+		},
+	} {
+		var n int
+		var arr []float64
+		_, n, arr = flatten(test.a)
+		a := NewSymDense(n, arr)
+		_, n, arr = flatten(test.want)
+		want := NewSymDense(n, arr)
+
+		var got SymDense
+
+		for j := 0; j < 2; j++ {
+			got.ApplySym(test.fn, a)
+			if !Equal(&got, want) {
+				t.Errorf("unexpected result for test %d iteration %d: got: %v want: %v", i, j, got.mat.Data, want.mat.Data)
+			}
+		}
+	}
+
+	for _, fn := range []func(r, c int, v float64) float64{
+		identity,
+		func(r, c int, v float64) float64 {
+			if r%2 == 0 && c%2 == 0 {
+				return v
+			}
+			return -v
+		},
+		func(_, _ int, v float64) float64 { return v * v },
+		func(_, _ int, v float64) float64 { return -v },
+	} {
+		method := func(receiver, x Matrix) {
+			type Applier interface {
+				ApplySym(func(r, c int, v float64) float64, Symmetric)
+			}
+			rd := receiver.(Applier)
+			rd.ApplySym(fn, x.(Symmetric))
+		}
+		denseComparison := func(receiver, x *Dense) {
+			receiver.Apply(fn, x)
+		}
+		testOneInput(t, "ApplySym", &SymDense{}, method, denseComparison,
+			func(a Matrix) bool{
+				_, ok := a.(Symmetric)
+				return ok
+			},
+			func (ar, ac int) bool {
+				if ar != ac {
+					return false}
+				return true
+			}, 0)
+	}
+}
+
 func TestCopy(t *testing.T) {
 	for _, test := range []struct {
 		n int

--- a/mat/vector.go
+++ b/mat/vector.go
@@ -139,10 +139,16 @@ func (v *VecDense) RawVector() blas64.Vector {
 // CopyVec makes a copy of elements of a into the receiver. It is similar to the
 // built-in copy; it copies as much as the overlap between the two vectors and
 // returns the number of elements it copied.
-func (v *VecDense) CopyVec(a *VecDense) int {
+func (v *VecDense) CopyVec(a Vector) int {
 	n := min(v.Len(), a.Len())
 	if v != a {
-		blas64.Copy(n, a.mat, v.mat)
+		if ra, ok := a.(RawVectorer); ok {
+			blas64.Copy(n, ra.RawVector(), v.mat)
+		} else {
+			for i := 0; i < n; i++ {
+				v.setVec(i, a.At(i, 0))
+			}
+		}
 	}
 	return n
 }
@@ -325,6 +331,31 @@ func (v *VecDense) DivElemVec(a, b *VecDense) {
 	}
 }
 
+// ApplyVec performs element-wise application of func fn, placing the result
+// in the receiver.
+func (v *VecDense) ApplyVec(fn func(i int, v float64) float64, a Vector) {
+	an := a.Len()
+
+	v.reuseAs(an)
+
+	if ra, ok := a.(RawVectorer); ok {
+		amat := ra.RawVector()
+		if v == a || v.checkOverlap(amat) {
+			var restore func()
+			v, restore = v.isolatedWorkspace(a)
+			defer restore()
+		}
+		for i := 0; i < an; i++ {
+			v.mat.Data[i*v.mat.Inc] = fn(i, amat.Data[i*amat.Inc])
+		}
+		return
+	}
+
+	for i := 0; i < an; i++ {
+		v.setVec(i, fn(i, a.At(i, 0)))
+	}
+}
+
 // MulVec computes a * b. The result is stored into the receiver.
 // MulVec panics if the number of columns in a does not equal the number of rows in b.
 func (v *VecDense) MulVec(a Matrix, b *VecDense) {
@@ -453,7 +484,7 @@ func (v *VecDense) IsZero() bool {
 	return v.mat.Inc == 0
 }
 
-func (v *VecDense) isolatedWorkspace(a *VecDense) (n *VecDense, restore func()) {
+func (v *VecDense) isolatedWorkspace(a Vector) (n *VecDense, restore func()) {
 	l := a.Len()
 	n = getWorkspaceVec(l, false)
 	return n, func() {


### PR DESCRIPTION
Reference #277 

But considering the discussion elsewhere, maybe there should just be a group of functions that act on Mutable interfaces.