### PR TITLE
stat: refactor Quantile to prepare for more CumulantKinds

### DIFF
--- a/stat/stat.go
+++ b/stat/stat.go
@@ -14,10 +14,10 @@ import (
 // CumulantKind specifies the behavior for calculating the empirical CDF or Quantile
 type CumulantKind int
 
+// List of supported CumulantKind values for the Quantile function.
+// Constant values should match the R nomenclature. See
+// https://en.wikipedia.org/wiki/Quantile#Estimating_the_quantiles_of_a_population
 const (
-	// Constant values should match the R nomenclature. See
-	// https://en.wikipedia.org/wiki/Quantile#Estimating_the_quantiles_of_a_population
-
 	// Empirical treats the distribution as the actual empirical distribution.
 	Empirical CumulantKind = 1
 )
@@ -1041,22 +1041,26 @@ func Quantile(p float64, c CumulantKind, x, weights []float64) float64 {
 	}
 	switch c {
 	case Empirical:
-		var cumsum float64
-		fidx := p * sumWeights
-		for i := range x {
-			if weights == nil {
-				cumsum++
-			} else {
-				cumsum += weights[i]
-			}
-			if cumsum >= fidx {
-				return x[i]
-			}
-		}
-		panic("impossible")
+		return empiricalQuantile(p, x, weights, sumWeights)
 	default:
 		panic("stat: bad cumulant kind")
 	}
+}
+
+func empiricalQuantile(p float64, x, weights []float64, sumWeights float64) float64 {
+	var cumsum float64
+	fidx := p * sumWeights
+	for i := range x {
+		if weights == nil {
+			cumsum++
+		} else {
+			cumsum += weights[i]
+		}
+		if cumsum >= fidx {
+			return x[i]
+		}
+	}
+	panic("impossible")
 }
 
 // Skew computes the skewness of the sample data.

--- a/stat/stat_test.go
+++ b/stat/stat_test.go
@@ -1702,5 +1702,4 @@ func TestStdScore(t *testing.T) {
 			t.Errorf("StdScore mismatch case %d. Expected %v, Found %v", i, test.z, z)
 		}
 	}
-
 }


### PR DESCRIPTION
This CL exposes some hidden documentation about stat.CumulantKinds and
refactors the current empirical Quantile into its own function.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
