### PR TITLE
lapack/testlapack: use testing Logf instead of log.Printf

### DIFF
--- a/lapack/testlapack/dgecon.go
+++ b/lapack/testlapack/dgecon.go
@@ -5,7 +5,6 @@
 package testlapack
 
 import (
-	"log"
 	"testing"
 
 	"gonum.org/v1/gonum/floats"
@@ -86,12 +85,12 @@ func DgeconTest(t *testing.T, impl Dgeconer) {
 		if !floats.EqualWithinAbsOrRel(condOne, test.condOne, 1e0, 1e0) {
 			t.Errorf("One norm mismatch. Want %v, got %v.", test.condOne, condOne)
 		} else if !floats.EqualWithinAbsOrRel(condOne, test.condOne, 1e-14, 1e-14) {
-			log.Printf("Dgecon one norm mismatch. Want %v, got %v.", test.condOne, condOne)
+			t.Logf("Dgecon one norm mismatch. Want %v, got %v.", test.condOne, condOne)
 		}
 		if !floats.EqualWithinAbsOrRel(condInf, test.condInf, 1e0, 1e0) {
 			t.Errorf("One norm mismatch. Want %v, got %v.", test.condInf, condInf)
 		} else if !floats.EqualWithinAbsOrRel(condInf, test.condInf, 1e-14, 1e-14) {
-			log.Printf("Dgecon one norm mismatch. Want %v, got %v.", test.condInf, condInf)
+			t.Logf("Dgecon one norm mismatch. Want %v, got %v.", test.condInf, condInf)
 		}
 	}
 }


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
