### PR TITLE
travis: use build caching and don't force complete rebuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,8 @@ script:
  - go get -d -t -v ./...
  - go build -v ./...
  - go test $TAGS -v ./...
- - if [[ $TRAVIS_SECURE_ENV_VARS = "true" ]]; then bash ./.travis/test-coverage.sh; fi
+ # Only run test coverage analysis if we are secure and on master.
+ - if [[ "${TRAVIS_BRANCH}" == master && "${TRAVIS_SECURE_ENV_VARS}" == true ]]; then bash ./.travis/test-coverage.sh; fi
  - ${TRAVIS_BUILD_DIR}/.travis/check-imports.sh
  # This is run last since it alters the tree.
  - ${TRAVIS_BUILD_DIR}/.travis/check-generate.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,8 @@ script:
  - go get -d -t -v ./...
  - go build -v ./...
  - go test $TAGS -v ./...
- # Only run test coverage analysis if we are secure and on master.
- - if [[ "${TRAVIS_BRANCH}" == master && "${TRAVIS_SECURE_ENV_VARS}" == true ]]; then bash ./.travis/test-coverage.sh; fi
+ # Only run test coverage analysis if we are secure and even with origin master.
+ - if [[ "${TRAVIS_SECURE_ENV_VARS}" == true && "$(git ls-remote origin master | cut -f1)" == "$(git rev-parse HEAD)" ]]; then bash ./.travis/test-coverage.sh; fi
  - ${TRAVIS_BUILD_DIR}/.travis/check-imports.sh
  # This is run last since it alters the tree.
  - ${TRAVIS_BUILD_DIR}/.travis/check-generate.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,14 @@ env:
  - TAGS="-tags noasm"
  - TAGS="-tags appengine"
 
+cache:
+ directories:
+   - $HOME/.cache/go-build
+   - $HOME/gopath/pkg/mod
+
+git:
+ depth: 1
+
 matrix:
  fast_finish: true
  allow_failures:
@@ -48,7 +56,7 @@ script:
  - ${TRAVIS_BUILD_DIR}/.travis/check-formatting.sh
  - go get -d -t -v ./...
  - go build -v ./...
- - go test -a $TAGS -v ./...
+ - go test $TAGS -v ./...
  - if [[ $TRAVIS_SECURE_ENV_VARS = "true" ]]; then bash ./.travis/test-coverage.sh; fi
  - ${TRAVIS_BUILD_DIR}/.travis/check-imports.sh
  # This is run last since it alters the tree.


### PR DESCRIPTION
This is an alternative to #800. I have confirmed that per matrix-factor-state caching is done by Travis (documented [here](https://docs.travis-ci.com/user/caching/#caches-and-build-matrices) and confirmed by experimentation). This change thus gives us both caching speed up and an informative display of build success states.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
