### PR TITLE
graph/multi: clean up missed changes and bugs

### DIFF
--- a/graph/multi/directed.go
+++ b/graph/multi/directed.go
@@ -193,7 +193,8 @@ func (g *DirectedGraph) Edges() graph.Edges {
 			}
 			if len(lines) != 0 {
 				edges = append(edges, Edge{
-					F: g.Node(u.ID()), T: g.Node(lines[0].To().ID()),
+					F:     g.Node(u.ID()),
+					T:     g.Node(lines[0].To().ID()),
 					Lines: iterator.NewOrderedLines(lines),
 				})
 			}

--- a/graph/multi/directed.go
+++ b/graph/multi/directed.go
@@ -181,15 +181,21 @@ func (g *DirectedGraph) Nodes() graph.Nodes {
 // Edges returns all the edges in the graph. Each edge in the returned slice
 // is a multi.Edge.
 func (g *DirectedGraph) Edges() graph.Edges {
+	if len(g.nodes) == 0 {
+		return nil
+	}
 	var edges []graph.Edge
 	for _, u := range g.nodes {
 		for _, e := range g.from[u.ID()] {
-			var lines Edge
+			var lines []graph.Line
 			for _, l := range e {
 				lines = append(lines, l)
 			}
 			if len(lines) != 0 {
-				edges = append(edges, lines)
+				edges = append(edges, Edge{
+					F: u, T: lines[0].To(),
+					Lines: iterator.NewOrderedLines(lines),
+				})
 			}
 		}
 	}
@@ -240,11 +246,11 @@ func (g *DirectedGraph) HasEdgeBetween(xid, yid int64) bool {
 // The node v must be directly reachable from u as defined by the From method.
 // The returned graph.Edge is a multi.Edge if an edge exists.
 func (g *DirectedGraph) Edge(uid, vid int64) graph.Edge {
-	lines := graph.LinesOf(g.Lines(uid, vid))
-	if len(lines) == 0 {
+	l := g.Lines(uid, vid)
+	if l == nil {
 		return nil
 	}
-	return Edge(lines)
+	return Edge{F: g.Node(uid), T: g.Node(vid), Lines: l}
 }
 
 // Lines returns the lines from u to v if such any such lines exists and nil otherwise.

--- a/graph/multi/directed.go
+++ b/graph/multi/directed.go
@@ -193,7 +193,7 @@ func (g *DirectedGraph) Edges() graph.Edges {
 			}
 			if len(lines) != 0 {
 				edges = append(edges, Edge{
-					F: u, T: lines[0].To(),
+					F: g.Node(u.ID()), T: g.Node(lines[0].To().ID()),
 					Lines: iterator.NewOrderedLines(lines),
 				})
 			}

--- a/graph/multi/multi.go
+++ b/graph/multi/multi.go
@@ -18,23 +18,17 @@ func (n Node) ID() int64 {
 }
 
 // Edge is a collection of multigraph edges sharing end points.
-type Edge []graph.Line
+type Edge struct {
+	F, T graph.Node
+
+	graph.Lines
+}
 
 // From returns the from-node of the edge.
-func (e Edge) From() graph.Node {
-	if len(e) == 0 {
-		return nil
-	}
-	return e[0].From()
-}
+func (e Edge) From() graph.Node { return e.F }
 
 // To returns the to-node of the edge.
-func (e Edge) To() graph.Node {
-	if len(e) == 0 {
-		return nil
-	}
-	return e[0].To()
-}
+func (e Edge) To() graph.Node { return e.T }
 
 // Line is a multigraph edge.
 type Line struct {
@@ -54,41 +48,42 @@ func (l Line) ID() int64 { return l.UID }
 
 // WeightedEdge is a collection of weighted multigraph edges sharing end points.
 type WeightedEdge struct {
-	Lines []graph.WeightedLine
+	F, T graph.Node
+
+	graph.WeightedLines
 
 	// WeightFunc calculates the aggregate
 	// weight of the lines in Lines. If
 	// WeightFunc is nil, the sum of weights
 	// is used as the edge weight.
-	WeightFunc func([]graph.WeightedLine) float64
+	// The graph.WeightedLines cam be expected
+	// to be positioned at the first line og
+	// the iterator on entry and must be
+	// Reset before exit.
+	// WeightFunc must accept a nil input.
+	WeightFunc func(graph.WeightedLines) float64
 }
 
 // From returns the from-node of the edge.
-func (e WeightedEdge) From() graph.Node {
-	if len(e.Lines) == 0 {
-		return nil
-	}
-	return e.Lines[0].From()
-}
+func (e WeightedEdge) From() graph.Node { return e.F }
 
 // To returns the to-node of the edge.
-func (e WeightedEdge) To() graph.Node {
-	if len(e.Lines) == 0 {
-		return nil
-	}
-	return e.Lines[0].To()
-}
+func (e WeightedEdge) To() graph.Node { return e.T }
 
 // Weight returns the weight of the edge.
 func (e WeightedEdge) Weight() float64 {
+	if e.WeightedLines == nil {
+		return 0
+	}
 	if e.WeightFunc == nil {
 		var w float64
-		for _, l := range e.Lines {
-			w += l.Weight()
+		for e.Next() {
+			w += e.WeightedLine().Weight()
 		}
+		e.WeightedLines.Reset()
 		return w
 	}
-	return e.WeightFunc(e.Lines)
+	return e.WeightFunc(e.WeightedLines)
 }
 
 // WeightedLine is a weighted multigraph edge.

--- a/graph/multi/multi.go
+++ b/graph/multi/multi.go
@@ -56,8 +56,8 @@ type WeightedEdge struct {
 	// weight of the lines in Lines. If
 	// WeightFunc is nil, the sum of weights
 	// is used as the edge weight.
-	// The graph.WeightedLines cam be expected
-	// to be positioned at the first line og
+	// The graph.WeightedLines can be expected
+	// to be positioned at the first line of
 	// the iterator on entry and must be
 	// Reset before exit.
 	// WeightFunc must accept a nil input.
@@ -70,7 +70,10 @@ func (e WeightedEdge) From() graph.Node { return e.F }
 // To returns the to-node of the edge.
 func (e WeightedEdge) To() graph.Node { return e.T }
 
-// Weight returns the weight of the edge.
+// Weight returns the weight of the edge. Weight uses WeightFunc
+// field to calculate the weight, so the WeightedLines field is
+// expected to be positioned at the first line and is reset before
+// Weight returns.
 func (e WeightedEdge) Weight() float64 {
 	if e.WeightedLines == nil {
 		return 0

--- a/graph/multi/undirected.go
+++ b/graph/multi/undirected.go
@@ -188,7 +188,7 @@ func (g *UndirectedGraph) Edges() graph.Edges {
 			}
 			if len(lines) != 0 {
 				edges = append(edges, Edge{
-					F: lines[0].From(), T: lines[0].To(),
+					F: g.Node(lines[0].From().ID()), T: g.Node(lines[0].To().ID()),
 					Lines: iterator.NewOrderedLines(lines),
 				})
 			}

--- a/graph/multi/undirected.go
+++ b/graph/multi/undirected.go
@@ -188,7 +188,8 @@ func (g *UndirectedGraph) Edges() graph.Edges {
 			}
 			if len(lines) != 0 {
 				edges = append(edges, Edge{
-					F: g.Node(lines[0].From().ID()), T: g.Node(lines[0].To().ID()),
+					F:     g.Node(lines[0].From().ID()),
+					T:     g.Node(lines[0].To().ID()),
 					Lines: iterator.NewOrderedLines(lines),
 				})
 			}

--- a/graph/multi/weighted_directed.go
+++ b/graph/multi/weighted_directed.go
@@ -204,7 +204,7 @@ func (g *WeightedDirectedGraph) Edges() graph.Edges {
 			}
 			if len(lines) != 0 {
 				edges = append(edges, WeightedEdge{
-					F: u, T: lines[0].To(),
+					F: g.Node(u.ID()), T: g.Node(lines[0].To().ID()),
 					WeightedLines: iterator.NewOrderedWeightedLines(lines),
 					WeightFunc:    g.EdgeWeightFunc,
 				})
@@ -229,7 +229,7 @@ func (g *WeightedDirectedGraph) WeightedEdges() graph.WeightedEdges {
 			}
 			if len(lines) != 0 {
 				edges = append(edges, WeightedEdge{
-					F: u, T: lines[0].To(),
+					F: g.Node(u.ID()), T: g.Node(lines[0].To().ID()),
 					WeightedLines: iterator.NewOrderedWeightedLines(lines),
 					WeightFunc:    g.EdgeWeightFunc,
 				})

--- a/graph/multi/weighted_directed.go
+++ b/graph/multi/weighted_directed.go
@@ -30,7 +30,7 @@ var (
 
 // WeightedDirectedGraph implements a generalized directed graph.
 type WeightedDirectedGraph struct {
-	// EdgeWEightFunc is used to provide
+	// EdgeWeightFunc is used to provide
 	// the WeightFunc function for WeightedEdge
 	// values returned by the graph.
 	// WeightFunc must accept a nil input.
@@ -204,7 +204,8 @@ func (g *WeightedDirectedGraph) Edges() graph.Edges {
 			}
 			if len(lines) != 0 {
 				edges = append(edges, WeightedEdge{
-					F: g.Node(u.ID()), T: g.Node(lines[0].To().ID()),
+					F:             g.Node(u.ID()),
+					T:             g.Node(lines[0].To().ID()),
 					WeightedLines: iterator.NewOrderedWeightedLines(lines),
 					WeightFunc:    g.EdgeWeightFunc,
 				})
@@ -229,7 +230,8 @@ func (g *WeightedDirectedGraph) WeightedEdges() graph.WeightedEdges {
 			}
 			if len(lines) != 0 {
 				edges = append(edges, WeightedEdge{
-					F: g.Node(u.ID()), T: g.Node(lines[0].To().ID()),
+					F:             g.Node(u.ID()),
+					T:             g.Node(lines[0].To().ID()),
 					WeightedLines: iterator.NewOrderedWeightedLines(lines),
 					WeightFunc:    g.EdgeWeightFunc,
 				})

--- a/graph/multi/weighted_undirected.go
+++ b/graph/multi/weighted_undirected.go
@@ -197,7 +197,7 @@ func (g *WeightedUndirectedGraph) Edges() graph.Edges {
 			}
 			if len(lines) != 0 {
 				edges = append(edges, WeightedEdge{
-					F: lines[0].From(), T: lines[0].To(),
+					F: g.Node(lines[0].From().ID()), T: g.Node(lines[0].To().ID()),
 					WeightedLines: iterator.NewOrderedWeightedLines(lines),
 					WeightFunc:    g.EdgeWeightFunc,
 				})
@@ -228,7 +228,7 @@ func (g *WeightedUndirectedGraph) WeightedEdges() graph.WeightedEdges {
 			}
 			if len(lines) != 0 {
 				edges = append(edges, WeightedEdge{
-					F: lines[0].From(), T: lines[0].To(),
+					F: g.Node(lines[0].From().ID()), T: g.Node(lines[0].To().ID()),
 					WeightedLines: iterator.NewOrderedWeightedLines(lines),
 					WeightFunc:    g.EdgeWeightFunc,
 				})

--- a/graph/multi/weighted_undirected.go
+++ b/graph/multi/weighted_undirected.go
@@ -197,7 +197,8 @@ func (g *WeightedUndirectedGraph) Edges() graph.Edges {
 			}
 			if len(lines) != 0 {
 				edges = append(edges, WeightedEdge{
-					F: g.Node(lines[0].From().ID()), T: g.Node(lines[0].To().ID()),
+					F:             g.Node(lines[0].From().ID()),
+					T:             g.Node(lines[0].To().ID()),
 					WeightedLines: iterator.NewOrderedWeightedLines(lines),
 					WeightFunc:    g.EdgeWeightFunc,
 				})
@@ -228,7 +229,8 @@ func (g *WeightedUndirectedGraph) WeightedEdges() graph.WeightedEdges {
 			}
 			if len(lines) != 0 {
 				edges = append(edges, WeightedEdge{
-					F: g.Node(lines[0].From().ID()), T: g.Node(lines[0].To().ID()),
+					F:             g.Node(lines[0].From().ID()),
+					T:             g.Node(lines[0].To().ID()),
 					WeightedLines: iterator.NewOrderedWeightedLines(lines),
 					WeightFunc:    g.EdgeWeightFunc,
 				})


### PR DESCRIPTION
This fixes some bugs in the multigraph handling of edges from lines and finishes changes that I had intended to go into the iterator PR (the change in container for `graph.*Lines` in the `multi.*Edge` types).

It has also raised an issue of how I have been dealing with empty collections. With the old approach we could always return a `nil` and people could still iterate over it without needing to check for `nil`. This is no longer true. We currently don't specify the `nil`-ness of returns for collections, so this is not terrible, but it might be an idea to tighten that down. I'm raising this here since you can see the impacts with these changes, but I will file an issue (#614).

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
