### PR TITLE
stat: optimize LinearRegression code, providing speedups of 40%

### DIFF
--- a/stat/stat.go
+++ b/stat/stat.go
@@ -284,6 +284,13 @@ func Covariance(x, y, weights []float64) float64 {
 	}
 	xu := Mean(x, weights)
 	yu := Mean(y, weights)
+	return covarianceMeans(x, y, weights, xu, yu)
+}
+
+// covarianceMeans returns the weighted covariance between x and y with the mean
+// of x and y already specified. See the documentation of Covariance for more
+// information.
+func covarianceMeans(x, y, weights []float64, xu, yu float64) float64 {
 	var (
 		ss            float64
 		xcompensation float64
@@ -761,8 +768,11 @@ func LinearRegression(x, y, weights []float64, origin bool) (alpha, beta float64
 		return 0, beta
 	}
 
-	beta = Covariance(x, y, weights) / Variance(x, weights)
-	alpha = Mean(y, weights) - beta*Mean(x, weights)
+	xu, xv := MeanVariance(x, weights)
+	yu := Mean(y, weights)
+	cov := covarianceMeans(x, y, weights, xu, yu)
+	beta = cov / xv
+	alpha = yu - beta*xu
 	return alpha, beta
 }
 

--- a/stat/stat_test.go
+++ b/stat/stat_test.go
@@ -7,10 +7,11 @@ package stat
 import (
 	"fmt"
 	"math"
-	"math/rand"
 	"reflect"
 	"strconv"
 	"testing"
+
+	"golang.org/x/exp/rand"
 
 	"gonum.org/v1/gonum/floats"
 )


### PR DESCRIPTION
BenchmarkLinearRegression/n10wtot-8        23.2          23.6          +1.72%
BenchmarkLinearRegression/n10wtot-8        23.7          23.9          +0.84%
BenchmarkLinearRegression/n10wtot-8        23.8          26.6          +11.76%
BenchmarkLinearRegression/n10wtot-8        23.4          25.4          +8.55%
BenchmarkLinearRegression/n10wtot-8        23.5          25.0          +6.38%
BenchmarkLinearRegression/n10wtof-8        120           99.8          -16.83%
BenchmarkLinearRegression/n10wtof-8        125           97.1          -22.32%
BenchmarkLinearRegression/n10wtof-8        122           92.1          -24.51%
BenchmarkLinearRegression/n10wtof-8        120           92.6          -22.83%
BenchmarkLinearRegression/n10wtof-8        122           91.0          -25.41%
BenchmarkLinearRegression/n10wfot-8        20.2          20.0          -0.99%
BenchmarkLinearRegression/n10wfot-8        19.7          19.9          +1.02%
BenchmarkLinearRegression/n10wfot-8        19.9          20.0          +0.50%
BenchmarkLinearRegression/n10wfot-8        19.9          20.0          +0.50%
BenchmarkLinearRegression/n10wfot-8        19.7          20.2          +2.54%
BenchmarkLinearRegression/n10wfof-8        116           78.6          -32.24%
BenchmarkLinearRegression/n10wfof-8        115           82.8          -28.00%
BenchmarkLinearRegression/n10wfof-8        116           79.6          -31.38%
BenchmarkLinearRegression/n10wfof-8        117           78.9          -32.56%
BenchmarkLinearRegression/n10wfof-8        117           80.5          -31.20%
BenchmarkLinearRegression/n100wtot-8       161           166           +3.11%
BenchmarkLinearRegression/n100wtot-8       164           165           +0.61%
BenchmarkLinearRegression/n100wtot-8       162           166           +2.47%
BenchmarkLinearRegression/n100wtot-8       161           164           +1.86%
BenchmarkLinearRegression/n100wtot-8       161           166           +3.11%
BenchmarkLinearRegression/n100wtof-8       749           509           -32.04%
BenchmarkLinearRegression/n100wtof-8       750           512           -31.73%
BenchmarkLinearRegression/n100wtof-8       751           507           -32.49%
BenchmarkLinearRegression/n100wtof-8       777           512           -34.11%
BenchmarkLinearRegression/n100wtof-8       773           552           -28.59%
BenchmarkLinearRegression/n100wfot-8       124           133           +7.26%
BenchmarkLinearRegression/n100wfot-8       126           129           +2.38%
BenchmarkLinearRegression/n100wfot-8       126           128           +1.59%
BenchmarkLinearRegression/n100wfot-8       125           130           +4.00%
BenchmarkLinearRegression/n100wfot-8       126           131           +3.97%
BenchmarkLinearRegression/n100wfof-8       686           451           -34.26%
BenchmarkLinearRegression/n100wfof-8       699           435           -37.77%
BenchmarkLinearRegression/n100wfof-8       688           456           -33.72%
BenchmarkLinearRegression/n100wfof-8       699           445           -36.34%
BenchmarkLinearRegression/n100wfof-8       691           451           -34.73%
BenchmarkLinearRegression/n1000wtot-8      1456          1495          +2.68%
BenchmarkLinearRegression/n1000wtot-8      1468          1461          -0.48%
BenchmarkLinearRegression/n1000wtot-8      1493          1471          -1.47%
BenchmarkLinearRegression/n1000wtot-8      1468          1482          +0.95%
BenchmarkLinearRegression/n1000wtot-8      1477          1483          +0.41%
BenchmarkLinearRegression/n1000wtof-8      7346          4698          -36.05%
BenchmarkLinearRegression/n1000wtof-8      7204          4708          -34.65%
BenchmarkLinearRegression/n1000wtof-8      7183          4673          -34.94%
BenchmarkLinearRegression/n1000wtof-8      7176          4733          -34.04%
BenchmarkLinearRegression/n1000wtof-8      7251          4727          -34.81%
BenchmarkLinearRegression/n1000wfot-8      1171          1184          +1.11%
BenchmarkLinearRegression/n1000wfot-8      1192          1158          -2.85%
BenchmarkLinearRegression/n1000wfot-8      1163          1182          +1.63%
BenchmarkLinearRegression/n1000wfot-8      1157          1150          -0.61%
BenchmarkLinearRegression/n1000wfot-8      1170          1160          -0.85%
BenchmarkLinearRegression/n1000wfof-8      6796          4197          -38.24%
BenchmarkLinearRegression/n1000wfof-8      6811          4122          -39.48%
BenchmarkLinearRegression/n1000wfof-8      6564          4132          -37.05%
BenchmarkLinearRegression/n1000wfof-8      6542          4179          -36.12%
BenchmarkLinearRegression/n1000wfof-8      6978          4109          -41.11%
BenchmarkLinearRegression/n10000wtot-8     14613         14738         +0.86%
BenchmarkLinearRegression/n10000wtot-8     14747         14746         -0.01%
BenchmarkLinearRegression/n10000wtot-8     14489         14487         -0.01%
BenchmarkLinearRegression/n10000wtot-8     14431         14549         +0.82%
BenchmarkLinearRegression/n10000wtot-8     14557         14363         -1.33%
BenchmarkLinearRegression/n10000wtof-8     70886         46425         -34.51%
BenchmarkLinearRegression/n10000wtof-8     70992         46446         -34.58%
BenchmarkLinearRegression/n10000wtof-8     71086         46828         -34.12%
BenchmarkLinearRegression/n10000wtof-8     70830         46792         -33.94%
BenchmarkLinearRegression/n10000wtof-8     71895         47131         -34.44%
BenchmarkLinearRegression/n10000wfot-8     11325         11498         +1.53%
BenchmarkLinearRegression/n10000wfot-8     11289         11635         +3.06%
BenchmarkLinearRegression/n10000wfot-8     11592         11605         +0.11%
BenchmarkLinearRegression/n10000wfot-8     11615         11929         +2.70%
BenchmarkLinearRegression/n10000wfot-8     11595         12005         +3.54%
BenchmarkLinearRegression/n10000wfof-8     70687         42916         -39.29%
BenchmarkLinearRegression/n10000wfof-8     66305         40844         -38.40%
BenchmarkLinearRegression/n10000wfof-8     66262         40922         -38.24%
BenchmarkLinearRegression/n10000wfof-8     65864         42854         -34.94%
BenchmarkLinearRegression/n10000wfof-8     65366         40753         -37.65%