### PR TITLE
diff: Derivative Performance

### DIFF
--- a/diff/fd/derivative.go
+++ b/diff/fd/derivative.go
@@ -6,8 +6,6 @@ package fd
 
 import (
 	"math"
-	"runtime"
-	"sync"
 )
 
 // Derivative estimates the derivative of the function f at the given location.
@@ -19,7 +17,7 @@ func Derivative(f func(float64) float64, x float64, settings *Settings) float64 
 	formula := Forward
 	step := formula.Step
 	var originValue float64
-	var originKnown, concurrent bool
+	var originKnown bool
 
 	// Use user settings if provided.
 	if settings != nil {
@@ -33,39 +31,16 @@ func Derivative(f func(float64) float64, x float64, settings *Settings) float64 
 		}
 		originKnown = settings.OriginKnown
 		originValue = settings.OriginValue
-		concurrent = settings.Concurrent
 	}
 
 	var deriv float64
-	if !concurrent || runtime.GOMAXPROCS(0) == 1 {
-		for _, pt := range formula.Stencil {
-			if originKnown && pt.Loc == 0 {
-				deriv += pt.Coeff * originValue
-				continue
-			}
-			deriv += pt.Coeff * f(x+step*pt.Loc)
-		}
-		return deriv / math.Pow(step, float64(formula.Derivative))
-	}
-
-	wg := &sync.WaitGroup{}
-	mux := &sync.Mutex{}
 	for _, pt := range formula.Stencil {
 		if originKnown && pt.Loc == 0 {
-			mux.Lock()
 			deriv += pt.Coeff * originValue
-			mux.Unlock()
 			continue
 		}
-		wg.Add(1)
-		go func(pt Point) {
-			defer wg.Done()
-			fofx := f(x + step*pt.Loc)
-			mux.Lock()
-			defer mux.Unlock()
-			deriv += pt.Coeff * fofx
-		}(pt)
+		deriv += pt.Coeff * f(x+step*pt.Loc)
 	}
-	wg.Wait()
+
 	return deriv / math.Pow(step, float64(formula.Derivative))
 }

--- a/diff/fd/derivative_test.go
+++ b/diff/fd/derivative_test.go
@@ -7,12 +7,9 @@ package fd
 import (
 	"math"
 	"testing"
-	"time"
 )
 
 var xSquared = func(x float64) float64 { return x * x }
-
-var xSquaredSlow = func(x float64) float64 { time.Sleep(500); return x * x }
 
 type testPoint struct {
 	f    func(float64) float64

--- a/diff/fd/derivative_test.go
+++ b/diff/fd/derivative_test.go
@@ -7,9 +7,12 @@ package fd
 import (
 	"math"
 	"testing"
+	"time"
 )
 
 var xSquared = func(x float64) float64 { return x * x }
+
+var xSquaredSlow = func(x float64) float64 { time.Sleep(500); return x * x }
 
 type testPoint struct {
 	f    func(float64) float64
@@ -141,5 +144,33 @@ func TestDerivativeDefault(t *testing.T) {
 		if math.Abs(test.ans-ans) > tol {
 			t.Errorf("Case %v: ans mismatch zero value: expected %v, found %v", i, test.ans, ans)
 		}
+	}
+}
+
+func BenchmarkDerivativeSerial(b *testing.B) {
+	// run the Derivative benchmark b.N times
+	for n := 0; n < b.N; n++ {
+		Derivative(xSquared, 10, &Settings{Concurrent: false})
+	}
+}
+
+func BenchmarkDerivativeConcurrent(b *testing.B) {
+	// run the Derivative benchmark b.N times
+	for n := 0; n < b.N; n++ {
+		Derivative(xSquared, 10, &Settings{Concurrent: true})
+	}
+}
+
+func BenchmarkDerivative2ndSerial(b *testing.B) {
+	// run the Derivative benchmark b.N times
+	for n := 0; n < b.N; n++ {
+		Derivative(xSquared, 10, &Settings{Formula: Forward2nd, Concurrent: false})
+	}
+}
+
+func BenchmarkDerivative2ndConcurrent(b *testing.B) {
+	// run the Derivative benchmark b.N times
+	for n := 0; n < b.N; n++ {
+		Derivative(xSquared, 10, &Settings{Formula: Forward2nd, Concurrent: true})
 	}
 }


### PR DESCRIPTION
Fixes #380 

The PR removes the concurrent code path in the `Derivative` function. To maintain backwards compatibility, the concurrent value in `Settings` is unchanged. However, the setting is now a no-op. 

`benchstat` comparison of the Derivative pre/post PR:
```
# benchstat old.txt new.txt 
name                       old time/op  new time/op  delta
DerivativeSerial-8         67.0ns ± 0%  28.3ns ± 0%   ~     (p=1.000 n=1+1)
DerivativeConcurrent-8     1.98µs ± 0%  0.03µs ± 0%   ~     (p=1.000 n=1+1)
Derivative2ndSerial-8       116ns ± 0%    74ns ± 0%   ~     (p=1.000 n=1+1)
Derivative2ndConcurrent-8  2.88µs ± 0%  0.07µs ± 0%   ~     (p=1.000 n=1+1)
```