### PR TITLE
Add edge-weighted PageRank algorithms

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,6 +61,7 @@ source{d} <hello@sourced.tech>
 Shawn Smith <shawnpsmith@gmail.com>
 Spencer Lyon <spencerlyon2@gmail.com>
 Steve McCoy <mccoyst@gmail.com>
+Takeshi Yoneda <cz.rk.t0415y.g@gmail.com>
 The University of Adelaide
 The University of Minnesota
 The University of Washington

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -67,6 +67,7 @@ Sebastien Binet <seb.binet@gmail.com>
 Shawn Smith <shawnpsmith@gmail.com>
 Spencer Lyon <spencerlyon2@gmail.com>
 Steve McCoy <mccoyst@gmail.com>
+Takeshi Yoneda <cz.rk.t0415y.g@gmail.com>
 Tobin Harding <me@tobin.cc>
 Vladimír Chalupecký <vladimir.chalupecky@gmail.com>
 Yevgeniy Vahlis <evahlis@gmail.com>

--- a/graph/network/page.go
+++ b/graph/network/page.go
@@ -14,12 +14,36 @@ import (
 	"gonum.org/v1/gonum/mat"
 )
 
-// EdgeWeightedPageRank returns the PageRank weights for nodes of the weighted directed graph g
+// PageRank returns the PageRank weights for nodes of the directed graph g
 // using the given damping factor and terminating when the 2-norm of the
 // vector difference between iterations is below tol. The returned map is
 // keyed on the graph node IDs.
