### PR TITLE
travis: shard tags over separate builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ go:
  - 1.10.x
  - master
 
+env:
+ - TAGS=""
+ - TAGS="-tags bounds"
+ - TAGS="-tags noasm"
+ - TAGS="-tags appengine"
+
 matrix:
  fast_finish: true
  allow_failures:
@@ -31,10 +37,7 @@ script:
  - ${TRAVIS_BUILD_DIR}/.travis/check-formatting.sh
  - go get -d -t -v ./...
  - go build -v ./...
- - go test -v ./...
- - go test -a -tags bounds -v ./...
- - go test -a -tags noasm -v ./...
- - go test -a -tags appengine -v ./...
+ - go test -a $TAGS -v ./...
  - if [[ $TRAVIS_SECURE_ENV_VARS = "true" ]]; then bash ./.travis/test-coverage.sh; fi
  - ${TRAVIS_BUILD_DIR}/.travis/check-rand.sh
  # This is run last since it alters the tree.

--- a/.travis/test-coverage.sh
+++ b/.travis/test-coverage.sh
@@ -13,7 +13,7 @@ testCover() {
 	# switch to the directory to check
 	pushd $d > /dev/null
 	# create the coverage profile
-	coverageresult=`go test -v -coverprofile=$PROFILE_OUT`
+	coverageresult=`go test -v $TAGS -coverprofile=$PROFILE_OUT`
 	# output the result so we can check the shell output
 	echo ${coverageresult}
 	# append the results to acc.out if coverage didn't fail, else set the retval to 1 (failed)


### PR DESCRIPTION
Travis seems to have been throwing weaker hardware at problems recently, so we have seen many test builds timing out.

This change shards the four different tags we use in testing, and additionally also adds tagged builds to the test coverage. This makes it possible for the tests to complete and has the additional advantage that tagged tests status is easier to see, and tagged coverage is now available.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
