### PR TITLE
graph: allow indeterminate iterator length

### DIFF
--- a/graph/nodes_edges.go
+++ b/graph/nodes_edges.go
@@ -20,6 +20,15 @@ type Iterator interface {
 
 	// Len returns the number of items remaining in the
 	// iterator.
+	//
+	// If the number of items in the iterator is unknown,
+	// too large to materialize or too costly to calculate
+	// then Len may return a negative value.
+	// In this case the consuming function must be able
+	// to operate on the items of the iterator directly
+	// without materializing the items into a slice.
+	// The magnitude of a negative length has
+	// implementation-dependent semantics.
 	Len() int
 
 	// Reset returns the iterator to its start position.
@@ -47,17 +56,22 @@ type NodeSlicer interface {
 
 // NodesOf returns it.Len() nodes from it. If it is a NodeSlicer, the NodeSlice method
 // is used to obtain the nodes. It is safe to pass a nil Nodes to NodesOf.
+//
+// If the Nodes has en indeterminate length, NodesOf will panic.
 func NodesOf(it Nodes) []Node {
 	if it == nil {
 		return nil
 	}
+	len := it.Len()
+	switch {
+	case len == 0:
+		return nil
+	case len < 0:
+		panic("graph: called NodesOf on indeterminate iterator")
+	}
 	switch it := it.(type) {
 	case NodeSlicer:
 		return it.NodeSlice()
-	}
-	len := it.Len()
-	if len == 0 {
-		return nil
 	}
 	n := make([]Node, 0, len)
 	for it.Next() {
@@ -87,17 +101,22 @@ type EdgeSlicer interface {
 
 // EdgesOf returns it.Len() nodes from it. If it is an EdgeSlicer, the EdgeSlice method is used
 // to obtain the edges. It is safe to pass a nil Edges to EdgesOf.
+//
+// If the Edges has en indeterminate length, EdgesOf will panic.
 func EdgesOf(it Edges) []Edge {
 	if it == nil {
 		return nil
 	}
+	len := it.Len()
+	switch {
+	case len == 0:
+		return nil
+	case len < 0:
+		panic("graph: called EdgesOf on indeterminate iterator")
+	}
 	switch it := it.(type) {
 	case EdgeSlicer:
 		return it.EdgeSlice()
-	}
-	len := it.Len()
-	if len == 0 {
-		return nil
 	}
 	e := make([]Edge, 0, len)
 	for it.Next() {
@@ -128,17 +147,22 @@ type WeightedEdgeSlicer interface {
 // WeightedEdgesOf returns it.Len() weighted edge from it. If it is a WeightedEdgeSlicer, the
 // WeightedEdgeSlice method is used to obtain the edges. It is safe to pass a nil WeightedEdges
 // to WeightedEdgesOf.
+//
+// If the WeightedEdges has en indeterminate length, WeightedEdgesOf will panic.
 func WeightedEdgesOf(it WeightedEdges) []WeightedEdge {
 	if it == nil {
 		return nil
 	}
+	len := it.Len()
+	switch {
+	case len == 0:
+		return nil
+	case len < 0:
+		panic("graph: called WeightedEdgesOf on indeterminate iterator")
+	}
 	switch it := it.(type) {
 	case WeightedEdgeSlicer:
 		return it.WeightedEdgeSlice()
-	}
-	len := it.Len()
-	if len == 0 {
-		return nil
 	}
 	e := make([]WeightedEdge, 0, len)
 	for it.Next() {
@@ -168,17 +192,22 @@ type LineSlicer interface {
 
 // LinesOf returns it.Len() nodes from it. If it is a LineSlicer, the LineSlice method is used
 // to obtain the lines. It is safe to pass a nil Lines to LinesOf.
+//
+// If the Lines has en indeterminate length, LinesOf will panic.
 func LinesOf(it Lines) []Line {
 	if it == nil {
 		return nil
 	}
+	len := it.Len()
+	switch {
+	case len == 0:
+		return nil
+	case len < 0:
+		panic("graph: called LinesOf on indeterminate iterator")
+	}
 	switch it := it.(type) {
 	case LineSlicer:
 		return it.LineSlice()
-	}
-	len := it.Len()
-	if len == 0 {
-		return nil
 	}
 	l := make([]Line, 0, len)
 	for it.Next() {
@@ -209,17 +238,22 @@ type WeightedLineSlicer interface {
 // WeightedLinesOf returns it.Len() weighted line from it. If it is a WeightedLineSlicer, the
 // WeightedLineSlice method is used to obtain the lines. It is safe to pass a nil WeightedLines
 // to WeightedLinesOf.
+//
+// If the WeightedLines has en indeterminate length, WeightedLinesOf will panic.
 func WeightedLinesOf(it WeightedLines) []WeightedLine {
 	if it == nil {
 		return nil
 	}
+	len := it.Len()
+	switch {
+	case len == 0:
+		return nil
+	case len < 0:
+		panic("graph: called WeightedLinesOf on indeterminate iterator")
+	}
 	switch it := it.(type) {
 	case WeightedLineSlicer:
 		return it.WeightedLineSlice()
-	}
-	len := it.Len()
-	if len == 0 {
-		return nil
 	}
 	l := make([]WeightedLine, 0, len)
 	for it.Next() {


### PR DESCRIPTION
Please take a look.

I have decided to use a panic in the slicer functions rather than returning nil to avoid silent failure from incorrect use.

The next step for this is to go through the functions that we have an document those that are able to work on indeterminate iterators. Then fix those that could but currently can not.

The intention with the semantics around the magnitude of the length return value are that for disk-backed graph the size can be known, but it may not be materialisabe. This is useful information, just not information that can be used directly by most of the analytical functions.

Updates #627.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
