### PR TITLE
graph/{multi,simple,testgraph}: extend edge testing

### DIFF
--- a/graph/multi/directed_test.go
+++ b/graph/multi/directed_test.go
@@ -52,6 +52,9 @@ func TestDirected(t *testing.T) {
 	t.Run("EdgeExistence", func(t *testing.T) {
 		testgraph.EdgeExistence(t, directedBuilder)
 	})
+	t.Run("LineExistence", func(t *testing.T) {
+		testgraph.LineExistence(t, directedBuilder, true)
+	})
 	t.Run("NodeExistence", func(t *testing.T) {
 		testgraph.NodeExistence(t, directedBuilder)
 	})

--- a/graph/multi/undirected_test.go
+++ b/graph/multi/undirected_test.go
@@ -52,6 +52,9 @@ func TestUndirected(t *testing.T) {
 	t.Run("EdgeExistence", func(t *testing.T) {
 		testgraph.EdgeExistence(t, undirectedBuilder)
 	})
+	t.Run("LineExistence", func(t *testing.T) {
+		testgraph.LineExistence(t, directedBuilder, true)
+	})
 	t.Run("NodeExistence", func(t *testing.T) {
 		testgraph.NodeExistence(t, undirectedBuilder)
 	})

--- a/graph/multi/weighted_directed.go
+++ b/graph/multi/weighted_directed.go
@@ -290,7 +290,7 @@ func (g *WeightedDirectedGraph) To(id int64) graph.Nodes {
 // EdgeWeightFunc. Weight returns true if an edge exists between x and y, false otherwise.
 func (g *WeightedDirectedGraph) Weight(uid, vid int64) (w float64, ok bool) {
 	lines := g.WeightedLines(uid, vid)
-	return WeightedEdge{WeightedLines: lines, WeightFunc: g.EdgeWeightFunc}.Weight(), lines != nil
+	return WeightedEdge{WeightedLines: lines, WeightFunc: g.EdgeWeightFunc}.Weight(), lines != graph.Empty
 }
 
 // WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
@@ -298,7 +298,7 @@ func (g *WeightedDirectedGraph) Weight(uid, vid int64) (w float64, ok bool) {
 // The returned graph.WeightedEdge is a multi.WeightedEdge if an edge exists.
 func (g *WeightedDirectedGraph) WeightedEdge(uid, vid int64) graph.WeightedEdge {
 	lines := g.WeightedLines(uid, vid)
-	if lines == nil {
+	if lines == graph.Empty {
 		return nil
 	}
 	return WeightedEdge{

--- a/graph/multi/weighted_directed_test.go
+++ b/graph/multi/weighted_directed_test.go
@@ -62,6 +62,9 @@ func TestWeightedDirected(t *testing.T) {
 	t.Run("EdgeExistence", func(t *testing.T) {
 		testgraph.EdgeExistence(t, weightedDirectedBuilder)
 	})
+	t.Run("LineExistence", func(t *testing.T) {
+		testgraph.LineExistence(t, directedBuilder, true)
+	})
 	t.Run("NodeExistence", func(t *testing.T) {
 		testgraph.NodeExistence(t, weightedDirectedBuilder)
 	})

--- a/graph/multi/weighted_undirected.go
+++ b/graph/multi/weighted_undirected.go
@@ -273,7 +273,7 @@ func (g *WeightedUndirectedGraph) SetWeightedLine(l graph.WeightedLine) {
 // EdgeWeightFunc. Weight returns true if an edge exists between x and y, false otherwise.
 func (g *WeightedUndirectedGraph) Weight(xid, yid int64) (w float64, ok bool) {
 	lines := g.WeightedLines(xid, yid)
-	return WeightedEdge{WeightedLines: lines, WeightFunc: g.EdgeWeightFunc}.Weight(), lines != nil
+	return WeightedEdge{WeightedLines: lines, WeightFunc: g.EdgeWeightFunc}.Weight(), lines != graph.Empty
 }
 
 // WeightedEdge returns the weighted edge from u to v if such an edge exists and nil otherwise.
@@ -281,7 +281,7 @@ func (g *WeightedUndirectedGraph) Weight(xid, yid int64) (w float64, ok bool) {
 // The returned graph.WeightedEdge is a multi.WeightedEdge if an edge exists.
 func (g *WeightedUndirectedGraph) WeightedEdge(uid, vid int64) graph.WeightedEdge {
 	lines := g.WeightedLines(uid, vid)
-	if lines == nil {
+	if lines == graph.Empty {
 		return nil
 	}
 	return WeightedEdge{

--- a/graph/multi/weighted_undirected_test.go
+++ b/graph/multi/weighted_undirected_test.go
@@ -62,6 +62,9 @@ func TestWeightedUndirected(t *testing.T) {
 	t.Run("EdgeExistence", func(t *testing.T) {
 		testgraph.EdgeExistence(t, weightedUndirectedBuilder)
 	})
+	t.Run("LineExistence", func(t *testing.T) {
+		testgraph.LineExistence(t, directedBuilder, true)
+	})
 	t.Run("NodeExistence", func(t *testing.T) {
 		testgraph.NodeExistence(t, weightedUndirectedBuilder)
 	})


### PR DESCRIPTION
This was found when I was implementing the edge reversal API and testing, but it should be done regardless of that and without the additional overhead of understanding it as well.


Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
