### PR TITLE
graph/encoding/dot: add multigraph serialization and deserialization support 

### DIFF
--- a/graph/encoding/dot/decode.go
+++ b/graph/encoding/dot/decode.go
@@ -50,6 +50,19 @@ func Unmarshal(data []byte, dst encoding.Builder) error {
 	return copyGraph(dst, file.Graphs[0])
 }
 
+// UnmarshalMulti parses the Graphviz DOT-encoded data as a multigraph and
+// stores the result in dst.
+func UnmarshalMulti(data []byte, dst encoding.MultiBuilder) error {
+	file, err := dot.ParseBytes(data)
+	if err != nil {
+		return err
+	}
+	if len(file.Graphs) != 1 {
+		return fmt.Errorf("invalid number of graphs; expected 1, got %d", len(file.Graphs))
+	}
+	return copyMultigraph(dst, file.Graphs[0])
+}
+
 // copyGraph copies the nodes and edges from the Graphviz AST source graph to
 // the destination graph. Edge direction is maintained if present.
 func copyGraph(dst encoding.Builder, src *ast.Graph) (err error) {
@@ -62,9 +75,41 @@ func copyGraph(dst encoding.Builder, src *ast.Graph) (err error) {
 			panic(e)
 		}
 	}()
-	gen := &generator{
-		directed: src.Directed,
-		ids:      make(map[string]graph.Node),
+	gen := &graphGenerator{
+		generator: generator{
+			directed: src.Directed,
+			ids:      make(map[string]graph.Node),
+		},
+	}
+	if dst, ok := dst.(DOTIDSetter); ok {
+		dst.SetDOTID(src.ID)
+	}
+	if a, ok := dst.(AttributeSetters); ok {
+		gen.graphAttr, gen.nodeAttr, gen.edgeAttr = a.DOTAttributeSetters()
+	}
+	for _, stmt := range src.Stmts {
+		gen.addStmt(dst, stmt)
+	}
+	return err
+}
+
+// copyMultigraph copies the nodes and edges from the Graphviz AST source graph to
+// the destination graph. Edge direction is maintained if present.
+func copyMultigraph(dst encoding.MultiBuilder, src *ast.Graph) (err error) {
+	defer func() {
+		switch e := recover().(type) {
+		case nil:
+		case error:
+			err = e
+		default:
+			panic(e)
+		}
+	}()
+	gen := &multigraphGenerator{
+		generator: generator{
+			directed: src.Directed,
+			ids:      make(map[string]graph.Node),
+		},
 	}
 	if dst, ok := dst.(DOTIDSetter); ok {
 		dst.SetDOTID(src.ID)
@@ -97,7 +142,7 @@ type generator struct {
 
 // node returns the gonum node corresponding to the given dot AST node ID,
 // generating a new such node if none exist.
-func (gen *generator) node(dst encoding.Builder, id string) graph.Node {
+func (gen *generator) node(dst graph.NodeAdder, id string) graph.Node {
 	if n, ok := gen.ids[id]; ok {
 		return n
 	}
@@ -117,8 +162,85 @@ func (gen *generator) node(dst encoding.Builder, id string) graph.Node {
 	return n
 }
 
+// applyPortsToEdge applies the available port metadata from an ast.Edge
+// to a graph.Edge
+func applyPortsToEdge(from ast.Vertex, to *ast.Edge, edge graph.Edge) {
+	if ps, isPortSetter := edge.(PortSetter); isPortSetter {
+		if n, vertexIsNode := from.(*ast.Node); vertexIsNode {
+			if n.Port != nil {
+				err := ps.SetFromPort(n.Port.ID, n.Port.CompassPoint.String())
+				if err != nil {
+					panic(fmt.Errorf("unable to unmarshal edge port (:%s:%s)", n.Port.ID, n.Port.CompassPoint.String()))
+				}
+			}
+		}
+
+		if n, vertexIsNode := to.Vertex.(*ast.Node); vertexIsNode {
+			if n.Port != nil {
+				err := ps.SetToPort(n.Port.ID, n.Port.CompassPoint.String())
+				if err != nil {
+					panic(fmt.Errorf("unable to unmarshal edge DOT port (:%s:%s)", n.Port.ID, n.Port.CompassPoint.String()))
+				}
+			}
+		}
+	}
+}
+
+// pushSubgraph pushes the node start index of the active subgraph onto the
+// stack.
+func (gen *generator) pushSubgraph() {
+	gen.subStart = append(gen.subStart, len(gen.subNodes))
+}
+
+// popSubgraph pops the node start index of the active subgraph from the stack,
+// and returns the nodes processed since.
+func (gen *generator) popSubgraph() []graph.Node {
+	// Get nodes processed since the subgraph became active.
+	start := gen.subStart[len(gen.subStart)-1]
+	// TODO: Figure out a better way to store subgraph nodes, so that duplicates
+	// may not occur.
+	nodes := unique(gen.subNodes[start:])
+	// Remove subgraph from stack.
+	gen.subStart = gen.subStart[:len(gen.subStart)-1]
+	if len(gen.subStart) == 0 {
+		// Remove subgraph nodes when the bottom-most subgraph has been processed.
+		gen.subNodes = gen.subNodes[:0]
+	}
+	return nodes
+}
+
+// unique returns the set of unique nodes contained within ns.
+func unique(ns []graph.Node) []graph.Node {
+	var nodes []graph.Node
+	seen := make(set.Int64s)
+	for _, n := range ns {
+		id := n.ID()
+		if seen.Has(id) {
+			// skip duplicate node
+			continue
+		}
+		seen.Add(id)
+		nodes = append(nodes, n)
+	}
+	return nodes
+}
+
+// isInSubgraph reports whether the active context is within a subgraph, that is
+// to be used as a vertex of an edge.
+func (gen *generator) isInSubgraph() bool {
+	return len(gen.subStart) > 0
+}
+
+// appendSubgraphNode appends the given node to the slice of nodes processed
+// within the context of a subgraph.
+func (gen *generator) appendSubgraphNode(n graph.Node) {
+	gen.subNodes = append(gen.subNodes, n)
+}
+
+type graphGenerator struct{ generator }
+
 // addStmt adds the given statement to the graph.
-func (gen *generator) addStmt(dst encoding.Builder, stmt ast.Stmt) {
+func (gen *graphGenerator) addStmt(dst encoding.Builder, stmt ast.Stmt) {
 	switch stmt := stmt.(type) {
 	case *ast.NodeStmt:
 		n, ok := gen.node(dst, stmt.Node.ID).(encoding.AttributeSetter)
@@ -181,32 +303,8 @@ func (gen *generator) addStmt(dst encoding.Builder, stmt ast.Stmt) {
 	}
 }
 
-// applyPortsToEdge applies the available port metadata from an ast.Edge
-// to a graph.Edge
-func applyPortsToEdge(from ast.Vertex, to *ast.Edge, edge graph.Edge) {
-	if ps, isPortSetter := edge.(PortSetter); isPortSetter {
-		if n, vertexIsNode := from.(*ast.Node); vertexIsNode {
-			if n.Port != nil {
-				err := ps.SetFromPort(n.Port.ID, n.Port.CompassPoint.String())
-				if err != nil {
-					panic(fmt.Errorf("unable to unmarshal edge port (:%s:%s)", n.Port.ID, n.Port.CompassPoint.String()))
-				}
-			}
-		}
-
-		if n, vertexIsNode := to.Vertex.(*ast.Node); vertexIsNode {
-			if n.Port != nil {
-				err := ps.SetToPort(n.Port.ID, n.Port.CompassPoint.String())
-				if err != nil {
-					panic(fmt.Errorf("unable to unmarshal edge DOT port (:%s:%s)", n.Port.ID, n.Port.CompassPoint.String()))
-				}
-			}
-		}
-	}
-}
-
 // addEdgeStmt adds the given edge statement to the graph.
-func (gen *generator) addEdgeStmt(dst encoding.Builder, stmt *ast.EdgeStmt) {
+func (gen *graphGenerator) addEdgeStmt(dst encoding.Builder, stmt *ast.EdgeStmt) {
 	fs := gen.addVertex(dst, stmt.From)
 	ts := gen.addEdge(dst, stmt.To, stmt.Attrs)
 	for _, f := range fs {
@@ -220,7 +318,7 @@ func (gen *generator) addEdgeStmt(dst encoding.Builder, stmt *ast.EdgeStmt) {
 }
 
 // addVertex adds the given vertex to the graph, and returns its set of nodes.
-func (gen *generator) addVertex(dst encoding.Builder, v ast.Vertex) []graph.Node {
+func (gen *graphGenerator) addVertex(dst encoding.Builder, v ast.Vertex) []graph.Node {
 	switch v := v.(type) {
 	case *ast.Node:
 		n := gen.node(dst, v.ID)
@@ -237,7 +335,7 @@ func (gen *generator) addVertex(dst encoding.Builder, v ast.Vertex) []graph.Node
 }
 
 // addEdge adds the given edge to the graph, and returns its set of nodes.
-func (gen *generator) addEdge(dst encoding.Builder, to *ast.Edge, attrs []*ast.Attr) []graph.Node {
+func (gen *graphGenerator) addEdge(dst encoding.Builder, to *ast.Edge, attrs []*ast.Attr) []graph.Node {
 	if !gen.directed && to.Directed {
 		panic(fmt.Errorf("directed edge to %v in undirected graph", to.Vertex))
 	}
@@ -256,55 +354,121 @@ func (gen *generator) addEdge(dst encoding.Builder, to *ast.Edge, attrs []*ast.A
 	return fs
 }
 
-// pushSubgraph pushes the node start index of the active subgraph onto the
-// stack.
-func (gen *generator) pushSubgraph() {
-	gen.subStart = append(gen.subStart, len(gen.subNodes))
-}
+type multigraphGenerator struct{ generator }
 
-// popSubgraph pops the node start index of the active subgraph from the stack,
-// and returns the nodes processed since.
-func (gen *generator) popSubgraph() []graph.Node {
-	// Get nodes processed since the subgraph became active.
-	start := gen.subStart[len(gen.subStart)-1]
-	// TODO: Figure out a better way to store subgraph nodes, so that duplicates
-	// may not occur.
-	nodes := unique(gen.subNodes[start:])
-	// Remove subgraph from stack.
-	gen.subStart = gen.subStart[:len(gen.subStart)-1]
-	if len(gen.subStart) == 0 {
-		// Remove subgraph nodes when the bottom-most subgraph has been processed.
-		gen.subNodes = gen.subNodes[:0]
-	}
-	return nodes
-}
-
-// unique returns the set of unique nodes contained within ns.
-func unique(ns []graph.Node) []graph.Node {
-	var nodes []graph.Node
-	seen := make(set.Int64s)
-	for _, n := range ns {
-		id := n.ID()
-		if seen.Has(id) {
-			// skip duplicate node
-			continue
+// addStmt adds the given statement to the multigraph.
+func (gen *multigraphGenerator) addStmt(dst encoding.MultiBuilder, stmt ast.Stmt) {
+	switch stmt := stmt.(type) {
+	case *ast.NodeStmt:
+		n, ok := gen.node(dst, stmt.Node.ID).(encoding.AttributeSetter)
+		if !ok {
+			return
 		}
-		seen.Add(id)
-		nodes = append(nodes, n)
+		for _, attr := range stmt.Attrs {
+			a := encoding.Attribute{
+				Key:   attr.Key,
+				Value: attr.Val,
+			}
+			if err := n.SetAttribute(a); err != nil {
+				panic(fmt.Errorf("unable to unmarshal node DOT attribute (%s=%s)", a.Key, a.Value))
+			}
+		}
+	case *ast.EdgeStmt:
+		gen.addEdgeStmt(dst, stmt)
+	case *ast.AttrStmt:
+		var n encoding.AttributeSetter
+		var dst string
+		switch stmt.Kind {
+		case ast.GraphKind:
+			if gen.graphAttr == nil {
+				return
+			}
+			n = gen.graphAttr
+			dst = "graph"
+		case ast.NodeKind:
+			if gen.nodeAttr == nil {
+				return
+			}
+			n = gen.nodeAttr
+			dst = "node"
+		case ast.EdgeKind:
+			if gen.edgeAttr == nil {
+				return
+			}
+			n = gen.edgeAttr
+			dst = "edge"
+		default:
+			panic("unreachable")
+		}
+		for _, attr := range stmt.Attrs {
+			a := encoding.Attribute{
+				Key:   attr.Key,
+				Value: attr.Val,
+			}
+			if err := n.SetAttribute(a); err != nil {
+				panic(fmt.Errorf("unable to unmarshal global %s DOT attribute (%s=%s)", dst, a.Key, a.Value))
+			}
+		}
+	case *ast.Attr:
+		// ignore.
+	case *ast.Subgraph:
+		for _, stmt := range stmt.Stmts {
+			gen.addStmt(dst, stmt)
+		}
+	default:
+		panic(fmt.Sprintf("unknown statement type %T", stmt))
 	}
-	return nodes
 }
 
-// isInSubgraph reports whether the active context is within a subgraph, that is
-// to be used as a vertex of an edge.
-func (gen *generator) isInSubgraph() bool {
-	return len(gen.subStart) > 0
+// addEdgeStmt adds the given edge statement to the multigraph.
+func (gen *multigraphGenerator) addEdgeStmt(dst encoding.MultiBuilder, stmt *ast.EdgeStmt) {
+	fs := gen.addVertex(dst, stmt.From)
+	ts := gen.addLine(dst, stmt.To, stmt.Attrs)
+	for _, f := range fs {
+		for _, t := range ts {
+			edge := dst.NewLine(f, t)
+			dst.SetLine(edge)
+			applyPortsToEdge(stmt.From, stmt.To, edge)
+			addEdgeAttrs(edge, stmt.Attrs)
+		}
+	}
 }
 
-// appendSubgraphNode appends the given node to the slice of nodes processed
-// within the context of a subgraph.
-func (gen *generator) appendSubgraphNode(n graph.Node) {
-	gen.subNodes = append(gen.subNodes, n)
+// addVertex adds the given vertex to the multigraph, and returns its set of nodes.
+func (gen *multigraphGenerator) addVertex(dst encoding.MultiBuilder, v ast.Vertex) []graph.Node {
+	switch v := v.(type) {
+	case *ast.Node:
+		n := gen.node(dst, v.ID)
+		return []graph.Node{n}
+	case *ast.Subgraph:
+		gen.pushSubgraph()
+		for _, stmt := range v.Stmts {
+			gen.addStmt(dst, stmt)
+		}
+		return gen.popSubgraph()
+	default:
+		panic(fmt.Sprintf("unknown vertex type %T", v))
+	}
+}
+
+// addLine adds the given edge to the multigraph, and returns its set of nodes.
+func (gen *multigraphGenerator) addLine(dst encoding.MultiBuilder, to *ast.Edge, attrs []*ast.Attr) []graph.Node {
+	if !gen.directed && to.Directed {
+		panic(fmt.Errorf("directed edge to %v in undirected graph", to.Vertex))
+	}
+	fs := gen.addVertex(dst, to.Vertex)
+	if to.To != nil {
+		ts := gen.addLine(dst, to.To, attrs)
+		for _, f := range fs {
+			for _, t := range ts {
+				edge := dst.NewLine(f, t)
+				dst.SetLine(edge)
+				applyPortsToEdge(to.Vertex, to.To, edge)
+				addEdgeAttrs(edge, attrs)
+			}
+		}
+	}
+	return fs
 }
 
 // addEdgeAttrs adds the attributes to the given edge.

--- a/graph/encoding/dot/encode.go
+++ b/graph/encoding/dot/encode.go
@@ -55,7 +55,7 @@ type Structurer interface {
 	Structure() []Graph
 }
 
-// Structurer represents a graph.Multigraph that can define sub-multigraphs.
+// MultiStructurer represents a graph.Multigraph that can define subgraphs.
 type MultiStructurer interface {
 	Structure() []Multigraph
 }
@@ -66,6 +66,7 @@ type Graph interface {
 	DOTID() string
 }
 
+// Multigraph wraps named graph.Multigraph values.
 type Multigraph interface {
 	graph.Multigraph
 	DOTID() string
@@ -76,7 +77,7 @@ type Subgrapher interface {
 	Subgraph() graph.Graph
 }
 
-// MultiSubgrapher wraps graph.Node values that represent sub-multigraphs.
+// MultiSubgrapher wraps graph.Node values that represent subgraphs.
 type MultiSubgrapher interface {
 	Subgraph() graph.Multigraph
 }
@@ -92,7 +93,7 @@ type MultiSubgrapher interface {
 // implementation of the Node, Attributer, Porter, Attributers, Structurer,
 // Subgrapher and Graph interfaces.
 func Marshal(g graph.Graph, name, prefix, indent string) ([]byte, error) {
-	var p graphprinter
+	var p simpleGraphPrinter
 	p.indent = indent
 	p.prefix = prefix
 	p.visited = make(map[edge]bool)
@@ -114,7 +115,7 @@ func Marshal(g graph.Graph, name, prefix, indent string) ([]byte, error) {
 // implementation of the Node, Attributer, Porter, Attributers, Structurer,
 // MultiSubgrapher and Multigraph interfaces.
 func MarshalMulti(g graph.Multigraph, name, prefix, indent string) ([]byte, error) {
-	var p multiprinter
+	var p multiGraphPrinter
 	p.indent = indent
 	p.prefix = prefix
 	p.visited = make(map[line]bool)
@@ -141,7 +142,7 @@ type edge struct {
 }
 
 
-func (p *graphprinter) print(g graph.Graph, name string, needsIndent, isSubgraph bool) error {
+func (p *simpleGraphPrinter) print(g graph.Graph, name string, needsIndent, isSubgraph bool) error {
 	if name == "" {
 		if g, ok := g.(Graph); ok {
 			name = g.DOTID()
@@ -424,12 +425,12 @@ func (p *printer) closeBlock(b string) {
 	p.buf.WriteString(b)
 }
 
-type graphprinter struct {
+type simpleGraphPrinter struct {
 	printer
 	visited map[edge]bool
 }
 
-type multiprinter struct {
+type multiGraphPrinter struct {
 	printer
 	visited map[line]bool
 }
@@ -439,7 +440,7 @@ type line struct {
 	id      int64
 }
 
-func (p *multiprinter) print(g graph.Multigraph, name string, needsIndent, isSubgraph bool) error {
+func (p *multiGraphPrinter) print(g graph.Multigraph, name string, needsIndent, isSubgraph bool) error {
 	if name == "" {
 		if g, ok := g.(Multigraph); ok {
 			name = g.DOTID()

--- a/graph/encoding/dot/encode.go
+++ b/graph/encoding/dot/encode.go
@@ -284,7 +284,7 @@ func (p *simpleGraphPrinter) print(g graph.Graph, name string, needsIndent, isSu
 		}
 	}
 
-	p.printBackMatter()
+	p.closeBlock("}")
 
 	return nil
 }
@@ -315,10 +315,6 @@ func (p *printer) printFrontMatter(name string, needsIndent, isSubgraph, isDirec
 
 	p.openBlock(" {")
 	return nil
-}
-
-func (p *printer) printBackMatter() {
-	p.closeBlock("}")
 }
 
 func (p *printer) writeNode(n graph.Node) {
@@ -582,7 +578,7 @@ func (p *multiGraphPrinter) print(g graph.Multigraph, name string, needsIndent, 
 		}
 	}
 
-	p.printBackMatter()
+	p.closeBlock("}")
 
 	return nil
 }

--- a/graph/encoding/encoding.go
+++ b/graph/encoding/encoding.go
@@ -12,7 +12,7 @@ type Builder interface {
 	graph.Builder
 }
 
-// Builder is a graph that can have user-defined nodes and edges added.
+// MultiBuilder is a graph that can have user-defined nodes and edges added.
 type MultiBuilder interface {
 	graph.Multigraph
 	graph.MultigraphBuilder

--- a/graph/encoding/encoding.go
+++ b/graph/encoding/encoding.go
@@ -12,6 +12,12 @@ type Builder interface {
 	graph.Builder
 }
 
+// Builder is a graph that can have user-defined nodes and edges added.
+type MultiBuilder interface {
+	graph.Multigraph
+	graph.MultigraphBuilder
+}
+
 // AttributeSetter is implemented by types that can set an encoded graph
 // attribute.
 type AttributeSetter interface {

--- a/graph/internal/ordered/sort.go
+++ b/graph/internal/ordered/sort.go
@@ -74,3 +74,20 @@ func Reverse(nodes []graph.Node) {
 		nodes[i], nodes[j] = nodes[j], nodes[i]
 	}
 }
+
+// LinesByIDs implements the sort.Interface sorting a slice of graph.LinesByIDs
+// lexically by the From IDs, then by the To IDs, finally by the Line IDs.
+type LinesByIDs []graph.Line
+
+func (n LinesByIDs) Len() int { return len(n) }
+func (n LinesByIDs) Less(i, j int) bool {
+	a, b := n[i], n[j]
+	if a.From().ID() != b.From().ID() {
+		return a.From().ID() < b.From().ID()
+	}
+	if a.To().ID() != b.To().ID() {
+		return a.To().ID() < b.To().ID()
+	}
+	return n[i].ID() < n[j].ID()
+}
+func (n LinesByIDs) Swap(i, j int) { n[i], n[j] = n[j], n[i] }


### PR DESCRIPTION
This should resolve issue #396, in the way that has been discussed there. This change introduces a new pair of `MarshalMulti()` and `UnmarshalMulti()` functions, both which take `graph.Multigraph`. Please take a look.

There are a couple outstanding questions on this particular implementation:

- The arguments for `Marshal()` have remained unchanged. However, the new function `MarshalMulti()` does not include the `strict` argument, because it doesn't _really_ make any sense in that context. But, I wonder if `Marshal()` should _always_ emit a strict DOT graph, because thats what it really represents. However, that might be too big of a breaking change here.

-  In the `multiprinter.print()` function, I need to iterate lines, which I do via `lines := graph.LinesOf(g.Lines(nid, tid))`, I'm not sure if I need to _explicitly_ sort the lines here to get a stable output, like one does a few lines up on `NodesOf()`, and if so, then what would be the preferred sorting strategy to use here?

If the approach looks worth moving forward, then I'll fill in some more testing coverage before finalizing the PR.

Thanks!

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
