### PR TITLE
gexf12: fix omitable and unbounded attributes

### DIFF
--- a/graph/formats/gexf12/gexf.go
+++ b/graph/formats/gexf12/gexf.go
@@ -61,9 +61,9 @@ func (t *Meta) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 
 // Graph stores the graph nodes, edges, dynamics and visualization data.
 type Graph struct {
-	Attributes *Attributes `xml:"attributes"`
-	Nodes      Nodes       `xml:"nodes"`
-	Edges      Edges       `xml:"edges"`
+	Attributes []Attributes `xml:"attributes"`
+	Nodes      Nodes        `xml:"nodes"`
+	Edges      Edges        `xml:"edges"`
 	// TimeFormat may be one of "integer", "double", "date" or "dateTime".
 	TimeFormat *string `xml:"timeformat,attr,omitempty"`
 	Start      *string `xml:"start,attr,omitempty"`
@@ -71,11 +71,11 @@ type Graph struct {
 	End        *string `xml:"end,attr,omitempty"`
 	Endopen    *string `xml:"endopen,attr,omitempty"`
 	// DefaultEdgeType may be one of "directed", "undirected" or "mutual".
-	DefaultEdgeType string `xml:"defaultedgetype,attr,omitempty"`
+	DefaultEdgeType *string `xml:"defaultedgetype,attr,omitempty"`
 	// IDType may be one of "integer" or "string".
-	IDType string `xml:"idtype,attr,omitempty"`
+	IDType *string `xml:"idtype,attr,omitempty"`
 	// Mode may be "static" or "dynamic".
-	Mode string `xml:"mode,attr,omitempty"`
+	Mode *string `xml:"mode,attr,omitempty"`
 }
 
 // Attributes holds a collection of potentially dynamic attributes
@@ -99,8 +99,8 @@ type Attribute struct {
 	// Type may be one of "integer", "long", "double", "float",
 	// "boolean", "liststring", "string", or "anyURI".
 	Type    string  `xml:"type,attr"`
-	Default *string `xml:"default"`
-	Options *string `xml:"options"`
+	Default *string `xml:"default,omitempty"`
+	Options *string `xml:"options,omitempty"`
 }
 
 // Nodes holds a collection of nodes constituting a graph or subgraph.

--- a/graph/formats/gexf12/gexf.go
+++ b/graph/formats/gexf12/gexf.go
@@ -23,8 +23,8 @@ type Content struct {
 	Meta    *Meta    `xml:"meta,omitempty"`
 	Graph   Graph    `xml:"graph"`
 	// Version must be "1.2".
-	Version string  `xml:"version,attr"`
-	Variant *string `xml:"variant,attr,omitempty"`
+	Version string `xml:"version,attr"`
+	Variant string `xml:"variant,attr,omitempty"`
 }
 
 // Meta holds optional metadata associated with the graph.
@@ -65,17 +65,17 @@ type Graph struct {
 	Nodes      Nodes        `xml:"nodes"`
 	Edges      Edges        `xml:"edges"`
 	// TimeFormat may be one of "integer", "double", "date" or "dateTime".
-	TimeFormat *string `xml:"timeformat,attr,omitempty"`
-	Start      *string `xml:"start,attr,omitempty"`
-	Startopen  *string `xml:"startopen,attr,omitempty"`
-	End        *string `xml:"end,attr,omitempty"`
-	Endopen    *string `xml:"endopen,attr,omitempty"`
+	TimeFormat string `xml:"timeformat,attr,omitempty"`
+	Start      string `xml:"start,attr,omitempty"`
+	Startopen  string `xml:"startopen,attr,omitempty"`
+	End        string `xml:"end,attr,omitempty"`
+	Endopen    string `xml:"endopen,attr,omitempty"`
 	// DefaultEdgeType may be one of "directed", "undirected" or "mutual".
-	DefaultEdgeType *string `xml:"defaultedgetype,attr,omitempty"`
+	DefaultEdgeType string `xml:"defaultedgetype,attr,omitempty"`
 	// IDType may be one of "integer" or "string".
-	IDType *string `xml:"idtype,attr,omitempty"`
+	IDType string `xml:"idtype,attr,omitempty"`
 	// Mode may be "static" or "dynamic".
-	Mode *string `xml:"mode,attr,omitempty"`
+	Mode string `xml:"mode,attr,omitempty"`
 }
 
 // Attributes holds a collection of potentially dynamic attributes
@@ -85,11 +85,11 @@ type Attributes struct {
 	// Class be one of "node" or "edge".
 	Class string `xml:"class,attr"`
 	// Mode may be "static" or "dynamic".
-	Mode      *string `xml:"mode,attr,omitempty"`
-	Start     *string `xml:"start,attr,omitempty"`
-	Startopen *string `xml:"startopen,attr,omitempty"`
-	End       *string `xml:"end,attr,omitempty"`
-	Endopen   *string `xml:"endopen,attr,omitempty"`
+	Mode      string `xml:"mode,attr,omitempty"`
+	Start     string `xml:"start,attr,omitempty"`
+	Startopen string `xml:"startopen,attr,omitempty"`
+	End       string `xml:"end,attr,omitempty"`
+	Endopen   string `xml:"endopen,attr,omitempty"`
 }
 
 // Attribute holds a single graph attribute.
@@ -98,14 +98,14 @@ type Attribute struct {
 	Title string `xml:"title,attr"`
 	// Type may be one of "integer", "long", "double", "float",
 	// "boolean", "liststring", "string", or "anyURI".
-	Type    string  `xml:"type,attr"`
-	Default *string `xml:"default,omitempty"`
-	Options *string `xml:"options,omitempty"`
+	Type    string `xml:"type,attr"`
+	Default string `xml:"default,omitempty"`
+	Options string `xml:"options,omitempty"`
 }
 
 // Nodes holds a collection of nodes constituting a graph or subgraph.
 type Nodes struct {
-	Count *int   `xml:"count,attr,omitempty"`
+	Count int    `xml:"count,attr,omitempty"`
 	Nodes []Node `xml:"node,omitempty"`
 }
 
@@ -117,16 +117,16 @@ type Node struct {
 	Spells    *Spells    `xml:"spells"`
 	Nodes     *Nodes     `xml:"nodes"`
 	Edges     *Edges     `xml:"edges"`
-	ParentID  *string    `xml:"pid,attr,omitempty"`
+	ParentID  string     `xml:"pid,attr,omitempty"`
 	Parents   *Parents   `xml:"parents"`
 	Color     *Color     `xml:"http://www.gexf.net/1.2draft/viz color"`
 	Position  *Position  `xml:"http://www.gexf.net/1.2draft/viz position"`
 	Size      *Size      `xml:"http://www.gexf.net/1.2draft/viz size"`
 	Shape     *NodeShape `xml:"http://www.gexf.net/1.2draft/viz shape"`
-	Start     *string    `xml:"start,attr,omitempty"`
-	Startopen *string    `xml:"startopen,attr,omitempty"`
-	End       *string    `xml:"end,attr,omitempty"`
-	Endopen   *string    `xml:"endopen,attr,omitempty"`
+	Start     string     `xml:"start,attr,omitempty"`
+	Startopen string     `xml:"startopen,attr,omitempty"`
+	End       string     `xml:"end,attr,omitempty"`
+	Endopen   string     `xml:"endopen,attr,omitempty"`
 }
 
 // NodeShape holds the visual representation of a node with associated
@@ -135,30 +135,30 @@ type NodeShape struct {
 	Spells *Spells `xml:"spells,omitempty"`
 	// Value be one of "disc", "square", "triangle",
 	// "diamond" or "image".
-	Shape     string  `xml:"value,attr"`
-	URI       *string `xml:"uri,attr,omitempty"`
-	Start     *string `xml:"start,attr,omitempty"`
-	Startopen *string `xml:"startopen,attr,omitempty"`
-	End       *string `xml:"end,attr,omitempty"`
-	Endopen   *string `xml:"endopen,attr,omitempty"`
+	Shape     string `xml:"value,attr"`
+	URI       string `xml:"uri,attr,omitempty"`
+	Start     string `xml:"start,attr,omitempty"`
+	Startopen string `xml:"startopen,attr,omitempty"`
+	End       string `xml:"end,attr,omitempty"`
+	Endopen   string `xml:"endopen,attr,omitempty"`
 }
 
 // Color represents a node or edge color and its associated dynamics.
 type Color struct {
-	Spells    *Spells  `xml:"spells,omitempty"`
-	R         byte     `xml:"r,attr"`
-	G         byte     `xml:"g,attr"`
-	B         byte     `xml:"b,attr"`
-	A         *float64 `xml:"a,attr,omitempty"`
-	Start     *string  `xml:"start,attr,omitempty"`
-	Startopen *string  `xml:"startopen,attr,omitempty"`
-	End       *string  `xml:"end,attr,omitempty"`
-	Endopen   *string  `xml:"endopen,attr,omitempty"`
+	Spells    *Spells `xml:"spells,omitempty"`
+	R         byte    `xml:"r,attr"`
+	G         byte    `xml:"g,attr"`
+	B         byte    `xml:"b,attr"`
+	A         float64 `xml:"a,attr,omitempty"`
+	Start     string  `xml:"start,attr,omitempty"`
+	Startopen string  `xml:"startopen,attr,omitempty"`
+	End       string  `xml:"end,attr,omitempty"`
+	Endopen   string  `xml:"endopen,attr,omitempty"`
 }
 
 // Edges holds a collection of edges constituting a graph or subgraph.
 type Edges struct {
-	Count *int   `xml:"count,attr,omitempty"`
+	Count int    `xml:"count,attr,omitempty"`
 	Edges []Edge `xml:"edge,omitempty"`
 }
 
@@ -170,16 +170,16 @@ type Edge struct {
 	Color     *Color     `xml:"http://www.gexf.net/1.2draft/viz color"`
 	Thickness *Thickness `xml:"http://www.gexf.net/1.2draft/viz thickness"`
 	Shape     *Edgeshape `xml:"http://www.gexf.net/1.2draft/viz shape"`
-	Start     *string    `xml:"start,attr,omitempty"`
-	Startopen *string    `xml:"startopen,attr,omitempty"`
-	End       *string    `xml:"end,attr,omitempty"`
-	Endopen   *string    `xml:"endopen,attr,omitempty"`
+	Start     string     `xml:"start,attr,omitempty"`
+	Startopen string     `xml:"startopen,attr,omitempty"`
+	End       string     `xml:"end,attr,omitempty"`
+	Endopen   string     `xml:"endopen,attr,omitempty"`
 	// Type may be one of directed, undirected, mutual
-	Type   *string  `xml:"type,attr,omitempty"`
-	Label  *string  `xml:"label,attr,omitempty"`
-	Source string   `xml:"source,attr"`
-	Target string   `xml:"target,attr"`
-	Weight *float64 `xml:"weight,attr,omitempty"`
+	Type   string  `xml:"type,attr,omitempty"`
+	Label  string  `xml:"label,attr,omitempty"`
+	Source string  `xml:"source,attr"`
+	Target string  `xml:"target,attr"`
+	Weight float64 `xml:"weight,attr,omitempty"`
 }
 
 // AttVlues holds a collection of attribute values.
@@ -189,12 +189,12 @@ type AttValues struct {
 
 // AttValues holds a single attribute value and its associated dynamics.
 type AttValue struct {
-	For       string  `xml:"for,attr"`
-	Value     string  `xml:"value,attr"`
-	Start     *string `xml:"start,attr,omitempty"`
-	Startopen *string `xml:"startopen,attr,omitempty"`
-	End       *string `xml:"end,attr,omitempty"`
-	Endopen   *string `xml:"endopen,attr,omitempty"`
+	For       string `xml:"for,attr"`
+	Value     string `xml:"value,attr"`
+	Start     string `xml:"start,attr,omitempty"`
+	Startopen string `xml:"startopen,attr,omitempty"`
+	End       string `xml:"end,attr,omitempty"`
+	Endopen   string `xml:"endopen,attr,omitempty"`
 }
 
 // EdgeShape holds the visual representation of an edge with associated
@@ -203,10 +203,10 @@ type Edgeshape struct {
 	// Shape be one of solid, dotted, dashed, double
 	Shape     string  `xml:"value,attr"`
 	Spells    *Spells `xml:"spells,omitempty"`
-	Start     *string `xml:"start,attr,omitempty"`
-	Startopen *string `xml:"startopen,attr,omitempty"`
-	End       *string `xml:"end,attr,omitempty"`
-	Endopen   *string `xml:"endopen,attr,omitempty"`
+	Start     string  `xml:"start,attr,omitempty"`
+	Startopen string  `xml:"startopen,attr,omitempty"`
+	End       string  `xml:"end,attr,omitempty"`
+	Endopen   string  `xml:"endopen,attr,omitempty"`
 }
 
 // Parents holds parent relationships between nodes in a hierarchical
@@ -226,30 +226,30 @@ type Position struct {
 	Y         float64 `xml:"y,attr"`
 	Z         float64 `xml:"z,attr"`
 	Spells    *Spells `xml:"spells,omitempty"`
-	Start     *string `xml:"start,attr,omitempty"`
-	Startopen *string `xml:"startopen,attr,omitempty"`
-	End       *string `xml:"end,attr,omitempty"`
-	Endopen   *string `xml:"endopen,attr,omitempty"`
+	Start     string  `xml:"start,attr,omitempty"`
+	Startopen string  `xml:"startopen,attr,omitempty"`
+	End       string  `xml:"end,attr,omitempty"`
+	Endopen   string  `xml:"endopen,attr,omitempty"`
 }
 
 // Size hold the visual size of a node and its dynamics.
 type Size struct {
 	Value     float64 `xml:"value,attr"`
 	Spells    *Spells `xml:"http://www.gexf.net/1.2draft/viz spells,omitempty"`
-	Start     *string `xml:"start,attr,omitempty"`
-	Startopen *string `xml:"startopen,attr,omitempty"`
-	End       *string `xml:"end,attr,omitempty"`
-	Endopen   *string `xml:"endopen,attr,omitempty"`
+	Start     string  `xml:"start,attr,omitempty"`
+	Startopen string  `xml:"startopen,attr,omitempty"`
+	End       string  `xml:"end,attr,omitempty"`
+	Endopen   string  `xml:"endopen,attr,omitempty"`
 }
 
 // Thickness hold the visual thickness of an edge and its dynamics.
 type Thickness struct {
 	Value     float64 `xml:"value,attr"`
 	Spells    *Spells `xml:"http://www.gexf.net/1.2draft/viz spells,omitempty"`
-	Start     *string `xml:"start,attr,omitempty"`
-	Startopen *string `xml:"startopen,attr,omitempty"`
-	End       *string `xml:"end,attr,omitempty"`
-	Endopen   *string `xml:"endopen,attr,omitempty"`
+	Start     string  `xml:"start,attr,omitempty"`
+	Startopen string  `xml:"startopen,attr,omitempty"`
+	End       string  `xml:"end,attr,omitempty"`
+	Endopen   string  `xml:"endopen,attr,omitempty"`
 }
 
 // Spells holds a collection of time dynamics for a graph entity.
@@ -259,10 +259,10 @@ type Spells struct {
 
 // Spell is a time interval.
 type Spell struct {
-	Start     *string `xml:"start,attr,omitempty"`
-	Startopen *string `xml:"startopen,attr,omitempty"`
-	End       *string `xml:"end,attr,omitempty"`
-	Endopen   *string `xml:"endopen,attr,omitempty"`
+	Start     string `xml:"start,attr,omitempty"`
+	Startopen string `xml:"startopen,attr,omitempty"`
+	End       string `xml:"end,attr,omitempty"`
+	Endopen   string `xml:"endopen,attr,omitempty"`
 }
 
 type xsdDate time.Time

--- a/graph/formats/gexf12/gexf_test.go
+++ b/graph/formats/gexf12/gexf_test.go
@@ -13,9 +13,6 @@ import (
 	"time"
 )
 
-func stringPtr(s string) *string    { return &s }
-func float64Ptr(f float64) *float64 { return &f }
-
 var gexfExampleTests = []struct {
 	path        string
 	unmarshaled Content
@@ -39,8 +36,8 @@ var gexfExampleTests = []struct {
 						{ID: "0", Source: "0", Target: "1"},
 					},
 				},
-				DefaultEdgeType: stringPtr("directed"),
-				Mode:            stringPtr("static"),
+				DefaultEdgeType: "directed",
+				Mode:            "static",
 			},
 			Version: "1.2",
 		},
@@ -83,7 +80,7 @@ var gexfExampleTests = []struct {
 							ID:      "2",
 							Title:   "frog",
 							Type:    "boolean",
-							Default: stringPtr("true"),
+							Default: "true",
 						},
 					},
 				}},
