### PR TITLE
lapack/gonum,mat: add Dpotri and use it in Cholesky

### DIFF
--- a/lapack/gonum/dpotri.go
+++ b/lapack/gonum/dpotri.go
@@ -1,0 +1,42 @@
+// Copyright ©2019 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+import "gonum.org/v1/gonum/blas"
+
+// Dpotri computes the inverse of a real symmetric positive definite matrix A
+// using its Cholesky factorization.
+//
+// On entry, a contains the triangular factor U or L from the Cholesky
+// factorization A = U^T*U or A = L*L^T, as computed by Dpotrf.
+// On return, a contains the upper or lower triangle of the (symmetric)
+// inverse of A, overwriting the input factor U or L.
+func (impl Implementation) Dpotri(uplo blas.Uplo, n int, a []float64, lda int) (ok bool) {
+	switch {
+	case uplo != blas.Upper && uplo != blas.Lower:
+		panic(badUplo)
+	case n < 0:
+		panic(nLT0)
+	case lda < max(1, n):
+		panic(badLdA)
+	case len(a) < (n-1)*lda+n:
+		panic("lapack: a has insufficient length")
+	}
+
+	// Quick return if possible.
+	if n == 0 {
+		return true
+	}
+
+	// Invert the triangular Cholesky factor U or L.
+	ok = impl.Dtrtri(uplo, blas.NonUnit, n, a, lda)
+	if !ok {
+		return false
+	}
+
+	// Form inv(U)*inv(U)^T or inv(L)^T*inv(L).
+	impl.Dlauum(uplo, n, a, lda)
+	return true
+}

--- a/lapack/gonum/lapack_test.go
+++ b/lapack/gonum/lapack_test.go
@@ -384,6 +384,10 @@ func TestDpotrf(t *testing.T) {
 	testlapack.DpotrfTest(t, impl)
 }
 
+func TestDpotri(t *testing.T) {
+	testlapack.DpotriTest(t, impl)
+}
+
 func TestDpotrs(t *testing.T) {
 	testlapack.DpotrsTest(t, impl)
 }

