### PR TITLE
lapack/gonum: relax requirement on work length in Dbdsqr

### DIFF
--- a/lapack/gonum/dbdsqr.go
+++ b/lapack/gonum/dbdsqr.go
@@ -43,7 +43,7 @@ import (
 // C is a matrix of size n×ncc whose elements are stored in c. The elements
 // of c are modified to contain Q^T * C on exit. C is not used if ncc == 0.
 //
-// work contains temporary storage and must have length at least 4*n. Dbdsqr
+// work contains temporary storage and must have length at least 4*(n-1). Dbdsqr
 // will panic if there is insufficient working memory.
 //
 // Dbdsqr returns whether the decomposition was successful.
@@ -68,7 +68,7 @@ func (impl Implementation) Dbdsqr(uplo blas.Uplo, n, ncvt, nru, ncc int, d, e, v
 	if len(e) < n-1 {
 		panic(badE)
 	}
-	if len(work) < 4*n {
+	if len(work) < 4*(n-1) {
 		panic(badWork)
 	}
 	var info int

--- a/lapack/testlapack/dbdsqr.go
+++ b/lapack/testlapack/dbdsqr.go
@@ -70,7 +70,7 @@ func DbdsqrTest(t *testing.T, impl Dbdsqrer) {
 				copy(dCopy, d)
 				eCopy := make([]float64, len(e))
 				copy(eCopy, e)
-				work := make([]float64, 4*n)
+				work := make([]float64, 4*(n-1))
 				for i := range work {
 					work[i] = rnd.NormFloat64()
 				}


### PR DESCRIPTION
A small adjustment made in netlib LAPACK in https://github.com/Reference-LAPACK/lapack/pull/234

Please take a look.