### PR TITLE
graph/formats/gexf12: new package for handling GEXF1.2 graph description files

### DIFF
--- a/graph/formats/gexf12/gexf.go
+++ b/graph/formats/gexf12/gexf.go
@@ -1,0 +1,304 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package gexf12 implements marshaling and unmarshaling of GEXF1.2 documents.
+//
+// For details of GEXF see https://gephi.org/gexf/format/.
+package gexf12 // import "gonum.org/v1/gonum/graph/formats/gexf12"
+
+import (
+	"bytes"
+	"encoding/xml"
+	"time"
+)
+
+// BUG(kortschak): The namespace for GEFX1.2 is 1.2draft, though it has
+// already been deprecated. There is no specification for 1.3, although
+// it is being used in the wild.
+
+// Content holds a GEFX graph and metadata.
+type Content struct {
+	XMLName xml.Name `xml:"http://www.gexf.net/1.2draft gexf"`
+	Meta    *Meta    `xml:"meta,omitempty"`
+	Graph   Graph    `xml:"graph"`
+	// Version must be "1.2".
+	Version string  `xml:"version,attr"`
+	Variant *string `xml:"variant,attr,omitempty"`
+}
+
+// Meta holds optional metadata associated with the graph.
+type Meta struct {
+	Creator      string    `xml:"creator,omitempty"`
+	Keywords     string    `xml:"keywords,omitempty"`
+	Description  string    `xml:"description,omitempty"`
+	LastModified time.Time `xml:"lastmodifieddate,attr,omitempty"`
+}
+
+// MarshalXML implements the xml.Marshaler interface.
+func (t *Meta) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type T Meta
+	var layout struct {
+		*T
+		LastModified *xsdDate `xml:"lastmodifieddate,attr,omitempty"`
+	}
+	layout.T = (*T)(t)
+	layout.LastModified = (*xsdDate)(&layout.T.LastModified)
+	return e.EncodeElement(layout, start)
+}
+
+// UnmarshalXML implements the xml.Unmarshaler interface.
+func (t *Meta) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type T Meta
+	var overlay struct {
+		*T
+		LastModified *xsdDate `xml:"lastmodifieddate,attr,omitempty"`
+	}
+	overlay.T = (*T)(t)
+	overlay.LastModified = (*xsdDate)(&overlay.T.LastModified)
+	return d.DecodeElement(&overlay, &start)
+}
+
+// Graph stores the graph nodes, edges, dynamics and visualization data.
+type Graph struct {
+	Attributes *Attributes `xml:"attributes"`
+	Nodes      Nodes       `xml:"nodes"`
+	Edges      Edges       `xml:"edges"`
+	// TimeFormat may be one of "integer", "double", "date" or "dateTime".
+	TimeFormat *string `xml:"timeformat,attr,omitempty"`
+	Start      *string `xml:"start,attr,omitempty"`
+	Startopen  *string `xml:"startopen,attr,omitempty"`
+	End        *string `xml:"end,attr,omitempty"`
+	Endopen    *string `xml:"endopen,attr,omitempty"`
+	// DefaultEdgeType may be one of "directed", "undirected" or "mutual".
+	DefaultEdgeType string `xml:"defaultedgetype,attr,omitempty"`
+	// IDType may be one of "integer" or "string".
+	IDType string `xml:"idtype,attr,omitempty"`
+	// Mode may be "static" or "dynamic".
+	Mode string `xml:"mode,attr,omitempty"`
+}
+
+// Attributes holds a collection of potentially dynamic attributes
+// associated with a graph.
+type Attributes struct {
+	Attributes []Attribute `xml:"attribute,omitempty"`
+	// Class be one of "node" or "edge".
+	Class string `xml:"class,attr"`
+	// Mode may be "static" or "dynamic".
+	Mode      *string `xml:"mode,attr,omitempty"`
+	Start     *string `xml:"start,attr,omitempty"`
+	Startopen *string `xml:"startopen,attr,omitempty"`
+	End       *string `xml:"end,attr,omitempty"`
+	Endopen   *string `xml:"endopen,attr,omitempty"`
+}
+
+// Attribute holds a single graph attribute.
+type Attribute struct {
+	ID    string `xml:"id,attr"`
+	Title string `xml:"title,attr"`
+	// Type may be one of "integer", "long", "double", "float",
+	// "boolean", "liststring", "string", or "anyURI".
+	Type    string  `xml:"type,attr"`
+	Default *string `xml:"default"`
+	Options *string `xml:"options"`
+}
+
+// Nodes holds a collection of nodes constituting a graph or subgraph.
+type Nodes struct {
+	Count *int   `xml:"count,attr,omitempty"`
+	Nodes []Node `xml:"node,omitempty"`
+}
+
+// Node is a single node and its associated attributes.
+type Node struct {
+	ID        string     `xml:"id,attr,omitempty"`
+	Label     string     `xml:"label,attr,omitempty"`
+	AttValues *AttValues `xml:"attvalues"`
+	Spells    *Spells    `xml:"spells"`
+	Nodes     *Nodes     `xml:"nodes"`
+	Edges     *Edges     `xml:"edges"`
+	ParentID  *string    `xml:"pid,attr,omitempty"`
+	Parents   *Parents   `xml:"parents"`
+	Color     *Color     `xml:"http://www.gexf.net/1.2draft/viz color"`
+	Position  *Position  `xml:"http://www.gexf.net/1.2draft/viz position"`
+	Size      *Size      `xml:"http://www.gexf.net/1.2draft/viz size"`
+	Shape     *NodeShape `xml:"http://www.gexf.net/1.2draft/viz shape"`
+	Start     *string    `xml:"start,attr,omitempty"`
+	Startopen *string    `xml:"startopen,attr,omitempty"`
+	End       *string    `xml:"end,attr,omitempty"`
+	Endopen   *string    `xml:"endopen,attr,omitempty"`
+}
+
+// NodeShape holds the visual representation of a node with associated
+// dynamics.
+type NodeShape struct {
+	Spells *Spells `xml:"spells,omitempty"`
+	// Value be one of "disc", "square", "triangle",
+	// "diamond" or "image".
+	Shape     string  `xml:"value,attr"`
+	URI       *string `xml:"uri,attr,omitempty"`
+	Start     *string `xml:"start,attr,omitempty"`
+	Startopen *string `xml:"startopen,attr,omitempty"`
+	End       *string `xml:"end,attr,omitempty"`
+	Endopen   *string `xml:"endopen,attr,omitempty"`
+}
+
+// Color represents a node or edge color and its associated dynamics.
+type Color struct {
+	Spells    *Spells  `xml:"spells,omitempty"`
+	R         byte     `xml:"r,attr"`
+	G         byte     `xml:"g,attr"`
+	B         byte     `xml:"b,attr"`
+	A         *float64 `xml:"a,attr,omitempty"`
+	Start     *string  `xml:"start,attr,omitempty"`
+	Startopen *string  `xml:"startopen,attr,omitempty"`
+	End       *string  `xml:"end,attr,omitempty"`
+	Endopen   *string  `xml:"endopen,attr,omitempty"`
+}
+
+// Edges holds a collection of edges constituting a graph or subgraph.
+type Edges struct {
+	Count *int   `xml:"count,attr,omitempty"`
+	Edges []Edge `xml:"edge,omitempty"`
+}
+
+// Edge is a single edge and its associated attributes.
+type Edge struct {
+	ID        string     `xml:"id,attr,omitempty"`
+	AttValues *AttValues `xml:"attvalues"`
+	Spells    *Spells    `xml:"spells"`
+	Color     *Color     `xml:"http://www.gexf.net/1.2draft/viz color"`
+	Thickness *Thickness `xml:"http://www.gexf.net/1.2draft/viz thickness"`
+	Shape     *Edgeshape `xml:"http://www.gexf.net/1.2draft/viz shape"`
+	Start     *string    `xml:"start,attr,omitempty"`
+	Startopen *string    `xml:"startopen,attr,omitempty"`
+	End       *string    `xml:"end,attr,omitempty"`
+	Endopen   *string    `xml:"endopen,attr,omitempty"`
+	// Type may be one of directed, undirected, mutual
+	Type   *string  `xml:"type,attr,omitempty"`
+	Label  *string  `xml:"label,attr,omitempty"`
+	Source string   `xml:"source,attr"`
+	Target string   `xml:"target,attr"`
+	Weight *float64 `xml:"weight,attr,omitempty"`
+}
+
+// AttVlues holds a collection of attribute values.
+type AttValues struct {
+	AttValues []AttValue `xml:"attvalue,omitempty"`
+}
+
+// AttValues holds a single attribute value and its associated dynamics.
+type AttValue struct {
+	For       string  `xml:"for,attr"`
+	Value     string  `xml:"value,attr"`
+	Start     *string `xml:"start,attr,omitempty"`
+	Startopen *string `xml:"startopen,attr,omitempty"`
+	End       *string `xml:"end,attr,omitempty"`
+	Endopen   *string `xml:"endopen,attr,omitempty"`
+}
+
+// EdgeShape holds the visual representation of an edge with associated
+// dynamics.
+type Edgeshape struct {
+	// Shape be one of solid, dotted, dashed, double
+	Shape     string  `xml:"value,attr"`
+	Spells    *Spells `xml:"spells,omitempty"`
+	Start     *string `xml:"start,attr,omitempty"`
+	Startopen *string `xml:"startopen,attr,omitempty"`
+	End       *string `xml:"end,attr,omitempty"`
+	Endopen   *string `xml:"endopen,attr,omitempty"`
+}
+
+// Parents holds parent relationships between nodes in a hierarchical
+// graph.
+type Parents struct {
+	Parent []Parent `xml:"parent,omitempty"`
+}
+
+// Parent is a single parent relationship.
+type Parent struct {
+	For string `xml:"for,attr"`
+}
+
+// Position hold the spatial position of a node and its dynamics.
+type Position struct {
+	X         float64 `xml:"x,attr"`
+	Y         float64 `xml:"y,attr"`
+	Z         float64 `xml:"z,attr"`
+	Spells    *Spells `xml:"spells,omitempty"`
+	Start     *string `xml:"start,attr,omitempty"`
+	Startopen *string `xml:"startopen,attr,omitempty"`
+	End       *string `xml:"end,attr,omitempty"`
+	Endopen   *string `xml:"endopen,attr,omitempty"`
+}
+
+// Size hold the visual size of a node and its dynamics.
+type Size struct {
+	Value     float64 `xml:"value,attr"`
+	Spells    *Spells `xml:"http://www.gexf.net/1.2draft/viz spells,omitempty"`
+	Start     *string `xml:"start,attr,omitempty"`
+	Startopen *string `xml:"startopen,attr,omitempty"`
+	End       *string `xml:"end,attr,omitempty"`
+	Endopen   *string `xml:"endopen,attr,omitempty"`
+}
+
+// Thickness hold the visual thickness of an edge and its dynamics.
+type Thickness struct {
+	Value     float64 `xml:"value,attr"`
+	Spells    *Spells `xml:"http://www.gexf.net/1.2draft/viz spells,omitempty"`
+	Start     *string `xml:"start,attr,omitempty"`
+	Startopen *string `xml:"startopen,attr,omitempty"`
+	End       *string `xml:"end,attr,omitempty"`
+	Endopen   *string `xml:"endopen,attr,omitempty"`
+}
+
+// Spells holds a collection of time dynamics for a graph entity.
+type Spells struct {
+	Spell []Spell `xml:"spell"`
+}
+
+// Spell is a time interval.
+type Spell struct {
+	Start     *string `xml:"start,attr,omitempty"`
+	Startopen *string `xml:"startopen,attr,omitempty"`
+	End       *string `xml:"end,attr,omitempty"`
+	Endopen   *string `xml:"endopen,attr,omitempty"`
+}
+
+type xsdDate time.Time
+
+func (t *xsdDate) UnmarshalText(text []byte) error {
+	return _unmarshalTime(text, (*time.Time)(t), "2006-01-02")
+}
+
+func (t xsdDate) MarshalText() ([]byte, error) {
+	return []byte((time.Time)(t).Format("2006-01-02")), nil
+}
+
+func (t xsdDate) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if (time.Time)(t).IsZero() {
+		return nil
+	}
+	m, err := t.MarshalText()
+	if err != nil {
+		return err
+	}
+	return e.EncodeElement(m, start)
+}
+
+func (t xsdDate) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	if (time.Time)(t).IsZero() {
+		return xml.Attr{}, nil
+	}
+	m, err := t.MarshalText()
+	return xml.Attr{Name: name, Value: string(m)}, err
+}
+
+func _unmarshalTime(text []byte, t *time.Time, format string) (err error) {
+	s := string(bytes.TrimSpace(text))
+	*t, err = time.Parse(format, s)
+	if _, ok := err.(*time.ParseError); ok {
+		*t, err = time.Parse(format+"Z07:00", s)
+	}
+	return err
+}

