### PR TITLE
graph/{multi,simple}: ensure implementations satisfy the interfaces they target

### DIFF
--- a/graph/multi/directed.go
+++ b/graph/multi/directed.go
@@ -19,6 +19,10 @@ var (
 	_ graph.Directed           = dg
 	_ graph.Multigraph         = dg
 	_ graph.DirectedMultigraph = dg
+	_ graph.NodeAdder          = dg
+	_ graph.NodeRemover        = dg
+	_ graph.LineAdder          = dg
+	_ graph.LineRemover        = dg
 )
 
 // DirectedGraph implements a generalized directed graph.

--- a/graph/multi/directed_test.go
+++ b/graph/multi/directed_test.go
@@ -4,18 +4,7 @@
 
 package multi
 
-import (
-	"testing"
-
-	"gonum.org/v1/gonum/graph"
-)
-
-var (
-	directedGraph = (*DirectedGraph)(nil)
-
-	_ graph.Graph    = directedGraph
-	_ graph.Directed = directedGraph
-)
+import "testing"
 
 // Tests Issue #27
 func TestEdgeOvercounting(t *testing.T) {

--- a/graph/multi/directed_test.go
+++ b/graph/multi/directed_test.go
@@ -4,7 +4,11 @@
 
 package multi
 
-import "testing"
+import (
+	"testing"
+
+	"gonum.org/v1/gonum/graph"
+)
 
 // Tests Issue #27
 func TestEdgeOvercounting(t *testing.T) {

--- a/graph/multi/undirected.go
+++ b/graph/multi/undirected.go
@@ -19,6 +19,10 @@ var (
 	_ graph.Undirected           = ug
 	_ graph.Multigraph           = ug
 	_ graph.UndirectedMultigraph = ug
+	_ graph.NodeAdder            = ug
+	_ graph.NodeRemover          = ug
+	_ graph.LineAdder            = ug
+	_ graph.LineRemover          = ug
 )
 
 // UndirectedGraph implements a generalized undirected graph.

--- a/graph/multi/undirected_test.go
+++ b/graph/multi/undirected_test.go
@@ -10,13 +10,6 @@ import (
 	"gonum.org/v1/gonum/graph"
 )
 
-var (
-	undirectedGraph = (*UndirectedGraph)(nil)
-
-	_ graph.Graph      = undirectedGraph
-	_ graph.Undirected = undirectedGraph
-)
-
 func TestMaxID(t *testing.T) {
 	g := NewUndirectedGraph()
 	nodes := make(map[graph.Node]struct{})

--- a/graph/multi/weighted_directed.go
+++ b/graph/multi/weighted_directed.go
@@ -16,11 +16,16 @@ var (
 	wdg *WeightedDirectedGraph
 
 	_ graph.Graph                      = wdg
+	_ graph.Weighted                   = wdg
 	_ graph.Directed                   = wdg
 	_ graph.WeightedDirected           = wdg
 	_ graph.Multigraph                 = wdg
 	_ graph.DirectedMultigraph         = wdg
 	_ graph.WeightedDirectedMultigraph = wdg
+	_ graph.NodeAdder                  = wdg
+	_ graph.NodeRemover                = wdg
+	_ graph.WeightedLineAdder          = wdg
+	_ graph.LineRemover                = wdg
 )
 
 // WeightedDirectedGraph implements a generalized directed graph.
@@ -126,26 +131,25 @@ func (g *WeightedDirectedGraph) SetWeightedLine(l graph.WeightedLine) {
 	g.lineIDs.Use(l.ID())
 }
 
-// RemoveWeightedLine removes l from the graph, leaving the terminal nodes. If the line does not exist
+// RemoveLine removes l from the graph, leaving the terminal nodes. If the line does not exist
 // it is a no-op.
-func (g *WeightedDirectedGraph) RemoveWeightedLine(l graph.WeightedLine) {
-	from, to := l.From(), l.To()
-	if _, ok := g.nodes[from.ID()]; !ok {
+func (g *WeightedDirectedGraph) RemoveLine(fid, tid, id int64) {
+	if _, ok := g.nodes[fid]; !ok {
 		return
 	}
-	if _, ok := g.nodes[to.ID()]; !ok {
+	if _, ok := g.nodes[tid]; !ok {
 		return
 	}
 
-	delete(g.from[from.ID()][to.ID()], l.ID())
-	if len(g.from[from.ID()][to.ID()]) == 0 {
-		delete(g.from[from.ID()], to.ID())
+	delete(g.from[fid][tid], id)
+	if len(g.from[fid][tid]) == 0 {
+		delete(g.from[fid], tid)
 	}
-	delete(g.to[to.ID()][from.ID()], l.ID())
-	if len(g.to[to.ID()][from.ID()]) == 0 {
-		delete(g.to[to.ID()], from.ID())
+	delete(g.to[tid][fid], id)
+	if len(g.to[tid][fid]) == 0 {
+		delete(g.to[tid], fid)
 	}
-	g.lineIDs.Release(l.ID())
+	g.lineIDs.Release(id)
 }
 
 // Node returns the node in the graph with the given ID.

--- a/graph/multi/weighted_directed.go
+++ b/graph/multi/weighted_directed.go
@@ -131,8 +131,8 @@ func (g *WeightedDirectedGraph) SetWeightedLine(l graph.WeightedLine) {
 	g.lineIDs.Use(l.ID())
 }
 
-// RemoveLine removes l from the graph, leaving the terminal nodes. If the line does not exist
-// it is a no-op.
+// RemoveLine removes the line with the given end point and line IDs from the graph,
+// leaving the terminal nodes. If the line does not exist it is a no-op.
 func (g *WeightedDirectedGraph) RemoveLine(fid, tid, id int64) {
 	if _, ok := g.nodes[fid]; !ok {
 		return

--- a/graph/multi/weighted_directed_test.go
+++ b/graph/multi/weighted_directed_test.go
@@ -4,19 +4,7 @@
 
 package multi
 
-import (
-	"testing"
-
-	"gonum.org/v1/gonum/graph"
-)
-
-var (
-	weightedDirectedGraph = (*WeightedDirectedGraph)(nil)
-
-	_ graph.Graph            = weightedDirectedGraph
-	_ graph.Directed         = weightedDirectedGraph
-	_ graph.WeightedDirected = weightedDirectedGraph
-)
+import "testing"
 
 // Tests Issue #27
 func TestWeightedEdgeOvercounting(t *testing.T) {

--- a/graph/multi/weighted_directed_test.go
+++ b/graph/multi/weighted_directed_test.go
@@ -4,7 +4,11 @@
 
 package multi
 
-import "testing"
+import (
+	"testing"
+
+	"gonum.org/v1/gonum/graph"
+)
 
 // Tests Issue #27
 func TestWeightedEdgeOvercounting(t *testing.T) {

--- a/graph/multi/weighted_undirected.go
+++ b/graph/multi/weighted_undirected.go
@@ -16,11 +16,16 @@ var (
 	wug *WeightedUndirectedGraph
 
 	_ graph.Graph                        = wug
+	_ graph.Weighted                     = wug
 	_ graph.Undirected                   = wug
 	_ graph.WeightedUndirected           = wug
 	_ graph.Multigraph                   = wug
 	_ graph.UndirectedMultigraph         = wug
 	_ graph.WeightedUndirectedMultigraph = wug
+	_ graph.NodeAdder                    = wug
+	_ graph.NodeRemover                  = wug
+	_ graph.WeightedLineAdder            = wug
+	_ graph.LineRemover                  = wug
 )
 
 // WeightedUndirectedGraph implements a generalized undirected graph.
@@ -86,12 +91,12 @@ func (g *WeightedUndirectedGraph) RemoveNode(id int64) {
 // NewLine returns a new WeightedLine from the source to the destination node.
 // The returned WeightedLine will have a graph-unique ID.
 // The Line's ID does not become valid in g until the Line is added to g.
-func (g *WeightedUndirectedGraph) NewLine(from, to graph.Node) graph.WeightedLine {
-	return &WeightedLine{F: from, T: to, UID: g.lineIDs.NewID()}
+func (g *WeightedUndirectedGraph) NewWeightedLine(from, to graph.Node, weight float64) graph.WeightedLine {
+	return &WeightedLine{F: from, T: to, W: weight, UID: g.lineIDs.NewID()}
 }
 
-// SetWeighted adds l, a line from one node to another. If the nodes do not exist, they are added.
-func (g *WeightedUndirectedGraph) SetWeighted(l graph.WeightedLine) {
+// SetWeightedLine adds l, a line from one node to another. If the nodes do not exist, they are added.
+func (g *WeightedUndirectedGraph) SetWeightedLine(l graph.WeightedLine) {
 	var (
 		from = l.From()
 		fid  = from.ID()

--- a/graph/multi/weighted_undirected.go
+++ b/graph/multi/weighted_undirected.go
@@ -88,7 +88,7 @@ func (g *WeightedUndirectedGraph) RemoveNode(id int64) {
 	g.nodeIDs.Release(id)
 }
 
-// NewLine returns a new WeightedLine from the source to the destination node.
+// NewWeightedLine returns a new WeightedLine from the source to the destination node.
 // The returned WeightedLine will have a graph-unique ID.
 // The Line's ID does not become valid in g until the Line is added to g.
 func (g *WeightedUndirectedGraph) NewWeightedLine(from, to graph.Node, weight float64) graph.WeightedLine {

--- a/graph/simple/dense_directed_matrix.go
+++ b/graph/simple/dense_directed_matrix.go
@@ -13,6 +13,13 @@ import (
 	"gonum.org/v1/gonum/mat"
 )
 
+var (
+	_ graph.Graph        = (*DirectedMatrix)(nil)
+	_ graph.Directed     = (*DirectedMatrix)(nil)
+	_ edgeSetter         = (*DirectedMatrix)(nil)
+	_ weightedEdgeSetter = (*DirectedMatrix)(nil)
+)
+
 // DirectedMatrix represents a directed graph using an adjacency
 // matrix such that all IDs are in a contiguous block from 0 to n-1.
 // Edges are stored implicitly as an edge weight, so edges stored in

--- a/graph/simple/dense_undirected_matrix.go
+++ b/graph/simple/dense_undirected_matrix.go
@@ -13,6 +13,13 @@ import (
 	"gonum.org/v1/gonum/mat"
 )
 
+var (
+	_ graph.Graph        = (*UndirectedMatrix)(nil)
+	_ graph.Undirected   = (*UndirectedMatrix)(nil)
+	_ edgeSetter         = (*UndirectedMatrix)(nil)
+	_ weightedEdgeSetter = (*UndirectedMatrix)(nil)
+)
+
 // UndirectedMatrix represents an undirected graph using an adjacency
 // matrix such that all IDs are in a contiguous block from 0 to n-1.
 // Edges are stored implicitly as an edge weight, so edges stored in

--- a/graph/simple/densegraph_test.go
+++ b/graph/simple/densegraph_test.go
@@ -9,22 +9,7 @@ import (
 	"sort"
 	"testing"
 
-	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
-)
-
-var (
-	directedMatrix = (*DirectedMatrix)(nil)
-
-	_ graph.Graph            = directedMatrix
-	_ graph.Directed         = directedMatrix
-	_ graph.WeightedDirected = directedMatrix
-
-	undirectedMatrix = (*UndirectedMatrix)(nil)
-
-	_ graph.Graph              = undirectedMatrix
-	_ graph.Undirected         = undirectedMatrix
-	_ graph.WeightedUndirected = undirectedMatrix
 )
 
 func TestBasicDenseImpassable(t *testing.T) {

--- a/graph/simple/densegraph_test.go
+++ b/graph/simple/densegraph_test.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"testing"
 
+	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
 )
 

--- a/graph/simple/directed.go
+++ b/graph/simple/directed.go
@@ -12,6 +12,17 @@ import (
 	"gonum.org/v1/gonum/graph/iterator"
 )
 
+var (
+	dg *DirectedGraph
+
+	_ graph.Graph       = dg
+	_ graph.Directed    = dg
+	_ graph.NodeAdder   = dg
+	_ graph.NodeRemover = dg
+	_ graph.EdgeAdder   = dg
+	_ graph.EdgeRemover = dg
+)
+
 // DirectedGraph implements a generalized directed graph.
 type DirectedGraph struct {
 	nodes map[int64]graph.Node

--- a/graph/simple/directed_test.go
+++ b/graph/simple/directed_test.go
@@ -4,18 +4,7 @@
 
 package simple
 
-import (
-	"testing"
-
-	"gonum.org/v1/gonum/graph"
-)
-
-var (
-	directedGraph = (*DirectedGraph)(nil)
-
-	_ graph.Graph    = directedGraph
-	_ graph.Directed = directedGraph
-)
+import "testing"
 
 // Tests Issue #27
 func TestEdgeOvercounting(t *testing.T) {

--- a/graph/simple/directed_test.go
+++ b/graph/simple/directed_test.go
@@ -4,7 +4,11 @@
 
 package simple
 
-import "testing"
+import (
+	"testing"
+
+	"gonum.org/v1/gonum/graph"
+)
 
 // Tests Issue #27
 func TestEdgeOvercounting(t *testing.T) {

--- a/graph/simple/simple.go
+++ b/graph/simple/simple.go
@@ -53,3 +53,11 @@ func (e WeightedEdge) Weight() float64 { return e.W }
 func isSame(a, b float64) bool {
 	return a == b || (math.IsNaN(a) && math.IsNaN(b))
 }
+
+type edgeSetter interface {
+	SetEdge(e graph.Edge)
+}
+
+type weightedEdgeSetter interface {
+	SetWeightedEdge(e graph.WeightedEdge)
+}

--- a/graph/simple/undirected.go
+++ b/graph/simple/undirected.go
@@ -12,6 +12,17 @@ import (
 	"gonum.org/v1/gonum/graph/iterator"
 )
 
+var (
+	ug *UndirectedGraph
+
+	_ graph.Graph       = ug
+	_ graph.Undirected  = ug
+	_ graph.NodeAdder   = ug
+	_ graph.NodeRemover = ug
+	_ graph.EdgeAdder   = ug
+	_ graph.EdgeRemover = ug
+)
+
 // UndirectedGraph implements a generalized undirected graph.
 type UndirectedGraph struct {
 	nodes map[int64]graph.Node

--- a/graph/simple/undirected_test.go
+++ b/graph/simple/undirected_test.go
@@ -10,13 +10,6 @@ import (
 	"gonum.org/v1/gonum/graph"
 )
 
-var (
-	undirectedGraph = (*UndirectedGraph)(nil)
-
-	_ graph.Graph      = undirectedGraph
-	_ graph.Undirected = undirectedGraph
-)
-
 func TestAssertMutableNotDirected(t *testing.T) {
 	var g graph.UndirectedBuilder = NewUndirectedGraph()
 	if _, ok := g.(graph.Directed); ok {

--- a/graph/simple/weighted_directed.go
+++ b/graph/simple/weighted_directed.go
@@ -12,6 +12,19 @@ import (
 	"gonum.org/v1/gonum/graph/iterator"
 )
 
+var (
+	wdg *WeightedDirectedGraph
+
+	_ graph.Graph             = wdg
+	_ graph.Weighted          = wdg
+	_ graph.Directed          = wdg
+	_ graph.WeightedDirected  = wdg
+	_ graph.NodeAdder         = wdg
+	_ graph.NodeRemover       = wdg
+	_ graph.WeightedEdgeAdder = wdg
+	_ graph.EdgeRemover       = wdg
+)
+
 // WeightedDirectedGraph implements a generalized weighted directed graph.
 type WeightedDirectedGraph struct {
 	nodes map[int64]graph.Node

--- a/graph/simple/weighted_directed_test.go
+++ b/graph/simple/weighted_directed_test.go
@@ -7,16 +7,6 @@ package simple
 import (
 	"math"
 	"testing"
-
-	"gonum.org/v1/gonum/graph"
-)
-
-var (
-	weightedDirectedGraph = (*WeightedDirectedGraph)(nil)
-
-	_ graph.Graph            = weightedDirectedGraph
-	_ graph.Directed         = weightedDirectedGraph
-	_ graph.WeightedDirected = weightedDirectedGraph
 )
 
 // Tests Issue #27

--- a/graph/simple/weighted_directed_test.go
+++ b/graph/simple/weighted_directed_test.go
@@ -7,6 +7,8 @@ package simple
 import (
 	"math"
 	"testing"
+
+	"gonum.org/v1/gonum/graph"
 )
 
 // Tests Issue #27

--- a/graph/simple/weighted_undirected.go
+++ b/graph/simple/weighted_undirected.go
@@ -12,6 +12,19 @@ import (
 	"gonum.org/v1/gonum/graph/iterator"
 )
 
+var (
+	wug *WeightedUndirectedGraph
+
+	_ graph.Graph              = wug
+	_ graph.Weighted           = wug
+	_ graph.Undirected         = wug
+	_ graph.WeightedUndirected = wug
+	_ graph.NodeAdder          = wug
+	_ graph.NodeRemover        = wug
+	_ graph.WeightedEdgeAdder  = wug
+	_ graph.EdgeRemover        = wug
+)
+
 // WeightedUndirectedGraph implements a generalized weighted undirected graph.
 type WeightedUndirectedGraph struct {
 	nodes map[int64]graph.Node

--- a/graph/simple/weighted_undirected_test.go
+++ b/graph/simple/weighted_undirected_test.go
@@ -11,14 +11,6 @@ import (
 	"gonum.org/v1/gonum/graph"
 )
 
-var (
-	weightedUndirectedGraph = (*WeightedUndirectedGraph)(nil)
-
-	_ graph.Graph              = weightedUndirectedGraph
-	_ graph.Undirected         = weightedUndirectedGraph
-	_ graph.WeightedUndirected = weightedUndirectedGraph
-)
-
 func TestAssertWeightedMutableNotDirected(t *testing.T) {
 	var g graph.UndirectedWeightedBuilder = NewWeightedUndirectedGraph(0, math.Inf(1))
 	if _, ok := g.(graph.Directed); ok {


### PR DESCRIPTION
There were a multitude of sins uncovered by looking into a simple fix to the `multi.WeightedUndirectedGraph` type sent by @highway900.

These were missed because the types are not properly tested. This change fixes the problem he found and others that were identified by performing compile time type assignability tests that will stand in for proper testing in the short term.

I have moved the assignability tests into the packages proper to ensure they don't get missed in reading.

Please take a look.

Closes #576.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
