### PR TITLE
coveralls: don't run coverage tests verbosely

### DIFF
--- a/.travis/test-coverage.sh
+++ b/.travis/test-coverage.sh
@@ -4,7 +4,7 @@ PROFILE_OUT=$PWD/profile.out
 ACC_OUT=$PWD/acc.out
 
 testCover() {
-	# set the return value to 0 (succesful)
+	# set the return value to 0 (successful)
 	retval=0
 	# get the directory to check from the parameter. Default to '.'
 	d=${1:-.}
@@ -13,7 +13,7 @@ testCover() {
 	# switch to the directory to check
 	pushd $d > /dev/null
 	# create the coverage profile
-	coverageresult=`go test -v $TAGS -coverprofile=$PROFILE_OUT`
+	coverageresult=`go test $TAGS -coverprofile=$PROFILE_OUT`
 	# output the result so we can check the shell output
 	echo ${coverageresult}
 	# append the results to acc.out if coverage didn't fail, else set the retval to 1 (failed)


### PR DESCRIPTION
This reduces the amount of output from running coverage tests, improving readability and reducing log output.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
