### PR TITLE
stat/spatial: fix example name suffix

### DIFF
--- a/stat/spatial/spatial_example_test.go
+++ b/stat/spatial/spatial_example_test.go
@@ -103,7 +103,7 @@ func ExampleGetisOrdGStar() {
 	// v=0 G*i=-1.225
 }
 
-func ExampleGetisOrd_band() {
+func ExampleGetisOrdGStar_banded() {
 	data := []float64{0, 0, 0, 1, 1, 1, 0, 1, 0, 0}
 
 	// The locality here describes spatial neighbor


### PR DESCRIPTION
This stops vet complaining for stat/spatial. ~~I'm not really happy about the 2sat change, but it is the documented behaviour in testing and vet doesn't like it though godoc will render it.~~

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
