### PR TITLE
mat: make Diagonal satisfy Symmetric

### DIFF
--- a/mat/diagonal.go
+++ b/mat/diagonal.go
@@ -25,8 +25,11 @@ var (
 // has non-zero terms on the diagonal.
 type Diagonal interface {
 	Matrix
-	// Diag returns the number of rows/columns in the matrix
+	// Diag and Symmetric return the number of rows/columns in
+	// the matrix. Both methods are included to allow diagonal
+	// matrices to be used in functions taking symmetric inputs.
 	Diag() int
+	Symmetric() int
 }
 
 // MutableDiagonal is a Diagonal matrix whose elements can be set.


### PR DESCRIPTION
Please take a look.

As far as I can see, this is the only addition that is needed to satisfy the linked issue (the `Symmetric` interface is already satisfied by symmetric banded implementation, and there is no single interface for that).

Fixes #610.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
