### PR TITLE
blas/blas64: reorder struct fields

### DIFF
--- a/blas/blas64/blas64.go
+++ b/blas/blas64/blas64.go
@@ -28,72 +28,72 @@ func Implementation() blas.Float64 {
 
 // Vector represents a vector with an associated element increment.
 type Vector struct {
-	Inc  int
 	Data []float64
+	Inc  int
 }
 
 // General represents a matrix using the conventional storage scheme.
 type General struct {
 	Rows, Cols int
-	Stride     int
 	Data       []float64
+	Stride     int
 }
 
 // Band represents a band matrix using the band storage scheme.
 type Band struct {
 	Rows, Cols int
 	KL, KU     int
-	Stride     int
 	Data       []float64
+	Stride     int
 }
 
 // Triangular represents a triangular matrix using the conventional storage scheme.
 type Triangular struct {
-	N      int
-	Stride int
-	Data   []float64
 	Uplo   blas.Uplo
 	Diag   blas.Diag
+	N      int
+	Data   []float64
+	Stride int
 }
 
 // TriangularBand represents a triangular matrix using the band storage scheme.
 type TriangularBand struct {
-	N, K   int
-	Stride int
-	Data   []float64
 	Uplo   blas.Uplo
 	Diag   blas.Diag
+	N, K   int
+	Data   []float64
+	Stride int
 }
 
 // TriangularPacked represents a triangular matrix using the packed storage scheme.
 type TriangularPacked struct {
-	N    int
-	Data []float64
 	Uplo blas.Uplo
 	Diag blas.Diag
+	N    int
+	Data []float64
 }
 
 // Symmetric represents a symmetric matrix using the conventional storage scheme.
 type Symmetric struct {
-	N      int
-	Stride int
-	Data   []float64
 	Uplo   blas.Uplo
+	N      int
+	Data   []float64
+	Stride int
 }
 
 // SymmetricBand represents a symmetric matrix using the band storage scheme.
 type SymmetricBand struct {
-	N, K   int
-	Stride int
-	Data   []float64
 	Uplo   blas.Uplo
+	N, K   int
+	Data   []float64
+	Stride int
 }
 
 // SymmetricPacked represents a symmetric matrix using the packed storage scheme.
 type SymmetricPacked struct {
+	Uplo blas.Uplo
 	N    int
 	Data []float64
-	Uplo blas.Uplo
 }
 
 // Level 1

--- a/lapack/testlapack/dgebak.go
+++ b/lapack/testlapack/dgebak.go
@@ -73,14 +73,14 @@ func testDgebak(t *testing.T, impl Dgebaker, job lapack.Job, side lapack.EVSide,
 		for i := n - 1; i > ihi; i-- {
 			scale[i] = float64(rnd.Intn(i + 1))
 			blas64.Swap(n,
-				blas64.Vector{p.Stride, p.Data[i:]},
-				blas64.Vector{p.Stride, p.Data[int(scale[i]):]})
+				blas64.Vector{p.Data[i:], p.Stride},
+				blas64.Vector{p.Data[int(scale[i]):], p.Stride})
 		}
 		for i := 0; i < ilo; i++ {
 			scale[i] = float64(i + rnd.Intn(ihi-i+1))
 			blas64.Swap(n,
-				blas64.Vector{p.Stride, p.Data[i:]},
-				blas64.Vector{p.Stride, p.Data[int(scale[i]):]})
+				blas64.Vector{p.Data[i:], p.Stride},
+				blas64.Vector{p.Data[int(scale[i]):], p.Stride})
 		}
 	}
 

--- a/lapack/testlapack/dgebal.go
+++ b/lapack/testlapack/dgebal.go
@@ -92,12 +92,12 @@ func testDgebal(t *testing.T, impl Dgebaler, job lapack.Job, a blas64.General) {
 		t.Errorf("%v: invalid ordering of ilo=%v and ihi=%v", prefix, ilo, ihi)
 	}
 