@@ -129,7 +126,7 @@ var gexfExampleTests = []struct {
 						{ID: "4", Source: "0", Target: "3"},
 					},
 				},
-				DefaultEdgeType: stringPtr("directed"),
+				DefaultEdgeType: "directed",
 			},
 			Version: "1.2",
 		},
@@ -239,8 +236,8 @@ var gexfExampleTests = []struct {
 						{ID: "8", Source: "a", Target: "j"},
 					},
 				},
-				DefaultEdgeType: stringPtr("directed"),
-				Mode:            stringPtr("static"),
+				DefaultEdgeType: "directed",
+				Mode:            "static",
 			},
 			Version: "1.2",
 		},
@@ -298,13 +295,13 @@ var gexfExampleTests = []struct {
 			Graph: Graph{
 				Nodes: Nodes{
 					Nodes: []Node{
-						{ID: "g", Label: "frog2", ParentID: stringPtr("e")},
+						{ID: "g", Label: "frog2", ParentID: "e"},
 						{ID: "a", Label: "Kevin Bacon"},
-						{ID: "c", Label: "human1", ParentID: stringPtr("b")},
-						{ID: "b", Label: "God", ParentID: stringPtr("a")},
-						{ID: "e", Label: "Me", ParentID: stringPtr("a")},
-						{ID: "d", Label: "human2", ParentID: stringPtr("b")},
-						{ID: "f", Label: "frog1", ParentID: stringPtr("e")},
+						{ID: "c", Label: "human1", ParentID: "b"},
+						{ID: "b", Label: "God", ParentID: "a"},
+						{ID: "e", Label: "Me", ParentID: "a"},
+						{ID: "d", Label: "human2", ParentID: "b"},
+						{ID: "f", Label: "frog1", ParentID: "e"},
 					},
 				},
 				Edges: Edges{
@@ -315,8 +312,8 @@ var gexfExampleTests = []struct {
 						{ID: "3", Source: "f", Target: "a"},
 					},
 				},
-				DefaultEdgeType: stringPtr("directed"),
-				Mode:            stringPtr("static"),
+				DefaultEdgeType: "directed",
+				Mode:            "static",
 			},
 			Version: "1.2",
 		},
