### PR TITLE
lapack/gonum: fix opt work in Dgeqrf for zero-sized matrix

### DIFF
--- a/lapack/gonum/dgeqrf.go
+++ b/lapack/gonum/dgeqrf.go
@@ -27,8 +27,7 @@ func (impl Implementation) Dgeqrf(m, n int, a []float64, lda int, tau, work []fl
 	}
 	// nb is the optimal blocksize, i.e. the number of columns transformed at a time.
 	nb := impl.Ilaenv(1, "DGEQRF", " ", m, n, -1, -1)
-	lworkopt := n * max(nb, 1)
-	lworkopt = max(n, lworkopt)
+	lworkopt := max(1, n*nb)
 	if lwork == -1 {
 		work[0] = float64(lworkopt)
 		return
@@ -42,7 +41,7 @@ func (impl Implementation) Dgeqrf(m, n int, a []float64, lda int, tau, work []fl
 		panic(badTau)
 	}
 	if k == 0 {
-		work[0] = float64(lworkopt)
+		work[0] = 1
 		return
 	}
 	nbmin := 2 // Minimal block size.

--- a/mat/qr_test.go
+++ b/mat/qr_test.go
@@ -17,6 +17,7 @@ func TestQR(t *testing.T) {
 	for _, test := range []struct {
 		m, n int
 	}{
+		{0, 0}, // Check that there is no panic for zero-sized matrix.
 		{5, 5},
 		{10, 5},
 	} {


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
