### PR TITLE
floats: use asm version of AddConst when available

### DIFF
--- a/floats/floats.go
+++ b/floats/floats.go
@@ -37,9 +37,7 @@ func AddTo(dst, s, t []float64) []float64 {
 
 // AddConst adds the scalar c to all of the values in dst.
 func AddConst(c float64, dst []float64) {
-	for i := range dst {
-		dst[i] += c
-	}
+	f64.AddConst(c, dst)
 }
 
 // AddScaled performs dst = dst + alpha * s.


### PR DESCRIPTION
Signed-off-by: Francesc Campoy <campoy@golang.org>