### PR TITLE
mat: add striding to DiagDense and capacity to extract diags from other matrices

### DIFF
--- a/mat/diagonal_test.go
+++ b/mat/diagonal_test.go
@@ -7,6 +7,8 @@ package mat
 import (
 	"reflect"
 	"testing"
+
+	"gonum.org/v1/gonum/blas/blas64"
 )
 
 func TestNewDiagonal(t *testing.T) {
@@ -20,7 +22,8 @@ func TestNewDiagonal(t *testing.T) {
 			data: []float64{1, 2, 3, 4, 5, 6},
 			n:    6,
 			mat: &DiagDense{
-				data: []float64{1, 2, 3, 4, 5, 6},
+				mat: blas64.Vector{Inc: 1, Data: []float64{1, 2, 3, 4, 5, 6}},
+				n:   6,
 			},
 			dense: NewDense(6, 6, []float64{
 				1, 0, 0, 0, 0, 0,
@@ -49,6 +52,75 @@ func TestNewDiagonal(t *testing.T) {
 		}
 		if !Equal(band, test.dense) {
 			t.Errorf("unexpected value via mat.Equal(band, dense) for test %d:\ngot:\n% v\nwant:\n% v", i, Formatted(band), Formatted(test.dense))
+		}
+	}
+}
+
+func TestDiagonalStride(t *testing.T) {
+	for _, test := range []struct {
+		diag  *DiagDense
+		dense *Dense
+	}{
+		{
+			diag: &DiagDense{
+				mat: blas64.Vector{Inc: 1, Data: []float64{1, 2, 3, 4, 5, 6}},
+				n:   6,
+			},
+			dense: NewDense(6, 6, []float64{
+				1, 0, 0, 0, 0, 0,
+				0, 2, 0, 0, 0, 0,
+				0, 0, 3, 0, 0, 0,
+				0, 0, 0, 4, 0, 0,
+				0, 0, 0, 0, 5, 0,
+				0, 0, 0, 0, 0, 6,
+			}),
+		},
+		{
+			diag: &DiagDense{
+				mat: blas64.Vector{Inc: 2, Data: []float64{
+					1, 0,
+					2, 0,
+					3, 0,
+					4, 0,
+					5, 0,
+					6,
+				}},
+				n: 6,
+			},
+			dense: NewDense(6, 6, []float64{
+				1, 0, 0, 0, 0, 0,
+				0, 2, 0, 0, 0, 0,
+				0, 0, 3, 0, 0, 0,
+				0, 0, 0, 4, 0, 0,
+				0, 0, 0, 0, 5, 0,
+				0, 0, 0, 0, 0, 6,
+			}),
+		},
+		{
+			diag: &DiagDense{
+				mat: blas64.Vector{Inc: 5, Data: []float64{
+					1, 0, 0, 0, 0,
+					2, 0, 0, 0, 0,
+					3, 0, 0, 0, 0,
+					4, 0, 0, 0, 0,
+					5, 0, 0, 0, 0,
+					6,
+				}},
+				n: 6,
+			},
+			dense: NewDense(6, 6, []float64{
+				1, 0, 0, 0, 0, 0,
+				0, 2, 0, 0, 0, 0,
+				0, 0, 3, 0, 0, 0,
+				0, 0, 0, 4, 0, 0,
+				0, 0, 0, 0, 5, 0,
+				0, 0, 0, 0, 0, 6,
+			}),
+		},
+	} {
+		if !Equal(test.diag, test.dense) {
+			t.Errorf("unexpected value via mat.Equal for stride %d: got: %v want: %v",
+				test.diag.mat.Inc, test.diag, test.dense)
 		}
 	}
 }

--- a/mat/diagonal_test.go
+++ b/mat/diagonal_test.go
@@ -5,6 +5,7 @@
 package mat
 
 import (
+	"math"
 	"reflect"
 	"testing"
 
@@ -121,6 +122,202 @@ func TestDiagonalStride(t *testing.T) {
 		if !Equal(test.diag, test.dense) {
 			t.Errorf("unexpected value via mat.Equal for stride %d: got: %v want: %v",
 				test.diag.mat.Inc, test.diag, test.dense)
+		}
+	}
+}
+
+func TestDiagOf(t *testing.T) {
+	for i, test := range []struct {
+		mat  Matrix
+		want *Dense
+	}{
+		{
+			mat: NewDiagonal(6, []float64{1, 2, 3, 4, 5, 6}),
+			want: NewDense(6, 6, []float64{
+				1, 0, 0, 0, 0, 0,
+				0, 2, 0, 0, 0, 0,
+				0, 0, 3, 0, 0, 0,
+				0, 0, 0, 4, 0, 0,
+				0, 0, 0, 0, 5, 0,
+				0, 0, 0, 0, 0, 6,
+			}),
+		},
+		{
+			mat: NewBandDense(6, 6, 1, 1, []float64{
+				math.NaN(), 1, math.NaN(),
+				math.NaN(), 2, math.NaN(),
+				math.NaN(), 3, math.NaN(),
+				math.NaN(), 4, math.NaN(),
+				math.NaN(), 5, math.NaN(),
+				math.NaN(), 6, math.NaN(),
+			}),
+			want: NewDense(6, 6, []float64{
+				1, 0, 0, 0, 0, 0,
+				0, 2, 0, 0, 0, 0,
+				0, 0, 3, 0, 0, 0,
+				0, 0, 0, 4, 0, 0,
+				0, 0, 0, 0, 5, 0,
+				0, 0, 0, 0, 0, 6,
+			}),
+		},
+		{
+			mat: NewDense(6, 6, []float64{
+				1, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), 3, math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), math.NaN(), 4, math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), math.NaN(), math.NaN(), 5, math.NaN(),
+				math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 6,
+			}),
+			want: NewDense(6, 6, []float64{
+				1, 0, 0, 0, 0, 0,
+				0, 2, 0, 0, 0, 0,
+				0, 0, 3, 0, 0, 0,
+				0, 0, 0, 4, 0, 0,
+				0, 0, 0, 0, 5, 0,
+				0, 0, 0, 0, 0, 6,
+			}),
+		},
+		{
+			mat: NewDense(6, 4, []float64{
+				1, math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), 2, math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), 3, math.NaN(),
+				math.NaN(), math.NaN(), math.NaN(), 4,
+				math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+			}),
+			want: NewDense(4, 4, []float64{
+				1, 0, 0, 0,
+				0, 2, 0, 0,
+				0, 0, 3, 0,
+				0, 0, 0, 4,
+			}),
+		},
+		{
+			mat: NewDense(4, 6, []float64{
+				1, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), 3, math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), math.NaN(), 4, math.NaN(), math.NaN(),
+			}),
+			want: NewDense(4, 4, []float64{
+				1, 0, 0, 0,
+				0, 2, 0, 0,
+				0, 0, 3, 0,
+				0, 0, 0, 4,
+			}),
+		},
+		{
+			mat: NewSymBandDense(6, 1, []float64{
+				1, math.NaN(),
+				2, math.NaN(),
+				3, math.NaN(),
+				4, math.NaN(),
+				5, math.NaN(),
+				6, math.NaN(),
+			}),
+			want: NewDense(6, 6, []float64{
+				1, 0, 0, 0, 0, 0,
+				0, 2, 0, 0, 0, 0,
+				0, 0, 3, 0, 0, 0,
+				0, 0, 0, 4, 0, 0,
+				0, 0, 0, 0, 5, 0,
+				0, 0, 0, 0, 0, 6,
+			}),
+		},
+		{
+			mat: NewSymDense(6, []float64{
+				1, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), 3, math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), math.NaN(), 4, math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), math.NaN(), math.NaN(), 5, math.NaN(),
+				math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 6,
+			}),
+			want: NewDense(6, 6, []float64{
+				1, 0, 0, 0, 0, 0,
+				0, 2, 0, 0, 0, 0,
+				0, 0, 3, 0, 0, 0,
+				0, 0, 0, 4, 0, 0,
+				0, 0, 0, 0, 5, 0,
+				0, 0, 0, 0, 0, 6,
+			}),
+		},
+		{
+			mat: NewTriDense(6, Upper, []float64{
+				1, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), 3, math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), math.NaN(), 4, math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), math.NaN(), math.NaN(), 5, math.NaN(),
+				math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 6,
+			}),
+			want: NewDense(6, 6, []float64{
+				1, 0, 0, 0, 0, 0,
+				0, 2, 0, 0, 0, 0,
+				0, 0, 3, 0, 0, 0,
+				0, 0, 0, 4, 0, 0,
+				0, 0, 0, 0, 5, 0,
+				0, 0, 0, 0, 0, 6,
+			}),
+		},
+		{
+			mat: NewTriDense(6, Lower, []float64{
+				1, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), 3, math.NaN(), math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), math.NaN(), 4, math.NaN(), math.NaN(),
+				math.NaN(), math.NaN(), math.NaN(), math.NaN(), 5, math.NaN(),
+				math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 6,
+			}),
+			want: NewDense(6, 6, []float64{
+				1, 0, 0, 0, 0, 0,
+				0, 2, 0, 0, 0, 0,
+				0, 0, 3, 0, 0, 0,
+				0, 0, 0, 4, 0, 0,
+				0, 0, 0, 0, 5, 0,
+				0, 0, 0, 0, 0, 6,
+			}),
+		},
+		{
+			mat:  NewVecDense(6, []float64{1, 2, 3, 4, 5, 6}),
+			want: NewDense(1, 1, []float64{1}),
+		},
+		{
+			mat: &basicMatrix{
+				mat: blas64.General{
+					Rows:   6,
+					Cols:   6,
+					Stride: 6,
+					Data: []float64{
+						1, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+						math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+						math.NaN(), math.NaN(), 3, math.NaN(), math.NaN(), math.NaN(),
+						math.NaN(), math.NaN(), math.NaN(), 4, math.NaN(), math.NaN(),
+						math.NaN(), math.NaN(), math.NaN(), math.NaN(), 5, math.NaN(),
+						math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 6,
+					},
+				},
+				capRows: 6,
+				capCols: 6,
+			},
+			want: NewDense(6, 6, []float64{
+				1, 0, 0, 0, 0, 0,
+				0, 2, 0, 0, 0, 0,
+				0, 0, 3, 0, 0, 0,
+				0, 0, 0, 4, 0, 0,
+				0, 0, 0, 0, 5, 0,
+				0, 0, 0, 0, 0, 6,
+			}),
+		},
+	} {
+		var got DiagDense
+		got.DiagOf(test.mat)
+		if !Equal(&got, test.want) {
+			r, c := test.mat.Dims()
+			t.Errorf("unexpected value via mat.Equal for %d×%d %T test %d:\ngot:\n% v\nwant:\n% v",
+				r, c, test.mat, i, Formatted(&got), Formatted(test.want))
 		}
 	}
 }

