### PR TITLE
replace `NewLine` func with `NewWeightedLine` for WeightedUndirectedG…

### DIFF
--- a/graph/multi/weighted_undirected.go
+++ b/graph/multi/weighted_undirected.go
@@ -82,11 +82,11 @@ func (g *WeightedUndirectedGraph) RemoveNode(id int64) {
 	g.nodeIDs.Release(id)
 }
 
-// NewLine returns a new WeightedLine from the source to the destination node.
+// NewWeightedLine returns a new WeightedLine from the source to the destination node.
 // The returned WeightedLine will have a graph-unique ID.
 // The Line's ID does not become valid in g until the Line is added to g.
-func (g *WeightedUndirectedGraph) NewLine(from, to graph.Node) graph.WeightedLine {
-	return &WeightedLine{F: from, T: to, UID: g.lineIDs.NewID()}
+func (g *WeightedUndirectedGraph) NewWeightedLine(from, to graph.Node, weight float64) graph.WeightedLine {
+	return &WeightedLine{F: from, T: to, W: weight, UID: g.lineIDs.NewID()}
 }
 
 // SetWeighted adds l, a line from one node to another. If the nodes do not exist, they are added.


### PR DESCRIPTION
…raph type. This appears to be the correct functionality

Correct me if I am wrong but `WeightedUndirectedGraph` should have `NewWeightedLine` functionality as opposed to `NewLine`

The current behavior makes it non-trivial to add a weight to a line using `NewLine`

This PR obviously needs some tests, but I just wanted to check I wasn't missing something obvious in regards to the functionality

Cheers

-Matt

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
