### PR TITLE
floats: fix nearest, span and min/max index behaviours

### DIFF
--- a/floats/floats.go
+++ b/floats/floats.go
@@ -433,13 +433,13 @@ func MaxIdx(s []float64) int {
 	if len(s) == 0 {
 		panic("floats: zero slice length")
 	}
-	max := math.Inf(-1)
+	max := math.NaN()
 	var ind int
 	for i, v := range s {
 		if math.IsNaN(v) {
 			continue
 		}
-		if v > max {
+		if v > max || math.IsNaN(max) {
 			max = v
 			ind = i
 		}
@@ -459,13 +459,13 @@ func MinIdx(s []float64) int {
 	if len(s) == 0 {
 		panic("floats: zero slice length")
 	}
-	min := math.Inf(1)
+	min := math.NaN()
 	var ind int
 	for i, v := range s {
 		if math.IsNaN(v) {
 			continue
 		}
-		if v < min {
+		if v < min || math.IsNaN(min) {
 			min = v
 			ind = i
 		}
@@ -538,14 +538,14 @@ func NearestIdx(s []float64, v float64) int {
 		return MinIdx(s)
 	}
 	var ind int
-	dist := math.Inf(1)
+	dist := math.NaN()
 	for i, val := range s {
 		newDist := math.Abs(v - val)
 		// A NaN distance will not be closer.
 		if math.IsNaN(newDist) {
 			continue
 		}
-		if newDist < dist {
+		if newDist < dist || math.IsNaN(dist) {
 			dist = newDist
 			ind = i
 		}
@@ -815,9 +815,14 @@ func Scale(c float64, dst []float64) {
 // Span returns a set of N equally spaced points between l and u, where N
 // is equal to the length of the destination. The first element of the destination
 // is l, the final element of the destination is u.
+//
+// If l and u  are infinities of opposite sign, then on return dst will contain half
+// of one infinity, and half the other, with the middle element being zero if dst is odd.
+//
 // Panics if len(dst) < 2.
 //
-// Also returns the mutated slice dst, so that it can be used in range expressions, like:
+// Span also returns the mutated slice dst, so that it can be used in range expressions,
+// like:
 //
 //     for i, x := range Span(dst, l, u) { ... }
 func Span(dst []float64, l, u float64) []float64 {
@@ -861,7 +866,7 @@ func Span(dst []float64, l, u float64) []float64 {
 		return dst
 	case math.IsInf(u, 0):
 		for i := range dst[1:] {
-			dst[i] = u
+			dst[i+1] = u
 		}
 		dst[0] = l
 		return dst

--- a/floats/floats.go
+++ b/floats/floats.go
@@ -433,9 +433,12 @@ func MaxIdx(s []float64) int {
 	if len(s) == 0 {
 		panic("floats: zero slice length")
 	}
-	max := s[0]
+	max := math.Inf(-1)
 	var ind int
 	for i, v := range s {
+		if math.IsNaN(v) {
+			continue
+		}
 		if v > max {
 			max = v
 			ind = i
@@ -453,9 +456,15 @@ func Min(s []float64) float64 {
 // entries have the maximum value, the first such index is returned. If the slice
 // is empty, MinIdx will panic.
 func MinIdx(s []float64) int {
-	min := s[0]
+	if len(s) == 0 {
+		panic("floats: zero slice length")
+	}
+	min := math.Inf(1)
 	var ind int
 	for i, v := range s {
+		if math.IsNaN(v) {
+			continue
+		}
 		if v < min {
 			min = v
 			ind = i

--- a/floats/floats.go
+++ b/floats/floats.go
@@ -556,12 +556,11 @@ func NearestIdx(s []float64, v float64) int {
 // NearestIdxForSpan return the index of a hypothetical vector created
 // by Span with length n and bounds l and u whose value is closest
 // to v. That is, NearestIdxForSpan(n, l, u, v) is equivalent to
-// Nearest(Span(make([]float64, n),l,u),v) without an allocation and
-// with a relaxation for the paramater n.
-// NearestIdxForSpan panics if n is less than one.
+// Nearest(Span(make([]float64, n),l,u),v) without an allocation.
+// NearestIdxForSpan panics if n is less than two.
 func NearestIdxForSpan(n int, l, u float64, v float64) int {
-	if n == 0 {
-		panic("floats: zero length span")
+	if n <= 1 {
+		panic("floats: span must have length >1")
 	}
 	if math.IsNaN(v) {
 		return 0
@@ -815,9 +814,6 @@ func Scale(c float64, dst []float64) {
 // Span returns a set of N equally spaced points between l and u, where N
 // is equal to the length of the destination. The first element of the destination
 // is l, the final element of the destination is u.
-//
-// If l and u  are infinities of opposite sign, then on return dst will contain half
-// of one infinity, and half the other, with the middle element being zero if dst is odd.
 //
 // Panics if len(dst) < 2.
 //

--- a/floats/floats_test.go
+++ b/floats/floats_test.go
@@ -894,7 +894,7 @@ func TestNaNPayload(t *testing.T) {
 	}
 }
 
-func TestNearest(t *testing.T) {
+func TestNearestIdx(t *testing.T) {
 	for _, test := range []struct {
 		in    []float64
 		query float64
@@ -974,14 +974,14 @@ func TestNearest(t *testing.T) {
 			desc:  "Wrong index returned when query is a number and only NaN elements exist",
 		},
 	} {
-		ind := Nearest(test.in, test.query)
+		ind := NearestIdx(test.in, test.query)
 		if ind != test.want {
 			t.Errorf(test.desc+": got:%d want:%d", ind, test.want)
 		}
 	}
 }
 
-func TestNearestIdx(t *testing.T) {
+func TestNearestIdxForSpan(t *testing.T) {
 	for i, test := range []struct {
 		length int
 		lower  float64
@@ -1046,6 +1046,13 @@ func TestNearestIdx(t *testing.T) {
 			idx:    0,
 		},
 		{
+			length: 5,
+			lower:  math.Inf(-1),
+			upper:  math.Inf(1),
+			value:  0,
+			idx:    2,
+		},
+		{
 			length: 4,
 			lower:  math.Inf(-1),
 			upper:  math.Inf(1),
@@ -1081,7 +1088,7 @@ func TestNearestIdx(t *testing.T) {
 			idx:    0,
 		},
 	} {
-		if idx := NearestIdx(test.length, test.lower, test.upper, test.value); test.idx != idx {
+		if idx := NearestIdxForSpan(test.length, test.lower, test.upper, test.value); test.idx != idx {
 			t.Errorf("Case %v mismatch: Want: %v, Got: %v", i, test.idx, idx)
 		}
 	}

--- a/floats/floats_test.go
+++ b/floats/floats_test.go
@@ -703,26 +703,76 @@ func TestLogSumExp(t *testing.T) {
 }
 
 func TestMaxAndIdx(t *testing.T) {
-	s := []float64{3, 4, 1, 7, 5}
-	ind := MaxIdx(s)
-	val := Max(s)
-	if val != 7 {
-		t.Errorf("Wrong value returned")
-	}
-	if ind != 3 {
-		t.Errorf("Wrong index returned")
+	for _, test := range []struct {
+		in      []float64
+		wantIdx int
+		wantVal float64
+		desc    string
+	}{
+		{
+			in:      []float64{3, 4, 1, 7, 5},
+			wantIdx: 3,
+			wantVal: 7,
+			desc:    "with only finite entries",
+		},
+		{
+			in:      []float64{math.NaN(), 4, 1, 7, 5},
+			wantIdx: 3,
+			wantVal: 7,
+			desc:    "with leading NaN",
+		},
+		{
+			in:      []float64{math.NaN(), math.NaN(), math.NaN()},
+			wantIdx: 0,
+			wantVal: math.NaN(),
+			desc:    "when only NaN elements exist",
+		},
+	} {
+		ind := MaxIdx(test.in)
+		if ind != test.wantIdx {
+			t.Errorf("Wrong index "+test.desc+": got:%d want:%d", ind, test.wantIdx)
+		}
+		val := Max(test.in)
+		if !same(val, test.wantVal) {
+			t.Errorf("Wrong value "+test.desc+": got:%f want:%f", val, test.wantVal)
+		}
 	}
 }
 
 func TestMinAndIdx(t *testing.T) {
-	s := []float64{3, 4, 1, 7, 5}
-	ind := MinIdx(s)
-	val := Min(s)
-	if val != 1 {
-		t.Errorf("Wrong value returned")
-	}
-	if ind != 2 {
-		t.Errorf("Wrong index returned")
+	for _, test := range []struct {
+		in      []float64
+		wantIdx int
+		wantVal float64
+		desc    string
+	}{
+		{
+			in:      []float64{3, 4, 1, 7, 5},
+			wantIdx: 2,
+			wantVal: 1,
+			desc:    "with only finite entries",
+		},
+		{
+			in:      []float64{math.NaN(), 4, 1, 7, 5},
+			wantIdx: 2,
+			wantVal: 1,
+			desc:    "with leading NaN",
+		},
+		{
+			in:      []float64{math.NaN(), math.NaN(), math.NaN()},
+			wantIdx: 0,
+			wantVal: math.NaN(),
+			desc:    "when only NaN elements exist",
+		},
+	} {
+		ind := MinIdx(test.in)
+		if ind != test.wantIdx {
+			t.Errorf("Wrong index "+test.desc+": got:%d want:%d", ind, test.wantIdx)
+		}
+		val := Min(test.in)
+		if !same(val, test.wantVal) {
+			t.Errorf("Wrong value "+test.desc+": got:%f want:%f", val, test.wantVal)
+		}
 	}
 }
 

--- a/floats/floats_test.go
+++ b/floats/floats_test.go
@@ -21,13 +21,13 @@ const (
 	Huge        = 10000000
 )
 
-func AreSlicesEqual(t *testing.T, truth, comp []float64, str string) {
+func areSlicesEqual(t *testing.T, truth, comp []float64, str string) {
 	if !EqualApprox(comp, truth, EqTolerance) {
 		t.Errorf(str+". Expected %v, returned %v", truth, comp)
 	}
 }
 
-func AreSlicesSame(t *testing.T, truth, comp []float64, str string) {
+func areSlicesSame(t *testing.T, truth, comp []float64, str string) {
 	ok := len(truth) == len(comp)
 	if ok {
 		for i, a := range truth {
@@ -68,10 +68,10 @@ func TestAdd(t *testing.T) {
 	Add(n, a)
 	Add(n, b)
 	Add(n, c)
-	AreSlicesEqual(t, truth, n, "Wrong addition of slices new receiver")
+	areSlicesEqual(t, truth, n, "Wrong addition of slices new receiver")
 	Add(a, b)
 	Add(a, c)
-	AreSlicesEqual(t, truth, n, "Wrong addition of slices for no new receiver")
+	areSlicesEqual(t, truth, n, "Wrong addition of slices for no new receiver")
 
 	// Test that it panics
 	if !Panics(func() { Add(make([]float64, 2), make([]float64, 3)) }) {
@@ -86,8 +86,8 @@ func TestAddTo(t *testing.T) {
 	n1 := make([]float64, len(a))
 
 	n2 := AddTo(n1, a, b)
-	AreSlicesEqual(t, truth, n1, "Bad addition from mutator")
-	AreSlicesEqual(t, truth, n2, "Bad addition from returned slice")
+	areSlicesEqual(t, truth, n1, "Bad addition from mutator")
+	areSlicesEqual(t, truth, n2, "Bad addition from returned slice")
 
 	// Test that it panics
 	if !Panics(func() { AddTo(make([]float64, 2), make([]float64, 3), make([]float64, 3)) }) {
@@ -104,7 +104,7 @@ func TestAddConst(t *testing.T) {
 	c := 6.0
 	truth := []float64{9, 10, 7, 13, 11}
 	AddConst(c, s)
-	AreSlicesEqual(t, truth, s, "Wrong addition of constant")
+	areSlicesEqual(t, truth, s, "Wrong addition of constant")
 }
 
 func TestAddScaled(t *testing.T) {
@@ -193,10 +193,10 @@ func TestCumProd(t *testing.T) {
 	receiver := make([]float64, len(s))
 	result := CumProd(receiver, s)
 	truth := []float64{3, 12, 12, 84, 420}
-	AreSlicesEqual(t, truth, receiver, "Wrong cumprod mutated with new receiver")
-	AreSlicesEqual(t, truth, result, "Wrong cumprod result with new receiver")
+	areSlicesEqual(t, truth, receiver, "Wrong cumprod mutated with new receiver")
+	areSlicesEqual(t, truth, result, "Wrong cumprod result with new receiver")
 	CumProd(receiver, s)
-	AreSlicesEqual(t, truth, receiver, "Wrong cumprod returned with reused receiver")
+	areSlicesEqual(t, truth, receiver, "Wrong cumprod returned with reused receiver")
 
 	// Test that it panics
 	if !Panics(func() { CumProd(make([]float64, 2), make([]float64, 3)) }) {
@@ -207,7 +207,7 @@ func TestCumProd(t *testing.T) {
 	emptyReceiver := make([]float64, 0)
 	truth = []float64{}
 	CumProd(emptyReceiver, emptyReceiver)
-	AreSlicesEqual(t, truth, emptyReceiver, "Wrong cumprod returned with empty receiver")
+	areSlicesEqual(t, truth, emptyReceiver, "Wrong cumprod returned with empty receiver")
 
 }
 
@@ -216,10 +216,10 @@ func TestCumSum(t *testing.T) {
 	receiver := make([]float64, len(s))
 	result := CumSum(receiver, s)
 	truth := []float64{3, 7, 8, 15, 20}
-	AreSlicesEqual(t, truth, receiver, "Wrong cumsum mutated with new receiver")
-	AreSlicesEqual(t, truth, result, "Wrong cumsum returned with new receiver")
+	areSlicesEqual(t, truth, receiver, "Wrong cumsum mutated with new receiver")
+	areSlicesEqual(t, truth, result, "Wrong cumsum returned with new receiver")
 	CumSum(receiver, s)
-	AreSlicesEqual(t, truth, receiver, "Wrong cumsum returned with reused receiver")
+	areSlicesEqual(t, truth, receiver, "Wrong cumsum returned with reused receiver")
 
 	// Test that it panics
 	if !Panics(func() { CumSum(make([]float64, 2), make([]float64, 3)) }) {
@@ -230,7 +230,7 @@ func TestCumSum(t *testing.T) {
 	emptyReceiver := make([]float64, 0)
 	truth = []float64{}
 	CumSum(emptyReceiver, emptyReceiver)
-	AreSlicesEqual(t, truth, emptyReceiver, "Wrong cumsum returned with empty receiver")
+	areSlicesEqual(t, truth, emptyReceiver, "Wrong cumsum returned with empty receiver")
 
 }
 
@@ -647,12 +647,12 @@ func TestLogSpan(t *testing.T) {
 	for i := range comp {
 		comp[i] = 1
 	}
-	AreSlicesEqual(t, comp, tst, "Improper logspace from mutator")
+	areSlicesEqual(t, comp, tst, "Improper logspace from mutator")
 
 	for i := range truth {
 		tst[i] = receiver2[i] / truth[i]
 	}
-	AreSlicesEqual(t, comp, tst, "Improper logspace from returned slice")
+	areSlicesEqual(t, comp, tst, "Improper logspace from returned slice")
 
 	if !Panics(func() { LogSpan(nil, 1, 5) }) {
 		t.Errorf("Span accepts nil argument")
@@ -1308,19 +1308,19 @@ func TestScale(t *testing.T) {
 	c := 5.0
 	truth := []float64{15, 20, 5, 35, 25}
 	Scale(c, s)
-	AreSlicesEqual(t, truth, s, "Bad scaling")
+	areSlicesEqual(t, truth, s, "Bad scaling")
 }
 
 func TestSpan(t *testing.T) {
 	receiver1 := make([]float64, 5)
 	truth := []float64{1, 2, 3, 4, 5}
 	receiver2 := Span(receiver1, 1, 5)
-	AreSlicesEqual(t, truth, receiver1, "Improper linspace from mutator")
-	AreSlicesEqual(t, truth, receiver2, "Improper linspace from returned slice")
+	areSlicesEqual(t, truth, receiver1, "Improper linspace from mutator")
+	areSlicesEqual(t, truth, receiver2, "Improper linspace from returned slice")
 	receiver1 = make([]float64, 6)
 	truth = []float64{0, 0.2, 0.4, 0.6, 0.8, 1.0}
 	Span(receiver1, 0, 1)
-	AreSlicesEqual(t, truth, receiver1, "Improper linspace")
+	areSlicesEqual(t, truth, receiver1, "Improper linspace")
 	if !Panics(func() { Span(nil, 1, 5) }) {
 		t.Errorf("Span accepts nil argument")
 	}
@@ -1375,7 +1375,7 @@ func TestSpan(t *testing.T) {
 		},
 	} {
 		got := Span(make([]float64, test.n), test.l, test.u)
-		AreSlicesSame(t, test.want, got,
+		areSlicesSame(t, test.want, got,
 			fmt.Sprintf("Unexpected slice of length %d for %f to %f", test.n, test.l, test.u))
 	}
 }
@@ -1385,7 +1385,7 @@ func TestSub(t *testing.T) {
 	v := []float64{1, 2, 3, 4, 5}
 	truth := []float64{2, 2, -2, 3, 0}
 	Sub(s, v)
-	AreSlicesEqual(t, truth, s, "Bad subtract")
+	areSlicesEqual(t, truth, s, "Bad subtract")
 	// Test that it panics
 	if !Panics(func() { Sub(make([]float64, 2), make([]float64, 3)) }) {
 		t.Errorf("Did not panic with length mismatch")
@@ -1398,8 +1398,8 @@ func TestSubTo(t *testing.T) {
 	truth := []float64{2, 2, -2, 3, 0}
 	dst1 := make([]float64, len(s))
 	dst2 := SubTo(dst1, s, v)
-	AreSlicesEqual(t, truth, dst1, "Bad subtract from mutator")
-	AreSlicesEqual(t, truth, dst2, "Bad subtract from returned slice")
+	areSlicesEqual(t, truth, dst1, "Bad subtract from mutator")
+	areSlicesEqual(t, truth, dst2, "Bad subtract from returned slice")
 	// Test that all mismatch combinations panic
 	if !Panics(func() { SubTo(make([]float64, 2), make([]float64, 3), make([]float64, 3)) }) {
 		t.Errorf("Did not panic with dst different length")

--- a/floats/floats_test.go
+++ b/floats/floats_test.go
@@ -727,6 +727,18 @@ func TestMaxAndIdx(t *testing.T) {
 			wantVal: math.NaN(),
 			desc:    "when only NaN elements exist",
 		},
+		{
+			in:      []float64{math.NaN(), math.Inf(-1)},
+			wantIdx: 1,
+			wantVal: math.Inf(-1),
+			desc:    "leading NaN followed by -Inf",
+		},
+		{
+			in:      []float64{math.NaN(), math.Inf(1)},
+			wantIdx: 1,
+			wantVal: math.Inf(1),
+			desc:    "leading NaN followed by +Inf",
+		},
 	} {
 		ind := MaxIdx(test.in)
 		if ind != test.wantIdx {
@@ -763,6 +775,18 @@ func TestMinAndIdx(t *testing.T) {
 			wantIdx: 0,
 			wantVal: math.NaN(),
 			desc:    "when only NaN elements exist",
+		},
+		{
+			in:      []float64{math.NaN(), math.Inf(-1)},
+			wantIdx: 1,
+			wantVal: math.Inf(-1),
+			desc:    "leading NaN followed by -Inf",
+		},
+		{
+			in:      []float64{math.NaN(), math.Inf(1)},
+			wantIdx: 1,
+			wantVal: math.Inf(1),
+			desc:    "leading NaN followed by +Inf",
 		},
 	} {
 		ind := MinIdx(test.in)
@@ -972,6 +996,12 @@ func TestNearestIdx(t *testing.T) {
 			query: 1,
 			want:  0,
 			desc:  "Wrong index returned when query is a number and only NaN elements exist",
+		},
+		{
+			in:    []float64{math.NaN(), math.Inf(-1)},
+			query: 1,
+			want:  1,
+			desc:  "Wrong index returned when query is a number and single NaN preceeds -Inf",
 		},
 	} {
 		ind := NearestIdx(test.in, test.query)
@@ -1372,6 +1402,30 @@ func TestSpan(t *testing.T) {
 		{
 			n: 5, l: math.NaN(), u: math.Inf(1),
 			want: []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.Inf(1)},
+		},
+		{
+			n: 5, l: 42, u: math.Inf(-1),
+			want: []float64{42, math.Inf(-1), math.Inf(-1), math.Inf(-1), math.Inf(-1)},
+		},
+		{
+			n: 5, l: 42, u: math.Inf(1),
+			want: []float64{42, math.Inf(1), math.Inf(1), math.Inf(1), math.Inf(1)},
+		},
+		{
+			n: 5, l: 42, u: math.NaN(),
+			want: []float64{42, math.NaN(), math.NaN(), math.NaN(), math.NaN()},
+		},
+		{
+			n: 5, l: math.Inf(-1), u: 42,
+			want: []float64{math.Inf(-1), math.Inf(-1), math.Inf(-1), math.Inf(-1), 42},
+		},
+		{
+			n: 5, l: math.Inf(1), u: 42,
+			want: []float64{math.Inf(1), math.Inf(1), math.Inf(1), math.Inf(1), 42},
+		},
+		{
+			n: 5, l: math.NaN(), u: 42,
+			want: []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 42},
 		},
 	} {
 		got := Span(make([]float64, test.n), test.l, test.u)


### PR DESCRIPTION
Please take a look.

I have not really touched the documentation, but I think that will probably need work too. Comments welcome for that.

Fixes #413.

/cc @aleh-null

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
