### PR TITLE
all: conform build tag comment to convention

### DIFF
--- a/graph/internal/set/same.go
+++ b/graph/internal/set/same.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !appengine
+// +build !appengine
 
 package set
 

--- a/graph/internal/set/same_appengine.go
+++ b/graph/internal/set/same_appengine.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build appengine
+// +build appengine
 
 package set
 

--- a/graph/topo/non_tomita_choice.go
+++ b/graph/topo/non_tomita_choice.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !tomita
+// +build !tomita
 
 package topo
 

--- a/graph/topo/tomita_choice.go
+++ b/graph/topo/tomita_choice.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build tomita
+// +build tomita
 
 package topo
 

--- a/internal/asm/c128/stubs_amd64.go
+++ b/internal/asm/c128/stubs_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+// +build !noasm,!appengine
 
 package c128
 

--- a/internal/asm/c128/stubs_noasm.go
+++ b/internal/asm/c128/stubs_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !amd64 noasm appengine
+// +build !amd64 noasm appengine
 
 package c128
 

--- a/internal/asm/c64/stubs_amd64.go
+++ b/internal/asm/c64/stubs_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+// +build !noasm,!appengine
 
 package c64
 

--- a/internal/asm/c64/stubs_noasm.go
+++ b/internal/asm/c64/stubs_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !amd64 noasm appengine
+// +build !amd64 noasm appengine
 
 package c64
 

--- a/internal/asm/f32/ge_amd64.go
+++ b/internal/asm/f32/ge_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+// +build !noasm,!appengine
 
 package f32
 

--- a/internal/asm/f32/ge_noasm.go
+++ b/internal/asm/f32/ge_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !amd64 noasm appengine
+// +build !amd64 noasm appengine
 
 package f32
 

--- a/internal/asm/f32/stubs_amd64.go
+++ b/internal/asm/f32/stubs_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+// +build !noasm,!appengine
 
 package f32
 

--- a/internal/asm/f32/stubs_noasm.go
+++ b/internal/asm/f32/stubs_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !amd64 noasm appengine
+// +build !amd64 noasm appengine
 
 package f32
 

--- a/internal/asm/f64/axpy.go
+++ b/internal/asm/f64/axpy.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !amd64 noasm appengine
+// +build !amd64 noasm appengine
 
 package f64
 

--- a/internal/asm/f64/dot.go
+++ b/internal/asm/f64/dot.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !amd64 noasm appengine
+// +build !amd64 noasm appengine
 
 package f64
 

--- a/internal/asm/f64/ge_amd64.go
+++ b/internal/asm/f64/ge_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+// +build !noasm,!appengine
 
 package f64
 

--- a/internal/asm/f64/ge_noasm.go
+++ b/internal/asm/f64/ge_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !amd64 noasm appengine
+// +build !amd64 noasm appengine
 
 package f64
 

--- a/internal/asm/f64/scal.go
+++ b/internal/asm/f64/scal.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !amd64 noasm appengine
+// +build !amd64 noasm appengine
 
 package f64
 

--- a/internal/asm/f64/stubs_amd64.go
+++ b/internal/asm/f64/stubs_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+// +build !noasm,!appengine
 
 package f64
 

--- a/internal/asm/f64/stubs_noasm.go
+++ b/internal/asm/f64/stubs_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !amd64 noasm appengine
+// +build !amd64 noasm appengine
 
 package f64
 

--- a/internal/math32/sqrt.go
+++ b/internal/math32/sqrt.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !amd64 noasm appengine
+// +build !amd64 noasm appengine
 
 package math32
 

--- a/internal/math32/sqrt_amd64.go
+++ b/internal/math32/sqrt_amd64.go
@@ -6,7 +6,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+// +build !noasm,!appengine
 
 package math32
 

--- a/mat/cblas_test.go
+++ b/mat/cblas_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build cblas
+// +build cblas
 
 package mat
 

--- a/mat/index_bound_checks.go
+++ b/mat/index_bound_checks.go
@@ -4,7 +4,7 @@
 
 // This file must be kept in sync with index_no_bound_checks.go.
 
-//+build bounds
+// +build bounds
 
 package mat
 

--- a/mat/index_no_bound_checks.go
+++ b/mat/index_no_bound_checks.go
@@ -4,7 +4,7 @@
 
 // This file must be kept in sync with index_bound_checks.go.
 
-//+build !bounds
+// +build !bounds
 
 package mat
 

--- a/mat/offset.go
+++ b/mat/offset.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !appengine
+// +build !appengine
 
 package mat
 

--- a/mat/offset_appengine.go
+++ b/mat/offset_appengine.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build appengine
+// +build appengine
 
 package mat
 


### PR DESCRIPTION
I've resisted this for a long time, but it seems that the convention in the Go tree is to have a space between the comment token and the `+build` (I think this is odd given that the `//go:` directives are abutted, but the data are there:
```
~/go [(go1.10.3)*]$ grep -Rl '// +build' | wc -l
936
~/go [(go1.10.3)*]$ grep -Rl '//+build' | wc -l
4
```

This change conforms all the build tag comments to this convention.

Done by `sed -i -e 's|//+build|// +build|' $(grep -l '//+build' -R|grep \.go$)`.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
