### PR TITLE
Add Go import comments.

### DIFF
--- a/graph/formats/dot/internal/errors/errors.go
+++ b/graph/formats/dot/internal/errors/errors.go
@@ -10,7 +10,7 @@
 // This file is made available under a Creative Commons CC0 1.0
 // Universal Public Domain Dedication.
 
-package errors
+package errors // import "gonum.org/v1/gonum/graph/formats/dot/internal/errors"
 
 import (
 	"bytes"

--- a/graph/formats/dot/internal/lexer/acttab.go
+++ b/graph/formats/dot/internal/lexer/acttab.go
@@ -10,7 +10,7 @@
 // This file is made available under a Creative Commons CC0 1.0
 // Universal Public Domain Dedication.
 
-package lexer
+package lexer // import "gonum.org/v1/gonum/graph/formats/dot/internal/lexer"
 
 import (
 	"fmt"

--- a/graph/formats/dot/internal/parser/productionstable.go
+++ b/graph/formats/dot/internal/parser/productionstable.go
@@ -10,7 +10,7 @@
 // This file is made available under a Creative Commons CC0 1.0
 // Universal Public Domain Dedication.
 
-package parser
+package parser // import "gonum.org/v1/gonum/graph/formats/dot/internal/parser"
 
 import (
 	"gonum.org/v1/gonum/graph/formats/dot/ast"

--- a/graph/formats/dot/internal/token/token.go
+++ b/graph/formats/dot/internal/token/token.go
@@ -10,7 +10,7 @@
 // This file is made available under a Creative Commons CC0 1.0
 // Universal Public Domain Dedication.
 
-package token
+package token // import "gonum.org/v1/gonum/graph/formats/dot/internal/token"
 
 import (
 	"fmt"

--- a/graph/formats/dot/internal/util/litconv.go
+++ b/graph/formats/dot/internal/util/litconv.go
@@ -10,7 +10,7 @@
 // This file is made available under a Creative Commons CC0 1.0
 // Universal Public Domain Dedication.
 
-package util
+package util // import "gonum.org/v1/gonum/graph/formats/dot/internal/util"
 
 import (
 	"fmt"

--- a/graph/internal/uid/uid.go
+++ b/graph/internal/uid/uid.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // Package uid implements unique ID provision for graphs.
-package uid
+package uid // import "gonum.org/v1/gonum/graph/internal/uid"
 
 import "gonum.org/v1/gonum/graph/internal/set"
 

--- a/graph/path/internal/grid.go
+++ b/graph/path/internal/grid.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package internal
+package internal // import "gonum.org/v1/gonum/graph/path/internal"
 
 import (
 	"errors"

--- a/graph/path/internal/testgraphs/shortest.go
+++ b/graph/path/internal/testgraphs/shortest.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package testgraphs
+package testgraphs // import "gonum.org/v1/gonum/graph/path/internal/testgraphs"
 
 import (
 	"fmt"


### PR DESCRIPTION
This pull request was made with an automated tool.

The suggested change adds an import comment to a file in each package
to ensure that the package is always imported using its canonical
import path. With this comment in place, the go tool guarantees
that the package can be imported only from this path.

For more information, see https://golang.org/s/go14customimport,
in particular the "Proposal" section.
