### PR TITLE
fix: documentation of Marshal was not accurate

### DIFF
--- a/graph/encoding/dot/encode.go
+++ b/graph/encoding/dot/encode.go
@@ -69,8 +69,7 @@ type Subgrapher interface {
 // Marshal returns the DOT encoding for the graph g, applying the prefix
 // and indent to the encoding. Name is used to specify the graph name. If
 // name is empty and g implements Graph, the returned string from DOTID
-// will be used. If strict is true the output bytes will be prefixed with
-// the DOT "strict" keyword.
+// will be used.
 //
 // Graph serialization will work for a graph.Graph without modification,
 // however, advanced GraphViz DOT features provided by Marshal depend on


### PR DESCRIPTION
The "strict" keyword mentioned in the documentation does not exist anymore

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
