### PR TITLE
encoding/dot: set DOT node ID before adding node to graph

### DIFF
--- a/graph/encoding/dot/decode.go
+++ b/graph/encoding/dot/decode.go
@@ -153,10 +153,10 @@ func (gen *generator) node(dst graph.NodeAdder, id string) graph.Node {
 		return n
 	}
 	n := dst.NewNode()
-	dst.AddNode(n)
 	if n, ok := n.(DOTIDSetter); ok {
 		n.SetDOTID(id)
 	}
+	dst.AddNode(n)
 	gen.ids[id] = n
 	// Check if within the context of a subgraph, that is to be used as a vertex
 	// of an edge.


### PR DESCRIPTION
This makes it possible to implement the AddNode method of
graph.NodeAdder to track the nodes of a graph by DOT node
ID, as they are added.

Please take a look.
