### PR TITLE
lapack/gonum, mat: add Dpotrs and use it in Cholesky

### DIFF
--- a/lapack/gonum/dpotrs.go
+++ b/lapack/gonum/dpotrs.go
@@ -1,0 +1,46 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+import (
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/blas64"
+)
+
+// Dpotrs solves a system of n linear equations A*X = B where A is an n×n
+// symmetric positive definite matrix and B is an n×nrhs matrix. The matrix A is
+// represented by its Cholesky factorization
+//  A = U^T*U  if uplo == blas.Upper
+//  A = L*L^T  if uplo == blas.Lower
+// as computed by Dpotrf. On entry, B contains the right-hand side matrix B, on
+// return it contains the solution matrix X.
+func (Implementation) Dpotrs(uplo blas.Uplo, n, nrhs int, a []float64, lda int, b []float64, ldb int) {
+	if uplo != blas.Upper && uplo != blas.Lower {
+		panic(badUplo)
+	}
+	checkMatrix(n, n, a, lda)
+	checkMatrix(n, nrhs, b, ldb)
+
+	if n == 0 || nrhs == 0 {
+		return
+	}
+
+	bi := blas64.Implementation()
+	if uplo == blas.Upper {
+		// Solve U^T * U * X = B where U is stored in the upper triangle of A.
+
+		// Solve U^T * X = B, overwriting B with X.
+		bi.Dtrsm(blas.Left, blas.Upper, blas.Trans, blas.NonUnit, n, nrhs, 1, a, lda, b, ldb)
+		// Solve U * X = B, overwriting B with X.
+		bi.Dtrsm(blas.Left, blas.Upper, blas.NoTrans, blas.NonUnit, n, nrhs, 1, a, lda, b, ldb)
+	} else {
+		// Solve L * L^T * X = B where L is stored in the lower triangle of A.
+
+		// Solve L * X = B, overwriting B with X.
+		bi.Dtrsm(blas.Left, blas.Lower, blas.NoTrans, blas.NonUnit, n, nrhs, 1, a, lda, b, ldb)
+		// Solve L^T * X = B, overwriting B with X.
+		bi.Dtrsm(blas.Left, blas.Lower, blas.Trans, blas.NonUnit, n, nrhs, 1, a, lda, b, ldb)
+	}
+}

--- a/lapack/gonum/lapack_test.go
+++ b/lapack/gonum/lapack_test.go
@@ -376,6 +376,10 @@ func TestDpotrf(t *testing.T) {
 	testlapack.DpotrfTest(t, impl)
 }
 
+func TestDpotrs(t *testing.T) {
+	testlapack.DpotrsTest(t, impl)
+}
+
 func TestDrscl(t *testing.T) {
 	testlapack.DrsclTest(t, impl)
 }