--- a/graph/formats/gexf12/gexf_test.go
+++ b/graph/formats/gexf12/gexf_test.go
@@ -1,0 +1,462 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gexf12
+
+import (
+	"encoding/xml"
+	"io/ioutil"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func stringPtr(s string) *string    { return &s }
+func float64Ptr(f float64) *float64 { return &f }
+
+var gexfExampleTests = []struct {
+	path        string
+	unmarshaled Content
+	marshaled   string
+}{
+	{
+		path: "basic.gexf",
+		unmarshaled: Content{
+			XMLName: xml.Name{Space: "http://www.gexf.net/1.2draft", Local: "gexf"},
+			Meta:    nil,
+			Graph: Graph{
+				Attributes: nil,
+				Nodes: Nodes{
+					Nodes: []Node{
+						{ID: "0", Label: "Hello"},
+						{ID: "1", Label: "Word"},
+					},
+				},
+				Edges: Edges{
+					Edges: []Edge{
+						{ID: "0", Source: "0", Target: "1"},
+					},
+				},
+				DefaultEdgeType: "directed",
+				Mode:            "static",
+			},
+			Version: "1.2",
+		},
+		marshaled: `<gexf xmlns="http://www.gexf.net/1.2draft" version="1.2">
+	<graph defaultedgetype="directed" mode="static">
+		<nodes>
+			<node id="0" label="Hello"></node>
+			<node id="1" label="Word"></node>
+		</nodes>
+		<edges>
+			<edge id="0" source="0" target="1"></edge>
+		</edges>
+	</graph>
+</gexf>`,
+	},
+	{
+		path: "data.gexf",
+		unmarshaled: Content{
+			XMLName: xml.Name{Space: "http://www.gexf.net/1.2draft", Local: "gexf"},
+			Meta: &Meta{
+				Creator:      "Gephi.org",
+				Description:  "A Web network",
+				LastModified: time.Date(2009, 03, 20, 0, 0, 0, 0, time.UTC),
+			},
+			Graph: Graph{
+				Attributes: &Attributes{
+					Class: "node",
+					Attributes: []Attribute{
+						{
+							ID:    "0",
+							Title: "url",
+							Type:  "string",
+						},
+						{
+							ID:    "1",
+							Title: "indegree",
+							Type:  "float",
+						},
+						{
+							ID:      "2",
+							Title:   "frog",
+							Type:    "boolean",
+							Default: stringPtr("true"),
+						},
+					},
+				},
+				Nodes: Nodes{
+					Nodes: []Node{
+						{
+							ID: "0", Label: "Gephi",
+							AttValues: &AttValues{AttValues: []AttValue{
+								{For: "0", Value: "http://gephi.org"},
+								{For: "1", Value: "1"},
+							}},
+						},
+						{
+							ID: "1", Label: "Webatlas",
+							AttValues: &AttValues{AttValues: []AttValue{
+								{For: "0", Value: "http://webatlas.fr"},
+								{For: "1", Value: "2"},
+							}},
+						},
+						{
+							ID: "2", Label: "RTGI",
+							AttValues: &AttValues{AttValues: []AttValue{
+								{For: "0", Value: "http://rtgi.fr"},
+								{For: "1", Value: "1"},
+							}},
+						},
+						{
+							ID: "3", Label: "BarabasiLab",
+							AttValues: &AttValues{AttValues: []AttValue{
+								{For: "0", Value: "http://barabasilab.com"},
+								{For: "1", Value: "1"},
+								{For: "2", Value: "false"},
+							}},
+						},
+					},
+				},
+				Edges: Edges{
+					Edges: []Edge{
+						{ID: "0", Source: "0", Target: "1"},
+						{ID: "1", Source: "0", Target: "2"},
+						{ID: "2", Source: "1", Target: "0"},
+						{ID: "3", Source: "2", Target: "1"},
+						{ID: "4", Source: "0", Target: "3"},
+					},
+				},
+				DefaultEdgeType: "directed",
+			},
+			Version: "1.2",
+		},
+		marshaled: `<gexf xmlns="http://www.gexf.net/1.2draft" version="1.2">
+	<meta lastmodifieddate="2009-03-20">
+		<creator>Gephi.org</creator>
+		<description>A Web network</description>
+	</meta>
+	<graph defaultedgetype="directed">
+		<attributes class="node">
+			<attribute id="0" title="url" type="string"></attribute>
+			<attribute id="1" title="indegree" type="float"></attribute>
+			<attribute id="2" title="frog" type="boolean">
+				<default>true</default>
+			</attribute>
+		</attributes>
+		<nodes>
+			<node id="0" label="Gephi">
+				<attvalues>
+					<attvalue for="0" value="http://gephi.org"></attvalue>
+					<attvalue for="1" value="1"></attvalue>
+				</attvalues>
+			</node>
+			<node id="1" label="Webatlas">
+				<attvalues>
+					<attvalue for="0" value="http://webatlas.fr"></attvalue>
+					<attvalue for="1" value="2"></attvalue>
+				</attvalues>
+			</node>
+			<node id="2" label="RTGI">
+				<attvalues>
+					<attvalue for="0" value="http://rtgi.fr"></attvalue>
+					<attvalue for="1" value="1"></attvalue>
+				</attvalues>
+			</node>
+			<node id="3" label="BarabasiLab">
+				<attvalues>
+					<attvalue for="0" value="http://barabasilab.com"></attvalue>
+					<attvalue for="1" value="1"></attvalue>
+					<attvalue for="2" value="false"></attvalue>
+				</attvalues>
+			</node>
+		</nodes>
+		<edges>
+			<edge id="0" source="0" target="1"></edge>
+			<edge id="1" source="0" target="2"></edge>
+			<edge id="2" source="1" target="0"></edge>
+			<edge id="3" source="2" target="1"></edge>
+			<edge id="4" source="0" target="3"></edge>
+		</edges>
+	</graph>
+</gexf>`,
+	},
+	{
+		path: "hierarchy1.gexf",
+		unmarshaled: Content{
+			XMLName: xml.Name{Space: "http://www.gexf.net/1.2draft", Local: "gexf"},
+			Meta: &Meta{
+				Creator:      "Gephi.org",
+				Description:  "A hierarchy file",
+				LastModified: time.Date(2009, 10, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Graph: Graph{
+				Nodes: Nodes{
+					Nodes: []Node{{
+						ID:    "a",
+						Label: "Kevin Bacon",
+						Nodes: &Nodes{
+							Nodes: []Node{
+								{
+									ID: "b", Label: "God",
+									Nodes: &Nodes{
+										Nodes: []Node{
+											{ID: "c", Label: "human1"},
+											{ID: "d", Label: "human2"},
+											{ID: "i", Label: "human3"},
+										},
+									},
+								},
+								{
+									ID: "e", Label: "Me",
+									Nodes: &Nodes{
+										Nodes: []Node{
+											{ID: "f", Label: "frog1"},
+											{ID: "g", Label: "frog2"},
+											{ID: "h", Label: "frog3"},
+										},
+									},
+								},
+								{
+									ID: "j", Label: "You",
+								},
+							},
+						},
+					}},
+				},
+				Edges: Edges{
+					Edges: []Edge{
+						{ID: "0", Source: "b", Target: "e"},
+						{ID: "1", Source: "c", Target: "d"},
+						{ID: "2", Source: "c", Target: "i"},
+						{ID: "3", Source: "g", Target: "b"},
+						{ID: "4", Source: "f", Target: "a"},
+						{ID: "5", Source: "f", Target: "g"},
+						{ID: "6", Source: "f", Target: "h"},
+						{ID: "7", Source: "g", Target: "h"},
+						{ID: "8", Source: "a", Target: "j"},
+					},
+				},
+				DefaultEdgeType: "directed",
+				Mode:            "static",
+			},
+			Version: "1.2",
+		},
+		marshaled: `<gexf xmlns="http://www.gexf.net/1.2draft" version="1.2">
+	<meta lastmodifieddate="2009-10-01">
+		<creator>Gephi.org</creator>
+		<description>A hierarchy file</description>
+	</meta>
+	<graph defaultedgetype="directed" mode="static">
+		<nodes>
+			<node id="a" label="Kevin Bacon">
+				<nodes>
+					<node id="b" label="God">
+						<nodes>
+							<node id="c" label="human1"></node>
+							<node id="d" label="human2"></node>
+							<node id="i" label="human3"></node>
+						</nodes>
+					</node>
+					<node id="e" label="Me">
+						<nodes>
+							<node id="f" label="frog1"></node>
+							<node id="g" label="frog2"></node>
+							<node id="h" label="frog3"></node>
+						</nodes>
+					</node>
+					<node id="j" label="You"></node>
+				</nodes>
+			</node>
+		</nodes>
+		<edges>
+			<edge id="0" source="b" target="e"></edge>
+			<edge id="1" source="c" target="d"></edge>
+			<edge id="2" source="c" target="i"></edge>
+			<edge id="3" source="g" target="b"></edge>
+			<edge id="4" source="f" target="a"></edge>
+			<edge id="5" source="f" target="g"></edge>
+			<edge id="6" source="f" target="h"></edge>
+			<edge id="7" source="g" target="h"></edge>
+			<edge id="8" source="a" target="j"></edge>
+		</edges>
+	</graph>
+</gexf>`,
+	},
+	{
+		path: "hierarchy4.gexf",
+		unmarshaled: Content{
+			XMLName: xml.Name{Space: "http://www.gexf.net/1.2draft", Local: "gexf"},
+			Meta: &Meta{
+				Creator:      "Gephi.org",
+				Keywords:     "",
+				Description:  "A hierarchy file",
+				LastModified: time.Date(2009, 10, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Graph: Graph{
+				Nodes: Nodes{
+					Nodes: []Node{
+						{ID: "g", Label: "frog2", ParentID: stringPtr("e")},
+						{ID: "a", Label: "Kevin Bacon"},
+						{ID: "c", Label: "human1", ParentID: stringPtr("b")},
+						{ID: "b", Label: "God", ParentID: stringPtr("a")},
+						{ID: "e", Label: "Me", ParentID: stringPtr("a")},
+						{ID: "d", Label: "human2", ParentID: stringPtr("b")},
+						{ID: "f", Label: "frog1", ParentID: stringPtr("e")},
+					},
+				},
+				Edges: Edges{
+					Edges: []Edge{
+						{ID: "0", Source: "b", Target: "e"},
+						{ID: "1", Source: "c", Target: "d"},
+						{ID: "2", Source: "g", Target: "b"},
+						{ID: "3", Source: "f", Target: "a"},
+					},
+				},
+				DefaultEdgeType: "directed",
+				Mode:            "static",
+			},
+			Version: "1.2",
+		},
+		marshaled: `<gexf xmlns="http://www.gexf.net/1.2draft" version="1.2">
+	<meta lastmodifieddate="2009-10-01">
+		<creator>Gephi.org</creator>
+		<description>A hierarchy file</description>
+	</meta>
+	<graph defaultedgetype="directed" mode="static">
+		<nodes>
+			<node id="g" label="frog2" pid="e"></node>
+			<node id="a" label="Kevin Bacon"></node>
+			<node id="c" label="human1" pid="b"></node>
+			<node id="b" label="God" pid="a"></node>
+			<node id="e" label="Me" pid="a"></node>
+			<node id="d" label="human2" pid="b"></node>
+			<node id="f" label="frog1" pid="e"></node>
+		</nodes>
+		<edges>
+			<edge id="0" source="b" target="e"></edge>
+			<edge id="1" source="c" target="d"></edge>
+			<edge id="2" source="g" target="b"></edge>
+			<edge id="3" source="f" target="a"></edge>
+		</edges>
+	</graph>
+</gexf>`,
+	},
+	{
+		path: "phylogeny.gexf",
+		unmarshaled: Content{
+			XMLName: xml.Name{Space: "http://www.gexf.net/1.2draft", Local: "gexf"},
+			Graph: Graph{
+				Nodes: Nodes{
+					Nodes: []Node{
+						{ID: "a", Label: "cheese"},
+						{ID: "b", Label: "cherry"},
+						{ID: "c", Label: "cake", Parents: &Parents{
+							Parent: []Parent{
+								{For: "a"},
+								{For: "b"},
+							},
+						},
+						},
+					},
+				},
+				Edges: Edges{
+					Edges: nil,
+					Count: nil,
+				},
+			},
+			Version: "1.2",
+		},
+		marshaled: `<gexf xmlns="http://www.gexf.net/1.2draft" version="1.2">
+	<graph>
+		<nodes>
+			<node id="a" label="cheese"></node>
+			<node id="b" label="cherry"></node>
+			<node id="c" label="cake">
+				<parents>
+					<parent for="a"></parent>
+					<parent for="b"></parent>
+				</parents>
+			</node>
+		</nodes>
+		<edges></edges>
+	</graph>
+</gexf>`,
+	},
+	{
+		path: "viz.gexf",
+		unmarshaled: Content{
+			XMLName: xml.Name{Space: "http://www.gexf.net/1.2draft", Local: "gexf"},
+			Graph: Graph{
+				Nodes: Nodes{
+					Nodes: []Node{
+						{
+							ID:    "a",
+							Label: "glossy",
+							Color: &Color{
+								R: 239,
+								G: 173,
+								B: 66,
+								A: float64Ptr(0.6),
+							},
+							Position: &Position{
+								X: 15.783598,
+								Y: 40.109245,
+								Z: 0,
+							},
+							Size: &Size{
+								Value: 2.0375757,
+							},
+						},
+					},
+				},
+				Edges: Edges{},
+			},
+			Version: "1.2",
+		},
+		marshaled: `<gexf xmlns="http://www.gexf.net/1.2draft" version="1.2">
+	<graph>
+		<nodes>
+			<node id="a" label="glossy">
+				<color xmlns="http://www.gexf.net/1.2draft/viz" r="239" g="173" b="66" a="0.6"></color>
+				<position xmlns="http://www.gexf.net/1.2draft/viz" x="15.783598" y="40.109245" z="0"></position>
+				<size xmlns="http://www.gexf.net/1.2draft/viz" value="2.0375757"></size>
+			</node>
+		</nodes>
+		<edges></edges>
+	</graph>
+</gexf>`,
+	},
+}
+
+func TestUnmarshal(t *testing.T) {
+	for _, test := range gexfExampleTests {
+		data, err := ioutil.ReadFile(filepath.Join("testdata", test.path))
+		if err != nil {
+			t.Errorf("failed to read %q: %v", test.path, err)
+			continue
+		}
+		var got Content
+		err = xml.Unmarshal(data, &got)
+		if !reflect.DeepEqual(got, test.unmarshaled) {
+			t.Errorf("unexpected result for %q:\ngot:\n%#v\nwant:\n%#v", test.path, got, test.unmarshaled)
+		}
+	}
+}
+
+// TODO(kortschak): Update this test when/if namespace
+// prefix handling in encoding/xml is fixed.
+func TestMarshal(t *testing.T) {
+	for _, test := range gexfExampleTests {
+		got, err := xml.MarshalIndent(test.unmarshaled, "", "\t")
+		if err != nil {
+			t.Errorf("failed to marshal %q: %v", test.path, err)
+			continue
+		}
+		if string(got) != test.marshaled {
+			t.Errorf("unexpected result for %q:\ngot:\n%s\nwant:\n%s", test.path, got, test.marshaled)
+		}
+	}
+}

--- a/graph/formats/gexf12/testdata/basic.gexf
+++ b/graph/formats/gexf12/testdata/basic.gexf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gexf xmlns="http://www.gexf.net/1.2draft" version="1.2">
+    <graph mode="static" defaultedgetype="directed">
+        <nodes>
+            <node id="0" label="Hello" />
+            <node id="1" label="Word" />
+        </nodes>
+        <edges>
+            <edge id="0" source="0" target="1" />
+        </edges>
+    </graph>
+</gexf>

--- a/graph/formats/gexf12/testdata/data.gexf
+++ b/graph/formats/gexf12/testdata/data.gexf
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gexf xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
+  <meta lastmodifieddate="2009-03-20">
+    <creator>Gephi.org</creator>
+    <description>A Web network</description>
+  </meta>
+  <graph defaultedgetype="directed">
+    <attributes class="node">
+      <attribute id="0" title="url" type="string"/>
+      <attribute id="1" title="indegree" type="float"/>
+      <attribute id="2" title="frog" type="boolean">
+        <default>true</default>
+      </attribute>
+    </attributes>
+    <nodes>
+      <node id="0" label="Gephi">
+        <attvalues>
+          <attvalue for="0" value="http://gephi.org"/>
+          <attvalue for="1" value="1"/>
+        </attvalues>
+      </node>
+      <node id="1" label="Webatlas">
+        <attvalues>
+          <attvalue for="0" value="http://webatlas.fr"/>
+          <attvalue for="1" value="2"/>
+        </attvalues>
+      </node>
+      <node id="2" label="RTGI">
+        <attvalues>
+          <attvalue for="0" value="http://rtgi.fr"/>
+          <attvalue for="1" value="1"/>
+        </attvalues>
+      </node>
+      <node id="3" label="BarabasiLab">
+        <attvalues>
+          <attvalue for="0" value="http://barabasilab.com"/>
+          <attvalue for="1" value="1"/>
+          <attvalue for="2" value="false"/>
+        </attvalues>
+      </node>
+    </nodes>
+    <edges>
+      <edge id="0" source="0" target="1"/>
+      <edge id="1" source="0" target="2"/>
+      <edge id="2" source="1" target="0"/>
+      <edge id="3" source="2" target="1"/>
+      <edge id="4" source="0" target="3"/>
+    </edges>
+  </graph>
+</gexf>
+

--- a/graph/formats/gexf12/testdata/hierarchy1.gexf
+++ b/graph/formats/gexf12/testdata/hierarchy1.gexf
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gexf xmlns="http://www.gexf.net/1.2draft"
+ xmlns:viz="http://www.gexf.net/1.2draft/viz"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://www.gexf.net/1.2draft
+                     http://www.gexf.net/1.2draft/gexf.xsd" 
+ version="1.2">
+    <meta lastmodifieddate="2009-10-01">
+        <creator>Gephi.org</creator>
+        <description>A hierarchy file</description>
+    </meta>
+    <graph mode="static" defaultedgetype="directed">
+        <nodes>
+          <node id="a" label="Kevin Bacon">
+            <nodes>
+              <node id="b" label="God">
+                <nodes>
+                  <node id="c" label="human1"/>
+                  <node id="d" label="human2"/>
+                  <node id="i" label="human3"/>
+                </nodes>
+              </node>
+              <node id="e" label="Me">
+                <nodes>
+                  <node id="f" label="frog1"/>
+                  <node id="g" label="frog2"/>
+                  <node id="h" label="frog3"/>
+                </nodes>
+              </node>
+              <node id="j" label="You" />
+            </nodes>
+          </node>
+        </nodes>
+        <edges>
+            <edge id="0" source="b" target="e" />
+            <edge id="1" source="c" target="d" />
+            <edge id="2" source="c" target="i" />
+            <edge id="3" source="g" target="b" />
+            <edge id="4" source="f" target="a" />
+            <edge id="5" source="f" target="g" />
+            <edge id="6" source="f" target="h" />
+            <edge id="7" source="g" target="h" />
+            <edge id="8" source="a" target="j" />
+        </edges>
+    </graph>
+</gexf>

--- a/graph/formats/gexf12/testdata/hierarchy4.gexf
+++ b/graph/formats/gexf12/testdata/hierarchy4.gexf
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gexf xmlns="http://www.gexf.net/1.2draft"
+ xmlns:viz="http://www.gexf.net/1.2draft/viz"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://www.gexf.net/1.2draft
+                     http://www.gexf.net/1.2draft/gexf.xsd" 
+ version="1.2">
+    <meta lastmodifieddate="2009-10-01">
+        <creator>Gephi.org</creator>
+        <description>A hierarchy file</description>
+    </meta>
+    <graph mode="static" defaultedgetype="directed">
+        <nodes>
+          <node id="g" label="frog2" pid="e" />
+          <node id="a" label="Kevin Bacon" />
+          <node id="c" label="human1" pid="b" />
+          <node id="b" label="God" pid="a" />
+          <node id="e" label="Me" pid="a" />
+          <node id="d" label="human2" pid="b" />
+          <node id="f" label="frog1" pid="e" />
+        </nodes>
+        <edges>
+            <edge id="0" source="b" target="e" />
+            <edge id="1" source="c" target="d" />
+            <edge id="2" source="g" target="b" />
+            <edge id="3" source="f" target="a" />
+        </edges>
+    </graph>
+</gexf>

--- a/graph/formats/gexf12/testdata/phylogeny.gexf
+++ b/graph/formats/gexf12/testdata/phylogeny.gexf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gexf xmlns="http://www.gexf.net/1.2draft" version="1.2">
+  <graph>
+    <nodes>
+      <node id="a" label="cheese" />
+      <node id="b" label="cherry" />
+      <node id="c" label="cake">
+        <parents>
+          <parent for="a" />
+          <parent for="b" />
+        </parents>
+      </node>
+    </nodes>
+  </graph>
+</gexf>

--- a/graph/formats/gexf12/testdata/viz.gexf
+++ b/graph/formats/gexf12/testdata/viz.gexf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gexf xmlns="http://www.gexf.net/1.2draft" xmlns:viz="http://www.gexf.net/1.2draft/viz" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
+    <graph>
+        <nodes>
+            <node id="a" label="glossy">
+				<viz:color r="239" g="173" b="66" a="0.6"/>
+				<viz:position x="15.783598" y="40.109245" z="0.0"/>
+				<viz:size value="2.0375757"/>
+		    </node>
+        </nodes>
+    </graph>
+</gexf>


### PR DESCRIPTION
This was largely written by aqwari.net/xml/cmd/xsdgen working on the XSD files available from the [gephy/gexf specs repository](https://github.com/gephi/gexf/tree/81ba4e7ccdc25631f836fc5caa4ed64ba5300379/specs/1.2draft), with some help; the specs use includes which cause xsdgen to fail, so I manually in-lined the includes.

The generated code was then edited to make optional attributes exist on pointers, to reduce the length of labels to within reasonably normal Go idiom and removing unnecessary namespacing.

The package is versioned since the format appears to arbitrarily be updated.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
