### PR TITLE
mathext: fix test

### DIFF
--- a/mathext/digamma_test.go
+++ b/mathext/digamma_test.go
@@ -7,11 +7,15 @@ package mathext
 import (
 	"math"
 	"testing"
+
+	"gonum.org/v1/gonum/floats"
 )
 
 var result float64
 
 func TestDigamma(t *testing.T) {
+	const tol = 1e-10
+
 	for i, test := range []struct {
 		x, want float64
 	}{
@@ -26,10 +30,12 @@ func TestDigamma(t *testing.T) {
 		{.5, -1.96351002602142347944097633299875556719315960466043},
 		{10, 2.251752589066721107647456163885851537211808918028330369448},
 		{math.Pow10(20), 46.05170185988091368035482909368728415202202143924212618733},
-		{-1.111111111e9, 30.497454343508262861},
+		{-1.111111111e9, math.NaN()},
+		{1.46, -0.001580561987083417676105544023567034348339520110000},
 	} {
 
-		if got := Digamma(test.x); math.Abs(got-test.want) > 1e-10 {
+		got := Digamma(test.x)
+		if !(math.IsNaN(got) && math.IsNaN(test.want)) && !floats.EqualWithinAbsOrRel(got, test.want, tol, tol) {
 			t.Errorf("test %d Digamma(%g) failed: got %g want %g", i, test.x, got, test.want)
 		}
 	}


### PR DESCRIPTION
This makes the tests abs or rel, and fixes an expectation that does not match wolfram-alpha, -1.1111...e9 should give cmplx.Inf(), which math.NaN() is close enough to. I don't know why the 30.49... was there in the tests, but it was only passing because got was NaN.

Please take a look.

Closes #306.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
