### PR TITLE
gexf12: make slice fields plural

### DIFF
--- a/graph/formats/gexf12/gexf.go
+++ b/graph/formats/gexf12/gexf.go
@@ -67,9 +67,9 @@ type Graph struct {
 	// TimeFormat may be one of "integer", "double", "date" or "dateTime".
 	TimeFormat string `xml:"timeformat,attr,omitempty"`
 	Start      string `xml:"start,attr,omitempty"`
-	Startopen  string `xml:"startopen,attr,omitempty"`
+	StartOpen  string `xml:"startopen,attr,omitempty"`
 	End        string `xml:"end,attr,omitempty"`
-	Endopen    string `xml:"endopen,attr,omitempty"`
+	EndOpen    string `xml:"endopen,attr,omitempty"`
 	// DefaultEdgeType may be one of "directed", "undirected" or "mutual".
 	DefaultEdgeType string `xml:"defaultedgetype,attr,omitempty"`
 	// IDType may be one of "integer" or "string".
@@ -87,9 +87,9 @@ type Attributes struct {
 	// Mode may be "static" or "dynamic".
 	Mode      string `xml:"mode,attr,omitempty"`
 	Start     string `xml:"start,attr,omitempty"`
-	Startopen string `xml:"startopen,attr,omitempty"`
+	StartOpen string `xml:"startopen,attr,omitempty"`
 	End       string `xml:"end,attr,omitempty"`
-	Endopen   string `xml:"endopen,attr,omitempty"`
+	EndOpen   string `xml:"endopen,attr,omitempty"`
 }
 
 // Attribute holds a single graph attribute.
@@ -124,9 +124,9 @@ type Node struct {
 	Size      *Size      `xml:"http://www.gexf.net/1.2draft/viz size"`
 	Shape     *NodeShape `xml:"http://www.gexf.net/1.2draft/viz shape"`
 	Start     string     `xml:"start,attr,omitempty"`
-	Startopen string     `xml:"startopen,attr,omitempty"`
+	StartOpen string     `xml:"startopen,attr,omitempty"`
 	End       string     `xml:"end,attr,omitempty"`
-	Endopen   string     `xml:"endopen,attr,omitempty"`
+	EndOpen   string     `xml:"endopen,attr,omitempty"`
 }
 
 // NodeShape holds the visual representation of a node with associated
@@ -138,9 +138,9 @@ type NodeShape struct {
 	Shape     string `xml:"value,attr"`
 	URI       string `xml:"uri,attr,omitempty"`
 	Start     string `xml:"start,attr,omitempty"`
-	Startopen string `xml:"startopen,attr,omitempty"`
+	StartOpen string `xml:"startopen,attr,omitempty"`
 	End       string `xml:"end,attr,omitempty"`
-	Endopen   string `xml:"endopen,attr,omitempty"`
+	EndOpen   string `xml:"endopen,attr,omitempty"`
 }
 
 // Color represents a node or edge color and its associated dynamics.
@@ -151,9 +151,9 @@ type Color struct {
 	B         byte    `xml:"b,attr"`
 	A         float64 `xml:"a,attr,omitempty"`
 	Start     string  `xml:"start,attr,omitempty"`
-	Startopen string  `xml:"startopen,attr,omitempty"`
+	StartOpen string  `xml:"startopen,attr,omitempty"`
 	End       string  `xml:"end,attr,omitempty"`
-	Endopen   string  `xml:"endopen,attr,omitempty"`
+	EndOpen   string  `xml:"endopen,attr,omitempty"`
 }
 
 // Edges holds a collection of edges constituting a graph or subgraph.
@@ -171,9 +171,9 @@ type Edge struct {
 	Thickness *Thickness `xml:"http://www.gexf.net/1.2draft/viz thickness"`
 	Shape     *Edgeshape `xml:"http://www.gexf.net/1.2draft/viz shape"`
 	Start     string     `xml:"start,attr,omitempty"`
-	Startopen string     `xml:"startopen,attr,omitempty"`
+	StartOpen string     `xml:"startopen,attr,omitempty"`
 	End       string     `xml:"end,attr,omitempty"`
-	Endopen   string     `xml:"endopen,attr,omitempty"`
+	EndOpen   string     `xml:"endopen,attr,omitempty"`
 	// Type may be one of directed, undirected, mutual
 	Type   string  `xml:"type,attr,omitempty"`
 	Label  string  `xml:"label,attr,omitempty"`
@@ -192,9 +192,9 @@ type AttValue struct {
 	For       string `xml:"for,attr"`
 	Value     string `xml:"value,attr"`
 	Start     string `xml:"start,attr,omitempty"`
-	Startopen string `xml:"startopen,attr,omitempty"`
+	StartOpen string `xml:"startopen,attr,omitempty"`
 	End       string `xml:"end,attr,omitempty"`
-	Endopen   string `xml:"endopen,attr,omitempty"`
+	EndOpen   string `xml:"endopen,attr,omitempty"`
 }
 
 // EdgeShape holds the visual representation of an edge with associated
@@ -204,15 +204,15 @@ type Edgeshape struct {
 	Shape     string  `xml:"value,attr"`
 	Spells    *Spells `xml:"spells,omitempty"`
 	Start     string  `xml:"start,attr,omitempty"`
-	Startopen string  `xml:"startopen,attr,omitempty"`
+	StartOpen string  `xml:"startopen,attr,omitempty"`
 	End       string  `xml:"end,attr,omitempty"`
-	Endopen   string  `xml:"endopen,attr,omitempty"`
+	EndOpen   string  `xml:"endopen,attr,omitempty"`
 }
 
 // Parents holds parent relationships between nodes in a hierarchical
 // graph.
 type Parents struct {
-	Parent []Parent `xml:"parent,omitempty"`
+	Parents []Parent `xml:"parent,omitempty"`
 }
 
 // Parent is a single parent relationship.
@@ -227,9 +227,9 @@ type Position struct {
 	Z         float64 `xml:"z,attr"`
 	Spells    *Spells `xml:"spells,omitempty"`
 	Start     string  `xml:"start,attr,omitempty"`
-	Startopen string  `xml:"startopen,attr,omitempty"`
+	StartOpen string  `xml:"startopen,attr,omitempty"`
 	End       string  `xml:"end,attr,omitempty"`
-	Endopen   string  `xml:"endopen,attr,omitempty"`
+	EndOpen   string  `xml:"endopen,attr,omitempty"`
 }
 
 // Size hold the visual size of a node and its dynamics.
@@ -237,9 +237,9 @@ type Size struct {
 	Value     float64 `xml:"value,attr"`
 	Spells    *Spells `xml:"http://www.gexf.net/1.2draft/viz spells,omitempty"`
 	Start     string  `xml:"start,attr,omitempty"`
-	Startopen string  `xml:"startopen,attr,omitempty"`
+	StartOpen string  `xml:"startopen,attr,omitempty"`
 	End       string  `xml:"end,attr,omitempty"`
-	Endopen   string  `xml:"endopen,attr,omitempty"`
+	EndOpen   string  `xml:"endopen,attr,omitempty"`
 }
 
 // Thickness hold the visual thickness of an edge and its dynamics.
@@ -247,22 +247,22 @@ type Thickness struct {
 	Value     float64 `xml:"value,attr"`
 	Spells    *Spells `xml:"http://www.gexf.net/1.2draft/viz spells,omitempty"`
 	Start     string  `xml:"start,attr,omitempty"`
-	Startopen string  `xml:"startopen,attr,omitempty"`
+	StartOpen string  `xml:"startopen,attr,omitempty"`
 	End       string  `xml:"end,attr,omitempty"`
-	Endopen   string  `xml:"endopen,attr,omitempty"`
+	EndOpen   string  `xml:"endopen,attr,omitempty"`
 }
 
 // Spells holds a collection of time dynamics for a graph entity.
 type Spells struct {
-	Spell []Spell `xml:"spell"`
+	Spells []Spell `xml:"spell"`
 }
 
 // Spell is a time interval.
 type Spell struct {
 	Start     string `xml:"start,attr,omitempty"`
-	Startopen string `xml:"startopen,attr,omitempty"`
+	StartOpen string `xml:"startopen,attr,omitempty"`
 	End       string `xml:"end,attr,omitempty"`
-	Endopen   string `xml:"endopen,attr,omitempty"`
+	EndOpen   string `xml:"endopen,attr,omitempty"`
 }
 
 type xsdDate time.Time

--- a/graph/formats/gexf12/gexf_test.go
+++ b/graph/formats/gexf12/gexf_test.go
@@ -351,7 +351,7 @@ var gexfExampleTests = []struct {
 						{ID: "a", Label: "cheese"},
 						{ID: "b", Label: "cherry"},
 						{ID: "c", Label: "cake", Parents: &Parents{
-							Parent: []Parent{
+							Parents: []Parent{
 								{For: "a"},
 								{For: "b"},
 							},


### PR DESCRIPTION
Apologies for this. I should have noticed it in the previous and also first PRs for this package. These will bug me continually if I leave them.

I looked into making it less stuttery, but the xml package doesn't help here unless I write unmarshalers and marshalers, which I'd rather avoid.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
