### PR TITLE
optimize: Change Settings to allow InitialLocation

### DIFF
--- a/optimize/local.go
+++ b/optimize/local.go
@@ -4,7 +4,11 @@
 
 package optimize
 
-import "math"
+import (
+	"math"
+
+	"gonum.org/v1/gonum/floats"
+)
 
 // Local finds a local minimum of a minimization problem using a sequential
 // algorithm. A maximization problem can be transformed into a minimization
@@ -62,6 +66,11 @@ func Local(p Problem, initX []float64, settings *Settings, method Method) (*Resu
 	if settings == nil {
 		settings = DefaultSettings()
 	}
+	// Check that the initial location matches the one in settings.
+	if settings.InitLocation != nil && settings.InitLocation.X != nil &&
+		!floats.Equal(settings.InitLocation.X, initX) {
+		panic("local: initX does not match settings x location")
+	}
 	lg := &localGlobal{
 		Method:   method,
 		InitX:    initX,
@@ -117,6 +126,7 @@ func (l *localGlobal) RunGlobal(operations chan<- GlobalTask, results <-chan Glo
 		l.cleanup(operations, results)
 		return
 	}
+
 	// Check the starting condition.
 	if math.IsInf(task.F, 1) || math.IsNaN(task.F) {
 		l.status = Failure
@@ -193,38 +203,24 @@ func (l *localGlobal) cleanup(operation chan<- GlobalTask, result <-chan GlobalT
 
 func (l *localGlobal) getStartingLocation(operation chan<- GlobalTask, result <-chan GlobalTask, task GlobalTask) Operation {
 	copy(task.X, l.InitX)
-	if l.Settings.UseInitialData {
-		task.F = l.Settings.InitialValue
-		if task.Gradient != nil {
-			g := l.Settings.InitialGradient
-			if g == nil {
-				panic("optimize: initial gradient is nil")
-			}
-			if len(g) != l.dim {
-				panic("optimize: initial gradient size mismatch")
-			}
-			copy(task.Gradient, g)
-		}
-		if task.Hessian != nil {
-			h := l.Settings.InitialHessian
-			if h == nil {
-				panic("optimize: initial Hessian is nil")
-			}
-			if h.Symmetric() != l.dim {
-				panic("optimize: initial Hessian size mismatch")
-			}
-			task.Hessian.CopySym(h)
-		}
+	// Construct the operation by what is missing.
+	needs := l.Method.Needs()
+	initOp := l.Settings.InitOperation
+	op := NoOperation
+	if initOp&FuncEvaluation == 0 {
+		op |= FuncEvaluation
+	}
+	if needs.Gradient && initOp&GradEvaluation == 0 {
+		op |= GradEvaluation
+	}
+	if needs.Hessian && initOp&HessEvaluation == 0 {
+		op |= HessEvaluation
+	}
+
+	if op == NoOperation {
 		return NoOperation
 	}
-	eval := FuncEvaluation
-	if task.Gradient != nil {
-		eval |= GradEvaluation
-	}
-	if task.Hessian != nil {
-		eval |= HessEvaluation
-	}
-	task.Op = eval
+	task.Op = op
 	operation <- task
 	task = <-result
 	return task.Op

--- a/optimize/types.go
+++ b/optimize/types.go
@@ -164,15 +164,20 @@ func (p Problem) satisfies(method Needser) error {
 // settings, convergence information, and Recorder information. In general, users
 // should use DefaultSettings rather than constructing a Settings literal.
 //
-// If UseInitData is true, InitialValue, InitialGradient and InitialHessian
-// specify function information at the initial location.
-//
 // If Recorder is nil, no information will be recorded.
 type Settings struct {
-	UseInitialData  bool          // Use supplied information about the conditions at the initial x.
-	InitialValue    float64       // Function value at the initial x.
-	InitialGradient []float64     // Gradient at the initial x.
-	InitialHessian  *mat.SymDense // Hessian at the initial x.
+	// InitLocation specifies an initial location for the Method, and optionally
+	// additional information about the function at the initial location. If
+	// InitLocation is nil, or InitLocation.X is nil, then a default location of
+	// 0 is used. Properties at the initial location (function value, gradient, etc.)
+	// may also be specified in InitLocation. The InitOperation field must also
+	// be set to specify which fields have been set, for example to FunctionEvaluation
+	// if InitLocation.F is correct, FunctionEvaluation | GradEvaluation if
+	// both InitLocation.F and InitLocation.Gradient are valid, etc.
+	InitLocation *Location
+	// InitOperation specifies the valid locations of the InitLocation field.
+	// See the InitLocation documentation for more information.
+	InitOperation Operation
 
 	// FunctionThreshold is the threshold for acceptably small values of the
 	// objective function. FunctionThreshold status is returned if

--- a/optimize/unconstrained_test.go
+++ b/optimize/unconstrained_test.go
@@ -1230,15 +1230,19 @@ func testLocal(t *testing.T, tests []unconstrainedTest, method Method) {
 
 		// We are going to restart the solution using known initial data, so
 		// evaluate them.
-		settings.UseInitialData = true
-		settings.InitialValue = test.p.Func(test.x)
+		settings.InitLocation = &Location{}
+		settings.InitLocation.X = test.x
+		settings.InitLocation.F = test.p.Func(test.x)
+		settings.InitOperation = FuncEvaluation
 		if method.Needs().Gradient {
-			settings.InitialGradient = resize(settings.InitialGradient, len(test.x))
-			test.p.Grad(settings.InitialGradient, test.x)
+			settings.InitLocation.Gradient = resize(settings.InitLocation.Gradient, len(test.x))
+			test.p.Grad(settings.InitLocation.Gradient, test.x)
+			settings.InitOperation |= GradEvaluation
 		}
 		if method.Needs().Hessian {
-			settings.InitialHessian = mat.NewSymDense(len(test.x), nil)
-			test.p.Hess(settings.InitialHessian, test.x)
+			settings.InitLocation.Hessian = mat.NewSymDense(len(test.x), nil)
+			test.p.Hess(settings.InitLocation.Hessian, test.x)
+			settings.InitOperation |= HessEvaluation
 		}
 
 		// Rerun the test again to make sure that it gets the same answer with


### PR DESCRIPTION
This modifies Settings to allow specifying an initial location and properties of the function (value, gradient, etc.). This allows to work with local optimizers that are seeded with initial settings. This has two fields that must be specified (both Location and Operation). The difficulty is that the default value of the function is 0, so we either must require the user to specify it is set (somehow), or require the user to change the default value away if it is not set. The former seems much safer.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
