### PR TITLE
testblas: use testing Log instead of log.Println

### DIFF
--- a/blas/testblas/level1double.go
+++ b/blas/testblas/level1double.go
@@ -6,13 +6,11 @@ package testblas
 
 import (
 	"fmt"
-	"log"
+	"math"
+	"testing"
 
 	"gonum.org/v1/gonum/blas"
 	"gonum.org/v1/gonum/floats"
-
-	"math"
-	"testing"
 )
 
 type DoubleOneVectorCase struct {
@@ -1433,7 +1431,7 @@ func IdamaxTest(t *testing.T, blasser Idamaxer) {
 		if v != c.Idamax {
 			s := fmt.Sprintf("idamax: mismatch %v: expected %v, found %v", c.Name, c.Idamax, v)
 			if floats.HasNaN(c.X) {
-				log.Println(s)
+				t.Log(s)
 			} else {
 				t.Errorf(s)
 			}


### PR DESCRIPTION
I missed this in the previous clean up. Also fix the mangled imports.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
