### PR TITLE
cytoscapejs: fix optional field marshaling and helper type naming

### DIFF
--- a/graph/formats/cytoscapejs/cytoscapejs.go
+++ b/graph/formats/cytoscapejs/cytoscapejs.go
@@ -24,8 +24,8 @@ type GraphElem struct {
 type Element struct {
 	Group            string      `json:"group,omitempty"`
 	Data             ElemData    `json:"data"`
-	Position         Position    `json:"position,omitempty"`
-	RenderedPosition Position    `json:"renderedPosition,omitempty"`
+	Position         *Position   `json:"position,omitempty"`
+	RenderedPosition *Position   `json:"renderedPosition,omitempty"`
 	Selected         bool        `json:"selected,omitempty"`
 	Selectable       bool        `json:"selectable,omitempty"`
 	Locked           bool        `json:"locked,omitempty"`
@@ -85,13 +85,13 @@ var (
 // MarshalJSON implements the json.Marshaler interface.
 func (e *ElemData) MarshalJSON() ([]byte, error) {
 	if e.Attributes == nil {
-		type edge struct {
+		type elem struct {
 			ID     string `json:"id"`
-			Source string `json:"source"`
-			Target string `json:"target"`
+			Source string `json:"source,omitempty"`
+			Target string `json:"target,omitempty"`
 			Parent string `json:"parent,omitempty"`
 		}
-		return json.Marshal(edge{ID: e.ID, Source: e.Source, Target: e.Target, Parent: e.Parent})
+		return json.Marshal(elem{ID: e.ID, Source: e.Source, Target: e.Target, Parent: e.Parent})
 	}
 	e.Attributes["id"] = e.ID
 	if e.Source != "" {
@@ -167,8 +167,8 @@ type Elements struct {
 // Node is a Cytoscape.js node.
 type Node struct {
 	Data             NodeData    `json:"data"`
-	Position         Position    `json:"position,omitempty"`
-	RenderedPosition Position    `json:"renderedPosition,omitempty"`
+	Position         *Position   `json:"position,omitempty"`
+	RenderedPosition *Position   `json:"renderedPosition,omitempty"`
 	Selected         bool        `json:"selected,omitempty"`
 	Selectable       bool        `json:"selectable,omitempty"`
 	Locked           bool        `json:"locked,omitempty"`

--- a/graph/formats/cytoscapejs/cytoscapejs_test.go
+++ b/graph/formats/cytoscapejs/cytoscapejs_test.go
@@ -181,7 +181,7 @@ var cytoscapejsNodeEdgeTests = []struct {
 					"y":            -357509.32,
 				},
 			},
-			Position: Position{
+			Position: &Position{
 				X: 1398668.75,
 				Y: -357509.32,
 			},


### PR DESCRIPTION
Fixes a copy/paste error and makes position generally optional ([optional on init](http://js.cytoscape.org/#notation/elements-json)) and source/target optional on elements (may be a node).

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
