### PR TITLE
mat: add examples for Col and Row

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ Brent Pedersen <bpederse@gmail.com>
 Chad Kunde <kunde21@gmail.com>
 Chih-Wei Chang <bert.cwchang@gmail.com>
 Chris Tessum <ctessum@gmail.com>
+Clayton Northey <clayton.northey@gmail.com>
 Dan Kortschak <dan.kortschak@adelaide.edu.au> <dan@kortschak.io>
 Daniel Fireman <danielfireman@gmail.com>
 David Samborski <bloggingarrow@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,6 +24,7 @@ Brent Pedersen <bpederse@gmail.com>
 Chad Kunde <kunde21@gmail.com>
 Chih-Wei Chang <bert.cwchang@gmail.com>
 Chris Tessum <ctessum@gmail.com>
+Clayton Northey <clayton.northey@gmail.com>
 Dan Kortschak <dan.kortschak@adelaide.edu.au> <dan@kortschak.io>
 Daniel Fireman <danielfireman@gmail.com>
 David Samborski <bloggingarrow@gmail.com>

--- a/mat/matrix_example_test.go
+++ b/mat/matrix_example_test.go
@@ -1,0 +1,43 @@
+// Copyright ©2019 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mat_test
+
+import (
+	"fmt"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func ExampleCol() {
+	// This example copies the second column of a matrix into col, allocating a new slice of float64.
+	m := mat.NewDense(3, 3, []float64{
+		2.0, 9.0, 3.0,
+		4.5, 6.7, 8.0,
+		1.2, 3.0, 6.0,
+	})
+
+	col := mat.Col(nil, 1, m)
+
+	fmt.Printf("col = %#v", col)
+	// Output:
+	//
+	// col = []float64{9, 6.7, 3}
+}
+
+func ExampleRow() {
+	// This example copies the third row of a matrix into row, allocating a new slice of float64.
+	m := mat.NewDense(3, 3, []float64{
+		2.0, 9.0, 3.0,
+		4.5, 6.7, 8.0,
+		1.2, 3.0, 6.0,
+	})
+
+	row := mat.Row(nil, 2, m)
+
+	fmt.Printf("row = %#v", row)
+	// Output:
+	//
+	// row = []float64{1.2, 3, 6}
+}


### PR DESCRIPTION
Added examples in godoc for `mat.Row` and `mat.Col` function calls.

Originally discussed here: https://groups.google.com/d/msg/gonum-dev/20ReoY6VmkU/jcwejOlvCwAJ

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
