### PR TITLE
lapack/testlapack: fix and extend test for Dlarfg

### DIFF
--- a/lapack/testlapack/dlarfg.go
+++ b/lapack/testlapack/dlarfg.go
@@ -43,7 +43,7 @@ func DlarfgTest(t *testing.T, impl Dlarfger) {
 		},
 		{
 			alpha: 1,
-			n:     2,
+			n:     4,
 			x:     []float64{4, 5, 6},
 		},
 	} {
@@ -56,6 +56,9 @@ func DlarfgTest(t *testing.T, impl Dlarfger) {
 				x[i] = rnd.Float64()
 			}
 		} else {
+			if len(test.x) != n-1 {
+				panic("bad test")
+			}
 			x = make([]float64, n-1)
 			copy(x, test.x)
 		}

--- a/lapack/testlapack/dlarfg.go
+++ b/lapack/testlapack/dlarfg.go
@@ -46,6 +46,16 @@ func DlarfgTest(t *testing.T, impl Dlarfger) {
 			n:     4,
 			x:     []float64{4, 5, 6},
 		},
+		{
+			alpha: 1,
+			n:     4,
+			x:     []float64{0, 0, 0},
+		},
+		{
+			alpha: dlamchS,
+			n:     4,
+			x:     []float64{dlamchS, dlamchS, dlamchS},
+		},
 	} {
 		n := test.n
 		incX := 1


### PR DESCRIPTION
Coverage for `Dlarfg` is complete with this.