### PR TITLE
graph/{multi,simple}: harmonise code organisation

### DIFF
--- a/graph/multi/weighted_directed.go
+++ b/graph/multi/weighted_directed.go
@@ -56,6 +56,97 @@ func NewWeightedDirectedGraph() *WeightedDirectedGraph {
 	}
 }
 
+// AddNode adds n to the graph. It panics if the added node ID matches an existing node ID.
+func (g *WeightedDirectedGraph) AddNode(n graph.Node) {
+	if _, exists := g.nodes[n.ID()]; exists {
+		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
+	}
+	g.nodes[n.ID()] = n
+	g.from[n.ID()] = make(map[int64]map[int64]graph.WeightedLine)
+	g.to[n.ID()] = make(map[int64]map[int64]graph.WeightedLine)
+	g.nodeIDs.Use(n.ID())
+}
+
+// Edge returns the edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+// The returned graph.Edge is a multi.WeightedEdge if an edge exists.
+func (g *WeightedDirectedGraph) Edge(uid, vid int64) graph.Edge {
+	return g.WeightedEdge(uid, vid)
+}
+
+// Edges returns all the edges in the graph. Each edge in the returned slice
+// is a multi.WeightedEdge.
+func (g *WeightedDirectedGraph) Edges() graph.Edges {
+	if len(g.nodes) == 0 {
+		return nil
+	}
+	var edges []graph.Edge
+	for _, u := range g.nodes {
+		for _, e := range g.from[u.ID()] {
+			var lines []graph.WeightedLine
+			for _, l := range e {
+				lines = append(lines, l)
+			}
+			if len(lines) != 0 {
+				edges = append(edges, WeightedEdge{
+					F:             g.Node(u.ID()),
+					T:             g.Node(lines[0].To().ID()),
+					WeightedLines: iterator.NewOrderedWeightedLines(lines),
+					WeightFunc:    g.EdgeWeightFunc,
+				})
+			}
+		}
+	}
+	return iterator.NewOrderedEdges(edges)
+}
+
+// From returns all nodes in g that can be reached directly from n.
+func (g *WeightedDirectedGraph) From(id int64) graph.Nodes {
+	if _, ok := g.from[id]; !ok {
+		return nil
+	}
+
+	from := make([]graph.Node, len(g.from[id]))
+	i := 0
+	for vid := range g.from[id] {
+		from[i] = g.nodes[vid]
+		i++
+	}
+	return iterator.NewOrderedNodes(from)
+}
+
+// HasEdgeBetween returns whether an edge exists between nodes x and y without
+// considering direction.
+func (g *WeightedDirectedGraph) HasEdgeBetween(xid, yid int64) bool {
+	if _, ok := g.from[xid][yid]; ok {
+		return true
+	}
+	_, ok := g.from[yid][xid]
+	return ok
+}
+
+// HasEdgeFromTo returns whether an edge exists in the graph from u to v.
+func (g *WeightedDirectedGraph) HasEdgeFromTo(uid, vid int64) bool {
+	if _, ok := g.from[uid][vid]; !ok {
+		return false
+	}
+	return true
+}
+
+// Lines returns the lines from u to v if such any such lines exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+func (g *WeightedDirectedGraph) Lines(uid, vid int64) graph.Lines {
+	edge := g.from[uid][vid]
+	if len(edge) == 0 {
+		return nil
+	}
+	var lines []graph.Line
+	for _, l := range edge {
+		lines = append(lines, l)
+	}
+	return iterator.NewOrderedLines(lines)
+}
+
 // NewNode returns a new unique Node to be added to g. The Node's ID does
 // not become valid in g until the Node is added to g.
 func (g *WeightedDirectedGraph) NewNode() graph.Node {
@@ -68,15 +159,53 @@ func (g *WeightedDirectedGraph) NewNode() graph.Node {
 	return Node(g.nodeIDs.NewID())
 }
 
-// AddNode adds n to the graph. It panics if the added node ID matches an existing node ID.
-func (g *WeightedDirectedGraph) AddNode(n graph.Node) {
-	if _, exists := g.nodes[n.ID()]; exists {
-		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
+// NewWeightedLine returns a new WeightedLine from the source to the destination node.
+// The returned WeightedLine will have a graph-unique ID.
+// The Line's ID does not become valid in g until the Line is added to g.
+func (g *WeightedDirectedGraph) NewWeightedLine(from, to graph.Node, weight float64) graph.WeightedLine {
+	return &WeightedLine{F: from, T: to, W: weight, UID: g.lineIDs.NewID()}
+}
+
+// Node returns the node with the given ID if it exists in the graph,
+// and nil otherwise.
+func (g *WeightedDirectedGraph) Node(id int64) graph.Node {
+	return g.nodes[id]
+}
+
+// Nodes returns all the nodes in the graph.
+func (g *WeightedDirectedGraph) Nodes() graph.Nodes {
+	if len(g.nodes) == 0 {
+		return nil
 	}
-	g.nodes[n.ID()] = n
-	g.from[n.ID()] = make(map[int64]map[int64]graph.WeightedLine)
-	g.to[n.ID()] = make(map[int64]map[int64]graph.WeightedLine)
-	g.nodeIDs.Use(n.ID())
+	nodes := make([]graph.Node, len(g.nodes))
+	i := 0
+	for _, n := range g.nodes {
+		nodes[i] = n
+		i++
+	}
+
+	return iterator.NewOrderedNodes(nodes)
+}
+
+// RemoveLine removes the line with the given end point and line IDs from the graph,
+// leaving the terminal nodes. If the line does not exist it is a no-op.
+func (g *WeightedDirectedGraph) RemoveLine(fid, tid, id int64) {
+	if _, ok := g.nodes[fid]; !ok {
+		return
+	}
+	if _, ok := g.nodes[tid]; !ok {
+		return
+	}
+
+	delete(g.from[fid][tid], id)
+	if len(g.from[fid][tid]) == 0 {
+		delete(g.from[fid], tid)
+	}
+	delete(g.to[tid][fid], id)
+	if len(g.to[tid][fid]) == 0 {
+		delete(g.to[tid], fid)
+	}
+	g.lineIDs.Release(id)
 }
 
 // RemoveNode removes the node with the given ID from the graph, as well as any edges attached
@@ -98,13 +227,6 @@ func (g *WeightedDirectedGraph) RemoveNode(id int64) {
 	delete(g.to, id)
 
 	g.nodeIDs.Release(id)
-}
-
-// NewWeightedLine returns a new WeightedLine from the source to the destination node.
-// The returned WeightedLine will have a graph-unique ID.
-// The Line's ID does not become valid in g until the Line is added to g.
-func (g *WeightedDirectedGraph) NewWeightedLine(from, to graph.Node, weight float64) graph.WeightedLine {
-	return &WeightedLine{F: from, T: to, W: weight, UID: g.lineIDs.NewID()}
 }
 
 // SetWeightedLine adds l, a line from one node to another. If the nodes do not exist, they are added
@@ -140,72 +262,41 @@ func (g *WeightedDirectedGraph) SetWeightedLine(l graph.WeightedLine) {
 	g.lineIDs.Use(l.ID())
 }
 
-// RemoveLine removes the line with the given end point and line IDs from the graph,
-// leaving the terminal nodes. If the line does not exist it is a no-op.
-func (g *WeightedDirectedGraph) RemoveLine(fid, tid, id int64) {
-	if _, ok := g.nodes[fid]; !ok {
-		return
-	}
-	if _, ok := g.nodes[tid]; !ok {
-		return
-	}
-
-	delete(g.from[fid][tid], id)
-	if len(g.from[fid][tid]) == 0 {
-		delete(g.from[fid], tid)
-	}
-	delete(g.to[tid][fid], id)
-	if len(g.to[tid][fid]) == 0 {
-		delete(g.to[tid], fid)
-	}
-	g.lineIDs.Release(id)
-}
-
-// Node returns the node with the given ID if it exists in the graph,
-// and nil otherwise.
-func (g *WeightedDirectedGraph) Node(id int64) graph.Node {
-	return g.nodes[id]
-}
-
-// Nodes returns all the nodes in the graph.
-func (g *WeightedDirectedGraph) Nodes() graph.Nodes {
-	if len(g.nodes) == 0 {
+// To returns all nodes in g that can reach directly to n.
+func (g *WeightedDirectedGraph) To(id int64) graph.Nodes {
+	if _, ok := g.from[id]; !ok {
 		return nil
 	}
-	nodes := make([]graph.Node, len(g.nodes))
+
+	to := make([]graph.Node, len(g.to[id]))
 	i := 0
-	for _, n := range g.nodes {
-		nodes[i] = n
+	for uid := range g.to[id] {
+		to[i] = g.nodes[uid]
 		i++
 	}
-
-	return iterator.NewOrderedNodes(nodes)
+	return iterator.NewOrderedNodes(to)
 }
 
-// Edges returns all the edges in the graph. Each edge in the returned slice
-// is a multi.WeightedEdge.
-func (g *WeightedDirectedGraph) Edges() graph.Edges {
-	if len(g.nodes) == 0 {
+// Weight returns the weight for the lines between x and y summarised by the receiver's
+// EdgeWeightFunc. Weight returns true if an edge exists between x and y, false otherwise.
+func (g *WeightedDirectedGraph) Weight(uid, vid int64) (w float64, ok bool) {
+	lines := g.WeightedLines(uid, vid)
+	return WeightedEdge{WeightedLines: lines, WeightFunc: g.EdgeWeightFunc}.Weight(), lines != nil
+}
+
+// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+// The returned graph.WeightedEdge is a multi.WeightedEdge if an edge exists.
+func (g *WeightedDirectedGraph) WeightedEdge(uid, vid int64) graph.WeightedEdge {
+	lines := g.WeightedLines(uid, vid)
+	if lines == nil {
 		return nil
 	}
-	var edges []graph.Edge
-	for _, u := range g.nodes {
-		for _, e := range g.from[u.ID()] {
-			var lines []graph.WeightedLine
-			for _, l := range e {
-				lines = append(lines, l)
-			}
-			if len(lines) != 0 {
-				edges = append(edges, WeightedEdge{
-					F:             g.Node(u.ID()),
-					T:             g.Node(lines[0].To().ID()),
-					WeightedLines: iterator.NewOrderedWeightedLines(lines),
-					WeightFunc:    g.EdgeWeightFunc,
-				})
-			}
-		}
+	return WeightedEdge{
+		F: g.Node(uid), T: g.Node(vid),
+		WeightedLines: lines,
+		WeightFunc:    g.EdgeWeightFunc,
 	}
-	return iterator.NewOrderedEdges(edges)
 }
 
 // WeightedEdges returns all the edges in the graph. Each edge in the returned slice
@@ -234,90 +325,6 @@ func (g *WeightedDirectedGraph) WeightedEdges() graph.WeightedEdges {
 	return iterator.NewOrderedWeightedEdges(edges)
 }
 
-// From returns all nodes in g that can be reached directly from n.
-func (g *WeightedDirectedGraph) From(id int64) graph.Nodes {
-	if _, ok := g.from[id]; !ok {
-		return nil
-	}
-
-	from := make([]graph.Node, len(g.from[id]))
-	i := 0
-	for vid := range g.from[id] {
-		from[i] = g.nodes[vid]
-		i++
-	}
-	return iterator.NewOrderedNodes(from)
-}
-
-// To returns all nodes in g that can reach directly to n.
-func (g *WeightedDirectedGraph) To(id int64) graph.Nodes {
-	if _, ok := g.from[id]; !ok {
-		return nil
-	}
-
-	to := make([]graph.Node, len(g.to[id]))
-	i := 0
-	for uid := range g.to[id] {
-		to[i] = g.nodes[uid]
-		i++
-	}
-	return iterator.NewOrderedNodes(to)
-}
-
-// HasEdgeBetween returns whether an edge exists between nodes x and y without
-// considering direction.
-func (g *WeightedDirectedGraph) HasEdgeBetween(xid, yid int64) bool {
-	if _, ok := g.from[xid][yid]; ok {
-		return true
-	}
-	_, ok := g.from[yid][xid]
-	return ok
-}
-
-// HasEdgeFromTo returns whether an edge exists in the graph from u to v.
-func (g *WeightedDirectedGraph) HasEdgeFromTo(uid, vid int64) bool {
-	if _, ok := g.from[uid][vid]; !ok {
-		return false
-	}
-	return true
-}
-
-// Edge returns the edge from u to v if such an edge exists and nil otherwise.
-// The node v must be directly reachable from u as defined by the From method.
-// The returned graph.Edge is a multi.WeightedEdge if an edge exists.
-func (g *WeightedDirectedGraph) Edge(uid, vid int64) graph.Edge {
-	return g.WeightedEdge(uid, vid)
-}
-
-// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
-// The node v must be directly reachable from u as defined by the From method.
-// The returned graph.WeightedEdge is a multi.WeightedEdge if an edge exists.
-func (g *WeightedDirectedGraph) WeightedEdge(uid, vid int64) graph.WeightedEdge {
-	lines := g.WeightedLines(uid, vid)
-	if lines == nil {
-		return nil
-	}
-	return WeightedEdge{
-		F: g.Node(uid), T: g.Node(vid),
-		WeightedLines: lines,
-		WeightFunc:    g.EdgeWeightFunc,
-	}
-}
-
-// Lines returns the lines from u to v if such any such lines exists and nil otherwise.
-// The node v must be directly reachable from u as defined by the From method.
-func (g *WeightedDirectedGraph) Lines(uid, vid int64) graph.Lines {
-	edge := g.from[uid][vid]
-	if len(edge) == 0 {
-		return nil
-	}
-	var lines []graph.Line
-	for _, l := range edge {
-		lines = append(lines, l)
-	}
-	return iterator.NewOrderedLines(lines)
-}
-
 // WeightedLines returns the weighted lines from u to v if such any such lines exists
 // and nil otherwise. The node v must be directly reachable from u as defined by the From method.
 func (g *WeightedDirectedGraph) WeightedLines(uid, vid int64) graph.WeightedLines {
@@ -330,11 +337,4 @@ func (g *WeightedDirectedGraph) WeightedLines(uid, vid int64) graph.WeightedLine
 		lines = append(lines, l)
 	}
 	return iterator.NewOrderedWeightedLines(lines)
-}
-
-// Weight returns the weight for the lines between x and y summarised by the receiver's
-// EdgeWeightFunc. Weight returns true if an edge exists between x and y, false otherwise.
-func (g *WeightedDirectedGraph) Weight(uid, vid int64) (w float64, ok bool) {
-	lines := g.WeightedLines(uid, vid)
-	return WeightedEdge{WeightedLines: lines, WeightFunc: g.EdgeWeightFunc}.Weight(), lines != nil
 }

--- a/graph/simple/dense_directed_matrix.go
+++ b/graph/simple/dense_directed_matrix.go
@@ -14,10 +14,12 @@ import (
 )
 
 var (
-	_ graph.Graph        = (*DirectedMatrix)(nil)
-	_ graph.Directed     = (*DirectedMatrix)(nil)
-	_ edgeSetter         = (*DirectedMatrix)(nil)
-	_ weightedEdgeSetter = (*DirectedMatrix)(nil)
+	dm *DirectedMatrix
+
+	_ graph.Graph        = dm
+	_ graph.Directed     = dm
+	_ edgeSetter         = dm
+	_ weightedEdgeSetter = dm
 )
 
 // DirectedMatrix represents a directed graph using an adjacency
@@ -71,32 +73,10 @@ func NewDirectedMatrixFrom(nodes []graph.Node, init, self, absent float64) *Dire
 	return g
 }
 
-// Node returns the node with the given ID if it exists in the graph,
-// and nil otherwise.
-func (g *DirectedMatrix) Node(id int64) graph.Node {
-	if !g.has(id) {
-		return nil
-	}
-	if g.nodes == nil {
-		return Node(id)
-	}
-	return g.nodes[id]
-}
-
-func (g *DirectedMatrix) has(id int64) bool {
-	r, _ := g.mat.Dims()
-	return 0 <= id && id < int64(r)
-}
-
-// Nodes returns all the nodes in the graph.
-func (g *DirectedMatrix) Nodes() graph.Nodes {
-	if g.nodes != nil {
-		nodes := make([]graph.Node, len(g.nodes))
-		copy(nodes, g.nodes)
-		return iterator.NewOrderedNodes(nodes)
-	}
-	r, _ := g.mat.Dims()
-	return iterator.NewImplicitNodes(0, r, newSimpleNode)
+// Edge returns the edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+func (g *DirectedMatrix) Edge(uid, vid int64) graph.Edge {
+	return g.WeightedEdge(uid, vid)
 }
 
 // Edges returns all the edges in the graph.
@@ -135,25 +115,6 @@ func (g *DirectedMatrix) From(id int64) graph.Nodes {
 	return iterator.NewOrderedNodes(nodes)
 }
 
-// To returns all nodes in g that can reach directly to n.
-func (g *DirectedMatrix) To(id int64) graph.Nodes {
-	if !g.has(id) {
-		return nil
-	}
-	var nodes []graph.Node
-	r, _ := g.mat.Dims()
-	for i := 0; i < r; i++ {
-		if int64(i) == id {
-			continue
-		}
-		// id is not greater than maximum int by this point.
-		if !isSame(g.mat.At(i, int(id)), g.absent) {
-			nodes = append(nodes, g.Node(int64(i)))
-		}
-	}
-	return iterator.NewOrderedNodes(nodes)
-}
-
 // HasEdgeBetween returns whether an edge exists between nodes x and y without
 // considering direction.
 func (g *DirectedMatrix) HasEdgeBetween(xid, yid int64) bool {
@@ -165,22 +126,6 @@ func (g *DirectedMatrix) HasEdgeBetween(xid, yid int64) bool {
 	}
 	// xid and yid are not greater than maximum int by this point.
 	return xid != yid && (!isSame(g.mat.At(int(xid), int(yid)), g.absent) || !isSame(g.mat.At(int(yid), int(xid)), g.absent))
-}
-
-// Edge returns the edge from u to v if such an edge exists and nil otherwise.
-// The node v must be directly reachable from u as defined by the From method.
-func (g *DirectedMatrix) Edge(uid, vid int64) graph.Edge {
-	return g.WeightedEdge(uid, vid)
-}
-
-// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
-// The node v must be directly reachable from u as defined by the From method.
-func (g *DirectedMatrix) WeightedEdge(uid, vid int64) graph.WeightedEdge {
-	if g.HasEdgeFromTo(uid, vid) {
-		// xid and yid are not greater than maximum int by this point.
-		return WeightedEdge{F: g.Node(uid), T: g.Node(vid), W: g.mat.At(int(uid), int(vid))}
-	}
-	return nil
 }
 
 // HasEdgeFromTo returns whether an edge exists in the graph from u to v.
@@ -195,19 +140,49 @@ func (g *DirectedMatrix) HasEdgeFromTo(uid, vid int64) bool {
 	return uid != vid && !isSame(g.mat.At(int(uid), int(vid)), g.absent)
 }
 
-// Weight returns the weight for the edge between x and y if Edge(x, y) returns a non-nil Edge.
-// If x and y are the same node or there is no joining edge between the two nodes the weight
-// value returned is either the graph's absent or self value. Weight returns true if an edge
-// exists between x and y or if x and y have the same ID, false otherwise.
-func (g *DirectedMatrix) Weight(xid, yid int64) (w float64, ok bool) {
-	if xid == yid {
-		return g.self, true
+// Matrix returns the mat.Matrix representation of the graph. The orientation
+// of the matrix is such that the matrix entry at G_{ij} is the weight of the edge
+// from node i to node j.
+func (g *DirectedMatrix) Matrix() mat.Matrix {
+	// Prevent alteration of dimensions of the returned matrix.
+	m := *g.mat
+	return &m
+}
+
+// Node returns the node with the given ID if it exists in the graph,
+// and nil otherwise.
+func (g *DirectedMatrix) Node(id int64) graph.Node {
+	if !g.has(id) {
+		return nil
 	}
-	if g.has(xid) && g.has(yid) {
-		// xid and yid are not greater than maximum int by this point.
-		return g.mat.At(int(xid), int(yid)), true
+	if g.nodes == nil {
+		return Node(id)
 	}
-	return g.absent, false
+	return g.nodes[id]
+}
+
+// Nodes returns all the nodes in the graph.
+func (g *DirectedMatrix) Nodes() graph.Nodes {
+	if g.nodes != nil {
+		nodes := make([]graph.Node, len(g.nodes))
+		copy(nodes, g.nodes)
+		return iterator.NewOrderedNodes(nodes)
+	}
+	r, _ := g.mat.Dims()
+	return iterator.NewImplicitNodes(0, r, newSimpleNode)
+}
+
+// RemoveEdge removes the edge with the given end point nodes from the graph, leaving the terminal
+// nodes. If the edge does not exist it is a no-op.
+func (g *DirectedMatrix) RemoveEdge(fid, tid int64) {
+	if !g.has(fid) {
+		return
+	}
+	if !g.has(tid) {
+		return
+	}
+	// fid and tid are not greater than maximum int by this point.
+	g.mat.Set(int(fid), int(tid), g.absent)
 }
 
 // SetEdge sets e, an edge from one node to another with unit weight. If the ends of the edge
@@ -246,24 +221,51 @@ func (g *DirectedMatrix) setWeightedEdge(e graph.Edge, weight float64) {
 	g.mat.Set(int(fid), int(tid), weight)
 }
 
-// RemoveEdge removes the edge with the given end point nodes from the graph, leaving the terminal
-// nodes. If the edge does not exist it is a no-op.
-func (g *DirectedMatrix) RemoveEdge(fid, tid int64) {
-	if !g.has(fid) {
-		return
+// To returns all nodes in g that can reach directly to n.
+func (g *DirectedMatrix) To(id int64) graph.Nodes {
+	if !g.has(id) {
+		return nil
 	}
-	if !g.has(tid) {
-		return
+	var nodes []graph.Node
+	r, _ := g.mat.Dims()
+	for i := 0; i < r; i++ {
+		if int64(i) == id {
+			continue
+		}
+		// id is not greater than maximum int by this point.
+		if !isSame(g.mat.At(i, int(id)), g.absent) {
+			nodes = append(nodes, g.Node(int64(i)))
+		}
 	}
-	// fid and tid are not greater than maximum int by this point.
-	g.mat.Set(int(fid), int(tid), g.absent)
+	return iterator.NewOrderedNodes(nodes)
 }
 
-// Matrix returns the mat.Matrix representation of the graph. The orientation
-// of the matrix is such that the matrix entry at G_{ij} is the weight of the edge
-// from node i to node j.
-func (g *DirectedMatrix) Matrix() mat.Matrix {
-	// Prevent alteration of dimensions of the returned matrix.
-	m := *g.mat
-	return &m
+// Weight returns the weight for the edge between x and y if Edge(x, y) returns a non-nil Edge.
+// If x and y are the same node or there is no joining edge between the two nodes the weight
+// value returned is either the graph's absent or self value. Weight returns true if an edge
+// exists between x and y or if x and y have the same ID, false otherwise.
+func (g *DirectedMatrix) Weight(xid, yid int64) (w float64, ok bool) {
+	if xid == yid {
+		return g.self, true
+	}
+	if g.has(xid) && g.has(yid) {
+		// xid and yid are not greater than maximum int by this point.
+		return g.mat.At(int(xid), int(yid)), true
+	}
+	return g.absent, false
+}
+
+// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+func (g *DirectedMatrix) WeightedEdge(uid, vid int64) graph.WeightedEdge {
+	if g.HasEdgeFromTo(uid, vid) {
+		// xid and yid are not greater than maximum int by this point.
+		return WeightedEdge{F: g.Node(uid), T: g.Node(vid), W: g.mat.At(int(uid), int(vid))}
+	}
+	return nil
+}
+
+func (g *DirectedMatrix) has(id int64) bool {
+	r, _ := g.mat.Dims()
+	return 0 <= id && id < int64(r)
 }

--- a/graph/simple/directed.go
+++ b/graph/simple/directed.go
@@ -43,6 +43,76 @@ func NewDirectedGraph() *DirectedGraph {
 	}
 }
 
+// AddNode adds n to the graph. It panics if the added node ID matches an existing node ID.
+func (g *DirectedGraph) AddNode(n graph.Node) {
+	if _, exists := g.nodes[n.ID()]; exists {
+		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
+	}
+	g.nodes[n.ID()] = n
+	g.from[n.ID()] = make(map[int64]graph.Edge)
+	g.to[n.ID()] = make(map[int64]graph.Edge)
+	g.nodeIDs.Use(n.ID())
+}
+
+// Edge returns the edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+func (g *DirectedGraph) Edge(uid, vid int64) graph.Edge {
+	edge, ok := g.from[uid][vid]
+	if !ok {
+		return nil
+	}
+	return edge
+}
+
+// Edges returns all the edges in the graph.
+func (g *DirectedGraph) Edges() graph.Edges {
+	var edges []graph.Edge
+	for _, u := range g.nodes {
+		for _, e := range g.from[u.ID()] {
+			edges = append(edges, e)
+		}
+	}
+	return iterator.NewOrderedEdges(edges)
+}
+
+// From returns all nodes in g that can be reached directly from n.
+func (g *DirectedGraph) From(id int64) graph.Nodes {
+	if _, ok := g.from[id]; !ok {
+		return nil
+	}
+
+	from := make([]graph.Node, len(g.from[id]))
+	i := 0
+	for vid := range g.from[id] {
+		from[i] = g.nodes[vid]
+		i++
+	}
+	return iterator.NewOrderedNodes(from)
+}
+
+// HasEdgeBetween returns whether an edge exists between nodes x and y without
+// considering direction.
+func (g *DirectedGraph) HasEdgeBetween(xid, yid int64) bool {
+	if _, ok := g.from[xid][yid]; ok {
+		return true
+	}
+	_, ok := g.from[yid][xid]
+	return ok
+}
+
+// HasEdgeFromTo returns whether an edge exists in the graph from u to v.
+func (g *DirectedGraph) HasEdgeFromTo(uid, vid int64) bool {
+	if _, ok := g.from[uid][vid]; !ok {
+		return false
+	}
+	return true
+}
+
+// NewEdge returns a new Edge from the source to the destination node.
+func (g *DirectedGraph) NewEdge(from, to graph.Node) graph.Edge {
+	return &Edge{F: from, T: to}
+}
+
 // NewNode returns a new unique Node to be added to g. The Node's ID does
 // not become valid in g until the Node is added to g.
 func (g *DirectedGraph) NewNode() graph.Node {
@@ -55,15 +125,38 @@ func (g *DirectedGraph) NewNode() graph.Node {
 	return Node(g.nodeIDs.NewID())
 }
 
-// AddNode adds n to the graph. It panics if the added node ID matches an existing node ID.
-func (g *DirectedGraph) AddNode(n graph.Node) {
-	if _, exists := g.nodes[n.ID()]; exists {
-		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
+// Node returns the node with the given ID if it exists in the graph,
+// and nil otherwise.
+func (g *DirectedGraph) Node(id int64) graph.Node {
+	return g.nodes[id]
+}
+
+// Nodes returns all the nodes in the graph.
+func (g *DirectedGraph) Nodes() graph.Nodes {
+	if len(g.nodes) == 0 {
+		return nil
 	}
-	g.nodes[n.ID()] = n
-	g.from[n.ID()] = make(map[int64]graph.Edge)
-	g.to[n.ID()] = make(map[int64]graph.Edge)
-	g.nodeIDs.Use(n.ID())
+	nodes := make([]graph.Node, len(g.nodes))
+	i := 0
+	for _, n := range g.nodes {
+		nodes[i] = n
+		i++
+	}
+	return iterator.NewOrderedNodes(nodes)
+}
+
+// RemoveEdge removes the edge with the given end point IDs from the graph, leaving the terminal
+// nodes. If the edge does not exist it is a no-op.
+func (g *DirectedGraph) RemoveEdge(fid, tid int64) {
+	if _, ok := g.nodes[fid]; !ok {
+		return
+	}
+	if _, ok := g.nodes[tid]; !ok {
+		return
+	}
+
+	delete(g.from[fid], tid)
+	delete(g.to[tid], fid)
 }
 
 // RemoveNode removes the node with the given ID from the graph, as well as any edges attached
@@ -85,11 +178,6 @@ func (g *DirectedGraph) RemoveNode(id int64) {
 	delete(g.to, id)
 
 	g.nodeIDs.Release(id)
-}
-
-// NewEdge returns a new Edge from the source to the destination node.
-func (g *DirectedGraph) NewEdge(from, to graph.Node) graph.Edge {
-	return &Edge{F: from, T: to}
 }
 
 // SetEdge adds e, an edge from one node to another. If the nodes do not exist, they are added
@@ -122,66 +210,6 @@ func (g *DirectedGraph) SetEdge(e graph.Edge) {
 	g.to[tid][fid] = e
 }
 
-// RemoveEdge removes the edge with the given end point IDs from the graph, leaving the terminal
-// nodes. If the edge does not exist it is a no-op.
-func (g *DirectedGraph) RemoveEdge(fid, tid int64) {
-	if _, ok := g.nodes[fid]; !ok {
-		return
-	}
-	if _, ok := g.nodes[tid]; !ok {
-		return
-	}
-
-	delete(g.from[fid], tid)
-	delete(g.to[tid], fid)
-}
-
-// Node returns the node with the given ID if it exists in the graph,
-// and nil otherwise.
-func (g *DirectedGraph) Node(id int64) graph.Node {
-	return g.nodes[id]
-}
-
-// Nodes returns all the nodes in the graph.
-func (g *DirectedGraph) Nodes() graph.Nodes {
-	if len(g.nodes) == 0 {
-		return nil
-	}
-	nodes := make([]graph.Node, len(g.nodes))
-	i := 0
-	for _, n := range g.nodes {
-		nodes[i] = n
-		i++
-	}
-	return iterator.NewOrderedNodes(nodes)
-}
-
-// Edges returns all the edges in the graph.
-func (g *DirectedGraph) Edges() graph.Edges {
-	var edges []graph.Edge
-	for _, u := range g.nodes {
-		for _, e := range g.from[u.ID()] {
-			edges = append(edges, e)
-		}
-	}
-	return iterator.NewOrderedEdges(edges)
-}
-
-// From returns all nodes in g that can be reached directly from n.
-func (g *DirectedGraph) From(id int64) graph.Nodes {
-	if _, ok := g.from[id]; !ok {
-		return nil
-	}
-
-	from := make([]graph.Node, len(g.from[id]))
-	i := 0
-	for vid := range g.from[id] {
-		from[i] = g.nodes[vid]
-		i++
-	}
-	return iterator.NewOrderedNodes(from)
-}
-
 // To returns all nodes in g that can reach directly to n.
 func (g *DirectedGraph) To(id int64) graph.Nodes {
 	if _, ok := g.from[id]; !ok {
@@ -195,32 +223,4 @@ func (g *DirectedGraph) To(id int64) graph.Nodes {
 		i++
 	}
 	return iterator.NewOrderedNodes(to)
-}
-
-// HasEdgeBetween returns whether an edge exists between nodes x and y without
-// considering direction.
-func (g *DirectedGraph) HasEdgeBetween(xid, yid int64) bool {
-	if _, ok := g.from[xid][yid]; ok {
-		return true
-	}
-	_, ok := g.from[yid][xid]
-	return ok
-}
-
-// Edge returns the edge from u to v if such an edge exists and nil otherwise.
-// The node v must be directly reachable from u as defined by the From method.
-func (g *DirectedGraph) Edge(uid, vid int64) graph.Edge {
-	edge, ok := g.from[uid][vid]
-	if !ok {
-		return nil
-	}
-	return edge
-}
-
-// HasEdgeFromTo returns whether an edge exists in the graph from u to v.
-func (g *DirectedGraph) HasEdgeFromTo(uid, vid int64) bool {
-	if _, ok := g.from[uid][vid]; !ok {
-		return false
-	}
-	return true
 }

--- a/graph/simple/weighted_undirected.go
+++ b/graph/simple/weighted_undirected.go
@@ -49,6 +49,70 @@ func NewWeightedUndirectedGraph(self, absent float64) *WeightedUndirectedGraph {
 	}
 }
 
+// AddNode adds n to the graph. It panics if the added node ID matches an existing node ID.
+func (g *WeightedUndirectedGraph) AddNode(n graph.Node) {
+	if _, exists := g.nodes[n.ID()]; exists {
+		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
+	}
+	g.nodes[n.ID()] = n
+	g.edges[n.ID()] = make(map[int64]graph.WeightedEdge)
+	g.nodeIDs.Use(n.ID())
+}
+
+// Edge returns the edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+func (g *WeightedUndirectedGraph) Edge(uid, vid int64) graph.Edge {
+	return g.WeightedEdgeBetween(uid, vid)
+}
+
+// EdgeBetween returns the edge between nodes x and y.
+func (g *WeightedUndirectedGraph) EdgeBetween(xid, yid int64) graph.Edge {
+	return g.WeightedEdgeBetween(xid, yid)
+}
+
+// Edges returns all the edges in the graph.
+func (g *WeightedUndirectedGraph) Edges() graph.Edges {
+	if len(g.edges) == 0 {
+		return nil
+	}
+	var edges []graph.Edge
+	seen := make(map[[2]int64]struct{})
+	for _, u := range g.edges {
+		for _, e := range u {
+			uid := e.From().ID()
+			vid := e.To().ID()
+			if _, ok := seen[[2]int64{uid, vid}]; ok {
+				continue
+			}
+			seen[[2]int64{uid, vid}] = struct{}{}
+			seen[[2]int64{vid, uid}] = struct{}{}
+			edges = append(edges, e)
+		}
+	}
+	return iterator.NewOrderedEdges(edges)
+}
+
+// From returns all nodes in g that can be reached directly from n.
+func (g *WeightedUndirectedGraph) From(id int64) graph.Nodes {
+	if _, ok := g.nodes[id]; !ok {
+		return nil
+	}
+
+	nodes := make([]graph.Node, len(g.edges[id]))
+	i := 0
+	for from := range g.edges[id] {
+		nodes[i] = g.nodes[from]
+		i++
+	}
+	return iterator.NewOrderedNodes(nodes)
+}
+
+// HasEdgeBetween returns whether an edge exists between nodes x and y.
+func (g *WeightedUndirectedGraph) HasEdgeBetween(xid, yid int64) bool {
+	_, ok := g.edges[xid][yid]
+	return ok
+}
+
 // NewNode returns a new unique Node to be added to g. The Node's ID does
 // not become valid in g until the Node is added to g.
 func (g *WeightedUndirectedGraph) NewNode() graph.Node {
@@ -61,14 +125,43 @@ func (g *WeightedUndirectedGraph) NewNode() graph.Node {
 	return Node(g.nodeIDs.NewID())
 }
 
-// AddNode adds n to the graph. It panics if the added node ID matches an existing node ID.
-func (g *WeightedUndirectedGraph) AddNode(n graph.Node) {
-	if _, exists := g.nodes[n.ID()]; exists {
-		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
+// NewWeightedEdge returns a new weighted edge from the source to the destination node.
+func (g *WeightedUndirectedGraph) NewWeightedEdge(from, to graph.Node, weight float64) graph.WeightedEdge {
+	return &WeightedEdge{F: from, T: to, W: weight}
+}
+
+// Node returns the node with the given ID if it exists in the graph,
+// and nil otherwise.
+func (g *WeightedUndirectedGraph) Node(id int64) graph.Node {
+	return g.nodes[id]
+}
+
+// Nodes returns all the nodes in the graph.
+func (g *WeightedUndirectedGraph) Nodes() graph.Nodes {
+	if len(g.nodes) == 0 {
+		return nil
 	}
-	g.nodes[n.ID()] = n
-	g.edges[n.ID()] = make(map[int64]graph.WeightedEdge)
-	g.nodeIDs.Use(n.ID())
+	nodes := make([]graph.Node, len(g.nodes))
+	i := 0
+	for _, n := range g.nodes {
+		nodes[i] = n
+		i++
+	}
+	return iterator.NewOrderedNodes(nodes)
+}
+
+// RemoveEdge removes the edge with the given end point IDs from the graph, leaving the terminal
+// nodes. If the edge does not exist  it is a no-op.
+func (g *WeightedUndirectedGraph) RemoveEdge(fid, tid int64) {
+	if _, ok := g.nodes[fid]; !ok {
+		return
+	}
+	if _, ok := g.nodes[tid]; !ok {
+		return
+	}
+
+	delete(g.edges[fid], tid)
+	delete(g.edges[tid], fid)
 }
 
 // RemoveNode removes the node with the given ID from the graph, as well as any edges attached
@@ -85,11 +178,6 @@ func (g *WeightedUndirectedGraph) RemoveNode(id int64) {
 	delete(g.edges, id)
 
 	g.nodeIDs.Release(id)
-}
-
-// NewWeightedEdge returns a new weighted edge from the source to the destination node.
-func (g *WeightedUndirectedGraph) NewWeightedEdge(from, to graph.Node, weight float64) graph.WeightedEdge {
-	return &WeightedEdge{F: from, T: to, W: weight}
 }
 
 // SetWeightedEdge adds a weighted edge from one node to another. If the nodes do not exist, they are added
@@ -122,60 +210,35 @@ func (g *WeightedUndirectedGraph) SetWeightedEdge(e graph.WeightedEdge) {
 	g.edges[tid][fid] = e
 }
 
-// RemoveEdge removes the edge with the given end point IDs from the graph, leaving the terminal
-// nodes. If the edge does not exist  it is a no-op.
-func (g *WeightedUndirectedGraph) RemoveEdge(fid, tid int64) {
-	if _, ok := g.nodes[fid]; !ok {
-		return
+// Weight returns the weight for the edge between x and y if Edge(x, y) returns a non-nil Edge.
+// If x and y are the same node or there is no joining edge between the two nodes the weight
+// value returned is either the graph's absent or self value. Weight returns true if an edge
+// exists between x and y or if x and y have the same ID, false otherwise.
+func (g *WeightedUndirectedGraph) Weight(xid, yid int64) (w float64, ok bool) {
+	if xid == yid {
+		return g.self, true
 	}
-	if _, ok := g.nodes[tid]; !ok {
-		return
-	}
-
-	delete(g.edges[fid], tid)
-	delete(g.edges[tid], fid)
-}
-
-// Node returns the node with the given ID if it exists in the graph,
-// and nil otherwise.
-func (g *WeightedUndirectedGraph) Node(id int64) graph.Node {
-	return g.nodes[id]
-}
-
-// Nodes returns all the nodes in the graph.
-func (g *WeightedUndirectedGraph) Nodes() graph.Nodes {
-	if len(g.nodes) == 0 {
-		return nil
-	}
-	nodes := make([]graph.Node, len(g.nodes))
-	i := 0
-	for _, n := range g.nodes {
-		nodes[i] = n
-		i++
-	}
-	return iterator.NewOrderedNodes(nodes)
-}
-
-// Edges returns all the edges in the graph.
-func (g *WeightedUndirectedGraph) Edges() graph.Edges {
-	if len(g.edges) == 0 {
-		return nil
-	}
-	var edges []graph.Edge
-	seen := make(map[[2]int64]struct{})
-	for _, u := range g.edges {
-		for _, e := range u {
-			uid := e.From().ID()
-			vid := e.To().ID()
-			if _, ok := seen[[2]int64{uid, vid}]; ok {
-				continue
-			}
-			seen[[2]int64{uid, vid}] = struct{}{}
-			seen[[2]int64{vid, uid}] = struct{}{}
-			edges = append(edges, e)
+	if n, ok := g.edges[xid]; ok {
+		if e, ok := n[yid]; ok {
+			return e.Weight(), true
 		}
 	}
-	return iterator.NewOrderedEdges(edges)
+	return g.absent, false
+}
+
+// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
+// The node v must be directly reachable from u as defined by the From method.
+func (g *WeightedUndirectedGraph) WeightedEdge(uid, vid int64) graph.WeightedEdge {
+	return g.WeightedEdgeBetween(uid, vid)
+}
+
+// WeightedEdgeBetween returns the weighted edge between nodes x and y.
+func (g *WeightedUndirectedGraph) WeightedEdgeBetween(xid, yid int64) graph.WeightedEdge {
+	edge, ok := g.edges[xid][yid]
+	if !ok {
+		return nil
+	}
+	return edge
 }
 
 // WeightedEdges returns all the weighted edges in the graph.
@@ -195,67 +258,4 @@ func (g *WeightedUndirectedGraph) WeightedEdges() graph.WeightedEdges {
 		}
 	}
 	return iterator.NewOrderedWeightedEdges(edges)
-}
-
-// From returns all nodes in g that can be reached directly from n.
-func (g *WeightedUndirectedGraph) From(id int64) graph.Nodes {
-	if _, ok := g.nodes[id]; !ok {
-		return nil
-	}
-
-	nodes := make([]graph.Node, len(g.edges[id]))
-	i := 0
-	for from := range g.edges[id] {
-		nodes[i] = g.nodes[from]
-		i++
-	}
-	return iterator.NewOrderedNodes(nodes)
-}
-
-// HasEdgeBetween returns whether an edge exists between nodes x and y.
-func (g *WeightedUndirectedGraph) HasEdgeBetween(xid, yid int64) bool {
-	_, ok := g.edges[xid][yid]
-	return ok
-}
-
-// Edge returns the edge from u to v if such an edge exists and nil otherwise.
-// The node v must be directly reachable from u as defined by the From method.
-func (g *WeightedUndirectedGraph) Edge(uid, vid int64) graph.Edge {
-	return g.WeightedEdgeBetween(uid, vid)
-}
-
-// WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
-// The node v must be directly reachable from u as defined by the From method.
-func (g *WeightedUndirectedGraph) WeightedEdge(uid, vid int64) graph.WeightedEdge {
-	return g.WeightedEdgeBetween(uid, vid)
-}
-
-// EdgeBetween returns the edge between nodes x and y.
-func (g *WeightedUndirectedGraph) EdgeBetween(xid, yid int64) graph.Edge {
-	return g.WeightedEdgeBetween(xid, yid)
-}
-
-// WeightedEdgeBetween returns the weighted edge between nodes x and y.
-func (g *WeightedUndirectedGraph) WeightedEdgeBetween(xid, yid int64) graph.WeightedEdge {
-	edge, ok := g.edges[xid][yid]
-	if !ok {
-		return nil
-	}
-	return edge
-}
-
-// Weight returns the weight for the edge between x and y if Edge(x, y) returns a non-nil Edge.
-// If x and y are the same node or there is no joining edge between the two nodes the weight
-// value returned is either the graph's absent or self value. Weight returns true if an edge
-// exists between x and y or if x and y have the same ID, false otherwise.
-func (g *WeightedUndirectedGraph) Weight(xid, yid int64) (w float64, ok bool) {
-	if xid == yid {
-		return g.self, true
-	}
-	if n, ok := g.edges[xid]; ok {
-		if e, ok := n[yid]; ok {
-			return e.Weight(), true
-		}
-	}
-	return g.absent, false
 }


### PR DESCRIPTION
This helps prevent the kind of errors that I found while doing this; the incomplete fix-up when removing the `Has` method.

Review requires no specific graph experience as it's almost entirely just text reordering.

Please take a look.

Updates #616.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