--- a/mat/diagonal_test.go
+++ b/mat/diagonal_test.go
@@ -126,7 +126,7 @@ func TestDiagonalStride(t *testing.T) {
 	}
 }
 
-func TestDiagOf(t *testing.T) {
+func TestDiagFrom(t *testing.T) {
 	for i, test := range []struct {
 		mat  Matrix
 		want *Dense
@@ -313,7 +313,7 @@ func TestDiagOf(t *testing.T) {
 		},
 	} {
 		var got DiagDense
-		got.DiagOf(test.mat)
+		got.DiagFrom(test.mat)
 		if !Equal(&got, test.want) {
 			r, c := test.mat.Dims()
 			t.Errorf("unexpected value via mat.Equal for %d×%d %T test %d:\ngot:\n% v\nwant:\n% v",

--- a/mat/index_bound_checks.go
+++ b/mat/index_bound_checks.go
@@ -238,16 +238,16 @@ func (d *DiagDense) At(i, j int) float64 {
 }
 
 func (d *DiagDense) at(i, j int) float64 {
-	if uint(i) >= uint(len(d.data)) {
+	if uint(i) >= uint(d.n) {
 		panic(ErrRowAccess)
 	}
-	if uint(j) >= uint(len(d.data)) {
+	if uint(j) >= uint(d.n) {
 		panic(ErrColAccess)
 	}
 	if i != j {
 		return 0
 	}
-	return d.data[i]
+	return d.mat.Data[i*d.mat.Inc]
 }
 
 // SetDiag sets the element at row i, column i to the value v.
@@ -257,8 +257,8 @@ func (d *DiagDense) SetDiag(i int, v float64) {
 }
 
 func (d *DiagDense) setDiag(i int, v float64) {
-	if uint(i) >= uint(len(d.data)) {
+	if uint(i) >= uint(d.n) {
 		panic(ErrRowAccess)
 	}
-	d.data[i] = v
+	d.mat.Data[i*d.mat.Inc] = v
 }

--- a/mat/index_no_bound_checks.go
+++ b/mat/index_no_bound_checks.go
@@ -238,10 +238,10 @@ func (s *SymBandDense) set(i, j int, v float64) {
 
 // At returns the element at row i, column j.
 func (d *DiagDense) At(i, j int) float64 {
-	if uint(i) >= uint(len(d.data)) {
+	if uint(i) >= uint(d.n) {
 		panic(ErrRowAccess)
 	}
-	if uint(j) >= uint(len(d.data)) {
+	if uint(j) >= uint(d.n) {
 		panic(ErrColAccess)
 	}
 	return d.at(i, j)
@@ -251,18 +251,18 @@ func (d *DiagDense) at(i, j int) float64 {
 	if i != j {
 		return 0
 	}
-	return d.data[i]
+	return d.mat.Data[i*d.mat.Inc]
 }
 
 // SetDiag sets the element at row i, column i to the value v.
 // It panics if the location is outside the appropriate region of the matrix.
 func (d *DiagDense) SetDiag(i int, v float64) {
-	if uint(i) >= uint(len(d.data)) {
+	if uint(i) >= uint(d.n) {
 		panic(ErrRowAccess)
 	}
 	d.setDiag(i, v)
 }
 
 func (d *DiagDense) setDiag(i int, v float64) {
-	d.data[i] = v
+	d.mat.Data[i*d.mat.Inc] = v
 }

--- a/mat/list_test.go
+++ b/mat/list_test.go
@@ -482,9 +482,10 @@ func makeCopyOf(a Matrix) Matrix {
 		return m
 	case *DiagDense:
 		d := &DiagDense{
-			data: make([]float64, len(t.data)),
+			mat: blas64.Vector{Inc: 1, Data: make([]float64, len(t.mat.Data))},
+			n:   t.n,
 		}
-		copy(d.data, t.data)
+		copy(d.mat.Data, t.mat.Data)
 		return d
 	}
 }
@@ -618,10 +619,12 @@ var testMatrices = []Matrix{
 	&SymDense{},
 	NewTriDense(3, true, nil),
 	NewTriDense(3, false, nil),
-	&VecDense{mat: blas64.Vector{Inc: 1}},
-	&DiagDense{},
 	&basicVector{},
+	&VecDense{mat: blas64.Vector{Inc: 1}},
 	&VecDense{mat: blas64.Vector{Inc: 10}},
+	&DiagDense{},
+	&DiagDense{mat: blas64.Vector{Inc: 1}},
+	&DiagDense{mat: blas64.Vector{Inc: 10}},
 	&basicMatrix{},
 	&basicSymmetric{},
 	&basicTriangular{cap: 3, mat: blas64.Triangular{N: 3, Stride: 3, Uplo: blas.Upper}},


### PR DESCRIPTION
Please take a look.

I'm not really all that happy with the approach in `DiagOf` because of the mixing of view and copy, but the alternatives that I can see are less attractive; have a collection of methods for each raw type, either on `DiagDense` or (less likely) the raw types, or alternatively panicking when a non-raw type is handed in.

Fixes #609.
Updates #213.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
