### PR TITLE
lapack: add BalanceJob type, remove Job and Comp types

### DIFF
--- a/lapack/gonum/dgebak.go
+++ b/lapack/gonum/dgebak.go
@@ -20,10 +20,10 @@ import (
 // the eigenvectors of the original matrix.
 //
 // Dgebak is an internal routine. It is exported for testing purposes.
-func (impl Implementation) Dgebak(job lapack.Job, side lapack.EVSide, n, ilo, ihi int, scale []float64, m int, v []float64, ldv int) {
+func (impl Implementation) Dgebak(job lapack.BalanceJob, side lapack.EVSide, n, ilo, ihi int, scale []float64, m int, v []float64, ldv int) {
 	switch job {
 	default:
-		panic(badJob)
+		panic(badBalanceJob)
 	case lapack.None, lapack.Permute, lapack.Scale, lapack.PermuteScale:
 	}
 	switch side {

--- a/lapack/gonum/dgebal.go
+++ b/lapack/gonum/dgebal.go
@@ -54,10 +54,10 @@ import (
 // scale must have length equal to n, otherwise Dgebal will panic.
 //
 // Dgebal is an internal routine. It is exported for testing purposes.
-func (impl Implementation) Dgebal(job lapack.Job, n int, a []float64, lda int, scale []float64) (ilo, ihi int) {
+func (impl Implementation) Dgebal(job lapack.BalanceJob, n int, a []float64, lda int, scale []float64) (ilo, ihi int) {
 	switch job {
 	default:
-		panic(badJob)
+		panic(badBalanceJob)
 	case lapack.None, lapack.Permute, lapack.Scale, lapack.PermuteScale:
 	}
 	checkMatrix(n, n, a, lda)

--- a/lapack/gonum/general.go
+++ b/lapack/gonum/general.go
@@ -35,7 +35,7 @@ const (
 	badIlo          = "lapack: ilo out of range"
 	badIhi          = "lapack: ihi out of range"
 	badIpiv         = "lapack: bad permutation length"
-	badJob          = "lapack: bad Job"
+	badBalanceJob   = "lapack: bad BalanceJob"
 	badK1           = "lapack: k1 out of range"
 	badK2           = "lapack: k2 out of range"
 	badKperm        = "lapack: incorrect permutation length"

--- a/lapack/lapack.go
+++ b/lapack/lapack.go
@@ -8,8 +8,6 @@ import "gonum.org/v1/gonum/blas"
 
 const None = 'N'
 
-type Comp byte
-
 // Complex128 defines the public complex128 LAPACK API supported by gonum/lapack.
 type Complex128 interface{}
 

--- a/lapack/lapack.go
+++ b/lapack/lapack.go
@@ -8,8 +8,6 @@ import "gonum.org/v1/gonum/blas"
 
 const None = 'N'
 
-type Job byte
-
 type Comp byte
 
 // Complex128 defines the public complex128 LAPACK API supported by gonum/lapack.

--- a/lapack/lapack.go
+++ b/lapack/lapack.go
@@ -155,11 +155,13 @@ const (
 	ComputeRightEV RightEVJob = 'V' // Compute right eigenvectors.
 )
 
-// Jobs for Dgebal.
+// BalanceJob specifies matrix balancing operation.
+type BalanceJob byte
+
 const (
-	Permute      Job = 'P'
-	Scale        Job = 'S'
-	PermuteScale Job = 'B'
+	Permute      BalanceJob = 'P'
+	Scale        BalanceJob = 'S'
+	PermuteScale BalanceJob = 'B'
 )
 
 // Job constants for Dhseqr.

--- a/lapack/testlapack/dgebak.go
+++ b/lapack/testlapack/dgebak.go
@@ -16,13 +16,13 @@ import (
 )
 
 type Dgebaker interface {
-	Dgebak(job lapack.Job, side lapack.EVSide, n, ilo, ihi int, scale []float64, m int, v []float64, ldv int)
+	Dgebak(job lapack.BalanceJob, side lapack.EVSide, n, ilo, ihi int, scale []float64, m int, v []float64, ldv int)
 }
 
 func DgebakTest(t *testing.T, impl Dgebaker) {
 	rnd := rand.New(rand.NewSource(1))
 
-	for _, job := range []lapack.Job{lapack.None, lapack.Permute, lapack.Scale, lapack.PermuteScale} {
+	for _, job := range []lapack.BalanceJob{lapack.None, lapack.Permute, lapack.Scale, lapack.PermuteScale} {
 		for _, side := range []lapack.EVSide{lapack.LeftEV, lapack.RightEV} {
 			for _, n := range []int{0, 1, 2, 3, 4, 5, 6, 10, 18, 31, 53} {
 				for _, extra := range []int{0, 11} {
@@ -44,7 +44,7 @@ func DgebakTest(t *testing.T, impl Dgebaker) {
 	}
 }
 
-func testDgebak(t *testing.T, impl Dgebaker, job lapack.Job, side lapack.EVSide, ilo, ihi int, v blas64.General, rnd *rand.Rand) {
+func testDgebak(t *testing.T, impl Dgebaker, job lapack.BalanceJob, side lapack.EVSide, ilo, ihi int, v blas64.General, rnd *rand.Rand) {
 	const tol = 1e-15
 	n := v.Rows
 	m := v.Cols

--- a/lapack/testlapack/dgebal.go
+++ b/lapack/testlapack/dgebal.go
@@ -16,13 +16,13 @@ import (
 )
 
 type Dgebaler interface {
-	Dgebal(job lapack.Job, n int, a []float64, lda int, scale []float64) (int, int)
+	Dgebal(job lapack.BalanceJob, n int, a []float64, lda int, scale []float64) (int, int)
 }
 
 func DgebalTest(t *testing.T, impl Dgebaler) {
 	rnd := rand.New(rand.NewSource(1))
 
-	for _, job := range []lapack.Job{lapack.None, lapack.Permute, lapack.Scale, lapack.PermuteScale} {
+	for _, job := range []lapack.BalanceJob{lapack.None, lapack.Permute, lapack.Scale, lapack.PermuteScale} {
 		for _, n := range []int{0, 1, 2, 3, 4, 5, 6, 10, 18, 31, 53, 100} {
 			for _, extra := range []int{0, 11} {
 				for cas := 0; cas < 100; cas++ {
@@ -34,7 +34,7 @@ func DgebalTest(t *testing.T, impl Dgebaler) {
 	}
 }
 
-func testDgebal(t *testing.T, impl Dgebaler, job lapack.Job, a blas64.General) {
+func testDgebal(t *testing.T, impl Dgebaler, job lapack.BalanceJob, a blas64.General) {
 	const tol = 1e-14
 
 	n := a.Rows


### PR DESCRIPTION
`Dgebal` and `Dgebak` are the only remaining functions that use the generic `Job` type. This PR adds a dedicated `BalanceJob` type and removes the `Job` and `Comp` types. This breaks the netlib/lapack packages, a follow-up PR to do the necessary changes there is ready.

Updates #570
Updates https://github.com/gonum/lapack/issues/163

It is only an update because:
1. ~~There is still the generic `Comp` type~~
2. I'm not sure whether we need a dedicated `None` constant for each type. There are `SVDNone` and `GSVDNone` for SVD but no such constants for eigenvalues. It is probably better to add the missing constants so that it is clear which types allow the `None` option. Opinions?
3. I want to review the names; after a quick look (G)SVD jobs use (G)SVD as a prefix, EV jobs use EV as a suffix, ...

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
