### PR TITLE
graph/encoding/dot: (un)quote attributes if needed during (un)marshal

### DIFF
--- a/graph/encoding/dot/decode.go
+++ b/graph/encoding/dot/decode.go
@@ -43,16 +43,9 @@ type PortSetter interface {
 // If the number of graphs encoded in data is not one, an error is returned and
 // dst will hold the first graph in data.
 //
-// Attributes that are not IDs are quoted during marshalling, to conform with
-// valid DOT syntax. A DOT ID is in one of four forms:
-//
-//    1. identifier
-//    2. numerals
-//    3. quoted string
-//    4. HTML string
-//
-// Quoted attributes are unquoted during unmarshaling, so the data is kept in
-// raw form.
+// Attributes and IDs are quoted if needed during marshalling, to conform with
+// valid DOT syntax. Quoted IDs and attributes are unquoted during unmarshaling,
+// so the data is kept in raw form.
 func Unmarshal(data []byte, dst encoding.Builder) error {
 	file, err := dot.ParseBytes(data)
 	if err != nil {
@@ -70,16 +63,9 @@ func Unmarshal(data []byte, dst encoding.Builder) error {
 // If the number of graphs encoded in data is not one, an error is returned and
 // dst will hold the first graph in data.
 //
-// Attributes that are not IDs are quoted during marshalling, to conform with
-// valid DOT syntax. A DOT ID is in one of four forms:
-//
-//    1. identifier
-//    2. numerals
-//    3. quoted string
-//    4. HTML string
-//
-// Quoted attributes are unquoted during unmarshaling, so the data is kept in
-// raw form.
+// Attributes and IDs are quoted if needed during marshalling, to conform with
+// valid DOT syntax. Quoted IDs and attributes are unquoted during unmarshaling,
+// so the data is kept in raw form.
 func UnmarshalMulti(data []byte, dst encoding.MultiBuilder) error {
 	file, err := dot.ParseBytes(data)
 	if err != nil {

--- a/graph/encoding/dot/decode.go
+++ b/graph/encoding/dot/decode.go
@@ -7,6 +7,7 @@ package dot
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/encoding"
@@ -506,6 +507,12 @@ func addEdgeAttrs(edge graph.Edge, attrs []*ast.Attr) {
 // unquoteID unquotes the given string if needed in the context of an ID. If s
 // is not already quoted the original string is returned.
 func unquoteID(s string) string {
+	// To make round-trips idempotent, don't unquote quoted HTML-like strings
+	//
+	//    /^"<.*>"$/
+	if len(s) >= 4 && strings.HasPrefix(s, `"<`) && strings.HasSuffix(s, `>"`) {
+		return s
+	}
 	// Unquote quoted string if possible.
 	if t, err := strconv.Unquote(s); err == nil {
 		return t

--- a/graph/encoding/dot/decode_test.go
+++ b/graph/encoding/dot/decode_test.go
@@ -43,6 +43,14 @@ func TestRoundTrip(t *testing.T) {
 			want:     undirectedWithPorts,
 			directed: false,
 		},
+		{
+			want:     directedAttrs,
+			directed: true,
+		},
+		{
+			want:     undirectedAttrs,
+			directed: false,
+		},
 	}
 	for i, g := range golden {
 		var dst encoding.Builder
@@ -163,6 +171,46 @@ const undirectedWithPorts = `strict graph {
 	D:foo:n -- E:bar:s;
 	D:e -- F:bar:w;
 	E:_ -- F:c;
+}`
+
+const directedAttrs = `strict digraph {
+	node [
+		shape=circle
+		style=filled
+		label="NODE"
+	];
+	edge [
+		penwidth=5
+		color=gray
+		label=3.14
+	];
+
+	// Node definitions.
+	A [label=<br>];
+	B [label=-14];
+
+	// Edge definitions.
+	A -> B [label="hello world"];
+}`
+
+const undirectedAttrs = `strict graph {
+	node [
+		shape=circle
+		style=filled
+		label="NODE"
+	];
+	edge [
+		penwidth=5
+		color=gray
+		label=3.14
+	];
+
+	// Node definitions.
+	A [label=<br>];
+	B [label=-14];
+
+	// Edge definitions.
+	A -- B [label="hello world"];
 }`
 
 func TestChainedEdgeAttributes(t *testing.T) {

--- a/graph/encoding/dot/encode.go
+++ b/graph/encoding/dot/encode.go
@@ -111,8 +111,7 @@ func Marshal(g graph.Graph, name, prefix, indent string) ([]byte, error) {
 // MarshalMulti returns the DOT encoding for the multigraph g, applying the
 // prefix and indent to the encoding. Name is used to specify the graph name. If
 // name is empty and g implements Graph, the returned string from DOTID will be
-// used. If strict is true the output bytes will be prefixed with the DOT
-// "strict" keyword.
+// used.
 //
 // Graph serialization will work for a graph.Multigraph without modification,
 // however, advanced GraphViz DOT features provided by Marshal depend on

--- a/graph/encoding/dot/encode.go
+++ b/graph/encoding/dot/encode.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"gonum.org/v1/gonum/graph"
@@ -356,7 +357,7 @@ func (p *printer) writeAttributeList(a encoding.Attributer) {
 		p.buf.WriteString(" [")
 		p.buf.WriteString(attributes[0].Key)
 		p.buf.WriteByte('=')
-		p.buf.WriteString(attributes[0].Value)
+		p.buf.WriteString(quoteAttr(attributes[0].Value))
 		p.buf.WriteString("]")
 	default:
 		p.openBlock(" [")
@@ -364,7 +365,7 @@ func (p *printer) writeAttributeList(a encoding.Attributer) {
 			p.newline()
 			p.buf.WriteString(att.Key)
 			p.buf.WriteByte('=')
-			p.buf.WriteString(att.Value)
+			p.buf.WriteString(quoteAttr(att.Value))
 		}
 		p.closeBlock("]")
 	}
@@ -390,7 +391,7 @@ func (p *printer) writeAttributeComplex(ca Attributers) {
 			p.newline()
 			p.buf.WriteString(att.Key)
 			p.buf.WriteByte('=')
-			p.buf.WriteString(att.Value)
+			p.buf.WriteString(quoteAttr(att.Value))
 		}
 		p.closeBlock("]")
 		haveWrittenBlock = true
@@ -579,4 +580,19 @@ func (p *multiGraphPrinter) print(g graph.Multigraph, name string, needsIndent, 
 	p.closeBlock("}")
 
 	return nil
+}
+
+// quoteAttr quotes the given string if needed in the context of an attribute
+// value. If s is already quoted, or if s does not contain any spaces or special
+// characters that need escaping, the original string is returned.
+func quoteAttr(s string) string {
+	if len(s) >= 2 && strings.HasPrefix(s, `"`) && strings.HasSuffix(s, `"`) {
+		// String already quoted.
+		return s
+	}
+	// TODO: Check if more characters need escaping.
+	if strings.ContainsAny(s, " ") {
+		return strconv.Quote(s)
+	}
+	return s
 }

--- a/graph/encoding/dot/encode.go
+++ b/graph/encoding/dot/encode.go
@@ -617,6 +617,8 @@ func isKeyword(s string) bool {
 	return false
 }
 
+// FIXME: see if we rewrite this in another way to remove our regexp dependency.
+
 // Regular expression to match identifier and numeral IDs.
 var (
 	reIdent   = regexp.MustCompile(`^[a-zA-Z\200-\377_][0-9a-zA-Z\200-\377_]*$`)

--- a/graph/encoding/dot/encode.go
+++ b/graph/encoding/dot/encode.go
@@ -84,26 +84,18 @@ type MultiSubgrapher interface {
 	Subgraph() graph.Multigraph
 }
 
-// Marshal returns the DOT encoding for the graph g, applying the prefix
-// and indent to the encoding. Name is used to specify the graph name. If
-// name is empty and g implements Graph, the returned string from DOTID
-// will be used.
+// Marshal returns the DOT encoding for the graph g, applying the prefix and
+// indent to the encoding. Name is used to specify the graph name. If name is
+// empty and g implements Graph, the returned string from DOTID will be used.
 //
 // Graph serialization will work for a graph.Graph without modification,
 // however, advanced GraphViz DOT features provided by Marshal depend on
 // implementation of the Node, Attributer, Porter, Attributers, Structurer,
 // Subgrapher and Graph interfaces.
 //
-// Attributes that are not IDs are quoted during marshalling, to conform with
-// valid DOT syntax. A DOT ID is in one of four forms:
-//
-//    1. identifier
-//    2. numerals
-//    3. quoted string
-//    4. HTML string
-//
-// Quoted attributes are unquoted during unmarshaling, so the data is kept in
-// raw form.
+// Attributes and IDs are quoted if needed during marshalling, to conform with
+// valid DOT syntax. Quoted IDs and attributes are unquoted during unmarshaling,
+// so the data is kept in raw form.
 func Marshal(g graph.Graph, name, prefix, indent string) ([]byte, error) {
 	var p simpleGraphPrinter
 	p.indent = indent
@@ -118,25 +110,18 @@ func Marshal(g graph.Graph, name, prefix, indent string) ([]byte, error) {
 
 // MarshalMulti returns the DOT encoding for the multigraph g, applying the
 // prefix and indent to the encoding. Name is used to specify the graph name. If
-// name is empty and g implements Graph, the returned string from DOTID
-// will be used. If strict is true the output bytes will be prefixed with
-// the DOT "strict" keyword.
+// name is empty and g implements Graph, the returned string from DOTID will be
+// used. If strict is true the output bytes will be prefixed with the DOT
+// "strict" keyword.
 //
 // Graph serialization will work for a graph.Multigraph without modification,
 // however, advanced GraphViz DOT features provided by Marshal depend on
 // implementation of the Node, Attributer, Porter, Attributers, Structurer,
 // MultiSubgrapher and Multigraph interfaces.
 //
-// Attributes that are not IDs are quoted during marshalling, to conform with
-// valid DOT syntax. A DOT ID is in one of four forms:
-//
-//    1. identifier
-//    2. numerals
-//    3. quoted string
-//    4. HTML string
-//
-// Quoted attributes are unquoted during unmarshaling, so the data is kept in
-// raw form.
+// Attributes and IDs are quoted if needed during marshalling, to conform with
+// valid DOT syntax. Quoted IDs and attributes are unquoted during unmarshaling,
+// so the data is kept in raw form.
 func MarshalMulti(g graph.Multigraph, name, prefix, indent string) ([]byte, error) {
 	var p multiGraphPrinter
 	p.indent = indent

--- a/graph/encoding/dot/encode.go
+++ b/graph/encoding/dot/encode.go
@@ -346,7 +346,7 @@ func (p *printer) writeNode(n graph.Node) {
 func (p *printer) writePorts(port, cp string) {
 	if port != "" {
 		p.buf.WriteByte(':')
-		p.buf.WriteString(port)
+		p.buf.WriteString(quoteID(port))
 	}
 	if cp != "" {
 		p.buf.WriteByte(':')

--- a/graph/encoding/dot/encode_test.go
+++ b/graph/encoding/dot/encode_test.go
@@ -950,6 +950,35 @@ var encodeTests = []struct {
 	3 -- 4 [color=red];
 }`,
 	},
+	{
+		g: undirectedEdgeAttrGraphFrom(powerMethodGraph, map[edge][]encoding.Attribute{
+			// label attributed not quoted and containing spaces.
+			{from: 0, to: 2}: {{Key: "label", Value: `hello world`}, {Key: "style", Value: "dashed"}},
+			{from: 2, to: 4}: {},
+			{from: 3, to: 4}: {{Key: "label", Value: `foo bar`}},
+		}),
+
+		want: `strict graph {
+	// Node definitions.
+	0;
+	1;
+	2;
+	3;
+	4;
+
+	// Edge definitions.
+	0 -- 1;
+	0 -- 2 [
+		label="hello world"
+		style=dashed
+	];
+	0 -- 4;
+	1 -- 3;
+	2 -- 3;
+	2 -- 4;
+	3 -- 4 [label="foo bar"];
+}`,
+	},
 
 	// Handling nodes with ports.
 	{

--- a/graph/encoding/dot/encode_test.go
+++ b/graph/encoding/dot/encode_test.go
@@ -979,6 +979,35 @@ var encodeTests = []struct {
 	3 -- 4 [label="foo bar"];
 }`,
 	},
+	{
+		g: undirectedEdgeAttrGraphFrom(powerMethodGraph, map[edge][]encoding.Attribute{
+			// keywords must be quoted if used as attributes.
+			{from: 0, to: 2}: {{Key: "label", Value: `NODE`}, {Key: "style", Value: "dashed"}},
+			{from: 2, to: 4}: {},
+			{from: 3, to: 4}: {{Key: "label", Value: `subgraph`}},
+		}),
+
+		want: `strict graph {
+	// Node definitions.
+	0;
+	1;
+	2;
+	3;
+	4;
+
+	// Edge definitions.
+	0 -- 1;
+	0 -- 2 [
+		label="NODE"
+		style=dashed
+	];
+	0 -- 4;
+	1 -- 3;
+	2 -- 3;
+	2 -- 4;
+	3 -- 4 [label="subgraph"];
+}`,
+	},
 
 	// Handling nodes with ports.
 	{

--- a/graph/encoding/dot/encode_test.go
+++ b/graph/encoding/dot/encode_test.go
@@ -952,7 +952,7 @@ var encodeTests = []struct {
 	},
 	{
 		g: undirectedEdgeAttrGraphFrom(powerMethodGraph, map[edge][]encoding.Attribute{
-			// label attributed not quoted and containing spaces.
+			// label attribute not quoted and containing spaces.
 			{from: 0, to: 2}: {{Key: "label", Value: `hello world`}, {Key: "style", Value: "dashed"}},
 			{from: 2, to: 4}: {},
 			{from: 3, to: 4}: {{Key: "label", Value: `foo bar`}},

--- a/graph/encoding/graphql/decode_test.go
+++ b/graph/encoding/graphql/decode_test.go
@@ -34,33 +34,33 @@ var decodeTests = []struct {
 		},
 		wantDOT: `strict digraph {
   // Node definitions.
-  0x8a10d5a2611fd03f [name="Richard Marquand"];
-  0xa3cff1a4c3ef3bb6 [
+  "0x8a10d5a2611fd03f" [name="Richard Marquand"];
+  "0xa3cff1a4c3ef3bb6" [
     name="Star Wars: Episode V - The Empire Strikes Back"
-    release_date=1980-05-21T00:00:00Z
+    release_date="1980-05-21T00:00:00Z"
     revenue=534000000
     running_time=124
   ];
-  0xb39aa14d66aedad5 [
+  "0xb39aa14d66aedad5" [
     name="Star Wars: Episode VI - Return of the Jedi"
-    release_date=1983-05-25T00:00:00Z
+    release_date="1983-05-25T00:00:00Z"
     revenue=572000000
     running_time=131
   ];
-  0x0312de17a7ee89f9 [name="Luke Skywalker"];
-  0x3da8d1dcab1bb381 [name="Han Solo"];
-  0x4a7d0b5fe91e78a4 [name="Irvin Kernshner"];
-  0x718337b9dcbaa7d9 [name="Princess Leia"];
+  "0x0312de17a7ee89f9" [name="Luke Skywalker"];
+  "0x3da8d1dcab1bb381" [name="Han Solo"];
+  "0x4a7d0b5fe91e78a4" [name="Irvin Kernshner"];
+  "0x718337b9dcbaa7d9" [name="Princess Leia"];
 
   // Edge definitions.
-  0xa3cff1a4c3ef3bb6 -> 0x0312de17a7ee89f9 [label=starring];
-  0xa3cff1a4c3ef3bb6 -> 0x3da8d1dcab1bb381 [label=starring];
-  0xa3cff1a4c3ef3bb6 -> 0x4a7d0b5fe91e78a4 [label=director];
-  0xa3cff1a4c3ef3bb6 -> 0x718337b9dcbaa7d9 [label=starring];
-  0xb39aa14d66aedad5 -> 0x8a10d5a2611fd03f [label=director];
-  0xb39aa14d66aedad5 -> 0x0312de17a7ee89f9 [label=starring];
-  0xb39aa14d66aedad5 -> 0x3da8d1dcab1bb381 [label=starring];
-  0xb39aa14d66aedad5 -> 0x718337b9dcbaa7d9 [label=starring];
+  "0xa3cff1a4c3ef3bb6" -> "0x0312de17a7ee89f9" [label=starring];
+  "0xa3cff1a4c3ef3bb6" -> "0x3da8d1dcab1bb381" [label=starring];
+  "0xa3cff1a4c3ef3bb6" -> "0x4a7d0b5fe91e78a4" [label=director];
+  "0xa3cff1a4c3ef3bb6" -> "0x718337b9dcbaa7d9" [label=starring];
+  "0xb39aa14d66aedad5" -> "0x8a10d5a2611fd03f" [label=director];
+  "0xb39aa14d66aedad5" -> "0x0312de17a7ee89f9" [label=starring];
+  "0xb39aa14d66aedad5" -> "0x3da8d1dcab1bb381" [label=starring];
+  "0xb39aa14d66aedad5" -> "0x718337b9dcbaa7d9" [label=starring];
 }`,
 	},
 	{
@@ -72,52 +72,52 @@ var decodeTests = []struct {
 		},
 		wantDOT: `strict digraph {
   // Node definitions.
-  0x892a6da7ee1fbdec [
+  "0x892a6da7ee1fbdec" [
     age=55
     name=Sarah
   ];
-  0x99b74c1b5ab100ec [
+  "0x99b74c1b5ab100ec" [
     age=35
     name=Artyom
   ];
-  0xb9e12a67e34d6acc [
+  "0xb9e12a67e34d6acc" [
     age=19
     name=Catalina
   ];
-  0xbf104824c777525d [name=Perro];
-  0xf590a923ea1fccaa [name=Goldie];
-  0xf92d7dbe272d680b [name="Hyung Sin"];
-  0x0fd90205a458151f [
+  "0xbf104824c777525d" [name=Perro];
+  "0xf590a923ea1fccaa" [name=Goldie];
+  "0xf92d7dbe272d680b" [name="Hyung Sin"];
+  "0x0fd90205a458151f" [
     age=39
     name=Michael
   ];
-  0x37734fcf0a6fcc69 [name="Rammy the sheep"];
-  0x52a80955d40ec819 [
+  "0x37734fcf0a6fcc69" [name="Rammy the sheep"];
+  "0x52a80955d40ec819" [
     age=35
     name=Amit
   ];
-  0x5e9ad1cd9466228c [
+  "0x5e9ad1cd9466228c" [
     age=24
     name="Sang Hyun"
   ];
 
   // Edge definitions.
-  0xb9e12a67e34d6acc -> 0xbf104824c777525d [label=owns_pet];
-  0xb9e12a67e34d6acc -> 0x5e9ad1cd9466228c [label=friend];
-  0xf92d7dbe272d680b -> 0x5e9ad1cd9466228c [label=friend];
-  0x0fd90205a458151f -> 0x892a6da7ee1fbdec [label=friend];
-  0x0fd90205a458151f -> 0x99b74c1b5ab100ec [label=friend];
-  0x0fd90205a458151f -> 0xb9e12a67e34d6acc [label=friend];
-  0x0fd90205a458151f -> 0x37734fcf0a6fcc69 [label=owns_pet];
-  0x0fd90205a458151f -> 0x52a80955d40ec819 [label=friend];
-  0x0fd90205a458151f -> 0x5e9ad1cd9466228c [label=friend];
-  0x52a80955d40ec819 -> 0x99b74c1b5ab100ec [label=friend];
-  0x52a80955d40ec819 -> 0x0fd90205a458151f [label=friend];
-  0x52a80955d40ec819 -> 0x5e9ad1cd9466228c [label=friend];
-  0x5e9ad1cd9466228c -> 0xb9e12a67e34d6acc [label=friend];
-  0x5e9ad1cd9466228c -> 0xf590a923ea1fccaa [label=owns_pet];
-  0x5e9ad1cd9466228c -> 0xf92d7dbe272d680b [label=friend];
-  0x5e9ad1cd9466228c -> 0x52a80955d40ec819 [label=friend];
+  "0xb9e12a67e34d6acc" -> "0xbf104824c777525d" [label=owns_pet];
+  "0xb9e12a67e34d6acc" -> "0x5e9ad1cd9466228c" [label=friend];
+  "0xf92d7dbe272d680b" -> "0x5e9ad1cd9466228c" [label=friend];
+  "0x0fd90205a458151f" -> "0x892a6da7ee1fbdec" [label=friend];
+  "0x0fd90205a458151f" -> "0x99b74c1b5ab100ec" [label=friend];
+  "0x0fd90205a458151f" -> "0xb9e12a67e34d6acc" [label=friend];
+  "0x0fd90205a458151f" -> "0x37734fcf0a6fcc69" [label=owns_pet];
+  "0x0fd90205a458151f" -> "0x52a80955d40ec819" [label=friend];
+  "0x0fd90205a458151f" -> "0x5e9ad1cd9466228c" [label=friend];
+  "0x52a80955d40ec819" -> "0x99b74c1b5ab100ec" [label=friend];
+  "0x52a80955d40ec819" -> "0x0fd90205a458151f" [label=friend];
+  "0x52a80955d40ec819" -> "0x5e9ad1cd9466228c" [label=friend];
+  "0x5e9ad1cd9466228c" -> "0xb9e12a67e34d6acc" [label=friend];
+  "0x5e9ad1cd9466228c" -> "0xf590a923ea1fccaa" [label=owns_pet];
+  "0x5e9ad1cd9466228c" -> "0xf92d7dbe272d680b" [label=friend];
+  "0x5e9ad1cd9466228c" -> "0x52a80955d40ec819" [label=friend];
 }`,
 	},
 	{


### PR DESCRIPTION
Add test case for encoding. The decoding test cases already
contained round-trip tests that trigger the unquote if
quoted code path.

Fixes #792.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
