### PR TITLE
optimize: completely overhaul Global

### DIFF
--- a/optimize/cmaes.go
+++ b/optimize/cmaes.go
@@ -319,7 +319,6 @@ Outer:
 			cma.sendInitTasks(tasks)
 			cma.taskIdx = len(tasks)
 		case FuncEvaluation:
-			// fmt.Println("fun received", cma.taskIdx, cma.receivedIdx)
 			cma.receivedIdx++
 			cma.fs[task.Index] = task.F
 			switch {

--- a/optimize/cmaes_test.go
+++ b/optimize/cmaes_test.go
@@ -26,7 +26,6 @@ type cmaTestCase struct {
 
 func cmaTestCases() []cmaTestCase {
 	localMinMean := []float64{2.2, -2.2}
-	_ = localMinMean
 	s := mat.NewSymDense(2, []float64{0.01, 0, 0, 0.01})
 	var localMinChol mat.Cholesky
 	localMinChol.Factorize(s)
@@ -106,7 +105,7 @@ func cmaTestCases() []cmaTestCase {
 			},
 		},
 		{
-			// Test that worksstops with some number of function evaluations.
+			// Test that work stops with some number of function evaluations.
 			dim: 5,
 			problem: Problem{
 				Func: functions.ExtendedRosenbrock{}.Func,

--- a/optimize/global.go
+++ b/optimize/global.go
@@ -10,106 +10,74 @@ import (
 	"time"
 )
 
-var (
-	nonpositiveDimension string = "optimize: non-positive input dimension"
-	negativeTasks        string = "optimize: negative input number of tasks"
-)
+// DefaultSettingsGlobal returns the default settings for Global optimization.
+func DefaultSettingsGlobal() *Settings {
+	return &Settings{
+		FunctionThreshold: math.Inf(-1),
+		FunctionConverge: &FunctionConverge{
+			Absolute:   1e-10,
+			Iterations: 100,
+		},
+	}
+}
 
-// GlobalMethod is an optimization method which seeks to find the global minimum
-// of an objective function.
-//
-// At the beginning of the optimization, InitGlobal is called to communicate
-// the dimension of the input and maximum number of concurrent tasks.
-// The actual number of concurrent tasks will be set from the return of InitGlobal,
-// which must not be greater than the input tasks.
-//
-// During the optimization, a reverse-communication interface is used between
-// the GlobalMethod and the caller.
-// GlobalMethod acts as a client that asks the caller to perform
-// needed operations given the return from IterateGlobal.
-// This allows and enforces automation of maintaining statistics and checking for
-// (various types of) convergence.
-//
-// The return from IterateGlobal can be an Evaluation, a MajorIteration or NoOperation.
-//
-// An evaluation is one or more of the Evaluation operations (FuncEvaluation,
-// GradEvaluation, etc.) combined with the bitwise or operator. In an evaluation
-// operation, the requested fields of Problem will be evaluated at the value
-// in Location.X, filling the corresponding fields of Location. These values
-// can be retrieved and used upon the next call to IterateGlobal with that task id.
-// The GlobalMethod interface requires that entries of Location are not modified
-// aside from the commanded evaluations. Thus, the type implementing GlobalMethod
-// may use multiple Operations to set the Location fields at a particular x value.
-//
-// When IterateGlobal declares MajorIteration, the caller updates the optimal
-// location to the values in Location, and checks for convergence. The type
-// implementing GlobalMethod must make sure that the fields of Location are valid
-// and consistent.
-//
-// IterateGlobal must not return InitIteration and PostIteration operations. These are
-// reserved for the clients to be passed to Recorders. A Method must also not
-// combine the Evaluation operations with the Iteration operations.
+// GlobalTask is a task to communicate between the GlobalMethod and
+type GlobalTask struct {
+	Index int
+	Operation
+	*Location
+}
+
+// GlobalMethod is a type which can search for a global optimum for an objective function.
 type GlobalMethod interface {
 	Needser
 	// InitGlobal communicates the input dimension and maximum number of tasks,
 	// and returns the number of concurrent processes. The return must be less
 	// than or equal to tasks.
 	InitGlobal(dim, tasks int) int
-
-	// IterateGlobal retrieves information from the location associated with
-	// the given task ID, and returns the next operation to perform with that
-	// Location. IterateGlobal may assume that the same pointer is associated
-	// with the same task.
-	IterateGlobal(task int, loc *Location) (Operation, error)
-
-	// Done communicates that the optimization has concluded to allow for shutdown.
-	// After Done is called, no more calls to IterateGlobal will be made.
-	Done()
+	// RunGlobal runs a global optimization using the GlobalMethod. The method
+	// communicates function evaulations, major iterations, etc. using GlobalTasks.
+	// The result of these tasks will be returned on Result. The optimization
+	// will continue until PostIteration is sent on result, at which point no
+	// more Evaluations will be performed. The details of the communication
+	// scheme are provided below.
+	//
+	// The GlobalTask contains an Operation to evaluate, which will be performed
+	// at the Location in the task. GlobalTask also has an Index field to identify
+	// specific tasks. Also provided is a set of tasks with initialized memory
+	// storage for the Location. The number provided tasks is equal to the value
+	// returned from InitGlobal.
+	//
+	// Tasks are sent on the operation channel to be evaluated. The results
+	// of these Operations are returned on result. The returned task will have
+	// the same Index and Operation as the sent task, which can be used to
+	// determine the next appropriate action.
+	//
+	// One per RunGlobal, a PostIteration task will be sent on result, signaling the
+	// conclusion of the optimization (i.e. convergence from user settings).
+	// More tasks may still be sent on operation, after this occurs, but
+	// no additional Evaluations will be conducted. MajorIteration operations,
+	// however, will still be conducted appropriately.
+	//
+	// Any Evaluations sent before PostIteration will be evaluated and returned
+	// on result. In order to successfully conclude the optimization, GlobalMethod
+	// must read from the result channel until it is closed, handling appropriately.
+	// For example, many GlobalMethods will want to send one or more
+	// MajorIteration on operation while draining the result channel. After
+	// all operations have been sent, the GlobalMethod must close the operation
+	// channel. Method then must return from RunGlobal.
+	//
+	// The GlobalMethod may have its own specific convergence criteria. If
+	// any of those are met, MethodDone should be sent on the operation channel.
+	// This will trigger a PostIteration to be sent on result. The MethodDone
+	// task will not be returned on result. If MethodDone is sent, the GlobalMethod
+	// must be a Statuser, and the call to Status must return a Status other than
+	// NotTerminated.
+	//
+	// The operation and result tasks have a buffer of the number of tasks.
+	RunGlobal(operation chan<- GlobalTask, result <-chan GlobalTask, tasks []GlobalTask)
 }
 
-// Global uses a global optimizer to search for the global minimum of a
-// function. A maximization problem can be transformed into a
-// minimization problem by multiplying the function by -1.
-//
-// The first argument represents the problem to be minimized. Its fields are
-// routines that evaluate the objective function, gradient, and other
-// quantities related to the problem. The objective function, p.Func, must not
-// be nil. The optimization method used may require other fields to be non-nil
-// as specified by method.Needs. Global will panic if these are not met. The
-// method can be determined automatically from the supplied problem which is
-// described below.
-//
-// If p.Status is not nil, it is called before every evaluation. If the
-// returned Status is other than NotTerminated or if the error is not nil, the
-// optimization run is terminated.
-//
-// The third argument contains the settings for the minimization. The
-// DefaultGlobalSettings function can be called for a Settings struct with the
-// default values initialized. If settings == nil, the default settings are used.
-// Global optimization methods typically do not make assumptions about the number
-// and location of local minima. Thus, the only convergence metric used is the
-// function values found at major iterations of the optimization. Bounds on the
-// length of optimization are obeyed, such as the number of allowed function
-// evaluations.
-//
-// The final argument is the optimization method to use. If method == nil, then
-// an appropriate default is chosen based on the properties of the other arguments
-// (dimension, gradient-free or gradient-based, etc.).
-//
-// If method implements Statuser, method.Status is called before every call
-// to method.Iterate. If the returned Status is not NotTerminated or the
-// error is non-nil, the optimization run is terminated.
-//
-// Global returns a Result struct and any error that occurred. See the
-// documentation of Result for more information.
-//
-// Be aware that the default behavior of Global is to find the minimum.
-// For certain functions and optimization methods, this process can take many
-// function evaluations. The Settings input struct can be used to limit this,
-// for example by modifying the maximum runtime or maximum function evaluations.
-//
-// Global cannot guarantee strict adherence to the bounds specified in Settings
-// when performing concurrent evaluations and updates.
 func Global(p Problem, dim int, settings *Settings, method GlobalMethod) (*Result, error) {
 	startTime := time.Now()
 	if method == nil {
@@ -160,20 +128,8 @@ func Global(p Problem, dim int, settings *Settings, method GlobalMethod) (*Resul
 // minimizeGlobal is the high-level function for a Global optimization. It launches
 // concurrent workers to perform the mimization, and shuts them down properly
 // at the conclusion.
-func minimizeGlobal(p *Problem, method GlobalMethod, settings *Settings, stats *Stats, optLoc *Location, startTime time.Time) (status Status, err error) {
+func minimizeGlobal(prob *Problem, method GlobalMethod, settings *Settings, stats *Stats, optLoc *Location, startTime time.Time) (Status, error) {
 	dim := len(optLoc.X)
-	statuser, _ := method.(Statuser)
-	gs := &globalStatus{
-		mux:       &sync.RWMutex{},
-		stats:     stats,
-		status:    NotTerminated,
-		p:         p,
-		startTime: startTime,
-		optLoc:    optLoc,
-		settings:  settings,
-		statuser:  statuser,
-	}
-
 	nTasks := settings.Concurrent
 	if nTasks == 0 {
 		nTasks = 1
@@ -184,158 +140,195 @@ func minimizeGlobal(p *Problem, method GlobalMethod, settings *Settings, stats *
 	}
 	nTasks = newNTasks
 
-	// Launch optimization workers. Each worker is individually responsible
-	// for maintaining stats and evaluating the function.
-	var wg sync.WaitGroup
-	for task := 0; task < nTasks; task++ {
-		wg.Add(1)
-		go func(task int) {
-			defer wg.Done()
-			loc := newLocation(dim, method)
+	// Algorithm overview:
+	// At a high level, we want to enable function evaluations in parallel.
+	// There are a couple challenges with this.
+	// - There are statistics that need to be tracked (i.e. function evaluations),
+	//   and these are inherently serial.
+	// - The method can specify MajorIterations, and there needs to be a clear
+	//   order to these calls (see #339, #344).
+	// - There are several ways the optimization can be stopped, and when any
+	//   of those ways happens the optimization needs to shut down. Specifically:
+	//   - MajorIteration can trigger the end (IterationLimit, FunctionThreshold)
+	//   - An Evaluation can trigger the end (FunctionEvaluationLimit)
+	//   - The method can trigger the end (MethodDone)
+	// - The shut down of the optimization can happen while functions are still
+	//   being evaluated. We want to enable the results of those evaluations to
+	//   be useful.
+	//
+	// The strategy is as follows:
+	// - Pass two channels to GlobalMethod via the RunGlobal call. The method
+	//   sends Operations to run on the operation channel, and this caller
+	//   script will send the results on the results chan.
+	// - A distributor receives tasks from the operation channel, and delegates.
+	//   If the task is an Evaluation, it is sent to the workers, otherwise the
+	//   Operation is sent to the stats updater.
+	// - A set of workers are launched to evaluate functions. A worker evaluates
+	//   the function, and then sends the Operation to the stats updater.
+	// - A stats updater reads in the completed Operations, updates the stats,
+	//   and checks convergence. The single point of combination prevents race
+	//   conditions in updating the stats and checking convergence. This also
+	//   ensures that MajorIteration updates happen in a predictable order.
+	// - When a termination condition is met, a Status is sent on statusChan.
+	//   only the first such termination signal is sent. This triggers a
+	//   PostIteration to be sent to Method, and triggers a series of shutdown steps.
+
+	var (
+		finalStatus Status
+		finalError  error
+	)
+	type final struct {
+		Status Status
+		Err    error
+	}
+
+	operations := make(chan GlobalTask, nTasks) // GlobalMethod sends tasks.
+	results := make(chan GlobalTask, nTasks)    // return results to GlobalMethod.
+	workerChan := make(chan GlobalTask)         // Delegate tasks to the workers.
+	evalStatsChan := make(chan GlobalTask)      // Send evaluation updates.
+	//iterStatsChan := make(chan GlobalTask)      // Send iteration updates.
+	statusChan := make(chan final)    // Send a termination status.
+	statusSent := make(chan struct{}) // Communicate the optimizaiton is done.
+	//statsDone := make(chan struct{})            // No further stats to update.
+	var statWG sync.WaitGroup // All stats are updated.
+	var distWG sync.WaitGroup // Distributor has successfully terminated.
+
+	// Launch the method.
+	go func() {
+		tasks := make([]GlobalTask, nTasks)
+		for i := range tasks {
+			tasks[i].Location = newLocation(dim, method)
+		}
+		method.RunGlobal(operations, results, tasks)
+	}()
+
+	// Launch the distributor
+	distWG.Add(1)
+	go func() {
+		defer distWG.Done()
+		// Note: This cannot be a range loop over operations because we want to
+		// still send to operation even after a termination Status has been sent.
+	Outer:
+		for {
+			select {
+			case <-statusSent:
+				break Outer
+			case task := <-operations: // Delegate the Operation.
+				switch task.Operation {
+				case InitIteration:
+					panic("optimize: GlobalMethod returned InitIteration")
+				case PostIteration:
+					panic("optimize: GlobalMethod returned PostIteration")
+				case NoOperation, MajorIteration, MethodDone:
+					evalStatsChan <- task
+				default: // Any of the Evaluation operations.
+					workerChan <- task
+				}
+			}
+		}
+	}()
+
+	// Launch the workers. After workerChan is closed, each worker signals
+	// to the stats updater that they have successfully terminated.
+	for worker := 0; worker < nTasks; worker++ {
+		go func() {
 			x := make([]float64, dim)
-			globalWorker(task, method, gs, loc, x)
-		}(task)
+			for task := range workerChan {
+				evaluate(prob, task.Location, task.Operation, x)
+				evalStatsChan <- task
+			}
+			evalStatsChan <- GlobalTask{Operation: signalOperation}
+		}()
 	}
-	wg.Wait()
-	method.Done()
-	return gs.status, gs.err
-}
 
-// globalWorker runs the optimization steps for a single (concurrently-executing)
-// optimization task.
-func globalWorker(task int, m GlobalMethod, g *globalStatus, loc *Location, x []float64) {
-	for {
-		// Find Evaluation location
-		op, err := m.IterateGlobal(task, loc)
-		if err != nil {
-			g.updateStatus(Failure, err)
-			break
+	// Launch the stats combiner.
+	statWG.Add(1)
+	go func() {
+		defer statWG.Done()
+		var workerDone int // effective wg for the workers
+		var status Status
+		var err error
+		for task := range evalStatsChan {
+			switch task.Operation {
+			default:
+				updateEvaluationStats(stats, task.Operation)
+				status, err = checkEvaluationLimits(prob, stats, settings)
+			case signalOperation:
+				workerDone++
+				if workerDone == nTasks {
+					close(results)
+				}
+				continue
+			case NoOperation:
+				// Just send the task back.
+			case MajorIteration:
+				status = performMajorIteration(optLoc, task.Location, stats, startTime, settings)
+			case MethodDone:
+				statuser, ok := method.(Statuser)
+				if !ok {
+					panic("optimize: global method returned MethodDone is not a Statuser")
+				}
+				status, err = statuser.Status()
+				if status == NotTerminated {
+					panic("optimize: global method returned MethodDone but a NotTerminated status")
+				}
+			}
+			if settings.Recorder != nil && status == NotTerminated && err == nil {
+				stats.Runtime = time.Since(startTime)
+				// Allow err to be overloaded if the Recorder fails.
+				err = settings.Recorder.Record(task.Location, task.Operation, stats)
+				if err != nil {
+					status = Failure
+				}
+			}
+			// If the optimization should be over, send the signal.
+			if status != NotTerminated || err != nil {
+				f := final{
+					Status: status,
+					Err:    err,
+				}
+				// Two cases: 1) A NotTerminated status has already been sent on
+				// statusChan, and so we can send the first here. 2) A NotTerminated
+				// status has already been sent. This means statusSent is closed
+				// and can be received from.
+				select {
+				case <-statusSent:
+				case statusChan <- f:
+					// Tell the distributor to quit, and send a PostIteration
+					close(statusSent)
+					results <- GlobalTask{
+						Operation: PostIteration,
+					}
+				}
+			}
+
+			// If there are still workers remaining, send the result back.
+			// Don't send MethodDone back.
+			if task.Operation != MethodDone {
+				if workerDone != nTasks {
+					results <- task
+				}
+			}
 		}
+	}()
 
-		// Evaluate location and/or update stats.
-		status := g.globalOperation(op, loc, x)
-		if status != NotTerminated {
-			break
+	// Wait until a termination is sent.
+	f := <-statusChan
+	finalStatus = f.Status
+	finalError = f.Err
+
+	// Sending the status triggered the distributor to quit. Wait until it does.
+	distWG.Wait()
+	close(workerChan)
+	// Read the final operations, only performing an action if MajorIteration.
+	for task := range operations {
+		switch task.Operation {
+		case MajorIteration:
+			evalStatsChan <- task
 		}
 	}
-}
-
-// globalStatus coordinates access to information shared between concurrently
-// executing optimization tasks.
-type globalStatus struct {
-	mux       *sync.RWMutex
-	stats     *Stats
-	status    Status
-	p         *Problem
-	startTime time.Time
-	optLoc    *Location
-	settings  *Settings
-	method    GlobalMethod
-	statuser  Statuser
-	err       error
-}
-
-// getStatus returns the current status of the optimization.
-func (g *globalStatus) getStatus() Status {
-	var status Status
-	g.mux.RLock()
-	defer g.mux.RUnlock()
-	status = g.status
-	return status
-}
-
-func (g *globalStatus) incrementMajorIteration() {
-	g.mux.Lock()
-	defer g.mux.Unlock()
-	g.stats.MajorIterations++
-}
-
-func (g *globalStatus) updateOptLoc(loc *Location) {
-	g.mux.Lock()
-	defer g.mux.Unlock()
-	copyLocation(g.optLoc, loc)
-}
-
-// checkConvergence checks the convergence of the global optimization and returns
-// the status
-func (g *globalStatus) checkConvergence() Status {
-	g.mux.RLock()
-	defer g.mux.RUnlock()
-	return checkConvergence(g.optLoc, g.settings, false)
-}
-
-// updateStats updates the evaluation statistics for the given operation.
-func (g *globalStatus) updateStats(op Operation) {
-	g.mux.Lock()
-	defer g.mux.Unlock()
-	updateEvaluationStats(g.stats, op)
-}
-
-// updateStatus updates the status and error fields of g. This update only happens
-// if status == NotTerminated, so that the first different status is the one
-// maintained.
-func (g *globalStatus) updateStatus(s Status, err error) {
-	g.mux.Lock()
-	defer g.mux.Unlock()
-	if s != NotTerminated {
-		g.status = s
-		g.err = err
-	}
-}
-
-func (g *globalStatus) finishIteration(status Status, err error, loc *Location, op Operation) (Status, error) {
-	g.mux.Lock()
-	defer g.mux.Unlock()
-	return finishIteration(status, err, g.stats, g.settings, g.statuser, g.startTime, loc, op)
-}
-
-// globalOperation executes the requested operation at the given location.
-// When modifying this function, keep in mind that it can be called concurrently.
-// Uses of the internal fields should be through the methods of globalStatus and
-// protected by a mutex where appropriate.
-func (g *globalStatus) globalOperation(op Operation, loc *Location, x []float64) Status {
-	// Do a quick check to see if one of the other workers converged in the meantime.
-	status := g.getStatus()
-	if status != NotTerminated {
-		return status
-	}
-	var err error
-	switch op {
-	case NoOperation:
-	case InitIteration:
-		panic("optimize: GlobalMethod returned InitIteration")
-	case PostIteration:
-		panic("optimize: GlobalMethod returned PostIteration")
-	case MajorIteration:
-		g.incrementMajorIteration()
-		g.updateOptLoc(loc)
-		status = g.checkConvergence()
-	default: // Any of the Evaluation operations.
-		status, err = evaluate(g.p, loc, op, x)
-		g.updateStats(op)
-	}
-
-	status, err = g.finishIteration(status, err, loc, op)
-	if status != NotTerminated || err != nil {
-		g.updateStatus(status, err)
-	}
-	return status
-}
-
-// DefaultSettingsGlobal returns the default settings for Global optimization.
-func DefaultSettingsGlobal() *Settings {
-	return &Settings{
-		FunctionThreshold: math.Inf(-1),
-		FunctionConverge: &FunctionConverge{
-			Absolute:   1e-10,
-			Iterations: 100,
-		},
-	}
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
+	// All stats have been sent. Close the channel and wait until all are updated.
+	close(evalStatsChan)
+	statWG.Wait()
+	return finalStatus, finalError
 }

--- a/optimize/guessandcheck.go
+++ b/optimize/guessandcheck.go
@@ -31,7 +31,7 @@ func (g *GuessAndCheck) InitGlobal(dim, tasks int) int {
 
 func (g *GuessAndCheck) sendNewLoc(operation chan<- GlobalTask, task GlobalTask) {
 	g.Rander.Rand(task.X)
-	task.Operation = FuncEvaluation
+	task.Op = FuncEvaluation
 	operation <- task
 }
 
@@ -44,14 +44,14 @@ func (g *GuessAndCheck) updateMajor(operation chan<- GlobalTask, task GlobalTask
 		task.F = g.bestF
 		copy(task.X, g.bestX)
 	}
-	task.Operation = MajorIteration
+	task.Op = MajorIteration
 	operation <- task
 }
 
 func (g *GuessAndCheck) RunGlobal(operation chan<- GlobalTask, result <-chan GlobalTask, tasks []GlobalTask) {
 	// Send initial tasks to evaluate
 	for i, task := range tasks {
-		task.Index = i + 1
+		task.ID = i + 1
 		g.sendNewLoc(operation, task)
 	}
 
@@ -59,7 +59,7 @@ func (g *GuessAndCheck) RunGlobal(operation chan<- GlobalTask, result <-chan Glo
 Outer:
 	for {
 		task := <-result
-		switch task.Operation {
+		switch task.Op {
 		default:
 			panic("unknown operation")
 		case PostIteration:
@@ -73,7 +73,7 @@ Outer:
 
 	// PostIteration was sent. Update the best new values.
 	for task := range result {
-		switch task.Operation {
+		switch task.Op {
 		default:
 			panic("unknown operation")
 		case MajorIteration:

--- a/optimize/guessandcheck.go
+++ b/optimize/guessandcheck.go
@@ -6,7 +6,6 @@ package optimize
 
 import (
 	"math"
-	"sync"
 
 	"gonum.org/v1/gonum/stat/distmv"
 )
@@ -16,9 +15,6 @@ import (
 type GuessAndCheck struct {
 	Rander distmv.Rander
 
-	eval []bool
-
-	mux   *sync.Mutex
 	bestF float64
 	bestX []float64
 }
@@ -27,34 +23,63 @@ func (g *GuessAndCheck) Needs() struct{ Gradient, Hessian bool } {
 	return struct{ Gradient, Hessian bool }{false, false}
 }
 
-func (g *GuessAndCheck) Done() {
-	// No cleanup needed
-}
-
 func (g *GuessAndCheck) InitGlobal(dim, tasks int) int {
-	g.eval = make([]bool, tasks)
 	g.bestF = math.Inf(1)
 	g.bestX = resize(g.bestX, dim)
-	g.mux = &sync.Mutex{}
 	return tasks
 }
 
-func (g *GuessAndCheck) IterateGlobal(task int, loc *Location) (Operation, error) {
-	// Task is true if it contains a new function evaluation.
-	if g.eval[task] {
-		g.eval[task] = false
-		g.mux.Lock()
-		if loc.F < g.bestF {
-			g.bestF = loc.F
-			copy(g.bestX, loc.X)
-		} else {
-			loc.F = g.bestF
-			copy(loc.X, g.bestX)
-		}
-		g.mux.Unlock()
-		return MajorIteration, nil
+func (g *GuessAndCheck) sendNewLoc(operation chan<- GlobalTask, task GlobalTask) {
+	g.Rander.Rand(task.X)
+	task.Operation = FuncEvaluation
+	operation <- task
+}
+
+func (g *GuessAndCheck) updateMajor(operation chan<- GlobalTask, task GlobalTask) {
+	// Update the best value seen so far, and send a MajorIteration.
+	if task.F < g.bestF {
+		g.bestF = task.F
+		copy(g.bestX, task.X)
+	} else {
+		task.F = g.bestF
+		copy(task.X, g.bestX)
 	}
-	g.eval[task] = true
-	g.Rander.Rand(loc.X)
-	return FuncEvaluation, nil
+	task.Operation = MajorIteration
+	operation <- task
+}
+
+func (g *GuessAndCheck) RunGlobal(operation chan<- GlobalTask, result <-chan GlobalTask, tasks []GlobalTask) {
+	// Send initial tasks to evaluate
+	for i, task := range tasks {
+		task.Index = i + 1
+		g.sendNewLoc(operation, task)
+	}
+
+	// Read from the channel until PostIteration is sent.
+Outer:
+	for {
+		task := <-result
+		switch task.Operation {
+		default:
+			panic("unknown operation")
+		case PostIteration:
+			break Outer
+		case MajorIteration:
+			g.sendNewLoc(operation, task)
+		case FuncEvaluation:
+			g.updateMajor(operation, task)
+		}
+	}
+
+	// PostIteration was sent. Update the best new values.
+	for task := range result {
+		switch task.Operation {
+		default:
+			panic("unknown operation")
+		case MajorIteration:
+		case FuncEvaluation:
+			g.updateMajor(operation, task)
+		}
+	}
+	close(operation)
 }

--- a/optimize/guessandcheck_test.go
+++ b/optimize/guessandcheck_test.go
@@ -27,6 +27,7 @@ func TestGuessAndCheck(t *testing.T) {
 		panic("bad test")
 	}
 	Global(problem, dim, nil, &GuessAndCheck{Rander: d})
+
 	settings := DefaultSettingsGlobal()
 	settings.Concurrent = 5
 	settings.MajorIterations = 15

--- a/optimize/local.go
+++ b/optimize/local.go
@@ -145,11 +145,11 @@ func minimize(p *Problem, method Method, settings *Settings, stats *Stats, optLo
 		case MethodDone:
 			statuser, ok := method.(Statuser)
 			if !ok {
-				panic("optimize: global method returned MethodDone is not a Statuser")
+				panic("optimize: method returned MethodDone is not a Statuser")
 			}
 			status, err = statuser.Status()
 			if status == NotTerminated {
-				panic("optimize: global method returned MethodDone but a NotTerminated status")
+				panic("optimize: method returned MethodDone but a NotTerminated status")
 			}
 		default: // Any of the Evaluation operations.
 			evaluate(p, loc, op, x)

--- a/optimize/local.go
+++ b/optimize/local.go
@@ -95,7 +95,7 @@ func Local(p Problem, initX []float64, settings *Settings, method Method) (*Resu
 	}
 
 	// Check if the starting location satisfies the convergence criteria.
-	status := checkConvergence(optLoc, settings, true)
+	status := checkLocationConvergence(optLoc, settings)
 
 	// Run optimization
 	if status == NotTerminated && err == nil {
@@ -123,8 +123,6 @@ func minimize(p *Problem, method Method, settings *Settings, stats *Stats, optLo
 	copyLocation(loc, optLoc)
 	x := make([]float64, len(loc.X))
 
-	statuser, _ := method.(Statuser)
-
 	var op Operation
 	op, err = method.Init(loc)
 	if err != nil {
@@ -143,17 +141,33 @@ func minimize(p *Problem, method Method, settings *Settings, stats *Stats, optLo
 		case PostIteration:
 			panic("optimize: Method returned PostIteration")
 		case MajorIteration:
-			copyLocation(optLoc, loc)
-			stats.MajorIterations++
-			status = checkConvergence(optLoc, settings, true)
+			status = performMajorIteration(optLoc, loc, stats, startTime, settings)
+		case MethodDone:
+			statuser, ok := method.(Statuser)
+			if !ok {
+				panic("optimize: global method returned MethodDone is not a Statuser")
+			}
+			status, err = statuser.Status()
+			if status == NotTerminated {
+				panic("optimize: global method returned MethodDone but a NotTerminated status")
+			}
 		default: // Any of the Evaluation operations.
-			status, err = evaluate(p, loc, op, x)
+			evaluate(p, loc, op, x)
 			updateEvaluationStats(stats, op)
+			status, err = checkEvaluationLimits(p, stats, settings)
 		}
-
-		status, err = finishIteration(status, err, stats, settings, statuser, startTime, loc, op)
 		if status != NotTerminated || err != nil {
 			return
+		}
+		if settings.Recorder != nil {
+			stats.Runtime = time.Since(startTime)
+			err = settings.Recorder.Record(loc, op, stats)
+			if err != nil {
+				if status == NotTerminated {
+					status = Failure
+				}
+				return status, err
+			}
 		}
 
 		op, err = method.Iterate(loc)

--- a/optimize/minimize.go
+++ b/optimize/minimize.go
@@ -13,6 +13,18 @@ import (
 	"gonum.org/v1/gonum/mat"
 )
 
+var (
+	nonpositiveDimension string = "optimize: non-positive input dimension"
+	negativeTasks        string = "optimize: negative input number of tasks"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 // newLocation allocates a new locatian structure of the appropriate size. It
 // allocates memory based on the dimension and the values in Needs. The initial
 // function value is set to math.Inf(1).
@@ -74,17 +86,11 @@ func checkOptimization(p Problem, dim int, method Needser, recorder Recorder) er
 }
 
 // evaluate evaluates the routines specified by the Operation at loc.X, and stores
-// the answer into loc. loc.X is copied into x before
-// evaluating in order to prevent the routines from modifying it.
-func evaluate(p *Problem, loc *Location, op Operation, x []float64) (Status, error) {
+// the answer into loc. loc.X is copied into x before evaluating in order to
+// prevent the routines from modifying it.
+func evaluate(p *Problem, loc *Location, op Operation, x []float64) {
 	if !op.isEvaluation() {
 		panic(fmt.Sprintf("optimize: invalid evaluation %v", op))
-	}
-	if p.Status != nil {
-		status, err := p.Status()
-		if err != nil || status != NotTerminated {
-			return status, err
-		}
 	}
 	copy(x, loc.X)
 	if op&FuncEvaluation != 0 {
@@ -96,29 +102,6 @@ func evaluate(p *Problem, loc *Location, op Operation, x []float64) (Status, err
 	if op&HessEvaluation != 0 {
 		p.Hess(loc.Hessian, x)
 	}
-	return NotTerminated, nil
-}
-
-// checkConvergence returns NotTerminated if the Location does not satisfy the
-// convergence criteria given by settings. Otherwise a corresponding status is
-// returned.
-// Unlike checkLimits, checkConvergence is called only at MajorIterations.
-//
-// If local is true, gradient convergence is also checked.
-func checkConvergence(loc *Location, settings *Settings, local bool) Status {
-	if local && loc.Gradient != nil {
-		norm := floats.Norm(loc.Gradient, math.Inf(1))
-		if norm < settings.GradientThreshold {
-			return GradientThreshold
-		}
-	}
-	if loc.F < settings.FunctionThreshold {
-		return FunctionThreshold
-	}
-	if settings.FunctionConverge != nil {
-		return settings.FunctionConverge.FunctionConverged(loc.F)
-	}
-	return NotTerminated
 }
 
 // updateEvaluationStats updates the statistics based on the operation.
@@ -134,70 +117,77 @@ func updateEvaluationStats(stats *Stats, op Operation) {
 	}
 }
 
-// checkLimits returns NotTerminated status if the various limits given by
-// settings have not been reached. Otherwise it returns a corresponding status.
-// Unlike checkConvergence, checkLimits is called by Local and Global at _every_
-// iteration.
-func checkLimits(loc *Location, stats *Stats, settings *Settings) Status {
-	// Check the objective function value for negative infinity because it
-	// could break the linesearches and -inf is the best we can do anyway.
+// checkLocationConvergence checks if the current optimal location satisfies
+// any of the convergence criteria based on the function location.
+//
+// checkLocationConvergence returns NotTerminated if the Location does not satisfy
+// the convergence criteria given by settings. Otherwise a corresponding status is
+// returned.
+// Unlike checkLimits, checkConvergence is called only at MajorIterations.
+func checkLocationConvergence(loc *Location, settings *Settings) Status {
 	if math.IsInf(loc.F, -1) {
 		return FunctionNegativeInfinity
 	}
-
-	if settings.MajorIterations > 0 && stats.MajorIterations >= settings.MajorIterations {
-		return IterationLimit
+	if loc.Gradient != nil {
+		norm := floats.Norm(loc.Gradient, math.Inf(1))
+		if norm < settings.GradientThreshold {
+			return GradientThreshold
+		}
 	}
-
-	if settings.FuncEvaluations > 0 && stats.FuncEvaluations >= settings.FuncEvaluations {
-		return FunctionEvaluationLimit
+	if loc.F < settings.FunctionThreshold {
+		return FunctionThreshold
 	}
-
-	if settings.GradEvaluations > 0 && stats.GradEvaluations >= settings.GradEvaluations {
-		return GradientEvaluationLimit
+	if settings.FunctionConverge != nil {
+		return settings.FunctionConverge.FunctionConverged(loc.F)
 	}
-
-	if settings.HessEvaluations > 0 && stats.HessEvaluations >= settings.HessEvaluations {
-		return HessianEvaluationLimit
-	}
-
-	// TODO(vladimir-ch): It would be nice to update Runtime here.
-	if settings.Runtime > 0 && stats.Runtime >= settings.Runtime {
-		return RuntimeLimit
-	}
-
 	return NotTerminated
 }
 
-// finishIteration performs cleanup tasks at the end of an optimization iteration.
-// It checks the status, sends information to recorders, and updates the runtime.
-func finishIteration(status Status, err error, stats *Stats, settings *Settings, statuser Statuser, startTime time.Time, loc *Location, op Operation) (Status, error) {
-	if status != NotTerminated || err != nil {
-		return status, err
-	}
-
-	if settings.Recorder != nil {
-		stats.Runtime = time.Since(startTime)
-		err = settings.Recorder.Record(loc, op, stats)
-		if err != nil {
-			if status == NotTerminated {
-				status = Failure
-			}
-			return status, err
-		}
-	}
-
-	stats.Runtime = time.Since(startTime)
-	status = checkLimits(loc, stats, settings)
-	if status != NotTerminated {
-		return status, nil
-	}
-
-	if statuser != nil {
-		status, err = statuser.Status()
+// checkEvaluationLimits checks the optimization limits after an evaluation
+// Operation. It checks the number of evaluations (of various kinds) and checks
+// the status of the Problem, if applicable.
+func checkEvaluationLimits(p *Problem, stats *Stats, settings *Settings) (Status, error) {
+	if p.Status != nil {
+		status, err := p.Status()
 		if err != nil || status != NotTerminated {
 			return status, err
 		}
 	}
-	return status, nil
+	if settings.FuncEvaluations > 0 && stats.FuncEvaluations >= settings.FuncEvaluations {
+		return FunctionEvaluationLimit, nil
+	}
+	if settings.GradEvaluations > 0 && stats.GradEvaluations >= settings.GradEvaluations {
+		return GradientEvaluationLimit, nil
+	}
+	if settings.HessEvaluations > 0 && stats.HessEvaluations >= settings.HessEvaluations {
+		return HessianEvaluationLimit, nil
+	}
+	return NotTerminated, nil
+}
+
+// checkIterationLimits checks if any of the limits on iterations affected by
+// MajorIteration.
+func checkIterationLimits(loc *Location, stats *Stats, settings *Settings) Status {
+	if settings.MajorIterations > 0 && stats.MajorIterations >= settings.MajorIterations {
+		return IterationLimit
+	}
+	// TODO(vladimir-ch): It would be nice to update Runtime here.
+	if settings.Runtime > 0 && stats.Runtime >= settings.Runtime {
+		return RuntimeLimit
+	}
+	return NotTerminated
+}
+
+// performMajorIteration does all of the steps needed to perform a MajorIteration.
+// It increments the iteration count, updates the optimal location, and checks
+// the necessary convergence criteria.
+func performMajorIteration(optLoc, loc *Location, stats *Stats, startTime time.Time, settings *Settings) Status {
+	copyLocation(optLoc, loc)
+	stats.MajorIterations++
+	stats.Runtime = time.Since(startTime)
+	status := checkLocationConvergence(optLoc, settings)
+	if status != NotTerminated {
+		return status
+	}
+	return checkIterationLimits(optLoc, stats, settings)
 }

--- a/optimize/minimize.go
+++ b/optimize/minimize.go
@@ -13,7 +13,7 @@ import (
 	"gonum.org/v1/gonum/mat"
 )
 
-var (
+const (
 	nonpositiveDimension string = "optimize: non-positive input dimension"
 	negativeTasks        string = "optimize: negative input number of tasks"
 )

--- a/optimize/minimize.go
+++ b/optimize/minimize.go
@@ -165,13 +165,11 @@ func checkEvaluationLimits(p *Problem, stats *Stats, settings *Settings) (Status
 	return NotTerminated, nil
 }
 
-// checkIterationLimits checks if any of the limits on iterations affected by
-// MajorIteration.
+// checkIterationLimits checks the limits on iterations affected by MajorIteration.
 func checkIterationLimits(loc *Location, stats *Stats, settings *Settings) Status {
 	if settings.MajorIterations > 0 && stats.MajorIterations >= settings.MajorIterations {
 		return IterationLimit
 	}
-	// TODO(vladimir-ch): It would be nice to update Runtime here.
 	if settings.Runtime > 0 && stats.Runtime >= settings.Runtime {
 		return RuntimeLimit
 	}

--- a/optimize/types.go
+++ b/optimize/types.go
@@ -26,12 +26,10 @@ const (
 	// NoOperation specifies that no evaluation or convergence check should
 	// take place.
 	NoOperation Operation = 0
-	// signal is used interally to signal completion.
-	signalOperation Operation = 1 << (iota - 1)
 	// InitIteration is sent to Recorder to indicate the initial location.
 	// All fields of the location to record must be valid.
 	// Method must not return it.
-	InitIteration
+	InitIteration Operation = 1 << (iota - 1)
 	// PostIteration is sent to Recorder to indicate the final location
 	// reached during an optimization run.
 	// All fields of the location to record must be valid.
@@ -53,6 +51,8 @@ const (
 	// HessEvaluation specifies that the Hessian
 	// of the objective function should be evaluated.
 	HessEvaluation
+	// signalDone is used internally to signal completion.
+	signalDone
 
 	// Mask for the evaluating operations.
 	evalMask = FuncEvaluation | GradEvaluation | HessEvaluation
@@ -78,12 +78,12 @@ func (op Operation) String() string {
 }
 
 var operationNames = map[Operation]string{
-	NoOperation:     "NoOperation",
-	signalOperation: "signalOperation",
-	InitIteration:   "InitIteration",
-	MajorIteration:  "MajorIteration",
-	PostIteration:   "PostIteration",
-	MethodDone:      "MethodDone",
+	NoOperation:    "NoOperation",
+	InitIteration:  "InitIteration",
+	MajorIteration: "MajorIteration",
+	PostIteration:  "PostIteration",
+	MethodDone:     "MethodDone",
+	signalDone:     "signalDone",
 }
 
 // Location represents a location in the optimization procedure.

--- a/optimize/types.go
+++ b/optimize/types.go
@@ -26,10 +26,12 @@ const (
 	// NoOperation specifies that no evaluation or convergence check should
 	// take place.
 	NoOperation Operation = 0
+	// signal is used interally to signal completion.
+	signalOperation Operation = 1 << (iota - 1)
 	// InitIteration is sent to Recorder to indicate the initial location.
 	// All fields of the location to record must be valid.
 	// Method must not return it.
-	InitIteration Operation = 1 << (iota - 1)
+	InitIteration
 	// PostIteration is sent to Recorder to indicate the final location
 	// reached during an optimization run.
 	// All fields of the location to record must be valid.
@@ -38,6 +40,10 @@ const (
 	// MajorIteration indicates that the next candidate location for
 	// an optimum has been found and convergence should be checked.
 	MajorIteration
+	// MethodDone declares that the method is done running. A method must
+	// be a Statuser in order to use this iteration, and after returning
+	// MethodDone, the Status must return other than NotTerminated.
+	MethodDone
 	// FuncEvaluation specifies that the objective function
 	// should be evaluated.
 	FuncEvaluation
@@ -72,10 +78,12 @@ func (op Operation) String() string {
 }
 
 var operationNames = map[Operation]string{
-	NoOperation:    "NoOperation",
-	InitIteration:  "InitIteration",
-	MajorIteration: "MajorIteration",
-	PostIteration:  "PostIteration",
+	NoOperation:     "NoOperation",
+	signalOperation: "signalOperation",
+	InitIteration:   "InitIteration",
+	MajorIteration:  "MajorIteration",
+	PostIteration:   "PostIteration",
+	MethodDone:      "MethodDone",
 }
 
 // Location represents a location in the optimization procedure.
@@ -201,7 +209,7 @@ type Settings struct {
 
 	// Runtime is the maximum runtime allowed. RuntimeLimit status is returned
 	// if the duration of the run is longer than this value. Runtime is only
-	// checked at iterations of the Method.
+	// checked at MajorIterations of the Method.
 	// If it equals zero, this setting has no effect.
 	// The default value is 0.
 	Runtime time.Duration


### PR DESCRIPTION
The previous implementation of Global was a minefield for incorrectly implementing global optimization methods. It was very difficult to correctly implement methods (both of the provided methods were incorrect), and the resulting code is very ugly. This commit switches to use channels to communicate, allowing a more clear ordering of concurrent code. This also enables better shutdown of methods.

In addition to the main fix of Global, this refactors the two Global methods to use the updated interface, and makes some small improvements that were previously not possible. In addition, there are some small cleanups of Local to better match between the two calls.

If anyone has been curious about what is meant by 'Don't communicate by sharing memory, share memory by communicating' this is it, and why.