### PR TITLE
blas/gonum: move panic strings into separate file

### DIFF
--- a/blas/gonum/errors.go
+++ b/blas/gonum/errors.go
@@ -1,0 +1,30 @@
+// Copyright ©2015 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+// Panic strings used during parameter checks.
+// This list is duplicated in netlib/blas/netlib. Keep in sync.
+const (
+	zeroIncX = "blas: zero x index increment"
+	zeroIncY = "blas: zero y index increment"
+
+	mLT0  = "blas: m < 0"
+	nLT0  = "blas: n < 0"
+	kLT0  = "blas: k < 0"
+	kLLT0 = "blas: kL < 0"
+	kULT0 = "blas: kU < 0"
+
+	badUplo      = "blas: illegal triangle"
+	badTranspose = "blas: illegal transpose"
+	badDiag      = "blas: illegal diagonal"
+	badSide      = "blas: illegal side"
+
+	badLdA = "blas: bad leading dimension of A"
+	badLdB = "blas: bad leading dimension of B"
+	badLdC = "blas: bad leading dimension of C"
+
+	badX = "blas: bad length of x"
+	badY = "blas: bad length of y"
+)

--- a/blas/gonum/gonum.go
+++ b/blas/gonum/gonum.go
@@ -10,30 +10,6 @@ import "math"
 
 type Implementation struct{}
 
-// The following are panic strings used during parameter checks.
-const (
-	zeroIncX = "blas: zero x index increment"
-	zeroIncY = "blas: zero y index increment"
-
-	mLT0  = "blas: m < 0"
-	nLT0  = "blas: n < 0"
-	kLT0  = "blas: k < 0"
-	kLLT0 = "blas: kL < 0"
-	kULT0 = "blas: kU < 0"
-
-	badUplo      = "blas: illegal triangle"
-	badTranspose = "blas: illegal transpose"
-	badDiag      = "blas: illegal diagonal"
-	badSide      = "blas: illegal side"
-
-	badLdA = "blas: bad leading dimension of A"
-	badLdB = "blas: bad leading dimension of B"
-	badLdC = "blas: bad leading dimension of C"
-
-	badX = "blas: bad length of x"
-	badY = "blas: bad length of y"
-)
-
 // [SD]gemm behavior constants. These are kept here to keep them out of the
 // way during single precision code genration.
 const (


### PR DESCRIPTION
Followup from https://github.com/gonum/netlib/pull/44

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