-	if ilo >= 2 && !isUpperTriangular(blas64.General{ilo - 1, ilo - 1, a.Stride, a.Data}) {
+	if ilo >= 2 && !isUpperTriangular(blas64.General{ilo - 1, ilo - 1, a.Data, a.Stride}) {
 		t.Errorf("%v: T1 is not upper triangular", prefix)
 	}
 	m := n - ihi - 1 // Order of T2.
 	k := ihi + 1
-	if m >= 2 && !isUpperTriangular(blas64.General{m, m, a.Stride, a.Data[k*a.Stride+k:]}) {
+	if m >= 2 && !isUpperTriangular(blas64.General{m, m, a.Data[k*a.Stride+k:], a.Stride}) {
 		t.Errorf("%v: T2 is not upper triangular", prefix)
 	}
 
@@ -145,13 +145,13 @@ func testDgebal(t *testing.T, impl Dgebaler, job lapack.Job, a blas64.General) {
 		p := eye(n, n)
 		for j := n - 1; j > ihi; j-- {
 			blas64.Swap(n,
-				blas64.Vector{p.Stride, p.Data[j:]},
-				blas64.Vector{p.Stride, p.Data[int(scale[j]):]})
+				blas64.Vector{p.Data[j:], p.Stride},
+				blas64.Vector{p.Data[int(scale[j]):], p.Stride})
 		}
 		for j := 0; j < ilo; j++ {
 			blas64.Swap(n,
-				blas64.Vector{p.Stride, p.Data[j:]},
-				blas64.Vector{p.Stride, p.Data[int(scale[j]):]})
+				blas64.Vector{p.Data[j:], p.Stride},
+				blas64.Vector{p.Data[int(scale[j]):], p.Stride})
 		}
 		// Compute P^T*A*P and store into want.
 		ap := zeros(n, n, n)

--- a/lapack/testlapack/dlacn2.go
+++ b/lapack/testlapack/dlacn2.go
@@ -55,10 +55,10 @@ func Dlacn2Test(t *testing.T, impl Dlacn2er) {
 				case 0:
 					break loop
 				case 1:
-					blas64.Gemv(blas.NoTrans, 1, a, blas64.Vector{1, x}, 0, blas64.Vector{1, work})
+					blas64.Gemv(blas.NoTrans, 1, a, blas64.Vector{x, 1}, 0, blas64.Vector{work, 1})
 					copy(x, work)
 				case 2:
-					blas64.Gemv(blas.Trans, 1, a, blas64.Vector{1, x}, 0, blas64.Vector{1, work})
+					blas64.Gemv(blas.Trans, 1, a, blas64.Vector{x, 1}, 0, blas64.Vector{work, 1})
 					copy(x, work)
 				}
 			}

