### PR TITLE
graph: avoid issues around graph node retrieval subtleties

### DIFF
--- a/graph/community/louvain_directed.go
+++ b/graph/community/louvain_directed.go
@@ -341,7 +341,7 @@ func (g *ReducedDirected) Has(id int64) bool {
 	return 0 <= id && id < int64(len(g.nodes))
 }
 
-// Node returns the node in the graph with the given ID if it exists,
+// Node returns the node with the given ID if it exists in the graph,
 // and nil otherwise.
 func (g *ReducedDirected) Node(id int64) graph.Node {
 	if g.Has(id) {

--- a/graph/community/louvain_directed.go
+++ b/graph/community/louvain_directed.go
@@ -341,7 +341,8 @@ func (g *ReducedDirected) Has(id int64) bool {
 	return 0 <= id && id < int64(len(g.nodes))
 }
 
-// Node returns the node with the given ID if it exists in the graph.
+// Node returns the node in the graph with the given ID if it exists,
+// and nil otherwise.
 func (g *ReducedDirected) Node(id int64) graph.Node {
 	if g.Has(id) {
 		return g.nodes[id]

--- a/graph/community/louvain_directed.go
+++ b/graph/community/louvain_directed.go
@@ -341,6 +341,14 @@ func (g *ReducedDirected) Has(id int64) bool {
 	return 0 <= id && id < int64(len(g.nodes))
 }
 
+// Node returns the node with the given ID if it exists in the graph.
+func (g *ReducedDirected) Node(id int64) graph.Node {
+	if g.Has(id) {
+		return g.nodes[id]
+	}
+	return nil
+}
+
 // Nodes returns all the nodes in the graph.
 func (g *ReducedDirected) Nodes() graph.Nodes {
 	nodes := make([]graph.Node, len(g.nodes))

--- a/graph/community/louvain_directed_multiplex.go
+++ b/graph/community/louvain_directed_multiplex.go
@@ -505,7 +505,7 @@ func (g directedLayerHandle) Has(id int64) bool {
 	return 0 <= id && id < int64(len(g.multiplex.nodes))
 }
 
-// Node returns the node in the graph with the given ID if it exists,
+// Node returns the node with the given ID if it exists in the graph,
 // and nil otherwise.
 func (g directedLayerHandle) Node(id int64) graph.Node {
 	if g.Has(id) {

--- a/graph/community/louvain_directed_multiplex.go
+++ b/graph/community/louvain_directed_multiplex.go
@@ -505,7 +505,8 @@ func (g directedLayerHandle) Has(id int64) bool {
 	return 0 <= id && id < int64(len(g.multiplex.nodes))
 }
 
-// Node returns the node with the given ID if it exists in the graph.
+// Node returns the node in the graph with the given ID if it exists,
+// and nil otherwise.
 func (g directedLayerHandle) Node(id int64) graph.Node {
 	if g.Has(id) {
 		return g.multiplex.nodes[id]

--- a/graph/community/louvain_directed_multiplex.go
+++ b/graph/community/louvain_directed_multiplex.go
@@ -505,6 +505,14 @@ func (g directedLayerHandle) Has(id int64) bool {
 	return 0 <= id && id < int64(len(g.multiplex.nodes))
 }
 
+// Node returns the node with the given ID if it exists in the graph.
+func (g directedLayerHandle) Node(id int64) graph.Node {
+	if g.Has(id) {
+		return g.multiplex.nodes[id]
+	}
+	return nil
+}
+
 // Nodes returns all the nodes in the graph.
 func (g directedLayerHandle) Nodes() graph.Nodes {
 	nodes := make([]graph.Node, len(g.multiplex.nodes))

--- a/graph/community/louvain_undirected.go
+++ b/graph/community/louvain_undirected.go
@@ -301,7 +301,8 @@ func (g *ReducedUndirected) Has(id int64) bool {
 	return 0 <= id || id < int64(len(g.nodes))
 }
 
-// Node returns the node with the given ID if it exists in the graph.
+// Node returns the node in the graph with the given ID if it exists,
+// and nil otherwise.
 func (g *ReducedUndirected) Node(id int64) graph.Node {
 	if g.Has(id) {
 		return g.nodes[id]

--- a/graph/community/louvain_undirected.go
+++ b/graph/community/louvain_undirected.go
@@ -301,6 +301,14 @@ func (g *ReducedUndirected) Has(id int64) bool {
 	return 0 <= id || id < int64(len(g.nodes))
 }
 
+// Node returns the node with the given ID if it exists in the graph.
+func (g *ReducedUndirected) Node(id int64) graph.Node {
+	if g.Has(id) {
+		return g.nodes[id]
+	}
+	return nil
+}
+
 // Nodes returns all the nodes in the graph.
 func (g *ReducedUndirected) Nodes() graph.Nodes {
 	nodes := make([]graph.Node, len(g.nodes))

--- a/graph/community/louvain_undirected.go
+++ b/graph/community/louvain_undirected.go
@@ -301,7 +301,7 @@ func (g *ReducedUndirected) Has(id int64) bool {
 	return 0 <= id || id < int64(len(g.nodes))
 }
 
-// Node returns the node in the graph with the given ID if it exists,
+// Node returns the node with the given ID if it exists in the graph,
 // and nil otherwise.
 func (g *ReducedUndirected) Node(id int64) graph.Node {
 	if g.Has(id) {

--- a/graph/community/louvain_undirected_multiplex.go
+++ b/graph/community/louvain_undirected_multiplex.go
@@ -463,7 +463,8 @@ func (g undirectedLayerHandle) Has(id int64) bool {
 	return 0 <= id && id < int64(len(g.multiplex.nodes))
 }
 
-// Node returns the node with the given ID if it exists in the graph.
+// Node returns the node in the graph with the given ID if it exists,
+// and nil otherwise.
 func (g undirectedLayerHandle) Node(id int64) graph.Node {
 	if g.Has(id) {
 		return g.multiplex.nodes[id]

--- a/graph/community/louvain_undirected_multiplex.go
+++ b/graph/community/louvain_undirected_multiplex.go
@@ -463,7 +463,7 @@ func (g undirectedLayerHandle) Has(id int64) bool {
 	return 0 <= id && id < int64(len(g.multiplex.nodes))
 }
 
-// Node returns the node in the graph with the given ID if it exists,
+// Node returns the node with the given ID if it exists in the graph,
 // and nil otherwise.
 func (g undirectedLayerHandle) Node(id int64) graph.Node {
 	if g.Has(id) {

--- a/graph/community/louvain_undirected_multiplex.go
+++ b/graph/community/louvain_undirected_multiplex.go
@@ -463,6 +463,14 @@ func (g undirectedLayerHandle) Has(id int64) bool {
 	return 0 <= id && id < int64(len(g.multiplex.nodes))
 }
 
+// Node returns the node with the given ID if it exists in the graph.
+func (g undirectedLayerHandle) Node(id int64) graph.Node {
+	if g.Has(id) {
+		return g.multiplex.nodes[id]
+	}
+	return nil
+}
+
 // Nodes returns all the nodes in the graph.
 func (g undirectedLayerHandle) Nodes() graph.Nodes {
 	nodes := make([]graph.Node, len(g.multiplex.nodes))

--- a/graph/ex/fdpclust/gn.go
+++ b/graph/ex/fdpclust/gn.go
@@ -17,34 +17,38 @@ type GraphNode struct {
 }
 
 func (g *GraphNode) Has(id int64) bool {
+	return g.Node(id) != nil
+}
+
+func (g *GraphNode) Node(id int64) graph.Node {
 	if id == g.id {
-		return true
+		return g
 	}
 
 	visited := map[int64]struct{}{g.id: {}}
 	for _, root := range g.roots {
 		if root.ID() == id {
-			return true
+			return root
 		}
 
 		if root.has(id, visited) {
-			return true
+			return root
 		}
 	}
 
 	for _, neigh := range g.neighbors {
 		if neigh.ID() == id {
-			return true
+			return neigh
 		}
 
 		if gn, ok := neigh.(*GraphNode); ok {
 			if gn.has(id, visited) {
-				return true
+				return gn
 			}
 		}
 	}
 
-	return false
+	return nil
 }
 
 func (g *GraphNode) has(id int64, visited map[int64]struct{}) bool {

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -32,7 +32,7 @@ type Graph interface {
 	Has(id int64) bool
 
 	// Node returns the node with the given ID if it exists
-	// in the graph.
+	// in the graph, and nil otherwise.
 	Node(id int64) Node
 
 	// Nodes returns all the nodes in the graph.

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -31,6 +31,10 @@ type Graph interface {
 	// within the graph.
 	Has(id int64) bool
 
+	// Node returns the node with the given ID if it exists
+	// in the graph.
+	Node(id int64) Node
+
 	// Nodes returns all the nodes in the graph.
 	Nodes() Nodes
 
@@ -146,8 +150,10 @@ type EdgeAdder interface {
 	// will be added if they do not exist, otherwise
 	// SetEdge will panic.
 	// The behavior of an EdgeAdder when the IDs
-	// returned by e.From and e.To are equal is
+	// returned by e.From() and e.To() are equal is
 	// implementation-dependent.
+	// Whether e, e.From() and e.To() are stored
+	// within the graph is implementation dependent.
 	SetEdge(e Edge)
 }
 
@@ -162,8 +168,10 @@ type WeightedEdgeAdder interface {
 	// the nodes will be added if they do not exist,
 	// otherwise SetWeightedEdge will panic.
 	// The behavior of a WeightedEdgeAdder when the IDs
-	// returned by e.From and e.To are equal is
+	// returned by e.From() and e.To() are equal is
 	// implementation-dependent.
+	// Whether e, e.From() and e.To() are stored
+	// within the graph is implementation dependent.
 	SetWeightedEdge(e WeightedEdge)
 }
 

--- a/graph/multi/directed.go
+++ b/graph/multi/directed.go
@@ -98,7 +98,8 @@ func (g *DirectedGraph) NewLine(from, to graph.Node) graph.Line {
 	return &Line{F: from, T: to, UID: g.lineIDs.NewID()}
 }
 
-// SetLine adds l, a line from one node to another. If the nodes do not exist, they are added.
+// SetLine adds l, a line from one node to another. If the nodes do not exist, they are added
+// and are set to the nodes of the line otherwise.
 func (g *DirectedGraph) SetLine(l graph.Line) {
 	var (
 		from = l.From()
@@ -110,12 +111,16 @@ func (g *DirectedGraph) SetLine(l graph.Line) {
 
 	if !g.Has(fid) {
 		g.AddNode(from)
+	} else {
+		g.nodes[fid] = from
 	}
 	if g.from[fid][tid] == nil {
 		g.from[fid][tid] = make(map[int64]graph.Line)
 	}
 	if !g.Has(tid) {
 		g.AddNode(to)
+	} else {
+		g.nodes[tid] = to
 	}
 	if g.to[tid][fid] == nil {
 		g.to[tid][fid] = make(map[int64]graph.Line)

--- a/graph/multi/directed.go
+++ b/graph/multi/directed.go
@@ -158,7 +158,7 @@ func (g *DirectedGraph) Has(id int64) bool {
 	return ok
 }
 
-// Node returns the node in the graph with the given ID if it exists,
+// Node returns the node with the given ID if it exists in the graph,
 // and nil otherwise.
 func (g *DirectedGraph) Node(id int64) graph.Node {
 	return g.nodes[id]

--- a/graph/multi/directed.go
+++ b/graph/multi/directed.go
@@ -152,15 +152,16 @@ func (g *DirectedGraph) RemoveLine(fid, tid, id int64) {
 	g.lineIDs.Release(id)
 }
 
-// Node returns the node in the graph with the given ID.
-func (g *DirectedGraph) Node(id int64) graph.Node {
-	return g.nodes[id]
-}
-
 // Has returns whether the node exists within the graph.
 func (g *DirectedGraph) Has(id int64) bool {
 	_, ok := g.nodes[id]
 	return ok
+}
+
+// Node returns the node in the graph with the given ID if it exists,
+// and nil otherwise.
+func (g *DirectedGraph) Node(id int64) graph.Node {
+	return g.nodes[id]
 }
 
 // Nodes returns all the nodes in the graph.

--- a/graph/multi/undirected.go
+++ b/graph/multi/undirected.go
@@ -90,7 +90,8 @@ func (g *UndirectedGraph) NewLine(from, to graph.Node) graph.Line {
 	return &Line{F: from, T: to, UID: g.lineIDs.NewID()}
 }
 
-// SetLine adds l, a line from one node to another. If the nodes do not exist, they are added.
+// SetLine adds l, a line from one node to another. If the nodes do not exist, they are added
+// and are set to the nodes of the line otherwise.
 func (g *UndirectedGraph) SetLine(l graph.Line) {
 	var (
 		from = l.From()
@@ -102,12 +103,16 @@ func (g *UndirectedGraph) SetLine(l graph.Line) {
 
 	if !g.Has(fid) {
 		g.AddNode(from)
+	} else {
+		g.nodes[fid] = from
 	}
 	if g.lines[fid][tid] == nil {
 		g.lines[fid][tid] = make(map[int64]graph.Line)
 	}
 	if !g.Has(tid) {
 		g.AddNode(to)
+	} else {
+		g.nodes[tid] = to
 	}
 	if g.lines[tid][fid] == nil {
 		g.lines[tid][fid] = make(map[int64]graph.Line)

--- a/graph/multi/undirected.go
+++ b/graph/multi/undirected.go
@@ -141,15 +141,16 @@ func (g *UndirectedGraph) RemoveLine(fid, tid, id int64) {
 	g.lineIDs.Release(id)
 }
 
-// Node returns the node in the graph with the given ID.
-func (g *UndirectedGraph) Node(id int64) graph.Node {
-	return g.nodes[id]
-}
-
 // Has returns whether the node exists within the graph.
 func (g *UndirectedGraph) Has(id int64) bool {
 	_, ok := g.nodes[id]
 	return ok
+}
+
+// Node returns the node in the graph with the given ID if it exists,
+// and nil otherwise.
+func (g *UndirectedGraph) Node(id int64) graph.Node {
+	return g.nodes[id]
 }
 
 // Nodes returns all the nodes in the graph.

--- a/graph/multi/undirected.go
+++ b/graph/multi/undirected.go
@@ -147,7 +147,7 @@ func (g *UndirectedGraph) Has(id int64) bool {
 	return ok
 }
 
-// Node returns the node in the graph with the given ID if it exists,
+// Node returns the node with the given ID if it exists in the graph,
 // and nil otherwise.
 func (g *UndirectedGraph) Node(id int64) graph.Node {
 	return g.nodes[id]

--- a/graph/multi/weighted_directed.go
+++ b/graph/multi/weighted_directed.go
@@ -103,7 +103,7 @@ func (g *WeightedDirectedGraph) NewWeightedLine(from, to graph.Node, weight floa
 	return &WeightedLine{F: from, T: to, W: weight, UID: g.lineIDs.NewID()}
 }
 
-// SetWeightedLine adds l, a line from one node to another. If the nodes do not exist, they are added.
+// SetWeightedLine adds l, a line from one node to another. If the nodes do not exist, they are added
 // and are set to the nodes of the line otherwise.
 func (g *WeightedDirectedGraph) SetWeightedLine(l graph.WeightedLine) {
 	var (

--- a/graph/multi/weighted_directed.go
+++ b/graph/multi/weighted_directed.go
@@ -157,16 +157,17 @@ func (g *WeightedDirectedGraph) RemoveLine(fid, tid, id int64) {
 	g.lineIDs.Release(id)
 }
 
-// Node returns the node in the graph with the given ID.
-func (g *WeightedDirectedGraph) Node(id int64) graph.Node {
-	return g.nodes[id]
-}
-
 // Has returns whether the node exists within the graph.
 func (g *WeightedDirectedGraph) Has(id int64) bool {
 	_, ok := g.nodes[id]
 
 	return ok
+}
+
+// Node returns the node in the graph with the given ID if it exists,
+// and nil otherwise.
+func (g *WeightedDirectedGraph) Node(id int64) graph.Node {
+	return g.nodes[id]
 }
 
 // Nodes returns all the nodes in the graph.

--- a/graph/multi/weighted_directed.go
+++ b/graph/multi/weighted_directed.go
@@ -104,6 +104,7 @@ func (g *WeightedDirectedGraph) NewWeightedLine(from, to graph.Node, weight floa
 }
 
 // SetWeightedLine adds l, a line from one node to another. If the nodes do not exist, they are added.
+// and are set to the nodes of the line otherwise.
 func (g *WeightedDirectedGraph) SetWeightedLine(l graph.WeightedLine) {
 	var (
 		from = l.From()
@@ -115,12 +116,16 @@ func (g *WeightedDirectedGraph) SetWeightedLine(l graph.WeightedLine) {
 
 	if !g.Has(fid) {
 		g.AddNode(from)
+	} else {
+		g.nodes[fid] = from
 	}
 	if g.from[fid][tid] == nil {
 		g.from[fid][tid] = make(map[int64]graph.WeightedLine)
 	}
 	if !g.Has(tid) {
 		g.AddNode(to)
+	} else {
+		g.nodes[tid] = to
 	}
 	if g.to[tid][fid] == nil {
 		g.to[tid][fid] = make(map[int64]graph.WeightedLine)

--- a/graph/multi/weighted_directed.go
+++ b/graph/multi/weighted_directed.go
@@ -164,7 +164,7 @@ func (g *WeightedDirectedGraph) Has(id int64) bool {
 	return ok
 }
 
-// Node returns the node in the graph with the given ID if it exists,
+// Node returns the node with the given ID if it exists in the graph,
 // and nil otherwise.
 func (g *WeightedDirectedGraph) Node(id int64) graph.Node {
 	return g.nodes[id]

--- a/graph/multi/weighted_undirected.go
+++ b/graph/multi/weighted_undirected.go
@@ -152,7 +152,7 @@ func (g *WeightedUndirectedGraph) Has(id int64) bool {
 	return ok
 }
 
-// Node returns the node in the graph with the given ID if it exists,
+// Node returns the node with the given ID if it exists in the graph,
 // and nil otherwise.
 func (g *WeightedUndirectedGraph) Node(id int64) graph.Node {
 	return g.nodes[id]

--- a/graph/multi/weighted_undirected.go
+++ b/graph/multi/weighted_undirected.go
@@ -146,15 +146,16 @@ func (g *WeightedUndirectedGraph) RemoveLine(fid, tid, id int64) {
 	g.lineIDs.Release(id)
 }
 
-// Node returns the node in the graph with the given ID.
-func (g *WeightedUndirectedGraph) Node(id int64) graph.Node {
-	return g.nodes[id]
-}
-
 // Has returns whether the node exists within the graph.
 func (g *WeightedUndirectedGraph) Has(id int64) bool {
 	_, ok := g.nodes[id]
 	return ok
+}
+
+// Node returns the node in the graph with the given ID if it exists,
+// and nil otherwise.
+func (g *WeightedUndirectedGraph) Node(id int64) graph.Node {
+	return g.nodes[id]
 }
 
 // Nodes returns all the nodes in the graph.

--- a/graph/multi/weighted_undirected.go
+++ b/graph/multi/weighted_undirected.go
@@ -95,7 +95,8 @@ func (g *WeightedUndirectedGraph) NewWeightedLine(from, to graph.Node, weight fl
 	return &WeightedLine{F: from, T: to, W: weight, UID: g.lineIDs.NewID()}
 }
 
-// SetWeightedLine adds l, a line from one node to another. If the nodes do not exist, they are added.
+// SetWeightedLine adds l, a line from one node to another. If the nodes do not exist, they are added
+// and are set to the nodes of the line otherwise.
 func (g *WeightedUndirectedGraph) SetWeightedLine(l graph.WeightedLine) {
 	var (
 		from = l.From()
@@ -107,12 +108,16 @@ func (g *WeightedUndirectedGraph) SetWeightedLine(l graph.WeightedLine) {
 
 	if !g.Has(fid) {
 		g.AddNode(from)
+	} else {
+		g.nodes[fid] = from
 	}
 	if g.lines[fid][tid] == nil {
 		g.lines[fid][tid] = make(map[int64]graph.WeightedLine)
 	}
 	if !g.Has(tid) {
 		g.AddNode(to)
+	} else {
+		g.nodes[tid] = to
 	}
 	if g.lines[tid][fid] == nil {
 		g.lines[tid][fid] = make(map[int64]graph.WeightedLine)

--- a/graph/multigraph.go
+++ b/graph/multigraph.go
@@ -23,6 +23,10 @@ type Multigraph interface {
 	// within the multigraph.
 	Has(id int64) bool
 
+	// Node returns the node with the given ID if it exists
+	// in the multigraph.
+	Node(id int64) Node
+
 	// Nodes returns all the nodes in the multigraph.
 	Nodes() Nodes
 
@@ -107,6 +111,8 @@ type LineAdder interface {
 	// If the multigraph supports node addition the nodes
 	// will be added if they do not exist, otherwise
 	// SetLine will panic.
+	// Whether l, l.From() and l.To() are stored
+	// within the graph is implementation dependent.
 	SetLine(l Line)
 }
 
@@ -120,7 +126,9 @@ type WeightedLineAdder interface {
 	// to another. If the multigraph supports node addition
 	// the nodes will be added if they do not exist,
 	// otherwise SetWeightedLine will panic.
-	SetWeightedLine(e WeightedLine)
+	// Whether l, l.From() and l.To() are stored
+	// within the graph is implementation dependent.
+	SetWeightedLine(l WeightedLine)
 }
 
 // LineRemover is an interface for removing lines from a multigraph.

--- a/graph/multigraph.go
+++ b/graph/multigraph.go
@@ -24,7 +24,7 @@ type Multigraph interface {
 	Has(id int64) bool
 
 	// Node returns the node with the given ID if it exists
-	// in the multigraph.
+	// in the multigraph, and nil otherwise.
 	Node(id int64) Node
 
 	// Nodes returns all the nodes in the multigraph.

--- a/graph/path/dynamic/dstarlite.go
+++ b/graph/path/dynamic/dstarlite.go
@@ -35,7 +35,6 @@ type DStarLite struct {
 type WorldModel interface {
 	graph.WeightedBuilder
 	graph.WeightedDirected
-	Node(id int64) graph.Node
 }
 
 // NewDStarLite returns a new DStarLite planner for the path from s to t in g using the

--- a/graph/path/internal/testgraphs/grid.go
+++ b/graph/path/internal/testgraphs/grid.go
@@ -108,7 +108,7 @@ func (g *Grid) Has(id int64) bool {
 	return 0 <= id && id < int64(len(g.open)) && (g.AllVisible || g.open[id])
 }
 
-// Node returns the node in the graph with the given ID if it exists,
+// Node returns the node with the given ID if it exists in the graph,
 // and nil otherwise.
 func (g *Grid) Node(id int64) graph.Node {
 	if g.Has(id) {

--- a/graph/path/internal/testgraphs/grid.go
+++ b/graph/path/internal/testgraphs/grid.go
@@ -102,11 +102,18 @@ func (g *Grid) Nodes() graph.Nodes {
 	return iterator.NewOrderedNodes(nodes)
 }
 
-// Has returns whether n is a node in the grid. The state of
-// the AllVisible field determines whether a non-open node is
-// present.
+// Has returns whether id represents a node in the grid. The state of
+// the AllVisible field determines whether a non-open node is present.
 func (g *Grid) Has(id int64) bool {
 	return 0 <= id && id < int64(len(g.open)) && (g.AllVisible || g.open[id])
+}
+
+// Node return a node from g if it exists.
+func (g *Grid) Node(id int64) graph.Node {
+	if g.Has(id) {
+		return simple.Node(id)
+	}
+	return nil
 }
 
 // HasOpen returns whether n is an open node in the grid.

--- a/graph/path/internal/testgraphs/grid.go
+++ b/graph/path/internal/testgraphs/grid.go
@@ -108,7 +108,8 @@ func (g *Grid) Has(id int64) bool {
 	return 0 <= id && id < int64(len(g.open)) && (g.AllVisible || g.open[id])
 }
 
-// Node return a node from g if it exists.
+// Node returns the node in the graph with the given ID if it exists,
+// and nil otherwise.
 func (g *Grid) Node(id int64) graph.Node {
 	if g.Has(id) {
 		return simple.Node(id)

--- a/graph/path/internal/testgraphs/limited.go
+++ b/graph/path/internal/testgraphs/limited.go
@@ -166,6 +166,14 @@ func (l *LimitedVisionGrid) Has(id int64) bool {
 	return 0 <= id && id < int64(len(l.Grid.open))
 }
 
+// Node return a node from g if it exists.
+func (l *LimitedVisionGrid) Node(id int64) graph.Node {
+	if l.Has(id) {
+		return simple.Node(id)
+	}
+	return nil
+}
+
 // From returns nodes that are optimistically reachable from u.
 func (l *LimitedVisionGrid) From(uid int64) graph.Nodes {
 	if !l.Has(uid) {

--- a/graph/path/internal/testgraphs/limited.go
+++ b/graph/path/internal/testgraphs/limited.go
@@ -161,12 +161,13 @@ func (l *LimitedVisionGrid) NodeAt(r, c int) graph.Node {
 	return l.Grid.NodeAt(r, c)
 }
 
-// Has returns whether n is a node in the grid.
+// Has returns whether the node with the given ID is a node in the grid.
 func (l *LimitedVisionGrid) Has(id int64) bool {
 	return 0 <= id && id < int64(len(l.Grid.open))
 }
 
-// Node return a node from g if it exists.
+// Node returns the node in the graph with the given ID if it exists,
+// and nil otherwise.
 func (l *LimitedVisionGrid) Node(id int64) graph.Node {
 	if l.Has(id) {
 		return simple.Node(id)

--- a/graph/path/internal/testgraphs/limited.go
+++ b/graph/path/internal/testgraphs/limited.go
@@ -166,7 +166,7 @@ func (l *LimitedVisionGrid) Has(id int64) bool {
 	return 0 <= id && id < int64(len(l.Grid.open))
 }
 
-// Node returns the node in the graph with the given ID if it exists,
+// Node returns the node with the given ID if it exists in the graph,
 // and nil otherwise.
 func (l *LimitedVisionGrid) Node(id int64) graph.Node {
 	if l.Has(id) {

--- a/graph/path/johnson_apsp.go
+++ b/graph/path/johnson_apsp.go
@@ -93,6 +93,10 @@ func (g johnsonWeightAdjuster) Has(id int64) bool {
 	panic("path: unintended use of johnsonWeightAdjuster")
 }
 
+func (g johnsonWeightAdjuster) Node(id int64) graph.Node {
+	panic("path: unintended use of johnsonWeightAdjuster")
+}
+
 func (g johnsonWeightAdjuster) Nodes() graph.Nodes {
 	if g.bellmanFord {
 		return newJohnsonNodeIterator(g.q, g.g.Nodes())

--- a/graph/simple/dense_directed_matrix.go
+++ b/graph/simple/dense_directed_matrix.go
@@ -81,7 +81,7 @@ func (g *DirectedMatrix) has(id int64) bool {
 	return 0 <= id && id < int64(r)
 }
 
-// Node returns the node in the graph with the given ID if it exists,
+// Node returns the node with the given ID if it exists in the graph,
 // and nil otherwise.
 func (g *DirectedMatrix) Node(id int64) graph.Node {
 	if !g.has(id) {

--- a/graph/simple/dense_directed_matrix.go
+++ b/graph/simple/dense_directed_matrix.go
@@ -227,8 +227,10 @@ func (g *DirectedMatrix) SetWeightedEdge(e graph.WeightedEdge) {
 }
 
 func (g *DirectedMatrix) setWeightedEdge(e graph.Edge, weight float64) {
-	fid := e.From().ID()
-	tid := e.To().ID()
+	from := e.From()
+	fid := from.ID()
+	to := e.To()
+	tid := to.ID()
 	if fid == tid {
 		panic("simple: set illegal edge")
 	}
@@ -237,6 +239,10 @@ func (g *DirectedMatrix) setWeightedEdge(e graph.Edge, weight float64) {
 	}
 	if int64(int(tid)) != tid {
 		panic("simple: unavailable to node ID for dense graph")
+	}
+	if g.nodes != nil {
+		g.nodes[fid] = from
+		g.nodes[tid] = to
 	}
 	// fid and tid are not greater than maximum int by this point.
 	g.mat.Set(int(fid), int(tid), weight)

--- a/graph/simple/dense_directed_matrix.go
+++ b/graph/simple/dense_directed_matrix.go
@@ -71,17 +71,6 @@ func NewDirectedMatrixFrom(nodes []graph.Node, init, self, absent float64) *Dire
 	return g
 }
 
-// Node returns the node in the graph with the given ID.
-func (g *DirectedMatrix) Node(id int64) graph.Node {
-	if !g.has(id) {
-		return nil
-	}
-	if g.nodes == nil {
-		return Node(id)
-	}
-	return g.nodes[id]
-}
-
 // Has returns whether the node exists within the graph.
 func (g *DirectedMatrix) Has(id int64) bool {
 	return g.has(id)
@@ -90,6 +79,18 @@ func (g *DirectedMatrix) Has(id int64) bool {
 func (g *DirectedMatrix) has(id int64) bool {
 	r, _ := g.mat.Dims()
 	return 0 <= id && id < int64(r)
+}
+
+// Node returns the node in the graph with the given ID if it exists,
+// and nil otherwise.
+func (g *DirectedMatrix) Node(id int64) graph.Node {
+	if !g.has(id) {
+		return nil
+	}
+	if g.nodes == nil {
+		return Node(id)
+	}
+	return g.nodes[id]
 }
 
 // Nodes returns all the nodes in the graph.
@@ -215,13 +216,15 @@ func (g *DirectedMatrix) Weight(xid, yid int64) (w float64, ok bool) {
 }
 
 // SetEdge sets e, an edge from one node to another with unit weight. If the ends of the edge
-// are not in g or the edge is a self loop, SetEdge panics.
+// are not in g or the edge is a self loop, SetEdge panics. SetEdge will store the nodes of
+// e in the graph if it was initialized with NewDirectedMatrixFrom.
 func (g *DirectedMatrix) SetEdge(e graph.Edge) {
 	g.setWeightedEdge(e, 1)
 }
 
 // SetWeightedEdge sets e, an edge from one node to another. If the ends of the edge are not in g
-// or the edge is a self loop, SetWeightedEdge panics.
+// or the edge is a self loop, SetWeightedEdge panics. SetWeightedEdge will store the nodes of
+// e in the graph if it was initialized with NewDirectedMatrixFrom.
 func (g *DirectedMatrix) SetWeightedEdge(e graph.WeightedEdge) {
 	g.setWeightedEdge(e, e.Weight())
 }

--- a/graph/simple/dense_undirected_matrix.go
+++ b/graph/simple/dense_undirected_matrix.go
@@ -71,17 +71,6 @@ func NewUndirectedMatrixFrom(nodes []graph.Node, init, self, absent float64) *Un
 	return g
 }
 
-// Node returns the node in the graph with the given ID.
-func (g *UndirectedMatrix) Node(id int64) graph.Node {
-	if !g.has(id) {
-		return nil
-	}
-	if g.nodes == nil {
-		return Node(id)
-	}
-	return g.nodes[id]
-}
-
 // Has returns whether the node exists within the graph.
 func (g *UndirectedMatrix) Has(id int64) bool {
 	return g.has(id)
@@ -90,6 +79,18 @@ func (g *UndirectedMatrix) Has(id int64) bool {
 func (g *UndirectedMatrix) has(id int64) bool {
 	r := g.mat.Symmetric()
 	return 0 <= id && id < int64(r)
+}
+
+// Node returns the node in the graph with the given ID if it exists,
+// and nil otherwise.
+func (g *UndirectedMatrix) Node(id int64) graph.Node {
+	if !g.has(id) {
+		return nil
+	}
+	if g.nodes == nil {
+		return Node(id)
+	}
+	return g.nodes[id]
 }
 
 // Nodes returns all the nodes in the graph.
@@ -190,13 +191,15 @@ func (g *UndirectedMatrix) Weight(xid, yid int64) (w float64, ok bool) {
 }
 
 // SetEdge sets e, an edge from one node to another with unit weight. If the ends of the edge are
-// not in g or the edge is a self loop, SetEdge panics.
+// not in g or the edge is a self loop, SetEdge panics. SetEdge will store the nodes of
+// e in the graph if it was initialized with NewUndirectedMatrixFrom.
 func (g *UndirectedMatrix) SetEdge(e graph.Edge) {
 	g.setWeightedEdge(e, 1)
 }
 
 // SetWeightedEdge sets e, an edge from one node to another. If the ends of the edge are not in g
-// or the edge is a self loop, SetWeightedEdge panics.
+// or the edge is a self loop, SetWeightedEdge panics. SetWeightedEdge will store the nodes of
+// e in the graph if it was initialized with NewUndirectedMatrixFrom.
 func (g *UndirectedMatrix) SetWeightedEdge(e graph.WeightedEdge) {
 	g.setWeightedEdge(e, e.Weight())
 }

--- a/graph/simple/dense_undirected_matrix.go
+++ b/graph/simple/dense_undirected_matrix.go
@@ -202,8 +202,10 @@ func (g *UndirectedMatrix) SetWeightedEdge(e graph.WeightedEdge) {
 }
 
 func (g *UndirectedMatrix) setWeightedEdge(e graph.Edge, weight float64) {
-	fid := e.From().ID()
-	tid := e.To().ID()
+	from := e.From()
+	fid := from.ID()
+	to := e.To()
+	tid := to.ID()
 	if fid == tid {
 		panic("simple: set illegal edge")
 	}
@@ -212,6 +214,10 @@ func (g *UndirectedMatrix) setWeightedEdge(e graph.Edge, weight float64) {
 	}
 	if int64(int(tid)) != tid {
 		panic("simple: unavailable to node ID for dense graph")
+	}
+	if g.nodes != nil {
+		g.nodes[fid] = from
+		g.nodes[tid] = to
 	}
 	// fid and tid are not greater than maximum int by this point.
 	g.mat.SetSym(int(fid), int(tid), weight)

--- a/graph/simple/dense_undirected_matrix.go
+++ b/graph/simple/dense_undirected_matrix.go
@@ -81,7 +81,7 @@ func (g *UndirectedMatrix) has(id int64) bool {
 	return 0 <= id && id < int64(r)
 }
 
-// Node returns the node in the graph with the given ID if it exists,
+// Node returns the node with the given ID if it exists in the graph,
 // and nil otherwise.
 func (g *UndirectedMatrix) Node(id int64) graph.Node {
 	if !g.has(id) {

--- a/graph/simple/directed.go
+++ b/graph/simple/directed.go
@@ -142,7 +142,7 @@ func (g *DirectedGraph) Has(id int64) bool {
 	return ok
 }
 
-// Node returns the node in the graph with the given ID if it exists,
+// Node returns the node with the given ID if it exists in the graph,
 // and nil otherwise.
 func (g *DirectedGraph) Node(id int64) graph.Node {
 	return g.nodes[id]

--- a/graph/simple/directed.go
+++ b/graph/simple/directed.go
@@ -136,15 +136,16 @@ func (g *DirectedGraph) RemoveEdge(fid, tid int64) {
 	delete(g.to[tid], fid)
 }
 
-// Node returns the node in the graph with the given ID.
-func (g *DirectedGraph) Node(id int64) graph.Node {
-	return g.nodes[id]
-}
-
 // Has returns whether the node exists within the graph.
 func (g *DirectedGraph) Has(id int64) bool {
 	_, ok := g.nodes[id]
 	return ok
+}
+
+// Node returns the node in the graph with the given ID if it exists,
+// and nil otherwise.
+func (g *DirectedGraph) Node(id int64) graph.Node {
+	return g.nodes[id]
 }
 
 // Nodes returns all the nodes in the graph.

--- a/graph/simple/directed.go
+++ b/graph/simple/directed.go
@@ -92,7 +92,8 @@ func (g *DirectedGraph) NewEdge(from, to graph.Node) graph.Edge {
 	return &Edge{F: from, T: to}
 }
 
-// SetEdge adds e, an edge from one node to another. If the nodes do not exist, they are added.
+// SetEdge adds e, an edge from one node to another. If the nodes do not exist, they are added
+// and are set to the nodes of the edge otherwise.
 // It will panic if the IDs of the e.From and e.To are equal.
 func (g *DirectedGraph) SetEdge(e graph.Edge) {
 	var (
@@ -108,9 +109,13 @@ func (g *DirectedGraph) SetEdge(e graph.Edge) {
 
 	if !g.Has(fid) {
 		g.AddNode(from)
+	} else {
+		g.nodes[fid] = from
 	}
 	if !g.Has(tid) {
 		g.AddNode(to)
+	} else {
+		g.nodes[tid] = to
 	}
 
 	g.from[fid][tid] = e

--- a/graph/simple/undirected.go
+++ b/graph/simple/undirected.go
@@ -84,7 +84,8 @@ func (g *UndirectedGraph) NewEdge(from, to graph.Node) graph.Edge {
 	return &Edge{F: from, T: to}
 }
 
-// SetEdge adds e, an edge from one node to another. If the nodes do not exist, they are added.
+// SetEdge adds e, an edge from one node to another. If the nodes do not exist, they are added
+// and are set to the nodes of the edge otherwise.
 // It will panic if the IDs of the e.From and e.To are equal.
 func (g *UndirectedGraph) SetEdge(e graph.Edge) {
 	var (
@@ -100,9 +101,13 @@ func (g *UndirectedGraph) SetEdge(e graph.Edge) {
 
 	if !g.Has(fid) {
 		g.AddNode(from)
+	} else {
+		g.nodes[fid] = from
 	}
 	if !g.Has(tid) {
 		g.AddNode(to)
+	} else {
+		g.nodes[tid] = to
 	}
 
 	g.edges[fid][tid] = e

--- a/graph/simple/undirected.go
+++ b/graph/simple/undirected.go
@@ -134,7 +134,7 @@ func (g *UndirectedGraph) Has(id int64) bool {
 	return ok
 }
 
-// Node returns the node in the graph with the given ID if it exists,
+// Node returns the node with the given ID if it exists in the graph,
 // and nil otherwise.
 func (g *UndirectedGraph) Node(id int64) graph.Node {
 	return g.nodes[id]

--- a/graph/simple/undirected.go
+++ b/graph/simple/undirected.go
@@ -128,15 +128,16 @@ func (g *UndirectedGraph) RemoveEdge(fid, tid int64) {
 	delete(g.edges[tid], fid)
 }
 
-// Node returns the node in the graph with the given ID.
-func (g *UndirectedGraph) Node(id int64) graph.Node {
-	return g.nodes[id]
-}
-
 // Has returns whether the node exists within the graph.
 func (g *UndirectedGraph) Has(id int64) bool {
 	_, ok := g.nodes[id]
 	return ok
+}
+
+// Node returns the node in the graph with the given ID if it exists,
+// and nil otherwise.
+func (g *UndirectedGraph) Node(id int64) graph.Node {
+	return g.nodes[id]
 }
 
 // Nodes returns all the nodes in the graph.

--- a/graph/simple/weighted_directed.go
+++ b/graph/simple/weighted_directed.go
@@ -144,15 +144,16 @@ func (g *WeightedDirectedGraph) RemoveEdge(fid, tid int64) {
 	delete(g.to[tid], fid)
 }
 
-// Node returns the node in the graph with the given ID.
-func (g *WeightedDirectedGraph) Node(id int64) graph.Node {
-	return g.nodes[id]
-}
-
 // Has returns whether the node exists within the graph.
 func (g *WeightedDirectedGraph) Has(id int64) bool {
 	_, ok := g.nodes[id]
 	return ok
+}
+
+// Node returns the node in the graph with the given ID if it exists,
+// and nil otherwise.
+func (g *WeightedDirectedGraph) Node(id int64) graph.Node {
+	return g.nodes[id]
 }
 
 // Nodes returns all the nodes in the graph.

--- a/graph/simple/weighted_directed.go
+++ b/graph/simple/weighted_directed.go
@@ -100,7 +100,8 @@ func (g *WeightedDirectedGraph) NewWeightedEdge(from, to graph.Node, weight floa
 	return &WeightedEdge{F: from, T: to, W: weight}
 }
 
-// SetWeightedEdge adds a weighted edge from one node to another. If the nodes do not exist, they are added.
+// SetWeightedEdge adds a weighted edge from one node to another. If the nodes do not exist, they are added
+// and are set to the nodes of the edge otherwise.
 // It will panic if the IDs of the e.From and e.To are equal.
 func (g *WeightedDirectedGraph) SetWeightedEdge(e graph.WeightedEdge) {
 	var (
@@ -116,9 +117,13 @@ func (g *WeightedDirectedGraph) SetWeightedEdge(e graph.WeightedEdge) {
 
 	if !g.Has(fid) {
 		g.AddNode(from)
+	} else {
+		g.nodes[fid] = from
 	}
 	if !g.Has(tid) {
 		g.AddNode(to)
+	} else {
+		g.nodes[tid] = to
 	}
 
 	g.from[fid][tid] = e

--- a/graph/simple/weighted_directed.go
+++ b/graph/simple/weighted_directed.go
@@ -150,7 +150,7 @@ func (g *WeightedDirectedGraph) Has(id int64) bool {
 	return ok
 }
 
-// Node returns the node in the graph with the given ID if it exists,
+// Node returns the node with the given ID if it exists in the graph,
 // and nil otherwise.
 func (g *WeightedDirectedGraph) Node(id int64) graph.Node {
 	return g.nodes[id]

--- a/graph/simple/weighted_undirected.go
+++ b/graph/simple/weighted_undirected.go
@@ -136,15 +136,16 @@ func (g *WeightedUndirectedGraph) RemoveEdge(fid, tid int64) {
 	delete(g.edges[tid], fid)
 }
 
-// Node returns the node in the graph with the given ID.
-func (g *WeightedUndirectedGraph) Node(id int64) graph.Node {
-	return g.nodes[id]
-}
-
 // Has returns whether the node exists within the graph.
 func (g *WeightedUndirectedGraph) Has(id int64) bool {
 	_, ok := g.nodes[id]
 	return ok
+}
+
+// Node returns the node in the graph with the given ID if it exists,
+// and nil otherwise.
+func (g *WeightedUndirectedGraph) Node(id int64) graph.Node {
+	return g.nodes[id]
 }
 
 // Nodes returns all the nodes in the graph.

--- a/graph/simple/weighted_undirected.go
+++ b/graph/simple/weighted_undirected.go
@@ -142,7 +142,7 @@ func (g *WeightedUndirectedGraph) Has(id int64) bool {
 	return ok
 }
 
-// Node returns the node in the graph with the given ID if it exists,
+// Node returns the node with the given ID if it exists in the graph,
 // and nil otherwise.
 func (g *WeightedUndirectedGraph) Node(id int64) graph.Node {
 	return g.nodes[id]

--- a/graph/simple/weighted_undirected.go
+++ b/graph/simple/weighted_undirected.go
@@ -92,7 +92,8 @@ func (g *WeightedUndirectedGraph) NewWeightedEdge(from, to graph.Node, weight fl
 	return &WeightedEdge{F: from, T: to, W: weight}
 }
 
-// SetWeightedEdge adds a weighted edge from one node to another. If the nodes do not exist, they are added.
+// SetWeightedEdge adds a weighted edge from one node to another. If the nodes do not exist, they are added
+// and are set to the nodes of the edge otherwise.
 // It will panic if the IDs of the e.From and e.To are equal.
 func (g *WeightedUndirectedGraph) SetWeightedEdge(e graph.WeightedEdge) {
 	var (
@@ -108,9 +109,13 @@ func (g *WeightedUndirectedGraph) SetWeightedEdge(e graph.WeightedEdge) {
 
 	if !g.Has(fid) {
 		g.AddNode(from)
+	} else {
+		g.nodes[fid] = from
 	}
 	if !g.Has(tid) {
 		g.AddNode(to)
+	} else {
+		g.nodes[tid] = to
 	}
 
 	g.edges[fid][tid] = e

--- a/graph/topo/johnson_cycles.go
+++ b/graph/topo/johnson_cycles.go
@@ -264,6 +264,9 @@ func (g johnsonGraph) From(id int64) graph.Nodes {
 func (johnsonGraph) Has(int64) bool {
 	panic("topo: unintended use of johnsonGraph")
 }
+func (johnsonGraph) Node(int64) graph.Node {
+	panic("topo: unintended use of johnsonGraph")
+}
 func (johnsonGraph) HasEdgeBetween(_, _ int64) bool {
 	panic("topo: unintended use of johnsonGraph")
 }

--- a/graph/undirect.go
+++ b/graph/undirect.go
@@ -14,6 +14,9 @@ var _ Undirected = Undirect{}
 // Has returns whether the node exists within the graph.
 func (g Undirect) Has(id int64) bool { return g.G.Has(id) }
 
+// Node returns the node with the given ID from the graph if it exists.
+func (g Undirect) Node(id int64) Node { return g.G.Node(id) }
+
 // Nodes returns all the nodes in the graph.
 func (g Undirect) Nodes() Nodes { return g.G.Nodes() }
 
@@ -78,6 +81,9 @@ var (
 
 // Has returns whether the node exists within the graph.
 func (g UndirectWeighted) Has(id int64) bool { return g.G.Has(id) }
+
+// Node returns the node with the given ID from the graph if it exists.
+func (g UndirectWeighted) Node(id int64) Node { return g.G.Node(id) }
 
 // Nodes returns all the nodes in the graph.
 func (g UndirectWeighted) Nodes() Nodes { return g.G.Nodes() }


### PR DESCRIPTION
With the approach to graph node mutation on edge setting the previously existed there was an issue that the edge last used connect a pair of nodes could result in a difference in the nodes being returned by a node query compared to the same node associated with edges returned from an edge query.

This change avoids dealing with that by making it implementation dependent and stating this, and by making all the node-storing graphs we provide mutate the nodes when edges are set.

There are a number of ways to deal with the situation of maintaining consistency between edges and nodes, so I think being open to that is the best approach, and while using `int64` for edges did seem plausible, it became difficult very quickly.

Please take a look.

Closes #31.
Fixes gonum/graph#87.
Updates #570.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
