### PR TITLE
mat: add Banded methods to Diagonal

### DIFF
--- a/mat/diagonal.go
+++ b/mat/diagonal.go
@@ -16,6 +16,7 @@ var (
 	_         MutableDiagonal = diagDense
 	_         Triangular      = diagDense
 	_         Symmetric       = diagDense
+	_         SymBanded       = diagDense
 	_         Banded          = diagDense
 	_         RawBander       = diagDense
 	_         RawSymBander    = diagDense
@@ -30,6 +31,12 @@ type Diagonal interface {
 	// matrices to be used in functions taking symmetric inputs.
 	Diag() int
 	Symmetric() int
+
+	// Bandwidth and TBand are included in the Diagonal interface
+	// to allow the use of Diagonal types in banded functions.
+	// Bandwidth will always return (0, 0).
+	Bandwidth() (kl, ku int)
+	TBand() Banded
 }
 
 // MutableDiagonal is a Diagonal matrix whose elements can be set.


### PR DESCRIPTION
Please take a look.

I'm not at all convinced by this. The concrete type already implements the methods. It seems like interface bloat. Are you sure you want this?

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
