### PR TITLE
lapack/gonum: use crossover point for blocked/unblocked code; clean up parameter checks

### DIFF
--- a/lapack/gonum/dgebrd.go
+++ b/lapack/gonum/dgebrd.go
@@ -53,46 +53,62 @@ import (
 //
 // Dgebrd is an internal routine. It is exported for testing purposes.
 func (impl Implementation) Dgebrd(m, n int, a []float64, lda int, d, e, tauQ, tauP, work []float64, lwork int) {
-	checkMatrix(m, n, a, lda)
-	// Calculate optimal work.
-	nb := impl.Ilaenv(1, "DGEBRD", " ", m, n, -1, -1)
-	var lworkOpt int
-	if lwork == -1 {
-		if len(work) < 1 {
-			panic(badWork)
-		}
-		lworkOpt = ((m + n) * nb)
-		work[0] = float64(max(1, lworkOpt))
+	switch {
+	case m < 0:
+		panic(mLT0)
+	case n < 0:
+		panic(nLT0)
+	case lda < max(1, n):
+		panic(badLdA)
+	case lwork < max(1, max(m, n)) && lwork != -1:
+		panic(badWork)
+	case len(work) < max(1, lwork):
+		panic(shortWork)
+	}
+
+	// Quick return if possible.
+	minmn := min(m, n)
+	if minmn == 0 {
+		work[0] = 1
 		return
 	}
-	minmn := min(m, n)
-	if len(d) < minmn {
+
+	nb := impl.Ilaenv(1, "DGEBRD", " ", m, n, -1, -1)
+	lwkopt := (m + n) * nb
+	if lwork == -1 {
+		work[0] = float64(lwkopt)
+		return
+	}
+
+	switch {
+	case len(a) < (m-1)*lda+n:
+		panic("lapack: insufficient length of a")
+	case len(d) < minmn:
 		panic(badD)
-	}
-	if len(e) < minmn-1 {
+	case len(e) < minmn-1:
 		panic(badE)
-	}
-	if len(tauQ) < minmn {
+	case len(tauQ) < minmn:
 		panic(badTauQ)
-	}
-	if len(tauP) < minmn {
+	case len(tauP) < minmn:
 		panic(badTauP)
 	}
+
+	nx := minmn
 	ws := max(m, n)
-	if lwork < max(1, ws) {
-		panic(badWork)
-	}
-	if len(work) < lwork {
-		panic(badWork)
-	}
-	var nx int
-	if nb > 1 && nb < minmn {
+	if 1 < nb && nb < minmn {
+		// At least one blocked operation can be done.
+		// Get the crossover point nx.
 		nx = max(nb, impl.Ilaenv(3, "DGEBRD", " ", m, n, -1, -1))
+		// Determine when to switch from blocked to unblocked code.
 		if nx < minmn {
+			// At least one blocked operation will be done.
 			ws = (m + n) * nb
 			if lwork < ws {
+				// Not enough work space for the optimal nb,
+				// consider using a smaller block size.
 				nbmin := impl.Ilaenv(2, "DGEBRD", " ", m, n, -1, -1)
 				if lwork >= (m+n)*nbmin {
+					// Enough work space for minimum block size.
 					nb = lwork / (m + n)
 				} else {
 					nb = minmn
@@ -100,17 +116,12 @@ func (impl Implementation) Dgebrd(m, n int, a []float64, lda int, d, e, tauQ, ta
 				}
 			}
 		}
-	} else {
-		nx = minmn
 	}
 	bi := blas64.Implementation()
 	ldworkx := nb
 	ldworky := nb
 	var i int
-	// Netlib lapack has minmn - nx, but this makes the last nx rows (which by
-	// default is large) be unblocked. As written here, the blocking is more
-	// consistent.
-	for i = 0; i < minmn-nb; i += nb {
+	for i = 0; i < minmn-nx; i += nb {
 		// Reduce rows and columns i:i+nb to bidiagonal form and return
 		// the matrices X and Y which are needed to update the unreduced
 		// part of the matrix.
@@ -146,5 +157,5 @@ func (impl Implementation) Dgebrd(m, n int, a []float64, lda int, d, e, tauQ, ta
 	}
 	// Use unblocked code to reduce the remainder of the matrix.
 	impl.Dgebd2(m-i, n-i, a[i*lda+i:], lda, d[i:], e[i:], tauQ[i:], tauP[i:], work)
-	work[0] = float64(lworkOpt)
+	work[0] = float64(ws)
 }

--- a/lapack/gonum/dgeev.go
+++ b/lapack/gonum/dgeev.go
@@ -117,19 +117,19 @@ func (impl Implementation) Dgeev(jobvl lapack.LeftEVJob, jobvr lapack.RightEVJob
 	if wantvl || wantvr {
 		maxwrk = max(maxwrk, 2*n+(n-1)*impl.Ilaenv(1, "DORGHR", " ", n, 1, n, -1))
 		impl.Dhseqr(lapack.EigenvaluesAndSchur, lapack.SchurOrig, n, 0, n-1,
-			nil, 1, nil, nil, nil, 1, work, -1)
+			a, lda, wr, wi, vl, ldvl, work, -1)
 		maxwrk = max(maxwrk, max(n+1, n+int(work[0])))
 		side := lapack.EVLeft
 		if wantvr {
 			side = lapack.EVRight
 		}
-		impl.Dtrevc3(side, lapack.EVAllMulQ, nil, n, nil, 1, nil, 1, nil, 1,
+		impl.Dtrevc3(side, lapack.EVAllMulQ, nil, n, a, lda, vl, ldvl, vr, ldvr,
 			n, work, -1)
 		maxwrk = max(maxwrk, n+int(work[0]))
 		maxwrk = max(maxwrk, 4*n)
 	} else {
 		impl.Dhseqr(lapack.EigenvaluesOnly, lapack.SchurNone, n, 0, n-1,
-			nil, 1, nil, nil, nil, 1, work, -1)
+			a, lda, wr, wi, vr, ldvr, work, -1)
 		maxwrk = max(maxwrk, max(n+1, n+int(work[0])))
 	}
 	maxwrk = max(maxwrk, minwrk)

--- a/lapack/gonum/dgehrd.go
+++ b/lapack/gonum/dgehrd.go
@@ -67,20 +67,18 @@ import (
 // Dgehrd is an internal routine. It is exported for testing purposes.
 func (impl Implementation) Dgehrd(n, ilo, ihi int, a []float64, lda int, tau, work []float64, lwork int) {
 	switch {
+	case n < 0:
+		panic(nLT0)
 	case ilo < 0 || max(0, n-1) < ilo:
 		panic(badIlo)
 	case ihi < min(ilo, n-1) || n <= ihi:
 		panic(badIhi)
+	case lda < max(1, n):
+		panic(badLdA)
 	case lwork < max(1, n) && lwork != -1:
 		panic(badWork)
 	case len(work) < lwork:
 		panic(shortWork)
-	}
-	if lwork != -1 {
-		checkMatrix(n, n, a, lda)
-		if len(tau) != n-1 && n > 0 {
-			panic(badTau)
-		}
 	}
 
 	const (
@@ -94,6 +92,13 @@ func (impl Implementation) Dgehrd(n, ilo, ihi int, a []float64, lda int, tau, wo
 	if lwork == -1 {
 		work[0] = float64(lwkopt)
 		return
+	}
+
+	if len(a) < (n-1)*lda+n {
+		panic("lapack: insufficient length of a")
+	}
+	if len(tau) != n-1 && n > 0 {
+		panic(badTau)
 	}
 
 	// Set tau[:ilo] and tau[ihi:] to zero.

--- a/lapack/gonum/dgelqf.go
+++ b/lapack/gonum/dgelqf.go
@@ -21,33 +21,45 @@ import (
 //
 // tau must have length at least min(m,n), and this function will panic otherwise.
 func (impl Implementation) Dgelqf(m, n int, a []float64, lda int, tau, work []float64, lwork int) {
-	nb := impl.Ilaenv(1, "DGELQF", " ", m, n, -1, -1)
-	lworkopt := m * max(nb, 1)
-	if lwork == -1 {
-		work[0] = float64(lworkopt)
-		return
-	}
-	checkMatrix(m, n, a, lda)
-	if len(work) < lwork {
+	switch {
+	case m < 0:
+		panic(mLT0)
+	case n < 0:
+		panic(nLT0)
+	case lda < max(1, n):
+		panic(badLdA)
+	case lwork < max(1, m) && lwork != -1:
+		panic(badWork)
+	case len(work) < max(1, lwork):
 		panic(shortWork)
 	}
-	if lwork < m {
-		panic(badWork)
-	}
+
 	k := min(m, n)
+	if k == 0 {
+		work[0] = 1
+		return
+	}
+
+	nb := impl.Ilaenv(1, "DGELQF", " ", m, n, -1, -1)
+	if lwork == -1 {
+		work[0] = float64(m * nb)
+		return
+	}
+
+	if len(a) < (m-1)*lda+n {
+		panic("lapack: insufficient length of a")
+	}
 	if len(tau) < k {
 		panic(badTau)
 	}
-	if k == 0 {
-		return
-	}
+
 	// Find the optimal blocking size based on the size of available memory
 	// and optimal machine parameters.
 	nbmin := 2
 	var nx int
 	iws := m
 	ldwork := nb
-	if nb > 1 && k > nb {
+	if 1 < nb && nb < k {
 		nx = max(0, impl.Ilaenv(3, "DGELQF", " ", m, n, -1, -1))
 		if nx < k {
 			iws = m * nb
@@ -59,7 +71,7 @@ func (impl Implementation) Dgelqf(m, n int, a []float64, lda int, tau, work []fl
 	}
 	// Computed blocked LQ factorization.
 	var i int
-	if nb >= nbmin && nb < k && nx < k {
+	if nbmin <= nb && nb < k && nx < k {
 		for i = 0; i < k-nx; i += nb {
 			ib := min(k-i, nb)
 			impl.Dgelq2(ib, n-i, a[i*lda+i:], lda, tau[i:], work)
@@ -81,4 +93,5 @@ func (impl Implementation) Dgelqf(m, n int, a []float64, lda int, tau, work []fl
 	if i < k {
 		impl.Dgelq2(m-i, n-i, a[i*lda+i:], lda, tau[i:], work)
 	}
+	work[0] = float64(iws)
 }

--- a/lapack/gonum/dgerqf.go
+++ b/lapack/gonum/dgerqf.go
@@ -32,36 +32,37 @@ import (
 //
 // Dgerqf is an internal routine. It is exported for testing purposes.
 func (impl Implementation) Dgerqf(m, n int, a []float64, lda int, tau, work []float64, lwork int) {
-	checkMatrix(m, n, a, lda)
-
-	if len(work) < max(1, lwork) {
+	switch {
+	case m < 0:
+		panic(mLT0)
+	case n < 0:
+		panic(nLT0)
+	case lda < max(1, n):
+		panic(badLdA)
+	case lwork < max(1, m) && lwork != -1:
+		panic(badWork)
+	case len(work) < max(1, lwork):
 		panic(shortWork)
 	}
-	if lwork != -1 && lwork < max(1, m) {
-		panic(badWork)
+
+	// Quick return if possible.
+	k := min(m, n)
+	if k == 0 {
+		work[0] = 1
+		return
 	}
 
-	k := min(m, n)
+	nb := impl.Ilaenv(1, "DGERQF", " ", m, n, -1, -1)
+	if lwork == -1 {
+		work[0] = float64(m * nb)
+		return
+	}
+
+	if len(a) < (m-1)*lda+n {
+		panic("lapack: insufficient length of a")
+	}
 	if len(tau) != k {
 		panic(badTau)
-	}
-
-	var nb, lwkopt int
-	if k == 0 {
-		lwkopt = 1
-	} else {
-		nb = impl.Ilaenv(1, "DGERQF", " ", m, n, -1, -1)
-		lwkopt = m * nb
-	}
-	work[0] = float64(lwkopt)
-
-	if lwork == -1 {
-		return
-	}
-
-	// Return quickly if possible.
-	if k == 0 {
-		return
 	}
 
 	nbmin := 2

--- a/lapack/gonum/dhseqr.go
+++ b/lapack/gonum/dhseqr.go
@@ -181,7 +181,7 @@ func (impl Implementation) Dhseqr(job lapack.SchurJob, compz lapack.SchurComp, n
 
 	// Quick return in case of a workspace query.
 	if lwork == -1 {
-		impl.Dlaqr04(wantt, wantz, n, ilo, ihi, nil, 0, nil, nil, ilo, ihi, nil, 0, work, -1, 1)
+		impl.Dlaqr04(wantt, wantz, n, ilo, ihi, h, ldh, wr, wi, ilo, ihi, z, ldz, work, -1, 1)
 		work[0] = math.Max(float64(n), work[0])
 		return 0
 	}

--- a/lapack/gonum/dlaqr04.go
+++ b/lapack/gonum/dlaqr04.go
@@ -217,8 +217,8 @@ func (impl Implementation) Dlaqr04(wantt, wantz bool, n, ilo, ihi int, h []float
 	nsr = max(2, nsr&^1)
 
 	// Workspace query call to Dlaqr23.
-	impl.Dlaqr23(wantt, wantz, n, ilo, ihi, nwr+1, nil, 0, iloz, ihiz, nil, 0,
-		nil, nil, nil, 0, n, nil, 0, n, nil, 0, work, -1, recur)
+	impl.Dlaqr23(wantt, wantz, n, ilo, ihi, nwr+1, h, ldh, iloz, ihiz, z, ldz,
+		wr, wi, h, ldh, n, h, ldh, n, h, ldh, work, -1, recur)
 	// Optimal workspace is max(Dlaqr5, Dlaqr23).
 	lwkopt := max(3*nsr/2, int(work[0]))
 	// Quick return in case of workspace query.

--- a/lapack/gonum/dlaqr23.go
+++ b/lapack/gonum/dlaqr23.go
@@ -137,14 +137,14 @@ func (impl Implementation) Dlaqr23(wantt, wantz bool, n, ktop, kbot, nw int, h [
 	lwkopt := max(1, 2*nw)
 	if jw > 2 {
 		// Workspace query call to Dgehrd.
-		impl.Dgehrd(jw, 0, jw-2, nil, 0, nil, work, -1)
+		impl.Dgehrd(jw, 0, jw-2, t, ldt, work, work, -1)
 		lwk1 := int(work[0])
 		// Workspace query call to Dormhr.
-		impl.Dormhr(blas.Right, blas.NoTrans, jw, jw, 0, jw-2, nil, 0, nil, nil, 0, work, -1)
+		impl.Dormhr(blas.Right, blas.NoTrans, jw, jw, 0, jw-2, t, ldt, work, v, ldv, work, -1)
 		lwk2 := int(work[0])
 		if recur > 0 {
 			// Workspace query call to Dlaqr04.
-			impl.Dlaqr04(true, true, jw, 0, jw-1, nil, 0, nil, nil, 0, jw-1, nil, 0, work, -1, recur-1)
+			impl.Dlaqr04(true, true, jw, 0, jw-1, t, ldt, sr, si, 0, jw-1, v, ldv, work, -1, recur-1)
 			lwk3 := int(work[0])
 			// Optimal workspace.
 			lwkopt = max(jw+max(lwk1, lwk2), lwk3)

--- a/lapack/gonum/dorglq.go
+++ b/lapack/gonum/dorglq.go
@@ -15,7 +15,7 @@ import (
 // Dorglq is the blocked version of Dorgl2 that makes greater use of level-3 BLAS
 // routines.
 //
-// len(tau) >= k, 0 <= k <= n, and 0 <= n <= m.
+// len(tau) >= k, 0 <= k <= m, and 0 <= m <= n.
 //
 // work is temporary storage, and lwork specifies the usable memory length. At minimum,
 // lwork >= m, and the amount of blocking is limited by the usable length.
@@ -26,39 +26,44 @@ import (
 //
 // Dorglq is an internal routine. It is exported for testing purposes.
 func (impl Implementation) Dorglq(m, n, k int, a []float64, lda int, tau, work []float64, lwork int) {
-	nb := impl.Ilaenv(1, "DORGLQ", " ", m, n, k, -1)
-	// work is treated as an n×nb matrix
-	if lwork == -1 {
-		work[0] = float64(max(1, m) * nb)
+	switch {
+	case k < 0:
+		panic(kLT0)
+	case m < k:
+		panic(kGTM)
+	case n < m:
+		panic(nLTM)
+	case lda < max(1, n):
+		panic(badLdA)
+	case lwork < max(1, m) && lwork != -1:
+		panic(badWork)
+	case len(work) < max(1, lwork):
+		panic(shortWork)
+	}
+
+	if m == 0 {
+		work[0] = 1
 		return
 	}
-	checkMatrix(m, n, a, lda)
-	if k < 0 {
-		panic(kLT0)
+
+	nb := impl.Ilaenv(1, "DORGLQ", " ", m, n, k, -1)
+	if lwork == -1 {
+		work[0] = float64(m * nb)
+		return
 	}
-	if k > m {
-		panic(kGTM)
-	}
-	if m > n {
-		panic(nLTM)
+
+	if len(a) < (m-1)*lda+n {
+		panic("lapack: insufficient length of a")
 	}
 	if len(tau) < k {
 		panic(badTau)
 	}
-	if len(work) < lwork {
-		panic(shortWork)
-	}
-	if lwork < m {
-		panic(badWork)
-	}
-	if m == 0 {
-		return
-	}
-	nbmin := 2 // Minimum number of blocks
-	var nx int // Minimum number of rows
+
+	nbmin := 2 // Minimum block size
+	var nx int // Crossover size from blocked to unbloked code
 	iws := m   // Length of work needed
 	var ldwork int
-	if nb > 1 && nb < k {
+	if 1 < nb && nb < k {
 		nx = max(0, impl.Ilaenv(3, "DORGLQ", " ", m, n, k, -1))
 		if nx < k {
 			ldwork = nb
@@ -70,12 +75,11 @@ func (impl Implementation) Dorglq(m, n, k int, a []float64, lda int, tau, work [
 			}
 		}
 	}
+
 	var ki, kk int
-	if nb >= nbmin && nb < k && nx < k {
+	if nbmin <= nb && nb < k && nx < k {
 		// The first kk rows are handled by the blocked method.
-		// Note: lapack has nx here, but this means the last nx rows are handled
-		// serially which could be quite different than nb.
-		ki = ((k - nb - 1) / nb) * nb
+		ki = ((k - nx - 1) / nb) * nb
 		kk = min(k, ki+nb)
 		for i := kk; i < m; i++ {
 			for j := 0; j < kk; j++ {
@@ -87,31 +91,31 @@ func (impl Implementation) Dorglq(m, n, k int, a []float64, lda int, tau, work [
 		// Perform the operation on colums kk to the end.
 		impl.Dorgl2(m-kk, n-kk, k-kk, a[kk*lda+kk:], lda, tau[kk:], work)
 	}
-	if kk == 0 {
-		return
-	}
-	// Perform the operation on column-blocks
-	for i := ki; i >= 0; i -= nb {
-		ib := min(nb, k-i)
-		if i+ib < m {
-			impl.Dlarft(lapack.Forward, lapack.RowWise,
-				n-i, ib,
-				a[i*lda+i:], lda,
-				tau[i:],
-				work, ldwork)
+	if kk > 0 {
+		// Perform the operation on column-blocks
+		for i := ki; i >= 0; i -= nb {
+			ib := min(nb, k-i)
+			if i+ib < m {
+				impl.Dlarft(lapack.Forward, lapack.RowWise,
+					n-i, ib,
+					a[i*lda+i:], lda,
+					tau[i:],
+					work, ldwork)
 
-			impl.Dlarfb(blas.Right, blas.Trans, lapack.Forward, lapack.RowWise,
-				m-i-ib, n-i, ib,
-				a[i*lda+i:], lda,
-				work, ldwork,
-				a[(i+ib)*lda+i:], lda,
-				work[ib*ldwork:], ldwork)
-		}
-		impl.Dorgl2(ib, n-i, ib, a[i*lda+i:], lda, tau[i:], work)
-		for l := i; l < i+ib; l++ {
-			for j := 0; j < i; j++ {
-				a[l*lda+j] = 0
+				impl.Dlarfb(blas.Right, blas.Trans, lapack.Forward, lapack.RowWise,
+					m-i-ib, n-i, ib,
+					a[i*lda+i:], lda,
+					work, ldwork,
+					a[(i+ib)*lda+i:], lda,
+					work[ib*ldwork:], ldwork)
+			}
+			impl.Dorgl2(ib, n-i, ib, a[i*lda+i:], lda, tau[i:], work)
+			for l := i; l < i+ib; l++ {
+				for j := 0; j < i; j++ {
+					a[l*lda+j] = 0
+				}
 			}
 		}
 	}
+	work[0] = float64(iws)
 }

--- a/lapack/gonum/dorgqr.go
+++ b/lapack/gonum/dorgqr.go
@@ -35,8 +35,6 @@ func (impl Implementation) Dorgqr(m, n, k int, a []float64, lda int, tau, work [
 		panic(kGTN)
 	case m < n:
 		panic(mLTN)
-	case lda < max(1, n):
-		panic(badLdA)
 	case lwork < max(1, n) && lwork != -1:
 		panic(badWork)
 	case len(work) < max(1, lwork):
@@ -55,10 +53,12 @@ func (impl Implementation) Dorgqr(m, n, k int, a []float64, lda int, tau, work [
 		return
 	}
 
-	if len(a) < (m-1)*lda+n {
+	switch {
+	case lda < max(1, n):
+		panic(badLdA)
+	case len(a) < (m-1)*lda+n:
 		panic("lapack: insuffcient length of a")
-	}
-	if len(tau) < k {
+	case len(tau) < k:
 		panic(badTau)
 	}
 

--- a/lapack/gonum/dorgqr.go
+++ b/lapack/gonum/dorgqr.go
@@ -28,39 +28,45 @@ import (
 //
 // Dorgqr is an internal routine. It is exported for testing purposes.
 func (impl Implementation) Dorgqr(m, n, k int, a []float64, lda int, tau, work []float64, lwork int) {
+	switch {
+	case k < 0:
+		panic(kLT0)
+	case n < k:
+		panic(kGTN)
+	case m < n:
+		panic(mLTN)
+	case lda < max(1, n):
+		panic(badLdA)
+	case lwork < max(1, n) && lwork != -1:
+		panic(badWork)
+	case len(work) < max(1, lwork):
+		panic(shortWork)
+	}
+
+	if n == 0 {
+		work[0] = 1
+		return
+	}
+
 	nb := impl.Ilaenv(1, "DORGQR", " ", m, n, k, -1)
 	// work is treated as an n×nb matrix
 	if lwork == -1 {
-		work[0] = float64(max(1, n) * nb)
+		work[0] = float64(n * nb)
 		return
 	}
-	checkMatrix(m, n, a, lda)
-	if k < 0 {
-		panic(kLT0)
-	}
-	if k > n {
-		panic(kGTN)
-	}
-	if n > m {
-		panic(mLTN)
+
+	if len(a) < (m-1)*lda+n {
+		panic("lapack: insuffcient length of a")
 	}
 	if len(tau) < k {
 		panic(badTau)
 	}
-	if len(work) < lwork {
-		panic(shortWork)
-	}
-	if lwork < n {
-		panic(badWork)
-	}
-	if n == 0 {
-		return
-	}
-	nbmin := 2 // Minimum number of blocks
-	var nx int // Minimum number of rows
+
+	nbmin := 2 // Minimum block size
+	var nx int // Crossover size from blocked to unbloked code
 	iws := n   // Length of work needed
 	var ldwork int
-	if nb > 1 && nb < k {
+	if 1 < nb && nb < k {
 		nx = max(0, impl.Ilaenv(3, "DORGQR", " ", m, n, k, -1))
 		if nx < k {
 			ldwork = nb
@@ -73,14 +79,12 @@ func (impl Implementation) Dorgqr(m, n, k int, a []float64, lda int, tau, work [
 		}
 	}
 	var ki, kk int
-	if nb >= nbmin && nb < k && nx < k {
+	if nbmin <= nb && nb < k && nx < k {
 		// The first kk columns are handled by the blocked method.
-		// Note: lapack has nx here, but this means the last nx rows are handled
-		// serially which could be quite different than nb.
-		ki = ((k - nb - 1) / nb) * nb
+		ki = ((k - nx - 1) / nb) * nb
 		kk = min(k, ki+nb)
-		for j := kk; j < n; j++ {
-			for i := 0; i < kk; i++ {
+		for i := 0; i < kk; i++ {
+			for j := kk; j < n; j++ {
 				a[i*lda+j] = 0
 			}
 		}
@@ -89,32 +93,32 @@ func (impl Implementation) Dorgqr(m, n, k int, a []float64, lda int, tau, work [
 		// Perform the operation on colums kk to the end.
 		impl.Dorg2r(m-kk, n-kk, k-kk, a[kk*lda+kk:], lda, tau[kk:], work)
 	}
-	if kk == 0 {
-		return
-	}
-	// Perform the operation on column-blocks
-	for i := ki; i >= 0; i -= nb {
-		ib := min(nb, k-i)
-		if i+ib < n {
-			impl.Dlarft(lapack.Forward, lapack.ColumnWise,
-				m-i, ib,
-				a[i*lda+i:], lda,
-				tau[i:],
-				work, ldwork)
+	if kk > 0 {
+		// Perform the operation on column-blocks.
+		for i := ki; i >= 0; i -= nb {
+			ib := min(nb, k-i)
+			if i+ib < n {
+				impl.Dlarft(lapack.Forward, lapack.ColumnWise,
+					m-i, ib,
+					a[i*lda+i:], lda,
+					tau[i:],
+					work, ldwork)
 
-			impl.Dlarfb(blas.Left, blas.NoTrans, lapack.Forward, lapack.ColumnWise,
-				m-i, n-i-ib, ib,
-				a[i*lda+i:], lda,
-				work, ldwork,
-				a[i*lda+i+ib:], lda,
-				work[ib*ldwork:], ldwork)
-		}
-		impl.Dorg2r(m-i, ib, ib, a[i*lda+i:], lda, tau[i:], work)
-		// Set rows 0:i-1 of current block to zero
-		for j := i; j < i+ib; j++ {
-			for l := 0; l < i; l++ {
-				a[l*lda+j] = 0
+				impl.Dlarfb(blas.Left, blas.NoTrans, lapack.Forward, lapack.ColumnWise,
+					m-i, n-i-ib, ib,
+					a[i*lda+i:], lda,
+					work, ldwork,
+					a[i*lda+i+ib:], lda,
+					work[ib*ldwork:], ldwork)
+			}
+			impl.Dorg2r(m-i, ib, ib, a[i*lda+i:], lda, tau[i:], work)
+			// Set rows 0:i-1 of current block to zero.
+			for j := i; j < i+ib; j++ {
+				for l := 0; l < i; l++ {
+					a[l*lda+j] = 0
+				}
 			}
 		}
 	}
+	work[0] = float64(iws)
 }

--- a/lapack/gonum/dsytrd.go
+++ b/lapack/gonum/dsytrd.go
@@ -55,33 +55,24 @@ import (
 //
 // Dsytrd is an internal routine. It is exported for testing purposes.
 func (impl Implementation) Dsytrd(uplo blas.Uplo, n int, a []float64, lda int, d, e, tau, work []float64, lwork int) {
-	checkMatrix(n, n, a, lda)
-	if len(d) < n {
-		panic(badD)
-	}
-	if len(e) < n-1 {
-		panic(badE)
-	}
-	if len(tau) < n-1 {
-		panic(badTau)
-	}
-	if len(work) < lwork {
-		panic(shortWork)
-	}
-	if lwork != -1 && lwork < 1 {
-		panic(badWork)
-	}
-
-	var upper bool
 	var opts string
 	switch uplo {
 	case blas.Upper:
-		upper = true
 		opts = "U"
 	case blas.Lower:
 		opts = "L"
 	default:
 		panic(badUplo)
+	}
+	switch {
+	case n < 0:
+		panic(nLT0)
+	case lda < max(1, n):
+		panic(badLdA)
+	case lwork < 1 && lwork != -1:
+		panic(badWork)
+	case len(work) < max(1, lwork):
+		panic(shortWork)
 	}
 
 	if n == 0 {
@@ -96,21 +87,29 @@ func (impl Implementation) Dsytrd(uplo blas.Uplo, n int, a []float64, lda int, d
 		return
 	}
 
+	switch {
+	case len(a) < (n-1)*lda+n:
+		panic("lapack: insufficient length of a")
+	case len(d) < n:
+		panic(badD)
+	case len(e) < n-1:
+		panic(badE)
+	case len(tau) < n-1:
+		panic(badTau)
+	}
+
 	nx := n
+	iws := 1
 	bi := blas64.Implementation()
 	var ldwork int
 	if 1 < nb && nb < n {
 		// Determine when to cross over from blocked to unblocked code. The last
 		// block is always handled by unblocked code.
-		opts := "L"
-		if upper {
-			opts = "U"
-		}
 		nx = max(nb, impl.Ilaenv(3, "DSYTRD", opts, n, -1, -1, -1))
 		if nx < n {
 			// Determine if workspace is large enough for blocked code.
 			ldwork = nb
-			iws := n * ldwork
+			iws = n * ldwork
 			if lwork < iws {
 				// Not enough workspace to use optimal nb: determine the minimum
 				// value of nb and reduce nb or force use of unblocked code by
@@ -129,7 +128,7 @@ func (impl Implementation) Dsytrd(uplo blas.Uplo, n int, a []float64, lda int, d
 	}
 	ldwork = nb
 
-	if upper {
+	if uplo == blas.Upper {
 		// Reduce the upper triangle of A. Columns 0:kk are handled by the
 		// unblocked method.
 		var i int
@@ -174,5 +173,5 @@ func (impl Implementation) Dsytrd(uplo blas.Uplo, n int, a []float64, lda int, d
 		// Use unblocked code to reduce the last or only block.
 		impl.Dsytd2(uplo, n-i, a[i*lda+i:], lda, d[i:], e[i:], tau[i:])
 	}
-	work[0] = float64(lworkopt)
+	work[0] = float64(iws)
 }

--- a/lapack/testlapack/dgeev.go
+++ b/lapack/testlapack/dgeev.go
@@ -579,7 +579,7 @@ func testDgeev(t *testing.T, impl Dgeever, tc string, test dgeevTest, jobvl lapa
 		}
 	case mediumWork:
 		work := make([]float64, 1)
-		impl.Dgeev(jobvl, jobvr, n, nil, 1, nil, nil, nil, 1, nil, 1, work, -1)
+		impl.Dgeev(jobvl, jobvr, n, a.Data, a.Stride, wr, wi, vl.Data, vl.Stride, vr.Data, vr.Stride, work, -1)
 		if jobvl == lapack.LeftEVCompute || jobvr == lapack.RightEVCompute {
 			lwork = (int(work[0]) + 4*n) / 2
 		} else {
@@ -588,7 +588,7 @@ func testDgeev(t *testing.T, impl Dgeever, tc string, test dgeevTest, jobvl lapa
 		lwork = max(1, lwork)
 	case optimumWork:
 		work := make([]float64, 1)
-		impl.Dgeev(jobvl, jobvr, n, nil, 1, nil, nil, nil, 1, nil, 1, work, -1)
+		impl.Dgeev(jobvl, jobvr, n, a.Data, a.Stride, wr, wi, vl.Data, vl.Stride, vr.Data, vr.Stride, work, -1)
 		lwork = int(work[0])
 	}
 	work := make([]float64, lwork)

--- a/lapack/testlapack/dgeev_bench.go
+++ b/lapack/testlapack/dgeev_bench.go
@@ -46,7 +46,7 @@ func DgeevBenchmark(b *testing.B, impl Dgeever) {
 		wr := make([]float64, n)
 		wi := make([]float64, n)
 		work := make([]float64, 1)
-		impl.Dgeev(lapack.LeftEVCompute, lapack.RightEVCompute, n, nil, n, nil, nil, nil, n, nil, n, work, -1)
+		impl.Dgeev(lapack.LeftEVCompute, lapack.RightEVCompute, n, a.Data, a.Stride, wr, wi, vl.Data, vl.Stride, vr.Data, vr.Stride, work, -1)
 		work = make([]float64, int(work[0]))
 		b.Run(bm.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {

--- a/lapack/testlapack/dgehrd.go
+++ b/lapack/testlapack/dgehrd.go
@@ -93,7 +93,7 @@ func testDgehrd(t *testing.T, impl Dgehrder, n, ilo, ihi, extra int, optwork boo
 	var work []float64
 	if optwork {
 		work = nanSlice(1)
-		impl.Dgehrd(n, ilo, ihi, nil, a.Stride, nil, work, -1)
+		impl.Dgehrd(n, ilo, ihi, a.Data, a.Stride, tau, work, -1)
 		work = nanSlice(int(work[0]))
 	} else {
 		work = nanSlice(max(1, n))

--- a/lapack/testlapack/dhseqr.go
+++ b/lapack/testlapack/dhseqr.go
@@ -70,7 +70,7 @@ func testDhseqr(t *testing.T, impl Dhseqrer, i int, test dhseqrTest, job lapack.
 
 	work := nanSlice(max(1, n))
 	if optwork {
-		impl.Dhseqr(job, lapack.SchurHess, n, ilo, ihi, nil, h.Stride, nil, nil, nil, z.Stride, work, -1)
+		impl.Dhseqr(job, lapack.SchurHess, n, ilo, ihi, h.Data, h.Stride, wr, wi, z.Data, z.Stride, work, -1)
 		work = nanSlice(int(work[0]))
 	}
 

--- a/lapack/testlapack/dlaqr04.go
+++ b/lapack/testlapack/dlaqr04.go
@@ -318,7 +318,7 @@ func testDlaqr04(t *testing.T, impl Dlaqr04er, test dlaqr04Test, optwork bool, r
 	var work []float64
 	if optwork {
 		work = nanSlice(1)
-		impl.Dlaqr04(wantt, wantz, n, ilo, ihi, nil, 0, nil, nil, iloz, ihiz, nil, 0, work, -1, recur)
+		impl.Dlaqr04(wantt, wantz, n, ilo, ihi, h.Data, h.Stride, wr, wi, iloz, ihiz, z.Data, z.Stride, work, -1, recur)
 		work = nanSlice(int(work[0]))
 	} else {
 		work = nanSlice(max(1, n))

--- a/lapack/testlapack/dlaqr23.go
+++ b/lapack/testlapack/dlaqr23.go
@@ -280,8 +280,8 @@ func testDlaqr23(t *testing.T, impl Dlaqr23er, test dlaqr23Test, opt bool, recur
 	if opt {
 		// Allocate work slice with optimal length.
 		work = nanSlice(1)
-		impl.Dlaqr23(wantt, wantz, n, ktop, kbot, nw, nil, h.Stride, iloz, ihiz, nil, z.Stride,
-			nil, nil, nil, v.Stride, tmat.Cols, nil, tmat.Stride, wv.Rows, nil, wv.Stride, work, -1, recur)
+		impl.Dlaqr23(wantt, wantz, n, ktop, kbot, nw, h.Data, h.Stride, iloz, ihiz, z.Data, z.Stride,
+			sr, si, v.Data, v.Stride, tmat.Cols, tmat.Data, tmat.Stride, wv.Rows, wv.Data, wv.Stride, work, -1, recur)
 		work = nanSlice(int(work[0]))
 	} else {
 		// Allocate work slice with minimum length.

--- a/lapack/testlapack/dorgql.go
+++ b/lapack/testlapack/dorgql.go
@@ -94,12 +94,12 @@ func DorgqlTest(t *testing.T, impl Dorgqler) {
 					lwork = max(1, n)
 				case mediumWork:
 					work := make([]float64, 1)
-					impl.Dorgql(m, n, k, nil, a.Stride, nil, work, -1)
+					impl.Dorgql(m, n, k, a.Data, a.Stride, tau, work, -1)
 					lwork = (int(work[0]) + n) / 2
 					lwork = max(1, lwork)
 				case optimumWork:
 					work := make([]float64, 1)
-					impl.Dorgql(m, n, k, nil, a.Stride, nil, work, -1)
+					impl.Dorgql(m, n, k, a.Data, a.Stride, tau, work, -1)
 					lwork = int(work[0])
 				}
 				work := make([]float64, lwork)

--- a/lapack/testlapack/dormlq.go
+++ b/lapack/testlapack/dormlq.go
@@ -67,7 +67,7 @@ func DormlqTest(t *testing.T, impl Dormlqer) {
 					// Generate a random matrix
 					lda := test.lda
 					if lda == 0 {
-						lda = na
+						lda = max(1, na)
 					}
 					a := make([]float64, ma*lda)
 					for i := range a {

--- a/lapack/testlapack/dormqr.go
+++ b/lapack/testlapack/dormqr.go
@@ -114,7 +114,7 @@ func DormqrTest(t *testing.T, impl Dormqrer) {
 
 				// Try with the optimum amount of work
 				copy(c, cCopy)
-				impl.Dormqr(side, trans, mc, nc, k, nil, lda, nil, nil, ldc, work, -1)
+				impl.Dormqr(side, trans, mc, nc, k, a, lda, tau, c, ldc, work, -1)
 				work = make([]float64, int(work[0]))
 				for i := range work {
 					work[i] = rnd.Float64()

--- a/lapack/testlapack/dtrevc3.go
+++ b/lapack/testlapack/dtrevc3.go
@@ -108,7 +108,8 @@ func testDtrevc3(t *testing.T, impl Dtrevc3er, side lapack.EVSide, howmny lapack
 
 	work := make([]float64, max(1, 3*n))
 	if optwork {
-		impl.Dtrevc3(side, howmny, nil, n, nil, 1, nil, 1, nil, 1, mWant, work, -1)
+		impl.Dtrevc3(side, howmny, selected, n, tmat.Data, tmat.Stride,
+			vl.Data, vl.Stride, vr.Data, vr.Stride, mWant, work, -1)
 		work = make([]float64, int(work[0]))
 	}
 


### PR DESCRIPTION
This got bigger than expected. The starting point was checking the list of functions from #83:
* Dgebrd
* Dorgql
* Dsytrd
* Dgeqrf
* Dgerqf
* Dorgqr
* Dgehrd
* Dorglq
* Dgelqf
that call `Ilanenv(3, ...)` and sometime chose to ignore the returned value.

While at that I cleaned up the parameter checks. Doing this
* made the checks stricter for workspace query calls and so broke some tests which I had to fix,
* revealed some inconsistencies, especially regarding `work[0]` value upon return in case of _non_-workspace query call. Some functions return `lwkopt` while other compute a separate `iws` value. I changed the code to follow the reference but we can either ask the reference about this or just use `lwkopt` everywhere.

In general, I think that the following order of initial checks is the most reasonable:
1. Check numerical parameters like `uplo`, `trans`, `m`, `n`, `k`, `lda`, `lwork` and the length of `work`.
2. Quick return if possible with setting `work[0] = 1`.
3. Compute optimal work length and return if query call
4. Check slice lengths

I could be convinced to move leading dimension checks to 4, or also in the opposite direction to move slice length checks to 1 although it might not be a good idea to be so strict as exemplified by Dorgqr.

Unlike with the other functions, in case of Dorgqr I had to move the lda check after the workspace query return. The reason is Dgesvd. Dorgqr is queried at several places in Dgesvd for workspace size with varying arguments. It is called as `Dorgqr(m, n, ..., a, lda, ..., -1)` and also as `Dorgqr(m, m, ..., a, lda, ..., -1)`. 
This is obviously impossible to pass. The reference gets around this because it's column-major
and the number of rows is the same for each call. I think that it would be more correct to call it in the second case with `u, ldu` but then the test for Dlapll fails because it does not need `U` and passes `nil, 0` for it.

Eventually we could delete `checkMatrix` also here in lapack.

The unified diff is big but the individual commits are focused.

Fixes #83 

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
