### PR TITLE
mat: fix incorrect netlib import

### DIFF
--- a/mat/cblas_test.go
+++ b/mat/cblas_test.go
@@ -8,9 +8,9 @@ package mat
 
 import (
 	"gonum.org/v1/gonum/blas/blas64"
-	"gonum.org/v1/netlib/blas"
+	"gonum.org/v1/netlib/blas/netlib"
 )
 
 func init() {
-	blas64.Use(blas.Implementation{})
+	blas64.Use(netlib.Implementation{})
 }


### PR DESCRIPTION
Please take a look.

Note that this may segfault when run because of OpenBLAS's thread limits - it's safe to run with GOMAXPROCS=1 or possibly GOMAXPROCS << NUM_CPU.

Fixes #548

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