--- a/lapack/testlapack/dorg2l.go
+++ b/lapack/testlapack/dorg2l.go
@@ -48,7 +48,7 @@ func Dorg2lTest(t *testing.T, impl Dorg2ler) {
 		impl.Dgeql2(m, n, a, lda, tau, work)
 
 		impl.Dorg2l(m, n, k, a, lda, tau[n-k:], work)
-		if !hasOrthonormalColumns(blas64.General{m, n, lda, a}) {
+		if !hasOrthonormalColumns(blas64.General{m, n, a, lda}) {
 			t.Errorf("Case m=%v, n=%v, k=%v: columns of Q not orthonormal", m, n, k)
 		}
 	}

--- a/lapack/testlapack/dorgql.go
+++ b/lapack/testlapack/dorgql.go
@@ -71,7 +71,7 @@ func DorgqlTest(t *testing.T, impl Dorgqler) {
 					h := eye(m, m)
 					jj := m - k + l
 					j := n - k + l
-					v := blas64.Vector{1, make([]float64, m)}
+					v := blas64.Vector{make([]float64, m), 1}
 					for i := 0; i < jj; i++ {
 						v.Data[i] = a.Data[i*a.Stride+j]
 					}

--- a/lapack/testlapack/general.go
+++ b/lapack/testlapack/general.go
@@ -1290,7 +1290,7 @@ func isRightEigenvectorOf(a blas64.General, xRe, xIm []float64, lambda complex12
 
 	// Compute A real(x) and store the result into xReAns.
 	xReAns := make([]float64, n)
-	blas64.Gemv(blas.NoTrans, 1, a, blas64.Vector{1, xRe}, 0, blas64.Vector{1, xReAns})
+	blas64.Gemv(blas.NoTrans, 1, a, blas64.Vector{xRe, 1}, 0, blas64.Vector{xReAns, 1})
 
 	if imag(lambda) == 0 && xIm == nil {
 		// Real eigenvalue and eigenvector.
@@ -1308,7 +1308,7 @@ func isRightEigenvectorOf(a blas64.General, xRe, xIm []float64, lambda complex12
 
 	// Compute A imag(x) and store the result into xImAns.
 	xImAns := make([]float64, n)
-	blas64.Gemv(blas.NoTrans, 1, a, blas64.Vector{1, xIm}, 0, blas64.Vector{1, xImAns})
+	blas64.Gemv(blas.NoTrans, 1, a, blas64.Vector{xIm, 1}, 0, blas64.Vector{xImAns, 1})
 
 	// Compute λx and store the result into lambdax.
 	lambdax := make([]complex128, n)
@@ -1349,7 +1349,7 @@ func isLeftEigenvectorOf(a blas64.General, yRe, yIm []float64, lambda complex128
 
 	// Compute A^T real(y) and store the result into yReAns.
 	yReAns := make([]float64, n)
-	blas64.Gemv(blas.Trans, 1, a, blas64.Vector{1, yRe}, 0, blas64.Vector{1, yReAns})
+	blas64.Gemv(blas.Trans, 1, a, blas64.Vector{yRe, 1}, 0, blas64.Vector{yReAns, 1})
 
 	if imag(lambda) == 0 && yIm == nil {
 		// Real eigenvalue and eigenvector.
@@ -1367,7 +1367,7 @@ func isLeftEigenvectorOf(a blas64.General, yRe, yIm []float64, lambda complex128
 
 	// Compute A^T imag(y) and store the result into yImAns.
 	yImAns := make([]float64, n)
-	blas64.Gemv(blas.Trans, 1, a, blas64.Vector{1, yIm}, 0, blas64.Vector{1, yImAns})
+	blas64.Gemv(blas.Trans, 1, a, blas64.Vector{yIm, 1}, 0, blas64.Vector{yImAns, 1})
 
 	// Compute conj(λ)y and store the result into lambday.
 	lambda = cmplx.Conj(lambda)

--- a/lapack/testlapack/matgen.go
+++ b/lapack/testlapack/matgen.go
@@ -716,7 +716,7 @@ func applyReflector(qh blas64.General, q blas64.General, v []float64) {
 		panic("bad size of q")
 	}
 	qv := make([]float64, n)
-	blas64.Gemv(blas.NoTrans, 1, q, blas64.Vector{1, v}, 0, blas64.Vector{1, qv})
+	blas64.Gemv(blas.NoTrans, 1, q, blas64.Vector{v, 1}, 0, blas64.Vector{qv, 1})
 	for i := 0; i < n; i++ {
 		for j := 0; j < n; j++ {
 			qh.Data[i*qh.Stride+j] = q.Data[i*q.Stride+j]

--- a/mat/cholesky.go
+++ b/mat/cholesky.go
@@ -478,12 +478,12 @@ func (c *Cholesky) SymRankOne(orig *Cholesky, alpha float64, x Vector) (ok bool)
 		tmp.CopyVec(x)
 		xmat = tmp.RawVector()
 	}
-	blas64.Copy(n, xmat, blas64.Vector{1, work})
+	blas64.Copy(n, xmat, blas64.Vector{work, 1})
 
 	if alpha > 0 {
 		// Compute rank-1 update.
 		if alpha != 1 {
-			blas64.Scal(n, math.Sqrt(alpha), blas64.Vector{1, work})
+			blas64.Scal(n, math.Sqrt(alpha), blas64.Vector{work, 1})
 		}
 		umat := c.chol.mat
 		stride := umat.Stride
@@ -504,8 +504,8 @@ func (c *Cholesky) SymRankOne(orig *Cholesky, alpha float64, x Vector) (ok bool)
 				// the Givens matrix from the left. Only
 				// the i-th row and x are modified.
 				blas64.Rot(n-i-1,
-					blas64.Vector{1, umat.Data[i*stride+i+1 : i*stride+n]},
-					blas64.Vector{1, work[i+1 : n]},
+					blas64.Vector{umat.Data[i*stride+i+1 : i*stride+n], 1},
+					blas64.Vector{work[i+1 : n], 1},
 					c, s)
 			}
 		}
@@ -516,7 +516,7 @@ func (c *Cholesky) SymRankOne(orig *Cholesky, alpha float64, x Vector) (ok bool)
 	// Compute rank-1 downdate.
 	alpha = math.Sqrt(-alpha)
 	if alpha != 1 {
-		blas64.Scal(n, alpha, blas64.Vector{1, work})
+		blas64.Scal(n, alpha, blas64.Vector{work, 1})
 	}
 	// Solve U^T * p = x storing the result into work.
 	ok = lapack64.Trtrs(blas.Trans, c.chol.RawTriangular(), blas64.General{
@@ -530,7 +530,7 @@ func (c *Cholesky) SymRankOne(orig *Cholesky, alpha float64, x Vector) (ok bool)
 		// the factorization is valid.
 		panic(badCholesky)
 	}
-	norm := blas64.Nrm2(n, blas64.Vector{1, work})
+	norm := blas64.Nrm2(n, blas64.Vector{work, 1})
 	if norm >= 1 {
 		// The updated matrix is not positive definite.
 		return false
@@ -557,7 +557,7 @@ func (c *Cholesky) SymRankOne(orig *Cholesky, alpha float64, x Vector) (ok bool)
 		// Apply Givens matrices to U.
 		// TODO(vladimir-ch): Use workspace to avoid modifying the
 		// receiver in case an invalid factorization is created.
-		blas64.Rot(n-i, blas64.Vector{1, work[i:n]}, blas64.Vector{1, umat.Data[i*stride+i : i*stride+n]}, cos[i], sin[i])
+		blas64.Rot(n-i, blas64.Vector{work[i:n], 1}, blas64.Vector{umat.Data[i*stride+i : i*stride+n], 1}, cos[i], sin[i])
 		if umat.Data[i*stride+i] == 0 {
 			// The matrix is singular (may rarely happen due to
 			// floating-point effects?).
@@ -567,7 +567,7 @@ func (c *Cholesky) SymRankOne(orig *Cholesky, alpha float64, x Vector) (ok bool)
 			// that on the i-th row the diagonal is negative,
 			// multiply U from the left by an identity matrix that
 			// has -1 on the i-th row.
-			blas64.Scal(n-i, -1, blas64.Vector{1, umat.Data[i*stride+i : i*stride+n]})
+			blas64.Scal(n-i, -1, blas64.Vector{umat.Data[i*stride+i : i*stride+n], 1})
 		}
 	}
 	if ok {

--- a/mat/format_test.go
+++ b/mat/format_test.go
@@ -26,7 +26,7 @@ func TestFormat(t *testing.T) {
 			[]rp{
 				{"%v", "⎡0  0  0⎤\n⎢0  0  0⎥\n⎣0  0  0⎦"},
 				{"% f", "⎡.  .  .⎤\n⎢.  .  .⎥\n⎣.  .  .⎦"},
-				{"%#v", "&mat.Dense{mat:blas64.General{Rows:3, Cols:3, Stride:3, Data:[]float64{0, 0, 0, 0, 0, 0, 0, 0, 0}}, capRows:3, capCols:3}"},
+				{"%#v", "&mat.Dense{mat:blas64.General{Rows:3, Cols:3, Data:[]float64{0, 0, 0, 0, 0, 0, 0, 0, 0}, Stride:3}, capRows:3, capCols:3}"},
 				{"%s", "%!s(*mat.Dense=Dims(3, 3))"},
 			},
 		},
@@ -35,7 +35,7 @@ func TestFormat(t *testing.T) {
 			[]rp{
 				{"%v", "⎡1  1  1⎤\n⎢1  1  1⎥\n⎣1  1  1⎦"},
 				{"% f", "⎡1  1  1⎤\n⎢1  1  1⎥\n⎣1  1  1⎦"},
-				{"%#v", "&mat.Dense{mat:blas64.General{Rows:3, Cols:3, Stride:3, Data:[]float64{1, 1, 1, 1, 1, 1, 1, 1, 1}}, capRows:3, capCols:3}"},
+				{"%#v", "&mat.Dense{mat:blas64.General{Rows:3, Cols:3, Data:[]float64{1, 1, 1, 1, 1, 1, 1, 1, 1}, Stride:3}, capRows:3, capCols:3}"},
 			},
 		},
 		{
@@ -43,7 +43,7 @@ func TestFormat(t *testing.T) {
 			[]rp{
 				{"%v", "⎡1  1  1⎤\n\t⎢1  1  1⎥\n\t⎣1  1  1⎦"},
 				{"% f", "⎡1  1  1⎤\n\t⎢1  1  1⎥\n\t⎣1  1  1⎦"},
-				{"%#v", "&mat.Dense{mat:blas64.General{Rows:3, Cols:3, Stride:3, Data:[]float64{1, 1, 1, 1, 1, 1, 1, 1, 1}}, capRows:3, capCols:3}"},
+				{"%#v", "&mat.Dense{mat:blas64.General{Rows:3, Cols:3, Data:[]float64{1, 1, 1, 1, 1, 1, 1, 1, 1}, Stride:3}, capRows:3, capCols:3}"},
 			},
 		},
 		{
@@ -51,7 +51,7 @@ func TestFormat(t *testing.T) {
 			[]rp{
 				{"%v", "⎡1  0  0⎤\n⎢0  1  0⎥\n⎣0  0  1⎦"},
 				{"% f", "⎡1  .  .⎤\n⎢.  1  .⎥\n⎣.  .  1⎦"},
-				{"%#v", "&mat.Dense{mat:blas64.General{Rows:3, Cols:3, Stride:3, Data:[]float64{1, 0, 0, 0, 1, 0, 0, 0, 1}}, capRows:3, capCols:3}"},
+				{"%#v", "&mat.Dense{mat:blas64.General{Rows:3, Cols:3, Data:[]float64{1, 0, 0, 0, 1, 0, 0, 0, 1}, Stride:3}, capRows:3, capCols:3}"},
 			},
 		},
 		{
@@ -59,7 +59,7 @@ func TestFormat(t *testing.T) {
 			[]rp{
 				{"%v", "⎡1  2  3⎤\n⎣4  5  6⎦"},
 				{"% f", "⎡1  2  3⎤\n⎣4  5  6⎦"},
-				{"%#v", "&mat.Dense{mat:blas64.General{Rows:2, Cols:3, Stride:3, Data:[]float64{1, 2, 3, 4, 5, 6}}, capRows:2, capCols:3}"},
+				{"%#v", "&mat.Dense{mat:blas64.General{Rows:2, Cols:3, Data:[]float64{1, 2, 3, 4, 5, 6}, Stride:3}, capRows:2, capCols:3}"},
 			},
 		},
 		{
@@ -67,7 +67,7 @@ func TestFormat(t *testing.T) {
 			[]rp{
 				{"%v", "⎡1  2⎤\n⎢3  4⎥\n⎣5  6⎦"},
 				{"% f", "⎡1  2⎤\n⎢3  4⎥\n⎣5  6⎦"},
-				{"%#v", "&mat.Dense{mat:blas64.General{Rows:3, Cols:2, Stride:2, Data:[]float64{1, 2, 3, 4, 5, 6}}, capRows:3, capCols:2}"},
+				{"%#v", "&mat.Dense{mat:blas64.General{Rows:3, Cols:2, Data:[]float64{1, 2, 3, 4, 5, 6}, Stride:2}, capRows:3, capCols:2}"},
 			},
 		},
 		{
@@ -80,7 +80,7 @@ func TestFormat(t *testing.T) {
 				{"%v", "⎡                 0                   1  1.4142135623730951⎤\n⎣1.7320508075688772                   2    2.23606797749979⎦"},
 				{"%.2f", "⎡0.00  1.00  1.41⎤\n⎣1.73  2.00  2.24⎦"},
 				{"% f", "⎡                 .                   1  1.4142135623730951⎤\n⎣1.7320508075688772                   2    2.23606797749979⎦"},
-				{"%#v", "&mat.Dense{mat:blas64.General{Rows:2, Cols:3, Stride:3, Data:[]float64{0, 1, 1.4142135623730951, 1.7320508075688772, 2, 2.23606797749979}}, capRows:2, capCols:3}"},
+				{"%#v", "&mat.Dense{mat:blas64.General{Rows:2, Cols:3, Data:[]float64{0, 1, 1.4142135623730951, 1.7320508075688772, 2, 2.23606797749979}, Stride:3}, capRows:2, capCols:3}"},
 			},
 		},
 		{
@@ -93,7 +93,7 @@ func TestFormat(t *testing.T) {
 				{"%v", "⎡                 0                   1⎤\n⎢1.4142135623730951  1.7320508075688772⎥\n⎣                 2    2.23606797749979⎦"},
 				{"%.2f", "⎡0.00  1.00⎤\n⎢1.41  1.73⎥\n⎣2.00  2.24⎦"},
 				{"% f", "⎡                 .                   1⎤\n⎢1.4142135623730951  1.7320508075688772⎥\n⎣                 2    2.23606797749979⎦"},
-				{"%#v", "&mat.Dense{mat:blas64.General{Rows:3, Cols:2, Stride:2, Data:[]float64{0, 1, 1.4142135623730951, 1.7320508075688772, 2, 2.23606797749979}}, capRows:3, capCols:2}"},
+				{"%#v", "&mat.Dense{mat:blas64.General{Rows:3, Cols:2, Data:[]float64{0, 1, 1.4142135623730951, 1.7320508075688772, 2, 2.23606797749979}, Stride:2}, capRows:3, capCols:2}"},
 			},
 		},
 		{
@@ -106,7 +106,7 @@ func TestFormat(t *testing.T) {
 				{"%v", "⎡                 0  1  1.4142135623730951⎤\n⎣1.7320508075688772  2    2.23606797749979⎦"},
 				{"%.2f", "⎡0.00  1.00  1.41⎤\n⎣1.73  2.00  2.24⎦"},
 				{"% f", "⎡                 .  1  1.4142135623730951⎤\n⎣1.7320508075688772  2    2.23606797749979⎦"},
-				{"%#v", "&mat.Dense{mat:blas64.General{Rows:2, Cols:3, Stride:3, Data:[]float64{0, 1, 1.4142135623730951, 1.7320508075688772, 2, 2.23606797749979}}, capRows:2, capCols:3}"},
+				{"%#v", "&mat.Dense{mat:blas64.General{Rows:2, Cols:3, Data:[]float64{0, 1, 1.4142135623730951, 1.7320508075688772, 2, 2.23606797749979}, Stride:3}, capRows:2, capCols:3}"},
 			},
 		},
 		{


### PR DESCRIPTION
Reorder vector and matrix struct fields to match the order in which BLAS
routines accept them. This makes calls with inline declarations with
unnamed fields consistent with the `blas/gonum` package and so easier to understand.

Please take a look.

Taken over from https://github.com/gonum/blas/issues/201

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