-func EdgeWeightedPageRank(g graph.WeightedDirected, damp, tol float64) map[int64]float64 {
-	// EdgeWeightedPageRank is implemented according to "How Google Finds Your Needle
+// If g is a graph.WeightedDirected, an edge-weighted PageRank is calculated.
+func PageRank(g graph.Directed, damp, tol float64) map[int64]float64 {
+	if g, ok := g.(graph.WeightedDirected); ok {
+		return edgeWeightedPageRank(g, damp, tol)
+	}
+	return pageRank(g, damp, tol)
+}
+
+// PageRankSparse returns the PageRank weights for nodes of the sparse directed
+// graph g using the given damping factor and terminating when the 2-norm of the
+// vector difference between iterations is below tol. The returned map is
+// keyed on the graph node IDs.
+// If g is a graph.WeightedDirected, an edge-weighted PageRank is calculated.
+func PageRankSparse(g graph.Directed, damp, tol float64) map[int64]float64 {
+	if g, ok := g.(graph.WeightedDirected); ok {
+		return edgeWeightedPageRankSparse(g, damp, tol)
+	}
+	return pageRankSparse(g, damp, tol)
+}
+
+// edgeWeightedPageRank returns the PageRank weights for nodes of the weighted directed graph g
+// using the given damping factor and terminating when the 2-norm of the
+// vector difference between iterations is below tol. The returned map is
+// keyed on the graph node IDs.
+func edgeWeightedPageRank(g graph.WeightedDirected, damp, tol float64) map[int64]float64 {
+	// edgeWeightedPageRank is implemented according to "How Google Finds Your Needle
 	// in the Web's Haystack" with the modification that
 	// the columns of hyperlink matrix H are calculated with edge weights.
 	//
@@ -101,7 +125,7 @@ func EdgeWeightedPageRank(g graph.WeightedDirected, damp, tol float64) map[int64
 // graph g using the given damping factor and terminating when the 2-norm of the
 // vector difference between iterations is below tol. The returned map is
 // keyed on the graph node IDs.
-func EdgeWeightedPageRankSparse(g graph.WeightedDirected, damp, tol float64) map[int64]float64 {
+func edgeWeightedPageRankSparse(g graph.WeightedDirected, damp, tol float64) map[int64]float64 {
 	// edgeWeightedPageRankSparse is implemented according to "How Google Finds Your Needle
 	// in the Web's Haystack" with the modification that
 	// the columns of hyperlink matrix H are calculated with edge weights.
@@ -179,12 +203,12 @@ func EdgeWeightedPageRankSparse(g graph.WeightedDirected, damp, tol float64) map
 	return ranks
 }
 
-// PageRank returns the PageRank weights for nodes of the directed graph g
+// pageRank returns the PageRank weights for nodes of the directed graph g
 // using the given damping factor and terminating when the 2-norm of the
 // vector difference between iterations is below tol. The returned map is
 // keyed on the graph node IDs.
-func PageRank(g graph.Directed, damp, tol float64) map[int64]float64 {
-	// PageRank is implemented according to "How Google Finds Your Needle
+func pageRank(g graph.Directed, damp, tol float64) map[int64]float64 {
+	// pageRank is implemented according to "How Google Finds Your Needle
 	// in the Web's Haystack".
 	//
 	// G.I^k = alpha.S.I^k + (1-alpha).1/n.1.I^k
@@ -252,12 +276,12 @@ func PageRank(g graph.Directed, damp, tol float64) map[int64]float64 {
 	return ranks
 }
 
-// PageRankSparse returns the PageRank weights for nodes of the sparse directed
+// pageRankSparse returns the PageRank weights for nodes of the sparse directed
 // graph g using the given damping factor and terminating when the 2-norm of the
 // vector difference between iterations is below tol. The returned map is
 // keyed on the graph node IDs.
-func PageRankSparse(g graph.Directed, damp, tol float64) map[int64]float64 {
-	// PageRankSparse is implemented according to "How Google Finds Your Needle
+func pageRankSparse(g graph.Directed, damp, tol float64) map[int64]float64 {
+	// pageRankSparse is implemented according to "How Google Finds Your Needle
 	// in the Web's Haystack".
 	//
 	// G.I^k = alpha.H.I^k + alpha.A.I^k + (1-alpha).1/n.1.I^k

--- a/graph/network/page.go
+++ b/graph/network/page.go
@@ -37,7 +37,7 @@ func EdgeWeightedPageRank(g graph.WeightedDirected, damp, tol float64) map[int64
 	dangling := damp / float64(len(nodes))
 	for j, u := range nodes {
 		to := g.From(u.ID())
-		z := float64(0)
+		var z float64
 		for _, v := range to {
 			if w, ok := g.Weight(u.ID(), v.ID()); ok {
 				z += w
@@ -101,7 +101,7 @@ func EdgeWeightedPageRank(g graph.WeightedDirected, damp, tol float64) map[int64
 // graph g using the given damping factor and terminating when the 2-norm of the
 // vector difference between iterations is below tol. The returned map is
 // keyed on the graph node IDs.
-func edgeWeightedPageRankSparse(g graph.WeightedDirected, damp, tol float64) map[int64]float64 {
+func EdgeWeightedPageRankSparse(g graph.WeightedDirected, damp, tol float64) map[int64]float64 {
 	// edgeWeightedPageRankSparse is implemented according to "How Google Finds Your Needle
 	// in the Web's Haystack" with the modification that
 	// the columns of hyperlink matrix H are calculated with edge weights.
@@ -121,7 +121,7 @@ func edgeWeightedPageRankSparse(g graph.WeightedDirected, damp, tol float64) map
 	df := damp / float64(len(nodes))
 	for j, u := range nodes {
 		to := g.From(u.ID())
-		z := float64(0)
+		var z float64
 		for _, v := range to {
 			if w, ok := g.Weight(u.ID(), v.ID()); ok {
 				z += w

--- a/graph/network/page.go
+++ b/graph/network/page.go
@@ -14,6 +14,87 @@ import (
 	"gonum.org/v1/gonum/mat"
 )
 
+// EdgeWeightedPageRank returns the PageRank weights for nodes of the directed graph g
+// using the given damping factor and terminating when the 2-norm of the
+// vector difference between iterations is below tol. The returned map is
+// keyed on the graph node IDs.
+func EdgeWeightedPageRank(g graph.WeightedDirected, damp, tol float64) map[int64]float64 {
+	// EdgeWeightedPageRank is implemented according to "PageRank beyond the Web"
+	//
+	// we solve the equation (2.1) in [1] by the power iteration method
+	//
+	// ref: [1] https://arxiv.org/abs/1407.5107
+
+	nodes := g.Nodes()
+	indexOf := make(map[int64]int, len(nodes))
+	for i, n := range nodes {
+		indexOf[n.ID()] = i
+	}
+
+	m := mat.NewDense(len(nodes), len(nodes), nil)
+	for j, u := range nodes {
+		to := g.From(u.ID())
+		z := float64(0)
+		for _, v := range to {
+			if w, ok := g.Weight(u.ID(), v.ID()); ok {
+				z += w
+			}
+		}
+		if z != 0 {
+			for _, v := range to {
+				if w, ok := g.Weight(u.ID(), v.ID()); ok {
+					m.Set(indexOf[v.ID()], j, (w*damp)/z)
+				}
+			}
+		} else {
+			dangling := damp / float64(len(nodes))
+			for i := range nodes {
+				m.Set(i, j, dangling)
+			}
+		}
+	}
+
+	matrix := m.RawMatrix().Data
+	dt := (1 - damp) / float64(len(nodes))
+	for i := range matrix {
+		matrix[i] += dt
+	}
+
+	last := make([]float64, len(nodes))
+	for i := range last {
+		last[i] = 1
+	}
+	lastV := mat.NewVecDense(len(nodes), last)
+
+	vec := make([]float64, len(nodes))
+	var sum float64
+	for i := range vec {
+		r := rand.NormFloat64()
+		sum += r
+		vec[i] = r
+	}
+	f := 1 / sum
+	for i := range vec {
+		vec[i] *= f
+	}
+	v := mat.NewVecDense(len(nodes), vec)
+
+	for {
+		lastV, v = v, lastV
+		v.MulVec(m, lastV)
+		if normDiff(vec, last) < tol {
+			break
+		}
+	}
+
+	ranks := make(map[int64]float64, len(nodes))
+	for i, r := range v.RawVector().Data {
+		ranks[nodes[i].ID()] = r
+	}
+
+	return ranks
+}
+
 // PageRank returns the PageRank weights for nodes of the directed graph g
 // using the given damping factor and terminating when the 2-norm of the
 // vector difference between iterations is below tol. The returned map is

--- a/graph/network/page_test.go
+++ b/graph/network/page_test.go
@@ -232,7 +232,7 @@ func TestEdgeWeightedPageRankSparse(t *testing.T) {
 				}
 			}
 		}
-		got := edgeWeightedPageRankSparse(g, test.damp, test.tol)
+		got := EdgeWeightedPageRankSparse(g, test.damp, test.tol)
 		prec := 1 - int(math.Log10(test.wantTol))
 		for n := range test.g {
 			if !floats.EqualWithinAbsOrRel(got[int64(n)], test.want[int64(n)], test.wantTol, test.wantTol) {

--- a/graph/network/page_test.go
+++ b/graph/network/page_test.go
@@ -138,12 +138,13 @@ var edgeWeightedPageRankTests = []struct {
 	want    map[int64]float64
 }{
 	{
-		// This test case is created according to the result on python 3.6.4 (using networkx of version 2.1)
+		// This test case is created according to the result with the following python code
+		// on python 3.6.4 (using "networkx" of version 2.1)
 		//
 		// >>> import networkx as nx
 		// >>> D = nx.DiGraph()
 		// >>> D.add_weighted_edges_from([('A', 'B', 0.3), ('A','C', 1.2), ('B', 'A', 0.4), ('C', 'B', 0.3), ('D', 'A', 0.3), ('D', 'B', 2.1)])
-		// >>> nx.pagerank(D, alpha=0.85, tol=1e-08)
+		// >>> nx.pagerank(D, alpha=0.85, tol=1e-10)
 		// {'A': 0.3409109390701202, 'B': 0.3522682754411842, 'C': 0.2693207854886954, 'D': 0.037500000000000006}
 
 		g: []set{
@@ -169,13 +170,13 @@ var edgeWeightedPageRankTests = []struct {
 			},
 		},
 		damp: 0.85,
-		tol:  1e-8,
+		tol:  1e-10,
 
 		wantTol: 1e-8,
 		want: map[int64]float64{
-			A: 0.3409120105795613,
-			B: 0.3522678093371774,
-			C: 0.2693201800832611,
+			A: 0.3409120160955594,
+			B: 0.3522678129306601,
+			C: 0.2693201709737804,
 			D: 0.037500000000000006,
 		},
 	},
@@ -201,6 +202,37 @@ func TestEdgeWeightedPageRank(t *testing.T) {
 			}
 		}
 		got := EdgeWeightedPageRank(g, test.damp, test.tol)
+		prec := 1 - int(math.Log10(test.wantTol))
+		for n := range test.g {
+			if !floats.EqualWithinAbsOrRel(got[int64(n)], test.want[int64(n)], test.wantTol, test.wantTol) {
+				t.Errorf("unexpected PageRank result for test %d:\ngot: %v\nwant:%v",
+					i, orderedFloats(got, prec), orderedFloats(test.want, prec))
+				break
+			}
+		}
+	}
+}
+
+func TestEdgeWeightedPageRankSparse(t *testing.T) {
+	for i, test := range edgeWeightedPageRankTests {
+		g := simple.NewWeightedDirectedGraph(test.self, test.absent)
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if !g.Has(int64(u)) {
+				g.AddNode(simple.Node(u))
+			}
+			ws, ok := test.edges[u]
+			if !ok {
+				t.Errorf("edges not found for %v", u)
+			}
+
+			for v := range e {
+				if w, ok := ws[v]; ok {
+					g.SetWeightedEdge(g.NewWeightedEdge(simple.Node(u), simple.Node(v), w))
+				}
+			}
+		}
+		got := edgeWeightedPageRankSparse(g, test.damp, test.tol)
 		prec := 1 - int(math.Log10(test.wantTol))
 		for n := range test.g {
 			if !floats.EqualWithinAbsOrRel(got[int64(n)], test.want[int64(n)], test.wantTol, test.wantTol) {

--- a/graph/network/page_test.go
+++ b/graph/network/page_test.go
@@ -91,7 +91,7 @@ func TestPageRank(t *testing.T) {
 				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 			}
 		}
-		got := PageRank(g, test.damp, test.tol)
+		got := pageRank(g, test.damp, test.tol)
 		prec := 1 - int(math.Log10(test.wantTol))
 		for n := range test.g {
 			if !floats.EqualWithinAbsOrRel(got[int64(n)], test.want[int64(n)], test.wantTol, test.wantTol) {
@@ -115,7 +115,7 @@ func TestPageRankSparse(t *testing.T) {
 				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
 			}
 		}
-		got := PageRankSparse(g, test.damp, test.tol)
+		got := pageRankSparse(g, test.damp, test.tol)
 		prec := 1 - int(math.Log10(test.wantTol))
 		for n := range test.g {
 			if !floats.EqualWithinAbsOrRel(got[int64(n)], test.want[int64(n)], test.wantTol, test.wantTol) {
@@ -201,7 +201,7 @@ func TestEdgeWeightedPageRank(t *testing.T) {
 				}
 			}
 		}
-		got := EdgeWeightedPageRank(g, test.damp, test.tol)
+		got := edgeWeightedPageRank(g, test.damp, test.tol)
 		prec := 1 - int(math.Log10(test.wantTol))
 		for n := range test.g {
 			if !floats.EqualWithinAbsOrRel(got[int64(n)], test.want[int64(n)], test.wantTol, test.wantTol) {
@@ -232,7 +232,7 @@ func TestEdgeWeightedPageRankSparse(t *testing.T) {
 				}
 			}
 		}
-		got := EdgeWeightedPageRankSparse(g, test.damp, test.tol)
+		got := edgeWeightedPageRankSparse(g, test.damp, test.tol)
 		prec := 1 - int(math.Log10(test.wantTol))
 		for n := range test.g {
 			if !floats.EqualWithinAbsOrRel(got[int64(n)], test.want[int64(n)], test.wantTol, test.wantTol) {


### PR DESCRIPTION
I implemented edge-weighted PageRank algorithms in `graph/network` package.

Although there seems to be no related issue, i hope this PR resolve [one of TODOs](https://github.com/gonum/gonum/blob/master/graph/network/network.go#L6).