### PR TITLE
encoding/dot: ensure that generated DOT is syntactically valid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,11 @@ before_install:
  # Required for dot parser checks.
  - ./.travis/install-gocc.sh 0e2cfc030005b281b2e5a2de04fa7fe1d5063722
 
+addons:
+  apt:
+    packages:
+     - graphviz
+
 go_import_path: gonum.org/v1/gonum
 
 # Get deps, build, test, and ensure the code is gofmt'ed.

--- a/graph/encoding/dot/encode_test.go
+++ b/graph/encoding/dot/encode_test.go
@@ -5,6 +5,8 @@
 package dot
 
 import (
+	"bytes"
+	"os/exec"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -1474,6 +1476,7 @@ func TestEncode(t *testing.T) {
 		if string(got) != test.want {
 			t.Errorf("unexpected DOT result for test %d:\ngot: %s\nwant:%s", i, got, test.want)
 		}
+		checkDOT(t, got)
 	}
 }
 
@@ -1729,5 +1732,24 @@ func TestEncodeMulti(t *testing.T) {
 		if string(got) != test.want {
 			t.Errorf("unexpected DOT result for test %d:\ngot: %s\nwant:%s", i, got, test.want)
 		}
+		checkDOT(t, got)
+	}
+}
+
+// checkDOT hands b to the dot executable if it exists and fails t if dot
+// returns an error.
+func checkDOT(t *testing.T, b []byte) {
+	dot, err := exec.LookPath("dot")
+	if err != nil {
+		t.Logf("skipping DOT syntax check: %v", err)
+		return
+	}
+	cmd := exec.Command(dot)
+	cmd.Stdin = bytes.NewReader(b)
+	stderr := &bytes.Buffer{}
+	cmd.Stderr = stderr
+	err = cmd.Run()
+	if err != nil {
+		t.Errorf("invalid DOT syntax: %v\n%s\ninput:\n%s", err, stderr.String(), b)
 	}
 }


### PR DESCRIPTION
Please take a look.

I would like to add the same check to the graphql tests, but they currently fail and will do so until the quoting PR is merged. So I'll leave until after that (or you can add it in there - unfortunately we need to just copy/paste this check function).

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