--- a/lapack/lapack.go
+++ b/lapack/lapack.go
@@ -35,6 +35,7 @@ type Float64 interface {
 	Dormlq(side blas.Side, trans blas.Transpose, m, n, k int, a []float64, lda int, tau, c []float64, ldc int, work []float64, lwork int)
 	Dpocon(uplo blas.Uplo, n int, a []float64, lda int, anorm float64, work []float64, iwork []int) float64
 	Dpotrf(ul blas.Uplo, n int, a []float64, lda int) (ok bool)
+	Dpotrs(ul blas.Uplo, n, nrhs int, a []float64, lda int, b []float64, ldb int)
 	Dsyev(jobz EVJob, uplo blas.Uplo, n int, a []float64, lda int, w, work []float64, lwork int) (ok bool)
 	Dtrcon(norm MatrixNorm, uplo blas.Uplo, diag blas.Diag, n int, a []float64, lda int, work []float64, iwork []int) float64
 	Dtrtri(uplo blas.Uplo, diag blas.Diag, n int, a []float64, lda int) (ok bool)

--- a/lapack/lapack64/lapack64.go
+++ b/lapack/lapack64/lapack64.go
@@ -37,6 +37,15 @@ func Potrf(a blas64.Symmetric) (t blas64.Triangular, ok bool) {
 	return
 }
 
+// Potrs solves a system of n linear equations A*X = B where A is an n×n
+// symmetric positive definite matrix and B is an n×nrhs matrix, using the
+// Cholesky factorization A = U^T*U or A = L*L^T. t contains the corresponding
+// triangular factor as returned by Potrf. On entry, B contains the right-hand
+// side matrix B, on return it contains the solution matrix X.
+func Potrs(t blas64.Triangular, b blas64.General) {
+	lapack64.Dpotrs(t.Uplo, t.N, b.Cols, t.Data, t.Stride, b.Data, b.Stride)
+}
+
 // Gecon estimates the reciprocal of the condition number of the n×n matrix A
 // given the LU decomposition of the matrix. The condition number computed may
 // be based on the 1-norm or the ∞-norm.

--- a/lapack/testlapack/dpotrs.go
+++ b/lapack/testlapack/dpotrs.go
@@ -1,0 +1,93 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/exp/rand"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/blas64"
+)
+
+type Dpotrser interface {
+	Dpotrs(uplo blas.Uplo, n, nrhs int, a []float64, lda int, b []float64, ldb int)
+
+	Dpotrf(uplo blas.Uplo, n int, a []float64, lda int) bool
+}
+
+func DpotrsTest(t *testing.T, impl Dpotrser) {
+	const tol = 1e-14
+
+	rnd := rand.New(rand.NewSource(1))
+	bi := blas64.Implementation()
+
+	for _, uplo := range []blas.Uplo{blas.Upper, blas.Lower} {
+		for _, n := range []int{1, 2, 5} {
+			for _, nrhs := range []int{1, 2, 5, 10} {
+				for _, ld := range []struct{ a, b int }{
+					{n, nrhs},
+					{n + 7, nrhs},
+					{n, nrhs + 3},
+					{n + 7, nrhs + 3},
+				} {
+					// Construct a random SPD matrix A by first making a symmetric matrix
+					// and then ensuring that it is diagonally dominant.
+					a := nanGeneral(n, n, ld.a)
+					for i := 0; i < n; i++ {
+						for j := i; j < n; j++ {
+							v := rnd.Float64()
+							a.Data[i*a.Stride+j] = v
+							a.Data[j*a.Stride+i] = v
+						}
+					}
+					for i := 0; i < n; i++ {
+						a.Data[i*a.Stride+i] += float64(n)
+					}
+
+					// Generate a random solution X.
+					want := nanGeneral(n, nrhs, ld.b)
+					for i := 0; i < n; i++ {
+						for j := 0; j < nrhs; j++ {
+							want.Data[i*want.Stride+j] = rnd.NormFloat64()
+						}
+					}
+
+					// Compute the right-hand side matrix as A * X.
+					b := nanGeneral(n, nrhs, ld.b)
+					bi.Dgemm(blas.NoTrans, blas.NoTrans, n, nrhs, n, 1, a.Data, a.Stride, want.Data, want.Stride, 0, b.Data, b.Stride)
+
+					// Compute the Cholesky decomposition of A.
+					ok := impl.Dpotrf(uplo, n, a.Data, a.Stride)
+					if !ok {
+						panic("bad test")
+					}
+
+					aCopy := cloneGeneral(a)
+
+					// Solve A * X = B.
+					impl.Dpotrs(uplo, n, nrhs, a.Data, a.Stride, b.Data, b.Stride)
+
+					name := fmt.Sprintf("uplo=%v,n=%v,nrhs=%v,lda=%v,ldb=%v", uplo, n, nrhs, a.Stride, b.Stride)
+
+					if !generalOutsideAllNaN(a) {
+						t.Errorf("%v: out-of-range modification of A", name)
+					}
+					if !equalApproxGeneral(a, aCopy, 0) {
+						t.Errorf("%v: unexpected modification of A", name)
+					}
+					if !generalOutsideAllNaN(b) {
+						t.Errorf("%v: out-of-range modification of B", name)
+					}
+					if !equalApproxGeneral(b, want, tol) {
+						t.Errorf("%v: unexpected result\ngot  %v\nwant %v", name, b, want)
+					}
+				}
+			}
+		}
+	}
+}

--- a/mat/cholesky.go
+++ b/mat/cholesky.go
@@ -175,8 +175,7 @@ func (c *Cholesky) Solve(x *Dense, b Matrix) error {
 	if b != x {
 		x.Copy(b)
 	}
-	blas64.Trsm(blas.Left, blas.Trans, 1, c.chol.mat, x.mat)
-	blas64.Trsm(blas.Left, blas.NoTrans, 1, c.chol.mat, x.mat)
+	lapack64.Potrs(c.chol.mat, x.mat)
 	if c.cond > ConditionTolerance {
 		return Condition(c.cond)
 	}
@@ -228,8 +227,7 @@ func (c *Cholesky) SolveVec(x *VecDense, b Vector) error {
 		if x != b {
 			x.CopyVec(b)
 		}
-		blas64.Trsv(blas.Trans, c.chol.mat, x.mat)
-		blas64.Trsv(blas.NoTrans, c.chol.mat, x.mat)
+		lapack64.Potrs(c.chol.mat, x.asGeneral())
 		if c.cond > ConditionTolerance {
 			return Condition(c.cond)
 		}


### PR DESCRIPTION
Not really a necessary addition but I felt like adding something new to our lapack implementation and this looked easy enough to do within my free time constrains. Apart from that, I do think it is good to move as much of the computational stuff to lapack as possible and let `mat` only do the matrix handling around it.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
