### PR TITLE
Revert "graph: change Edge interface to include ID method"

### DIFF
--- a/graph/community/louvain_common.go
+++ b/graph/community/louvain_common.go
@@ -259,7 +259,6 @@ type edge struct {
 
 func (e edge) From() graph.Node { return e.from }
 func (e edge) To() graph.Node   { return e.to }
-func (e edge) ID() int64        { return 0 }
 func (e edge) Weight() float64  { return e.weight }
 
 // multiplexCommunity is a reduced multiplex graph node describing its membership.
@@ -283,7 +282,6 @@ type multiplexEdge struct {
 
 func (e multiplexEdge) From() graph.Node { return e.from }
 func (e multiplexEdge) To() graph.Node   { return e.to }
-func (e multiplexEdge) ID() int64        { return 0 }
 func (e multiplexEdge) Weight() float64  { return e.weight }
 
 // commIdx is an index of a node in a community held by a localMover.

--- a/graph/encoding/dot/encode_test.go
+++ b/graph/encoding/dot/encode_test.go
@@ -216,7 +216,6 @@ type attrEdge struct {
 
 func (e attrEdge) From() graph.Node                 { return e.from }
 func (e attrEdge) To() graph.Node                   { return e.to }
-func (e attrEdge) ID() int64                        { return 0 }
 func (e attrEdge) Weight() float64                  { return 0 }
 func (e attrEdge) Attributes() []encoding.Attribute { return e.attr }
 
@@ -255,7 +254,6 @@ type portedEdge struct {
 
 func (e portedEdge) From() graph.Node { return e.from }
 func (e portedEdge) To() graph.Node   { return e.to }
-func (e portedEdge) ID() int64        { return 0 }
 func (e portedEdge) Weight() float64  { return 0 }
 
 // TODO(kortschak): Figure out a better way to handle the fact that

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -4,18 +4,15 @@
 
 package graph
 
-// Node is a graph node. It returns a graph-unique integer node ID.
+// Node is a graph node. It returns a graph-unique integer ID.
 type Node interface {
 	ID() int64
 }
 
 // Edge is a graph edge. In directed graphs, the direction of the
 // edge is given from -> to, otherwise the edge is semantically
-// unordered. An Edge returns an ID which must be graph-unique
-// integer edge ID if the containing graph is a multigraph, otherwise
-// no constraint exists on ID values.
+// unordered.
 type Edge interface {
-	ID() int64
 	From() Node
 	To() Node
 }

--- a/graph/path/a_star_test.go
+++ b/graph/path/a_star_test.go
@@ -224,7 +224,6 @@ type weightedEdge struct {
 
 func (e weightedEdge) From() graph.Node { return e.from }
 func (e weightedEdge) To() graph.Node   { return e.to }
-func (e weightedEdge) ID() int64        { return 0 }
 func (e weightedEdge) Weight() float64  { return e.cost }
 
 func isMonotonic(g UndirectedWeightLister, h Heuristic) (ok bool, at graph.Edge, goal graph.Node) {

--- a/graph/simple/simple.go
+++ b/graph/simple/simple.go
@@ -30,9 +30,6 @@ func (e Edge) From() graph.Node { return e.F }
 // To returns the to-node of the edge.
 func (e Edge) To() graph.Node { return e.T }
 
-// ID returns zero.
-func (e Edge) ID() int64 { return 0 }
-
 // WeightedEdge is a simple weighted graph edge.
 type WeightedEdge struct {
 	F, T graph.Node
@@ -44,9 +41,6 @@ func (e WeightedEdge) From() graph.Node { return e.F }
 
 // To returns the to-node of the edge.
 func (e WeightedEdge) To() graph.Node { return e.T }
-
-// ID returns zero.
-func (e WeightedEdge) ID() int64 { return 0 }
 
 // Weight returns the weight of the edge.
 func (e WeightedEdge) Weight() float64 { return e.W }

--- a/graph/topo/clique_graph.go
+++ b/graph/topo/clique_graph.go
@@ -101,9 +101,6 @@ func (e CliqueGraphEdge) From() graph.Node { return e.from }
 // To returns the to node of the edge.
 func (e CliqueGraphEdge) To() graph.Node { return e.to }
 
-// ID returns zero.
-func (e CliqueGraphEdge) ID() int64 { return 0 }
-
 // Nodes returns the common nodes in the cliques of the underlying graph
 // corresponding to the from and to nodes in the clique graph.
 func (e CliqueGraphEdge) Nodes() []graph.Node { return e.nodes }

--- a/graph/undirect.go
+++ b/graph/undirect.go
@@ -214,16 +214,6 @@ func (e EdgePair) To() Node {
 	return nil
 }
 
-// ID returns the ID of the first non-nil edge, or 0.
-func (e EdgePair) ID() int64 {
-	if e[0] != nil {
-		return e[0].ID()
-	} else if e[1] != nil {
-		return e[1].ID()
-	}
-	return 0
-}
-
 // WeightedEdgePair is an opposed pair of directed edges.
 type WeightedEdgePair struct {
 	EdgePair


### PR DESCRIPTION
This reverts commit 1a83fdba7a89a738f20ebb74f6ab0efaf2ebc42c.

Further design discussion leads to a better approach with an additional edge-type interface.

Please take a look. (I'll want two approvals this time).

Updates #342.