### PR TITLE
Add doc related to sumWeights <= 1 case when computing variance

### DIFF
--- a/stat/stat.go
+++ b/stat/stat.go
@@ -1076,6 +1076,7 @@ func empiricalQuantile(p float64, x, weights []float64, sumWeights float64) floa
 // Skew computes the skewness of the sample data.
 // If weights is nil then all of the weights are 1. If weights is not nil, then
 // len(x) must equal len(weights).
+// Note that in case of weights summing to 1, a biaised variance estimator must be used instead
 func Skew(x, weights []float64) float64 {
 
 	mean, std := MeanStdDev(x, weights)
@@ -1195,7 +1196,8 @@ func StdDev(x, weights []float64) float64 {
 	return std
 }
 
-// MeanStdDev returns the sample mean and standard deviation
+// MeanStdDev returns the sample mean and unbiaised standard deviation
+// Note that in case of weights summing to 1, a biaised variance estimator must be used instead
 func MeanStdDev(x, weights []float64) (mean, std float64) {
 	mean, variance := MeanVariance(x, weights)
 	return mean, math.Sqrt(variance)
@@ -1213,28 +1215,30 @@ func StdScore(x, mean, std float64) float64 {
 	return (x - mean) / std
 }
 
-// Variance computes the weighted sample variance:
+// Variance computes the unbiaised weighted sample variance:
 //  \sum_i w_i (x_i - mean)^2 / (sum_i w_i - 1)
 // If weights is nil then all of the weights are 1. If weights is not nil, then
 // len(x) must equal len(weights).
+// Note that in case of weights summing to 1, a biaised variance estimator must be used instead
 func Variance(x, weights []float64) float64 {
 	_, variance := MeanVariance(x, weights)
 	return variance
 }
 
-// MeanVariance computes the sample mean and variance, where the mean and variance are
+// MeanVariance computes the sample mean and unbiaised variance, where the mean and variance are
 //  \sum_i w_i * x_i / (sum_i w_i)
 //  \sum_i w_i (x_i - mean)^2 / (sum_i w_i - 1)
 // respectively.
 // If weights is nil then all of the weights are 1. If weights is not nil, then
 // len(x) must equal len(weights).
-func MeanVariance(x, weights []float64) (mean, variance float64) {
+// Note that in case of weights summing to 1, a biaised variance estimator must be used instead
+func MeanVariance(x, weights []float64) (float64, float64) {
 	// This uses the corrected two-pass algorithm (1.7), from "Algorithms for computing
 	// the sample variance: Analysis and recommendations" by Chan, Tony F., Gene H. Golub,
 	// and Randall J. LeVeque.
 
 	// note that this will panic if the slice lengths do not match
-	mean = Mean(x, weights)
+	mean := Mean(x, weights)
 	var (
 		ss           float64
 		compensation float64
@@ -1245,8 +1249,8 @@ func MeanVariance(x, weights []float64) (mean, variance float64) {
 			ss += d * d
 			compensation += d
 		}
-		variance = (ss - compensation*compensation/float64(len(x))) / float64(len(x)-1)
-		return
+		variance := (ss - compensation*compensation/float64(len(x))) / float64(len(x)-1)
+		return mean, variance
 	}
 
 	var sumWeights float64
@@ -1258,6 +1262,6 @@ func MeanVariance(x, weights []float64) (mean, variance float64) {
 		compensation += wd
 		sumWeights += w
 	}
-	variance = (ss - compensation*compensation/sumWeights) / (sumWeights - 1)
-	return
+	variance := (ss - compensation*compensation/sumWeights) / (sumWeights - 1)
+	return mean, variance
 }

--- a/stat/stat.go
+++ b/stat/stat.go
@@ -1076,8 +1076,7 @@ func empiricalQuantile(p float64, x, weights []float64, sumWeights float64) floa
 // Skew computes the skewness of the sample data.
 // If weights is nil then all of the weights are 1. If weights is not nil, then
 // len(x) must equal len(weights).
-// Note that in case of weights summing to less than (or equal) to 1,
-// a biased variance estimator must be used instead
+// When weights sum to 1 or less, a biased variance estimator should be used.
 func Skew(x, weights []float64) float64 {
 
 	mean, std := MeanStdDev(x, weights)
@@ -1198,8 +1197,7 @@ func StdDev(x, weights []float64) float64 {
 }
 
 // MeanStdDev returns the sample mean and unbiased standard deviation
-// Note that in case of weights summing to less than (or equal) to 1,
-// a biased variance estimator must be used instead
+// When weights sum to 1 or less, a biased variance estimator should be used.
 func MeanStdDev(x, weights []float64) (mean, std float64) {
 	mean, variance := MeanVariance(x, weights)
 	return mean, math.Sqrt(variance)
@@ -1221,8 +1219,7 @@ func StdScore(x, mean, std float64) float64 {
 //  \sum_i w_i (x_i - mean)^2 / (sum_i w_i - 1)
 // If weights is nil then all of the weights are 1. If weights is not nil, then
 // len(x) must equal len(weights).
-// Note that in case of weights summing to less than (or equal) to 1,
-// a biased variance estimator must be used instead
+// When weights sum to 1 or less, a biased variance estimator should be used.
 func Variance(x, weights []float64) float64 {
 	_, variance := MeanVariance(x, weights)
 	return variance
@@ -1234,8 +1231,7 @@ func Variance(x, weights []float64) float64 {
 // respectively.
 // If weights is nil then all of the weights are 1. If weights is not nil, then
 // len(x) must equal len(weights).
-// Note that in case of weights summing to less than (or equal) to 1,
-// a biased variance estimator must be used instead
+// When weights sum to 1 or less, a biased variance estimator should be used.
 func MeanVariance(x, weights []float64) (mean, variance float64) {
 	// This uses the corrected two-pass algorithm (1.7), from "Algorithms for computing
 	// the sample variance: Analysis and recommendations" by Chan, Tony F., Gene H. Golub,

--- a/stat/stat.go
+++ b/stat/stat.go
@@ -1076,7 +1076,7 @@ func empiricalQuantile(p float64, x, weights []float64, sumWeights float64) floa
 // Skew computes the skewness of the sample data.
 // If weights is nil then all of the weights are 1. If weights is not nil, then
 // len(x) must equal len(weights).
-// Note that in case of weights summing to 1, a biaised variance estimator must be used instead
+// Note that in case of weights summing to 1, a biased variance estimator must be used instead
 func Skew(x, weights []float64) float64 {
 
 	mean, std := MeanStdDev(x, weights)
@@ -1196,8 +1196,8 @@ func StdDev(x, weights []float64) float64 {
 	return std
 }
 
-// MeanStdDev returns the sample mean and unbiaised standard deviation
-// Note that in case of weights summing to 1, a biaised variance estimator must be used instead
+// MeanStdDev returns the sample mean and unbiased standard deviation
+// Note that in case of weights summing to 1, a biased variance estimator must be used instead
 func MeanStdDev(x, weights []float64) (mean, std float64) {
 	mean, variance := MeanVariance(x, weights)
 	return mean, math.Sqrt(variance)
@@ -1215,23 +1215,23 @@ func StdScore(x, mean, std float64) float64 {
 	return (x - mean) / std
 }
 
-// Variance computes the unbiaised weighted sample variance:
+// Variance computes the unbiased weighted sample variance:
 //  \sum_i w_i (x_i - mean)^2 / (sum_i w_i - 1)
 // If weights is nil then all of the weights are 1. If weights is not nil, then
 // len(x) must equal len(weights).
-// Note that in case of weights summing to 1, a biaised variance estimator must be used instead
+// Note that in case of weights summing to 1, a biased variance estimator must be used instead
 func Variance(x, weights []float64) float64 {
 	_, variance := MeanVariance(x, weights)
 	return variance
 }
 
-// MeanVariance computes the sample mean and unbiaised variance, where the mean and variance are
+// MeanVariance computes the sample mean and unbiased variance, where the mean and variance are
 //  \sum_i w_i * x_i / (sum_i w_i)
 //  \sum_i w_i (x_i - mean)^2 / (sum_i w_i - 1)
 // respectively.
 // If weights is nil then all of the weights are 1. If weights is not nil, then
 // len(x) must equal len(weights).
-// Note that in case of weights summing to 1, a biaised variance estimator must be used instead
+// Note that in case of weights summing to 1, a biased variance estimator must be used instead
 func MeanVariance(x, weights []float64) (float64, float64) {
 	// This uses the corrected two-pass algorithm (1.7), from "Algorithms for computing
 	// the sample variance: Analysis and recommendations" by Chan, Tony F., Gene H. Golub,

--- a/stat/stat.go
+++ b/stat/stat.go
@@ -1076,7 +1076,8 @@ func empiricalQuantile(p float64, x, weights []float64, sumWeights float64) floa
 // Skew computes the skewness of the sample data.
 // If weights is nil then all of the weights are 1. If weights is not nil, then
 // len(x) must equal len(weights).
-// Note that in case of weights summing to 1, a biased variance estimator must be used instead
+// Note that in case of weights summing to less than (or equal) to 1,
+// a biased variance estimator must be used instead
 func Skew(x, weights []float64) float64 {
 
 	mean, std := MeanStdDev(x, weights)
@@ -1197,7 +1198,8 @@ func StdDev(x, weights []float64) float64 {
 }
 
 // MeanStdDev returns the sample mean and unbiased standard deviation
-// Note that in case of weights summing to 1, a biased variance estimator must be used instead
+// Note that in case of weights summing to less than (or equal) to 1,
+// a biased variance estimator must be used instead
 func MeanStdDev(x, weights []float64) (mean, std float64) {
 	mean, variance := MeanVariance(x, weights)
 	return mean, math.Sqrt(variance)
@@ -1219,7 +1221,8 @@ func StdScore(x, mean, std float64) float64 {
 //  \sum_i w_i (x_i - mean)^2 / (sum_i w_i - 1)
 // If weights is nil then all of the weights are 1. If weights is not nil, then
 // len(x) must equal len(weights).
-// Note that in case of weights summing to 1, a biased variance estimator must be used instead
+// Note that in case of weights summing to less than (or equal) to 1,
+// a biased variance estimator must be used instead
 func Variance(x, weights []float64) float64 {
 	_, variance := MeanVariance(x, weights)
 	return variance
@@ -1231,14 +1234,15 @@ func Variance(x, weights []float64) float64 {
 // respectively.
 // If weights is nil then all of the weights are 1. If weights is not nil, then
 // len(x) must equal len(weights).
-// Note that in case of weights summing to 1, a biased variance estimator must be used instead
-func MeanVariance(x, weights []float64) (float64, float64) {
+// Note that in case of weights summing to less than (or equal) to 1,
+// a biased variance estimator must be used instead
+func MeanVariance(x, weights []float64) (mean, variance float64) {
 	// This uses the corrected two-pass algorithm (1.7), from "Algorithms for computing
 	// the sample variance: Analysis and recommendations" by Chan, Tony F., Gene H. Golub,
 	// and Randall J. LeVeque.
 
 	// note that this will panic if the slice lengths do not match
-	mean := Mean(x, weights)
+	mean = Mean(x, weights)
 	var (
 		ss           float64
 		compensation float64
@@ -1249,8 +1253,8 @@ func MeanVariance(x, weights []float64) (float64, float64) {
 			ss += d * d
 			compensation += d
 		}
-		variance := (ss - compensation*compensation/float64(len(x))) / float64(len(x)-1)
-		return mean, variance
+		variance = (ss - compensation*compensation/float64(len(x))) / float64(len(x)-1)
+		return
 	}
 
 	var sumWeights float64
@@ -1262,6 +1266,6 @@ func MeanVariance(x, weights []float64) (float64, float64) {
 		compensation += wd
 		sumWeights += w
 	}
-	variance := (ss - compensation*compensation/sumWeights) / (sumWeights - 1)
-	return mean, variance
+	variance = (ss - compensation*compensation/sumWeights) / (sumWeights - 1)
+	return
 }


### PR DESCRIPTION
When the sum of weights equals 1, the unbiased estimator used to compute the variance is ill-defined. This PR adds some doc to inform the user that a biased estimator should be used instead
