### PR TITLE
encoding/dot: make all simple graph marshalling strict

### DIFF
--- a/graph/encoding/dot/decode_test.go
+++ b/graph/encoding/dot/decode_test.go
@@ -55,7 +55,7 @@ func TestRoundTrip(t *testing.T) {
 			t.Errorf("i=%d: unable to unmarshal DOT graph; %v", i, err)
 			continue
 		}
-		buf, err := Marshal(dst, "", "", "\t", false)
+		buf, err := Marshal(dst, "", "", "\t")
 		if err != nil {
 			t.Errorf("i=%d: unable to marshal graph; %v", i, dst)
 			continue
@@ -68,7 +68,7 @@ func TestRoundTrip(t *testing.T) {
 	}
 }
 
-const directed = `digraph {
+const directed = `strict digraph {
 	graph [
 		outputorder=edgesfirst
 	];
@@ -89,7 +89,7 @@ const directed = `digraph {
 	A -> B [label="baz 2"];
 }`
 
-const undirected = `graph {
+const undirected = `strict graph {
 	graph [
 		outputorder=edgesfirst
 	];
@@ -110,7 +110,7 @@ const undirected = `graph {
 	A -- B [label="baz 2"];
 }`
 
-const directedID = `digraph G {
+const directedID = `strict digraph G {
 	// Node definitions.
 	A;
 	B;
@@ -119,7 +119,7 @@ const directedID = `digraph G {
 	A -> B;
 }`
 
-const undirectedID = `graph H {
+const undirectedID = `strict graph H {
 	// Node definitions.
 	A;
 	B;
@@ -128,7 +128,7 @@ const undirectedID = `graph H {
 	A -- B;
 }`
 
-const directedWithPorts = `digraph {
+const directedWithPorts = `strict digraph {
 	// Node definitions.
 	A;
 	B;
@@ -146,7 +146,7 @@ const directedWithPorts = `digraph {
 	E:_ -> F:c;
 }`
 
-const undirectedWithPorts = `graph {
+const undirectedWithPorts = `strict graph {
 	// Node definitions.
 	A;
 	B;
@@ -192,7 +192,7 @@ func TestChainedEdgeAttributes(t *testing.T) {
 			t.Errorf("i=%d: unable to unmarshal DOT graph; %v", i, err)
 			continue
 		}
-		buf, err := Marshal(dst, "", "", "\t", false)
+		buf, err := Marshal(dst, "", "", "\t")
 		if err != nil {
 			t.Errorf("i=%d: unable to marshal graph; %v", i, dst)
 			continue
@@ -205,7 +205,7 @@ func TestChainedEdgeAttributes(t *testing.T) {
 	}
 }
 
-const directedChained = `digraph {
+const directedChained = `strict digraph {
 	graph [
 		outputorder=edgesfirst
 	];
@@ -226,7 +226,7 @@ const directedChained = `digraph {
 	A -> B -> A [label="baz 2"];
 }`
 
-const directedNonchained = `digraph {
+const directedNonchained = `strict digraph {
 	graph [
 		outputorder=edgesfirst
 	];
@@ -270,7 +270,7 @@ const undirectedChained = `graph {
 	A -- B -- C [label="baz 2"];
 }`
 
-const undirectedNonchained = `graph {
+const undirectedNonchained = `strict graph {
 	graph [
 		outputorder=edgesfirst
 	];

--- a/graph/encoding/dot/encode.go
+++ b/graph/encoding/dot/encode.go
@@ -76,14 +76,11 @@ type Subgrapher interface {
 // however, advanced GraphViz DOT features provided by Marshal depend on
 // implementation of the Node, Attributer, Porter, Attributers, Structurer,
 // Subgrapher and Graph interfaces.
-func Marshal(g graph.Graph, name, prefix, indent string, strict bool) ([]byte, error) {
+func Marshal(g graph.Graph, name, prefix, indent string) ([]byte, error) {
 	var p printer
 	p.indent = indent
 	p.prefix = prefix
 	p.visited = make(map[edge]bool)
-	if strict {
-		p.buf.WriteString("strict ")
-	}
 	err := p.print(g, name, false, false)
 	if err != nil {
 		return nil, err
@@ -117,6 +114,9 @@ func (p *printer) print(g graph.Graph, name string, needsIndent, isSubgraph bool
 		for i := 0; i < p.depth; i++ {
 			p.buf.WriteString(p.indent)
 		}
+	}
+	if !isSubgraph {
+		p.buf.WriteString("strict ")
 	}
 	_, isDirected := g.(graph.Directed)
 	if isSubgraph {

--- a/graph/encoding/dot/encode_test.go
+++ b/graph/encoding/dot/encode_test.go
@@ -410,9 +410,8 @@ func undirectedSubGraphFrom(g []intset, s map[int64][]intset) graph.Graph {
 }
 
 var encodeTests = []struct {
-	name   string
-	g      graph.Graph
-	strict bool
+	name string
+	g    graph.Graph
 
 	prefix string
 
@@ -423,7 +422,7 @@ var encodeTests = []struct {
 		name: "PageRank",
 		g:    directedGraphFrom(pageRankGraph),
 
-		want: `digraph PageRank {
+		want: `strict digraph PageRank {
 	// Node definitions.
 	0;
 	1;
@@ -460,7 +459,7 @@ var encodeTests = []struct {
 	{
 		g: undirectedGraphFrom(pageRankGraph),
 
-		want: `graph {
+		want: `strict graph {
 	// Node definitions.
 	0;
 	1;
@@ -495,7 +494,7 @@ var encodeTests = []struct {
 	{
 		g: directedGraphFrom(powerMethodGraph),
 
-		want: `digraph {
+		want: `strict digraph {
 	// Node definitions.
 	0;
 	1;
@@ -516,7 +515,7 @@ var encodeTests = []struct {
 	{
 		g: undirectedGraphFrom(powerMethodGraph),
 
-		want: `graph {
+		want: `strict graph {
 	// Node definitions.
 	0;
 	1;
@@ -538,7 +537,7 @@ var encodeTests = []struct {
 		g:      undirectedGraphFrom(powerMethodGraph),
 		prefix: "# ",
 
-		want: `# graph {
+		want: `# strict graph {
 # 	// Node definitions.
 # 	0;
 # 	1;
@@ -562,7 +561,7 @@ var encodeTests = []struct {
 		name: "PageRank",
 		g:    directedNamedIDGraphFrom(pageRankGraph),
 
-		want: `digraph PageRank {
+		want: `strict digraph PageRank {
 	// Node definitions.
 	A;
 	B;
@@ -599,7 +598,7 @@ var encodeTests = []struct {
 	{
 		g: undirectedNamedIDGraphFrom(pageRankGraph),
 
-		want: `graph {
+		want: `strict graph {
 	// Node definitions.
 	A;
 	B;
@@ -634,7 +633,7 @@ var encodeTests = []struct {
 	{
 		g: directedNamedIDGraphFrom(powerMethodGraph),
 
-		want: `digraph {
+		want: `strict digraph {
 	// Node definitions.
 	A;
 	B;
@@ -655,7 +654,7 @@ var encodeTests = []struct {
 	{
 		g: undirectedNamedIDGraphFrom(powerMethodGraph),
 
-		want: `graph {
+		want: `strict graph {
 	// Node definitions.
 	A;
 	B;
@@ -677,7 +676,7 @@ var encodeTests = []struct {
 		g:      undirectedNamedIDGraphFrom(powerMethodGraph),
 		prefix: "# ",
 
-		want: `# graph {
+		want: `# strict graph {
 # 	// Node definitions.
 # 	A;
 # 	B;
@@ -700,7 +699,7 @@ var encodeTests = []struct {
 	{
 		g: directedNodeAttrGraphFrom(powerMethodGraph, nil),
 
-		want: `digraph {
+		want: `strict digraph {
 	// Node definitions.
 	0;
 	1;
@@ -721,7 +720,7 @@ var encodeTests = []struct {
 	{
 		g: undirectedNodeAttrGraphFrom(powerMethodGraph, nil),
 
-		want: `graph {
+		want: `strict graph {
 	// Node definitions.
 	0;
 	1;
@@ -745,7 +744,7 @@ var encodeTests = []struct {
 			4: {},
 		}),
 
-		want: `digraph {
+		want: `strict digraph {
 	// Node definitions.
 	0;
 	1;
@@ -772,7 +771,7 @@ var encodeTests = []struct {
 			4: {},
 		}),
 
-		want: `graph {
+		want: `strict graph {
 	// Node definitions.
 	0;
 	1;
@@ -799,7 +798,7 @@ var encodeTests = []struct {
 			4: {},
 		}),
 
-		want: `digraph {
+		want: `strict digraph {
 	// Node definitions.
 	A;
 	B;
@@ -829,7 +828,7 @@ var encodeTests = []struct {
 			4: {},
 		}),
 
-		want: `graph {
+		want: `strict graph {
 	// Node definitions.
 	A;
 	B;
@@ -855,7 +854,7 @@ var encodeTests = []struct {
 	{
 		g: directedEdgeAttrGraphFrom(powerMethodGraph, nil),
 
-		want: `digraph {
+		want: `strict digraph {
 	// Node definitions.
 	0;
 	1;
@@ -876,7 +875,7 @@ var encodeTests = []struct {
 	{
 		g: undirectedEdgeAttrGraphFrom(powerMethodGraph, nil),
 
-		want: `graph {
+		want: `strict graph {
 	// Node definitions.
 	0;
 	1;
@@ -901,7 +900,7 @@ var encodeTests = []struct {
 			{from: 3, to: 4}: {{Key: "color", Value: "red"}},
 		}),
 
-		want: `digraph {
+		want: `strict digraph {
 	// Node definitions.
 	0;
 	1;
@@ -929,7 +928,7 @@ var encodeTests = []struct {
 			{from: 3, to: 4}: {{Key: "color", Value: "red"}},
 		}),
 
-		want: `graph {
+		want: `strict graph {
 	// Node definitions.
 	0;
 	1;
@@ -955,7 +954,7 @@ var encodeTests = []struct {
 	{
 		g: directedPortedAttrGraphFrom(powerMethodGraph, nil, nil),
 
-		want: `digraph {
+		want: `strict digraph {
 	// Node definitions.
 	0;
 	1;
@@ -976,7 +975,7 @@ var encodeTests = []struct {
 	{
 		g: undirectedPortedAttrGraphFrom(powerMethodGraph, nil, nil),
 
-		want: `graph {
+		want: `strict graph {
 	// Node definitions.
 	0;
 	1;
@@ -1010,7 +1009,7 @@ var encodeTests = []struct {
 			},
 		),
 
-		want: `digraph {
+		want: `strict digraph {
 	// Node definitions.
 	0;
 	1;
@@ -1050,7 +1049,7 @@ var encodeTests = []struct {
 			},
 		),
 
-		want: `graph {
+		want: `strict graph {
 	// Node definitions.
 	0;
 	1;
@@ -1083,7 +1082,7 @@ var encodeTests = []struct {
 			{from: 3, to: 4}: {{Key: "color", Value: "red"}},
 		})},
 
-		want: `graph {
+		want: `strict graph {
 	// Node definitions.
 	0;
 	1;
@@ -1114,7 +1113,7 @@ var encodeTests = []struct {
 			node:  []encoding.Attribute{{Key: "fontsize", Value: "16"}, {Key: "shape", Value: "ellipse"}},
 		},
 
-		want: `graph {
+		want: `strict graph {
 	graph [
 		rankdir="LR"
 	];
@@ -1148,7 +1147,7 @@ var encodeTests = []struct {
 	{
 		g: undirectedStructuredGraphFrom(nil, powerMethodGraph, pageRankGraph),
 
-		want: `graph {
+		want: `strict graph {
 	subgraph A {
 		// Node definitions.
 		0;
@@ -1202,7 +1201,7 @@ var encodeTests = []struct {
 	{
 		g: undirectedStructuredGraphFrom([]edge{{from: 0, to: 9}}, powerMethodGraph, pageRankGraph),
 
-		want: `graph {
+		want: `strict graph {
 	subgraph A {
 		// Node definitions.
 		0;
@@ -1264,7 +1263,7 @@ var encodeTests = []struct {
 	{
 		g: undirectedSubGraphFrom(pageRankGraph, map[int64][]intset{2: powerMethodGraph}),
 
-		want: `graph {
+		want: `strict graph {
 	// Node definitions.
 	5;
 	6;
@@ -1312,9 +1311,8 @@ var encodeTests = []struct {
 }`,
 	},
 	{
-		name:   "H",
-		g:      undirectedSubGraphFrom(pageRankGraph, map[int64][]intset{1: powerMethodGraph}),
-		strict: true,
+		name: "H",
+		g:    undirectedSubGraphFrom(pageRankGraph, map[int64][]intset{1: powerMethodGraph}),
 
 		want: `strict graph H {
 	// Node definitions.
@@ -1409,7 +1407,7 @@ var encodeTests = []struct {
 
 func TestEncode(t *testing.T) {
 	for i, test := range encodeTests {
-		got, err := Marshal(test.g, test.name, test.prefix, "\t", test.strict)
+		got, err := Marshal(test.g, test.name, test.prefix, "\t")
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 			continue

--- a/graph/encoding/dot/example_test.go
+++ b/graph/encoding/dot/example_test.go
@@ -32,7 +32,7 @@ func ExamplePorter() {
 		toPort:   "p2",
 	})
 
-	result, _ := dot.Marshal(g, "", "", "  ", true)
+	result, _ := dot.Marshal(g, "", "", "  ")
 	fmt.Print(string(result))
 
 	// Output:

--- a/graph/encoding/graphql/decode_test.go
+++ b/graph/encoding/graphql/decode_test.go
@@ -32,7 +32,7 @@ var decodeTests = []struct {
 			0xa3cff1a4c3ef3bb6: true,
 			0xb39aa14d66aedad5: true,
 		},
-		wantDOT: `digraph {
+		wantDOT: `strict digraph {
   // Node definitions.
   0x8a10d5a2611fd03f [name="Richard Marquand"];
   0xa3cff1a4c3ef3bb6 [
@@ -70,7 +70,7 @@ var decodeTests = []struct {
 			0xfd90205a458151f:  true,
 			0x52a80955d40ec819: true,
 		},
-		wantDOT: `digraph {
+		wantDOT: `strict digraph {
   // Node definitions.
   0x892a6da7ee1fbdec [
     age=55
@@ -139,7 +139,7 @@ func TestDecode(t *testing.T) {
 			}
 			continue
 		}
-		b, err := dot.Marshal(dst, "", "", "  ", false)
+		b, err := dot.Marshal(dst, "", "", "  ")
 		if err != nil {
 			t.Fatalf("failed to DOT marshal graph %q: %v", test.name, err)
 		}

--- a/graph/topo/clique_graph_test.go
+++ b/graph/topo/clique_graph_test.go
@@ -27,7 +27,7 @@ var cliqueGraphTests = []struct {
 			5: nil,
 			6: nil,
 		},
-		want: `graph {
+		want: `strict graph {
   // Node definitions.
   0 [nodes="[0 1 2 6]"];
   1 [nodes="[0 1 4 6]"];
@@ -46,7 +46,7 @@ var cliqueGraphTests = []struct {
 	},
 	{
 		g: batageljZaversnikGraph,
-		want: `graph {
+		want: `strict graph {
   // Node definitions.
   0 [nodes="[0]"];
   1 [nodes="[1 2]"];
@@ -102,7 +102,7 @@ func TestCliqueGraph(t *testing.T) {
 		dst := simple.NewUndirectedGraph()
 		CliqueGraph(dst, g)
 
-		b, _ := dot.Marshal(dst, "", "", "  ", false)
+		b, _ := dot.Marshal(dst, "", "", "  ")
 		got := string(b)
 
 		if got != test.want {


### PR DESCRIPTION
Note that prior to this change the order of the prefix and the `strict` keyword was incorrect; if `strict` was `true` and `prefix` was not `""` the output would be `strict <prefix> graph...`.

Please take a look.

Closes #625.

/cc @32bitkid 

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
