### PR TITLE
encoding/dot: run gofmt

### DIFF
--- a/graph/encoding/dot/decode.go
+++ b/graph/encoding/dot/decode.go
@@ -32,7 +32,7 @@ type PortSetter interface {
 	// SetFromPort sets the From port and
 	// compass direction of the receiver.
 	SetFromPort(port, compass string) error
-	
+
 	// SetToPort sets the To port and compass
 	// direction of the receiver.
 	SetToPort(port, compass string) error


### PR DESCRIPTION
The git PR rendering of this completely fails the utility test; you must select the blankness in order to be able to see that there is a tab present.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