@@ -364,7 +361,7 @@ var gexfExampleTests = []struct {
 				},
 				Edges: Edges{
 					Edges: nil,
-					Count: nil,
+					Count: 0,
 				},
 			},
 			Version: "1.2",
@@ -399,7 +396,7 @@ var gexfExampleTests = []struct {
 								R: 239,
 								G: 173,
 								B: 66,
-								A: float64Ptr(0.6),
+								A: 0.6,
 							},
 							Position: &Position{
 								X: 15.783598,

--- a/graph/formats/gexf12/gexf_test.go
+++ b/graph/formats/gexf12/gexf_test.go
@@ -39,8 +39,8 @@ var gexfExampleTests = []struct {
 						{ID: "0", Source: "0", Target: "1"},
 					},
 				},
-				DefaultEdgeType: "directed",
-				Mode:            "static",
+				DefaultEdgeType: stringPtr("directed"),
+				Mode:            stringPtr("static"),
 			},
 			Version: "1.2",
 		},
@@ -66,7 +66,7 @@ var gexfExampleTests = []struct {
 				LastModified: time.Date(2009, 03, 20, 0, 0, 0, 0, time.UTC),
 			},
 			Graph: Graph{
-				Attributes: &Attributes{
+				Attributes: []Attributes{{
 					Class: "node",
 					Attributes: []Attribute{
 						{
@@ -86,7 +86,7 @@ var gexfExampleTests = []struct {
 							Default: stringPtr("true"),
 						},
 					},
-				},
+				}},
 				Nodes: Nodes{
 					Nodes: []Node{
 						{
@@ -129,7 +129,7 @@ var gexfExampleTests = []struct {
 						{ID: "4", Source: "0", Target: "3"},
 					},
 				},
-				DefaultEdgeType: "directed",
+				DefaultEdgeType: stringPtr("directed"),
 			},
 			Version: "1.2",
 		},
@@ -239,8 +239,8 @@ var gexfExampleTests = []struct {
 						{ID: "8", Source: "a", Target: "j"},
 					},
 				},
-				DefaultEdgeType: "directed",
-				Mode:            "static",
+				DefaultEdgeType: stringPtr("directed"),
+				Mode:            stringPtr("static"),
 			},
 			Version: "1.2",
 		},
@@ -315,8 +315,8 @@ var gexfExampleTests = []struct {
 						{ID: "3", Source: "f", Target: "a"},
 					},
 				},
-				DefaultEdgeType: "directed",
-				Mode:            "static",
+				DefaultEdgeType: stringPtr("directed"),
+				Mode:            stringPtr("static"),
 			},
 			Version: "1.2",
 		},


### PR DESCRIPTION
Even with mechanical help I can get XML wrong.

1. Fix `xml:` tag to omitempty for `Attribute`.
2. Fix pointer type for omitable  fields in `Graph`.
3. Make `Attributes` in `Graph` a `[]Attribute` to match the [xsd](https://github.com/gephi/gexf/blob/81ba4e7ccdc25631f836fc5caa4ed64ba5300379/specs/1.2draft/data.xsd#L6-L12) and the [rnc](https://github.com/gephi/gexf/blob/81ba4e7ccdc25631f836fc5caa4ed64ba5300379/specs/1.2draft/data.rnc#L8-L9).

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
