### PR TITLE
fix duplicated switch case

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,6 +32,7 @@ Francesc Campoy <campoy@golang.org>
 Google Inc
 Gustaf Johansson <gustaf@pinon.se>
 Iakov Davydov <iakov.davydov@unil.ch>
+Iskander Sharipov <quasilyte@gmail.com>
 Jalem Raj Rohit <jrajrohit33@gmail.com>
 James Bell <james@stellentus.com>
 James Bowman <james.edward.bowman@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -38,6 +38,7 @@ Fazlul Shahriar <fshahriar@gmail.com>
 Francesc Campoy <campoy@golang.org>
 Gustaf Johansson <gustaf@pinon.se>
 Iakov Davydov <iakov.davydov@unil.ch>
+Iskander Sharipov <quasilyte@gmail.com>
 Jalem Raj Rohit <jrajrohit33@gmail.com>
 James Bell <james@stellentus.com>
 James Bowman <james.edward.bowman@gmail.com>

--- a/mat/triangular_test.go
+++ b/mat/triangular_test.go
@@ -191,7 +191,7 @@ func TestTriDenseCopy(t *testing.T) {
 						if got := l.At(m, n); got != want {
 							t.Errorf("unexpected diagonal value for At(%d, %d) for test %d: got: %v want: %v", m, n, i, got, want)
 						}
-					case m < n: // Lower triangular matrix.
+					case m > n: // Lower triangular matrix.
 						if got := l.At(m, n); got != want {
 							t.Errorf("unexpected lower value for At(%d, %d) for test %d: got: %v want: %v", m, n, i, got, want)
 						}


### PR DESCRIPTION
The `m < n` case was repeated twice.
Found using gocritic linter, `dupCase` checker.
