### PR TITLE
blas: fix documentation of Use functions

### DIFF
--- a/blas/blas32/blas32.go
+++ b/blas/blas32/blas32.go
@@ -12,7 +12,8 @@ import (
 var blas32 blas.Float32 = gonum.Implementation{}
 
 // Use sets the BLAS float32 implementation to be used by subsequent BLAS calls.
-// The default implementation is native.Implementation.
+// The default implementation is
+// gonum.org/v1/gonum/blas/gonum.Implementation.
 func Use(b blas.Float32) {
 	blas32 = b
 }

--- a/blas/blas64/blas64.go
+++ b/blas/blas64/blas64.go
@@ -12,7 +12,8 @@ import (
 var blas64 blas.Float64 = gonum.Implementation{}
 
 // Use sets the BLAS float64 implementation to be used by subsequent BLAS calls.
-// The default implementation is native.Implementation.
+// The default implementation is
+// gonum.org/v1/gonum/blas/gonum.Implementation.
 func Use(b blas.Float64) {
 	blas64 = b
 }

--- a/blas/cblas128/cblas128.go
+++ b/blas/cblas128/cblas128.go
@@ -12,7 +12,8 @@ import (
 var cblas128 blas.Complex128 = gonum.Implementation{}
 
 // Use sets the BLAS complex128 implementation to be used by subsequent BLAS calls.
-// The default implementation is cgo.Implementation.
+// The default implementation is
+// gonum.org/v1/gonum/blas/gonum.Implementation.
 func Use(b blas.Complex128) {
 	cblas128 = b
 }

--- a/blas/cblas64/cblas64.go
+++ b/blas/cblas64/cblas64.go
@@ -12,7 +12,8 @@ import (
 var cblas64 blas.Complex64 = gonum.Implementation{}
 
 // Use sets the BLAS complex64 implementation to be used by subsequent BLAS calls.
-// The default implementation is cgo.Implementation.
+// The default implementation is
+// gonum.org/v1/gonum/blas/gonum.Implementation.
 func Use(b blas.Complex64) {
 	cblas64 = b
 }


### PR DESCRIPTION
This was noticed while adapting JuliaLang/Microbenchmarks#27 to the new
Gonum import paths.
This CL somewhat clarifies the correct default implementation (pure-Go)
used by the various blas{32,64} and cblas{64,128} packages.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
