### PR TITLE
all: add safe synonym for appengine tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Building gonum applications will work without knowing how to use these tags, but
 The current list of non-internal tags is as follows:
 
 - appengine — do not use assembly or unsafe
+- safe — synonym for appengine
 - bounds — use bounds checks even in internal calls
 - cblas — use CGO gonum.org/v1/netlib/blas/netlib BLAS implementation in tests (only in [mat package](https://godoc.org/gonum.org/v1/gonum/mat))
 - noasm — do not use assembly implementations

--- a/graph/internal/set/same.go
+++ b/graph/internal/set/same.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !appengine
+// +build !appengine,!safe
 
 package set
 

--- a/graph/internal/set/same_appengine.go
+++ b/graph/internal/set/same_appengine.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build appengine
+// +build appengine safe
 
 package set
 

--- a/internal/asm/c128/axpyinc_amd64.s
+++ b/internal/asm/c128/axpyinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/axpyincto_amd64.s
+++ b/internal/asm/c128/axpyincto_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/axpyunitary_amd64.s
+++ b/internal/asm/c128/axpyunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/axpyunitaryto_amd64.s
+++ b/internal/asm/c128/axpyunitaryto_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/dotcinc_amd64.s
+++ b/internal/asm/c128/dotcinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/dotcunitary_amd64.s
+++ b/internal/asm/c128/dotcunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/dotuinc_amd64.s
+++ b/internal/asm/c128/dotuinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/dotuunitary_amd64.s
+++ b/internal/asm/c128/dotuunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/dscalinc_amd64.s
+++ b/internal/asm/c128/dscalinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/dscalunitary_amd64.s
+++ b/internal/asm/c128/dscalunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/scalUnitary_amd64.s
+++ b/internal/asm/c128/scalUnitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/scalinc_amd64.s
+++ b/internal/asm/c128/scalinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/stubs_amd64.go
+++ b/internal/asm/c128/stubs_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!appengine
+// +build !noasm,!appengine,!safe
 
 package c128
 

--- a/internal/asm/c128/stubs_noasm.go
+++ b/internal/asm/c128/stubs_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm appengine
+// +build !amd64 noasm appengine safe
 
 package c128
 

--- a/internal/asm/c64/axpyinc_amd64.s
+++ b/internal/asm/c64/axpyinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c64/axpyincto_amd64.s
+++ b/internal/asm/c64/axpyincto_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c64/axpyunitary_amd64.s
+++ b/internal/asm/c64/axpyunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c64/axpyunitaryto_amd64.s
+++ b/internal/asm/c64/axpyunitaryto_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c64/dotcinc_amd64.s
+++ b/internal/asm/c64/dotcinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c64/dotcunitary_amd64.s
+++ b/internal/asm/c64/dotcunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c64/dotuinc_amd64.s
+++ b/internal/asm/c64/dotuinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c64/dotuunitary_amd64.s
+++ b/internal/asm/c64/dotuunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c64/stubs_amd64.go
+++ b/internal/asm/c64/stubs_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!appengine
+// +build !noasm,!appengine,!safe
 
 package c64
 

--- a/internal/asm/c64/stubs_noasm.go
+++ b/internal/asm/c64/stubs_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm appengine
+// +build !amd64 noasm appengine safe
 
 package c64
 

--- a/internal/asm/f32/axpyinc_amd64.s
+++ b/internal/asm/f32/axpyinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/axpyincto_amd64.s
+++ b/internal/asm/f32/axpyincto_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/axpyunitary_amd64.s
+++ b/internal/asm/f32/axpyunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/axpyunitaryto_amd64.s
+++ b/internal/asm/f32/axpyunitaryto_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/ddotinc_amd64.s
+++ b/internal/asm/f32/ddotinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/ddotunitary_amd64.s
+++ b/internal/asm/f32/ddotunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/dotinc_amd64.s
+++ b/internal/asm/f32/dotinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/dotunitary_amd64.s
+++ b/internal/asm/f32/dotunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/ge_amd64.go
+++ b/internal/asm/f32/ge_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!appengine
+// +build !noasm,!appengine,!safe
 
 package f32
 

--- a/internal/asm/f32/ge_amd64.s
+++ b/internal/asm/f32/ge_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/ge_noasm.go
+++ b/internal/asm/f32/ge_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm appengine
+// +build !amd64 noasm appengine safe
 
 package f32
 

--- a/internal/asm/f32/stubs_amd64.go
+++ b/internal/asm/f32/stubs_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!appengine
+// +build !noasm,!appengine,!safe
 
 package f32
 

--- a/internal/asm/f32/stubs_noasm.go
+++ b/internal/asm/f32/stubs_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm appengine
+// +build !amd64 noasm appengine safe
 
 package f32
 

--- a/internal/asm/f64/abssum_amd64.s
+++ b/internal/asm/f64/abssum_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!appengine
+// +build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/abssuminc_amd64.s
+++ b/internal/asm/f64/abssuminc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!appengine
+// +build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/add_amd64.s
+++ b/internal/asm/f64/add_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!appengine
+// +build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/addconst_amd64.s
+++ b/internal/asm/f64/addconst_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!appengine
+// +build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/axpy.go
+++ b/internal/asm/f64/axpy.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm appengine
+// +build !amd64 noasm appengine safe
 
 package f64
 

--- a/internal/asm/f64/axpyinc_amd64.s
+++ b/internal/asm/f64/axpyinc_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/axpyincto_amd64.s
+++ b/internal/asm/f64/axpyincto_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/axpyunitary_amd64.s
+++ b/internal/asm/f64/axpyunitary_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/axpyunitaryto_amd64.s
+++ b/internal/asm/f64/axpyunitaryto_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/cumprod_amd64.s
+++ b/internal/asm/f64/cumprod_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!appengine
+// +build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/cumsum_amd64.s
+++ b/internal/asm/f64/cumsum_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!appengine
+// +build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/div_amd64.s
+++ b/internal/asm/f64/div_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!appengine
+// +build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/divto_amd64.s
+++ b/internal/asm/f64/divto_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!appengine
+// +build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/dot.go
+++ b/internal/asm/f64/dot.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm appengine
+// +build !amd64 noasm appengine safe
 
 package f64
 

--- a/internal/asm/f64/dot_amd64.s
+++ b/internal/asm/f64/dot_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/ge_amd64.go
+++ b/internal/asm/f64/ge_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!appengine
+// +build !noasm,!appengine,!safe
 
 package f64
 

--- a/internal/asm/f64/ge_noasm.go
+++ b/internal/asm/f64/ge_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm appengine
+// +build !amd64 noasm appengine safe
 
 package f64
 

--- a/internal/asm/f64/gemvN_amd64.s
+++ b/internal/asm/f64/gemvN_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/gemvT_amd64.s
+++ b/internal/asm/f64/gemvT_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/ger_amd64.s
+++ b/internal/asm/f64/ger_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/l1norm_amd64.s
+++ b/internal/asm/f64/l1norm_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!appengine
+// +build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/linfnorm_amd64.s
+++ b/internal/asm/f64/linfnorm_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!appengine
+// +build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/scal.go
+++ b/internal/asm/f64/scal.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm appengine
+// +build !amd64 noasm appengine safe
 
 package f64
 

--- a/internal/asm/f64/scalinc_amd64.s
+++ b/internal/asm/f64/scalinc_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/scalincto_amd64.s
+++ b/internal/asm/f64/scalincto_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/scalunitary_amd64.s
+++ b/internal/asm/f64/scalunitary_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/scalunitaryto_amd64.s
+++ b/internal/asm/f64/scalunitaryto_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/stubs_amd64.go
+++ b/internal/asm/f64/stubs_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!appengine
+// +build !noasm,!appengine,!safe
 
 package f64
 

--- a/internal/asm/f64/stubs_noasm.go
+++ b/internal/asm/f64/stubs_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm appengine
+// +build !amd64 noasm appengine safe
 
 package f64
 

--- a/internal/math32/sqrt.go
+++ b/internal/math32/sqrt.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm appengine
+// +build !amd64 noasm appengine safe
 
 package math32
 

--- a/internal/math32/sqrt_amd64.go
+++ b/internal/math32/sqrt_amd64.go
@@ -6,7 +6,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!appengine
+// +build !noasm,!appengine,!safe
 
 package math32
 

--- a/internal/math32/sqrt_amd64.s
+++ b/internal/math32/sqrt_amd64.s
@@ -6,7 +6,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !noasm,!appengine
+//+build !noasm,!appengine,!safe
 
 // TODO(kortschak): use textflag.h after we drop Go 1.3 support
 //#include "textflag.h"

--- a/mat/offset.go
+++ b/mat/offset.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !appengine
+// +build !appengine,!safe
 
 package mat
 

--- a/mat/offset_appengine.go
+++ b/mat/offset_appengine.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build appengine
+// +build appengine safe
 
 package mat
 


### PR DESCRIPTION
This add a tag "safe" that is a synonym for "appengine". There seems to have developed a convention for the use of this tag, so let's add it here.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