--- a/lapack/lapack.go
+++ b/lapack/lapack.go
@@ -29,6 +29,7 @@ type Float64 interface {
 	Dormlq(side blas.Side, trans blas.Transpose, m, n, k int, a []float64, lda int, tau, c []float64, ldc int, work []float64, lwork int)
 	Dpocon(uplo blas.Uplo, n int, a []float64, lda int, anorm float64, work []float64, iwork []int) float64
 	Dpotrf(ul blas.Uplo, n int, a []float64, lda int) (ok bool)
+	Dpotri(ul blas.Uplo, n int, a []float64, lda int) (ok bool)
 	Dpotrs(ul blas.Uplo, n, nrhs int, a []float64, lda int, b []float64, ldb int)
 	Dsyev(jobz EVJob, uplo blas.Uplo, n int, a []float64, lda int, w, work []float64, lwork int) (ok bool)
 	Dtrcon(norm MatrixNorm, uplo blas.Uplo, diag blas.Diag, n int, a []float64, lda int, work []float64, iwork []int) float64

--- a/lapack/lapack64/lapack64.go
+++ b/lapack/lapack64/lapack64.go
@@ -37,6 +37,26 @@ func Potrf(a blas64.Symmetric) (t blas64.Triangular, ok bool) {
 	return
 }
 
+// Potri computes the inverse of a real symmetric positive definite matrix A
+// using its Cholesky factorization.
+//
+// On entry, t contains the triangular factor U or L from the Cholesky
+// factorization A = U^T*U or A = L*L^T, as computed by Potrf.
+//
+// On return, the upper or lower triangle of the (symmetric) inverse of A is
+// stored in t, overwriting the input factor U or L, and also returned in a. The
+// underlying data between a and t is shared.
+//
+// The returned bool indicates whether the inverse was computed successfully.
+func Potri(t blas64.Triangular) (a blas64.Symmetric, ok bool) {
+	ok = lapack64.Dpotri(t.Uplo, t.N, t.Data, t.Stride)
+	a.Uplo = t.Uplo
+	a.N = t.N
+	a.Data = t.Data
+	a.Stride = t.Stride
+	return
+}
+
 // Potrs solves a system of n linear equations A*X = B where A is an n×n
 // symmetric positive definite matrix and B is an n×nrhs matrix, using the
 // Cholesky factorization A = U^T*U or A = L*L^T. t contains the corresponding

--- a/lapack/testlapack/dgetri.go
+++ b/lapack/testlapack/dgetri.go
@@ -5,7 +5,6 @@
 package testlapack
 
 import (
-	"math"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -67,23 +66,8 @@ func DgetriTest(t *testing.T, impl Dgetrier) {
 		// Check that A(inv) * A = I.
 		ans := make([]float64, len(a))
 		bi.Dgemm(blas.NoTrans, blas.NoTrans, n, n, n, 1, aCopy, lda, a, lda, 0, ans, lda)
-		isEye := true
-		for i := 0; i < n; i++ {
-			for j := 0; j < n; j++ {
-				if i == j {
-					// This tolerance is so high because computing matrix inverses
-					// is very unstable.
-					if math.Abs(ans[i*lda+j]-1) > 5e-2 {
-						isEye = false
-					}
-				} else {
-					if math.Abs(ans[i*lda+j]) > 5e-2 {
-						isEye = false
-					}
-				}
-			}
-		}
-		if !isEye {
+		// The tolerance is so high because computing matrix inverses is very unstable.
+		if !isIdentity(n, ans, lda, 5e-2) {
 			t.Errorf("Inv(A) * A != I. n = %v, lda = %v", n, lda)
 		}
 	}

--- a/lapack/testlapack/dlarfg.go
+++ b/lapack/testlapack/dlarfg.go
@@ -104,21 +104,7 @@ func DlarfgTest(t *testing.T, impl Dlarfger) {
 			Data:   make([]float64, n*n),
 		}
 		blas64.Gemm(blas.Trans, blas.NoTrans, 1, hmat, hmat, 0, eye)
-		iseye := true
-		for i := 0; i < n; i++ {
-			for j := 0; j < n; j++ {
-				if i == j {
-					if math.Abs(eye.Data[i*n+j]-1) > 1e-14 {
-						iseye = false
-					}
-				} else {
-					if math.Abs(eye.Data[i*n+j]) > 1e-14 {
-						iseye = false
-					}
-				}
-			}
-		}
-		if !iseye {
+		if !isIdentity(n, eye.Data, n, 1e-14) {
 			t.Errorf("H^T * H is not I %v", eye)
 		}
 

--- a/lapack/testlapack/dlauu2.go
+++ b/lapack/testlapack/dlauu2.go
@@ -38,7 +38,6 @@ func dlauuTest(t *testing.T, dlauu func(blas.Uplo, int, []float64, int), uplo bl
 	rnd := rand.New(rand.NewSource(1))
 
 	for _, n := range ns {
-	loop:
 		for _, lda := range []int{max(1, n), n + 11} {
 			prefix := fmt.Sprintf("n=%v,lda=%v", n, lda)
 
@@ -59,27 +58,27 @@ func dlauuTest(t *testing.T, dlauu func(blas.Uplo, int, []float64, int), uplo bl
 				continue
 			}
 
-			// * Check that the triangle opposite to uplo has not been modified.
+			// * Check that the triangle of A opposite to uplo has not been modified.
 			// * Convert the result of Dlauu? into a dense symmetric matrix.
 			// * Zero out the triangle in aCopy opposite to uplo.
 			if uplo == blas.Upper {
+				if !sameLowerTri(n, aCopy, lda, a, lda) {
+					t.Errorf("%v: unexpected modification in lower triangle", prefix)
+					continue
+				}
 				for i := 1; i < n; i++ {
 					for j := 0; j < i; j++ {
-						if aCopy[i*lda+j] != a[i*lda+j] {
-							t.Errorf("%v: unexpected modification in lower triangle", prefix)
-							break loop
-						}
 						a[i*lda+j] = a[j*lda+i]
 						aCopy[i*lda+j] = 0
 					}
 				}
 			} else {
+				if !sameUpperTri(n, aCopy, lda, a, lda) {
+					t.Errorf("%v: unexpected modification in upper triangle", prefix)
+					continue
+				}
 				for i := 0; i < n-1; i++ {
 					for j := i + 1; j < n; j++ {
-						if aCopy[i*lda+j] != a[i*lda+j] {
-							t.Errorf("%v: unexpected modification in upper triangle", prefix)
-							break loop
-						}
 						a[i*lda+j] = a[j*lda+i]
 						aCopy[i*lda+j] = 0
 					}

--- a/lapack/testlapack/dpotri.go
+++ b/lapack/testlapack/dpotri.go
@@ -1,0 +1,108 @@
+// Copyright ©2019 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/exp/rand"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/blas64"
+)
+
+type Dpotrier interface {
+	Dpotri(uplo blas.Uplo, n int, a []float64, lda int) bool
+
+	Dpotrf(uplo blas.Uplo, n int, a []float64, lda int) bool
+}
+
+func DpotriTest(t *testing.T, impl Dpotrier) {
+	for _, uplo := range []blas.Uplo{blas.Upper, blas.Lower} {
+		name := "Upper"
+		if uplo == blas.Lower {
+			name = "Lower"
+		}
+		t.Run(name, func(t *testing.T) {
+			// Include small and large sizes to make sure that both
+			// unblocked and blocked paths are taken.
+			ns := []int{0, 1, 2, 3, 4, 5, 10, 25, 31, 32, 33, 63, 64, 65, 127, 128, 129}
+			const tol = 1e-12
+
+			bi := blas64.Implementation()
+			rnd := rand.New(rand.NewSource(1))
+			for _, n := range ns {
+				for _, lda := range []int{max(1, n), n + 11} {
+					prefix := fmt.Sprintf("n=%v,lda=%v", n, lda)
+
+					// Generate a random diagonal matrix D with positive entries.
+					d := make([]float64, n)
+					Dlatm1(d, 3, 10000, false, 2, rnd)
+
+					// Construct a positive definite matrix A as
+					//  A = U * D * U^T
+					// where U is a random orthogonal matrix.
+					a := make([]float64, n*lda)
+					Dlagsy(n, 0, d, a, lda, rnd, make([]float64, 2*n))
+					// Create a copy of A.
+					aCopy := make([]float64, len(a))
+					copy(aCopy, a)
+					// Compute the Cholesky factorization of A.
+					ok := impl.Dpotrf(uplo, n, a, lda)
+					if !ok {
+						t.Fatalf("%v: unexpected Cholesky failure", prefix)
+					}
+
+					// Compute the inverse inv(A).
+					ok = impl.Dpotri(uplo, n, a, lda)
+					if !ok {
+						t.Errorf("%v: unexpected failure", prefix)
+						continue
+					}
+
+					// Check that the triangle of A opposite to uplo has not been modified.
+					if uplo == blas.Upper && !sameLowerTri(n, aCopy, lda, a, lda) {
+						t.Errorf("%v: unexpected modification in lower triangle", prefix)
+						continue
+					}
+					if uplo == blas.Lower && !sameUpperTri(n, aCopy, lda, a, lda) {
+						t.Errorf("%v: unexpected modification in upper triangle", prefix)
+						continue
+					}
+
+					// Change notation for the sake of clarity.
+					ainv := a
+					ldainv := lda
+
+					// Expand ainv into a full dense matrix so that we can call Dsymm below.
+					if uplo == blas.Upper {
+						for i := 1; i < n; i++ {
+							for j := 0; j < i; j++ {
+								ainv[i*ldainv+j] = ainv[j*ldainv+i]
+							}
+						}
+					} else {
+						for i := 0; i < n-1; i++ {
+							for j := i + 1; j < n; j++ {
+								ainv[i*ldainv+j] = ainv[j*ldainv+i]
+							}
+						}
+					}
+
+					// Compute A*inv(A) and store the result into want.
+					ldwant := max(1, n)
+					want := make([]float64, n*ldwant)
+					bi.Dsymm(blas.Left, uplo, n, n, 1, aCopy, lda, ainv, ldainv, 0, want, ldwant)
+
+					// Check that want is the identity matrix.
+					if !isIdentity(n, want, ldwant, tol) {
+						t.Errorf("%v: A * inv(A) != I", prefix)
+					}
+				}
+			}
+		})
+	}
+}

--- a/lapack/testlapack/dtrti2.go
+++ b/lapack/testlapack/dtrti2.go
@@ -5,7 +5,6 @@
 package testlapack
 
 import (
-	"math"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -149,23 +148,7 @@ func Dtrti2Test(t *testing.T, impl Dtrti2er) {
 				ans := make([]float64, len(a))
 				bi.Dgemm(blas.NoTrans, blas.NoTrans, n, n, n, 1, a, lda, aCopy, lda, 0, ans, lda)
 				// Check that ans is the identity matrix.
-				iseye := true
-				for i := 0; i < n; i++ {
-					for j := 0; j < n; j++ {
-						if i == j {
-							if math.Abs(ans[i*lda+i]-1) > tol {
-								iseye = false
-								break
-							}
-						} else {
-							if math.Abs(ans[i*lda+j]) > tol {
-								iseye = false
-								break
-							}
-						}
-					}
-				}
-				if !iseye {
+				if !isIdentity(n, ans, lda, tol) {
 					t.Errorf("inv(A) * A != I. Upper = %v, unit = %v, ans = %v", uplo == blas.Upper, diag == blas.Unit, ans)
 				}
 			}

--- a/lapack/testlapack/dtrtri.go
+++ b/lapack/testlapack/dtrtri.go
@@ -5,7 +5,6 @@
 package testlapack
 
 import (
-	"math"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -80,23 +79,7 @@ func DtrtriTest(t *testing.T, impl Dtrtrier) {
 				ans := make([]float64, len(a))
 				bi.Dgemm(blas.NoTrans, blas.NoTrans, n, n, n, 1, a, lda, aCopy, lda, 0, ans, lda)
 				// Check that ans is the identity matrix.
-				iseye := true
-				for i := 0; i < n; i++ {
-					for j := 0; j < n; j++ {
-						if i == j {
-							if math.Abs(ans[i*lda+i]-1) > tol {
-								iseye = false
-								break
-							}
-						} else {
-							if math.Abs(ans[i*lda+j]) > tol {
-								iseye = false
-								break
-							}
-						}
-					}
-				}
-				if !iseye {
+				if !isIdentity(n, ans, lda, tol) {
 					t.Errorf("inv(A) * A != I. Upper = %v, unit = %v, n = %v, lda = %v",
 						uplo == blas.Upper, diag == blas.Unit, n, lda)
 				}

--- a/lapack/testlapack/general.go
+++ b/lapack/testlapack/general.go
@@ -1464,3 +1464,28 @@ func constructGSVPresults(n, p, m, k, l int, a, b blas64.General) (zeroA, zeroB 
 
 	return zeroA, zeroB
 }
+
+// isIdentity returns whether an n×n matrix A is approximately equal to the
+// identity matrix.
+func isIdentity(n int, a []float64, lda int, tol float64) bool {
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			aij := a[i*lda+j]
+			if math.IsNaN(aij) {
+				return false
+			}
+			if i == j {
+				if math.Abs(aij-1) > tol {
+					fmt.Println(i, j, aij)
+					return false
+				}
+			} else {
+				if math.Abs(aij) > tol {
+					fmt.Println(i, j, aij)
+					return false
+				}
+			}
+		}
+	}
+	return true
+}

--- a/lapack/testlapack/general.go
+++ b/lapack/testlapack/general.go
@@ -1489,3 +1489,35 @@ func isIdentity(n int, a []float64, lda int, tol float64) bool {
 	}
 	return true
 }
+
+func sameFloat64(a, b float64) bool {
+	return a == b || math.IsNaN(a) && math.IsNaN(b)
+}
+
+// sameLowerTri returns whether n×n matrices A and B are same under the diagonal.
+func sameLowerTri(n int, a []float64, lda int, b []float64, ldb int) bool {
+	for i := 1; i < n; i++ {
+		for j := 0; j < i; j++ {
+			aij := a[i*lda+j]
+			bij := b[i*ldb+j]
+			if !sameFloat64(aij, bij) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// sameUpperTri returns whether n×n matrices A and B are same above the diagonal.
+func sameUpperTri(n int, a []float64, lda int, b []float64, ldb int) bool {
+	for i := 0; i < n-1; i++ {
+		for j := i + 1; j < n; j++ {
+			aij := a[i*lda+j]
+			bij := b[i*ldb+j]
+			if !sameFloat64(aij, bij) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/mat/cholesky_test.go
+++ b/mat/cholesky_test.go
@@ -616,3 +616,31 @@ func BenchmarkCholeskyToSym(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkCholeskyInverseTo(b *testing.B) {
+	for _, n := range []int{10, 100, 1000} {
+		b.Run("n="+strconv.Itoa(n), func(b *testing.B) {
+			rnd := rand.New(rand.NewSource(1))
+
+			data := make([]float64, n*n)
+			for i := range data {
+				data[i] = rnd.NormFloat64()
+			}
+			var a SymDense
+			a.SymOuterK(1, NewDense(n, n, data))
+
+			var chol Cholesky
+			ok := chol.Factorize(&a)
+			if !ok {
+				panic("not positive definite")
+			}
+
+			dst := NewSymDense(n, nil)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				chol.InverseTo(dst)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`Dlauum` has a use after all.

Please take a look.

```
name                        old time/op  new time/op  delta
CholeskyInverseTo/n=10-4    10.8µs ± 2%   3.2µs ± 1%  -70.16%  (p=0.008 n=5+5)
CholeskyInverseTo/n=100-4   1.07ms ± 2%  0.51ms ± 2%  -52.06%  (p=0.008 n=5+5)
CholeskyInverseTo/n=1000-4   713ms ± 1%   315ms ± 1%  -55.83%  (p=0.008 n=5+5)
```

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
