### PR TITLE
 mat: rewrite Cholesky.ToSym without calling SymOuterK

### DIFF
--- a/mat/cholesky_test.go
+++ b/mat/cholesky_test.go
@@ -588,3 +588,31 @@ func BenchmarkCholeskyFactorize(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkCholeskyToSym(b *testing.B) {
+	for _, n := range []int{10, 100, 1000} {
+		b.Run("n="+strconv.Itoa(n), func(b *testing.B) {
+			rnd := rand.New(rand.NewSource(1))
+
+			data := make([]float64, n*n)
+			for i := range data {
+				data[i] = rnd.NormFloat64()
+			}
+			var a SymDense
+			a.SymOuterK(1, NewDense(n, n, data))
+
+			var chol Cholesky
+			ok := chol.Factorize(&a)
+			if !ok {
+				panic("not positive definite")
+			}
+
+			dst := NewSymDense(n, nil)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				chol.ToSym(dst)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A substitute for the Dlauum attempt. `Cholesky.ToSym` is not super important but with this PR it becomes slightly faster.

```
name                    old time/op  new time/op  delta
CholeskyToSym/n=10-4    2.65µs ± 2%  0.78µs ± 0%  -70.75%  (p=0.029 n=4+4)
CholeskyToSym/n=100-4    329µs ± 1%   124µs ± 0%  -62.33%  (p=0.029 n=4+4)
CholeskyToSym/n=1000-4   241ms ± 2%   175ms ± 0%  -27.34%  (p=0.029 n=4+4)
```

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
