### PR TITLE
graph/path: fix negative cycle handling by AllShortest and FloydWarshall

### DIFF
--- a/graph/path/floydwarshall.go
+++ b/graph/path/floydwarshall.go
@@ -13,7 +13,7 @@ import (
 // FloydWarshall returns a shortest-path tree for the graph g or false indicating
 // that a negative cycle exists in the graph. If a negative cycle exists in the graph
 // the returned paths will be valid and edge weights on the negative cycle will be
-// set to NaN. If the graph does not implement Weighted, UniformCost is used.
+// set to -Inf. If the graph does not implement Weighted, UniformCost is used.
 //
 // The time complexity of FloydWarshall is O(|V|^3).
 func FloydWarshall(g graph.Graph) (paths AllShortest, ok bool) {
@@ -65,7 +65,7 @@ func FloydWarshall(g graph.Graph) (paths AllShortest, ok bool) {
 
 	if !ok {
 		// If we have a negative cycle, mark all
-		// the edges in the cycles with NaN weight.
+		// the edges in the cycles with -Inf weight.
 		d := paths.dist
 		for i := range nodes {
 			for j := range nodes {
@@ -73,9 +73,9 @@ func FloydWarshall(g graph.Graph) (paths AllShortest, ok bool) {
 					if math.IsInf(d.At(i, k), 1) || math.IsInf(d.At(k, j), 1) {
 						continue
 					}
-					if d.At(k, k) < 0 || math.IsNaN(d.At(k, k)) {
-						d.Set(k, k, math.NaN())
-						d.Set(i, j, math.NaN())
+					if d.At(k, k) < 0 {
+						d.Set(k, k, math.Inf(-1))
+						d.Set(i, j, math.Inf(-1))
 					}
 				}
 			}

--- a/graph/path/floydwarshall.go
+++ b/graph/path/floydwarshall.go
@@ -65,7 +65,10 @@ func FloydWarshall(g graph.Graph) (paths AllShortest, ok bool) {
 
 	if !ok {
 		// If we have a negative cycle, mark all
-		// the edges in the cycles with -Inf weight.
+		// the edges in the cycles with NaN(0xdefaced)
+		// weight. These weights are internal, being
+		// returned as -Inf in user calls.
+
 		d := paths.dist
 		for i := range nodes {
 			for j := range nodes {
@@ -74,8 +77,10 @@ func FloydWarshall(g graph.Graph) (paths AllShortest, ok bool) {
 						continue
 					}
 					if d.At(k, k) < 0 {
-						d.Set(k, k, math.Inf(-1))
-						d.Set(i, j, math.Inf(-1))
+						d.Set(k, k, defaced)
+						d.Set(i, j, defaced)
+					} else if math.Float64bits(d.At(k, k)) == defacedBits {
+						d.Set(i, j, defaced)
 					}
 				}
 			}

--- a/graph/path/johnson_apsp.go
+++ b/graph/path/johnson_apsp.go
@@ -14,7 +14,8 @@ import (
 )
 
 // JohnsonAllPaths returns a shortest-path tree for shortest paths in the graph g.
-// If the graph does not implement Weighted, UniformCost is used.
+// If the graph does not implement Weighted, UniformCost is used. If a negative cycle
+// exists in g, ok will be returned false and paths will not contain valid data.
 //
 // The time complexity of JohnsonAllPaths is O(|V|.|E|+|V|^2.log|V|).
 func JohnsonAllPaths(g graph.Graph) (paths AllShortest, ok bool) {

--- a/graph/path/negative_cycles_example_test.go
+++ b/graph/path/negative_cycles_example_test.go
@@ -14,10 +14,7 @@ import (
 
 func ExampleBellmanFordFrom_negativecycles() {
 	// BellmanFordFrom can be used to find a non-exhaustive
-	// set of negative cycles in a graph. Enumerating the
-	// exhaustive list requires iterations of the procedure
-	// here successively omitting links from the new node
-	// to already found negative cycles.
+	// set of negative cycles in a graph.
 
 	// Construct a graph with a negative cycle.
 	edges := []simple.WeightedEdge{
@@ -47,10 +44,10 @@ func ExampleBellmanFordFrom_negativecycles() {
 		fmt.Println("no negative cycle present")
 		return
 	}
-	for _, n := range []simple.Node{'a', 'b', 'c', 'd', 'e', 'f'} {
-		p, w := pt.To(n.ID())
+	for _, id := range []int64{'a', 'b', 'c', 'd', 'e', 'f'} {
+		p, w := pt.To(id)
 		if math.IsNaN(w) {
-			fmt.Printf("negative cycle in path to %c path:%c\n", n, p)
+			fmt.Printf("negative cycle in path to %c path:%c\n", id, p)
 		}
 	}
 
@@ -59,4 +56,76 @@ func ExampleBellmanFordFrom_negativecycles() {
 	// negative cycle in path to b path:[b c a b]
 	// negative cycle in path to c path:[c a b c]
 	// negative cycle in path to f path:[a b c a f]
+}
+
+func ExampleFloydWarshall_negativecycles() {
+	// FloydWarshall can be used to find an exhaustive
+	// set of nodes in negative cycles in a graph.
+
+	// Construct a graph with a negative cycle.
+	edges := []simple.WeightedEdge{
+		{F: simple.Node('a'), T: simple.Node('f'), W: -1},
+		{F: simple.Node('b'), T: simple.Node('a'), W: 1},
+		{F: simple.Node('b'), T: simple.Node('c'), W: -1},
+		{F: simple.Node('b'), T: simple.Node('d'), W: 1},
+		{F: simple.Node('c'), T: simple.Node('b'), W: 0},
+		{F: simple.Node('e'), T: simple.Node('a'), W: 1},
+		{F: simple.Node('f'), T: simple.Node('e'), W: -1},
+	}
+	g := simple.NewWeightedDirectedGraph(0, math.Inf(1))
+	for _, e := range edges {
+		g.SetWeightedEdge(e)
+	}
+
+	// Find the shortest path to each node from Q.
+	pt, ok := path.FloydWarshall(g)
+	if ok {
+		fmt.Println("no negative cycle present")
+		return
+	}
+
+	ids := []int64{'a', 'b', 'c', 'd', 'e', 'f'}
+
+	for _, id := range ids {
+		if math.IsNaN(pt.Weight(id, id)) {
+			fmt.Printf("%c is in a negative cycle\n", id)
+		}
+	}
+
+	for _, uid := range ids {
+		for _, vid := range ids {
+			_, w, unique := pt.Between(uid, vid)
+			if math.IsNaN(w) {
+				fmt.Printf("negative cycle in path from %c to %c unique=%t\n", uid, vid, unique)
+			}
+		}
+	}
+
+	// Output:
+	// a is in a negative cycle
+	// b is in a negative cycle
+	// c is in a negative cycle
+	// e is in a negative cycle
+	// f is in a negative cycle
+	// negative cycle in path from a to a unique=false
+	// negative cycle in path from a to e unique=false
+	// negative cycle in path from a to f unique=false
+	// negative cycle in path from b to a unique=false
+	// negative cycle in path from b to b unique=false
+	// negative cycle in path from b to c unique=false
+	// negative cycle in path from b to d unique=false
+	// negative cycle in path from b to e unique=false
+	// negative cycle in path from b to f unique=false
+	// negative cycle in path from c to a unique=false
+	// negative cycle in path from c to b unique=false
+	// negative cycle in path from c to c unique=false
+	// negative cycle in path from c to d unique=false
+	// negative cycle in path from c to e unique=false
+	// negative cycle in path from c to f unique=false
+	// negative cycle in path from e to a unique=false
+	// negative cycle in path from e to e unique=false
+	// negative cycle in path from e to f unique=false
+	// negative cycle in path from f to a unique=false
+	// negative cycle in path from f to e unique=false
+	// negative cycle in path from f to f unique=false
 }

--- a/graph/path/negative_cycles_example_test.go
+++ b/graph/path/negative_cycles_example_test.go
@@ -46,7 +46,7 @@ func ExampleBellmanFordFrom_negativecycles() {
 	}
 	for _, id := range []int64{'a', 'b', 'c', 'd', 'e', 'f'} {
 		p, w := pt.To(id)
-		if math.IsNaN(w) {
+		if math.IsInf(w, -1) {
 			fmt.Printf("negative cycle in path to %c path:%c\n", id, p)
 		}
 	}
@@ -87,7 +87,7 @@ func ExampleFloydWarshall_negativecycles() {
 	ids := []int64{'a', 'b', 'c', 'd', 'e', 'f'}
 
 	for _, id := range ids {
-		if math.IsNaN(pt.Weight(id, id)) {
+		if math.IsInf(pt.Weight(id, id), -1) {
 			fmt.Printf("%c is in a negative cycle\n", id)
 		}
 	}
@@ -95,7 +95,7 @@ func ExampleFloydWarshall_negativecycles() {
 	for _, uid := range ids {
 		for _, vid := range ids {
 			_, w, unique := pt.Between(uid, vid)
-			if math.IsNaN(w) {
+			if math.IsInf(w, -1) {
 				fmt.Printf("negative cycle in path from %c to %c unique=%t\n", uid, vid, unique)
 			}
 		}

--- a/graph/path/shortest.go
+++ b/graph/path/shortest.go
@@ -119,7 +119,7 @@ func (p Shortest) WeightTo(vid int64) float64 {
 
 // To returns a shortest path to v and the weight of the path. If the path
 // to v includes a negative cycle, one pass through the cycle will be included
-// in path and weight will be returned as NaN.
+// in path and weight will be returned as -Inf.
 func (p Shortest) To(vid int64) (path []graph.Node, weight float64) {
 	to, toOK := p.indexOf[vid]
 	if !toOK || math.IsInf(p.dist[to], 1) {
@@ -133,7 +133,7 @@ func (p Shortest) To(vid int64) (path []graph.Node, weight float64) {
 		seen.Add(from)
 		for to != from {
 			if seen.Has(to) {
-				weight = math.NaN()
+				weight = math.Inf(-1)
 				break
 			}
 			seen.Add(to)
@@ -253,7 +253,7 @@ func (p AllShortest) Weight(uid, vid int64) float64 {
 // one shortest path exists between u and v, a randomly chosen path will be returned and
 // unique is returned false. If a cycle with zero weight exists in the path, it will not
 // be included, but unique will be returned false. If a negative cycle exists on the path
-// from u to v, path will be returned nil, weight will be NaN and unique will be false.
+// from u to v, path will be returned nil, weight will be -Inf and unique will be false.
 func (p AllShortest) Between(uid, vid int64) (path []graph.Node, weight float64, unique bool) {
 	from, fromOK := p.indexOf[uid]
 	to, toOK := p.indexOf[vid]
@@ -265,7 +265,7 @@ func (p AllShortest) Between(uid, vid int64) (path []graph.Node, weight float64,
 	}
 
 	weight = p.dist.At(from, to)
-	if math.IsNaN(weight) {
+	if math.IsInf(weight, -1) {
 		return nil, weight, false
 	}
 
@@ -314,7 +314,7 @@ func (p AllShortest) Between(uid, vid int64) (path []graph.Node, weight float64,
 
 // AllBetween returns all shortest paths from u to v and the weight of the paths. Paths
 // containing zero-weight cycles are not returned. If a negative cycle exists between
-// u and v, paths is returned nil and weight is returned as NaN.
+// u and v, paths is returned nil and weight is returned as -Inf.
 func (p AllShortest) AllBetween(uid, vid int64) (paths [][]graph.Node, weight float64) {
 	from, fromOK := p.indexOf[uid]
 	to, toOK := p.indexOf[vid]
@@ -326,7 +326,7 @@ func (p AllShortest) AllBetween(uid, vid int64) (paths [][]graph.Node, weight fl
 	}
 
 	weight = p.dist.At(from, to)
-	if math.IsNaN(weight) {
+	if math.IsInf(weight, -1) {
 		return nil, weight
 	}
 


### PR DESCRIPTION
Over the past ... time ... I've been having doubts about my claim for the approach obtaining a complete set of negative cycles in a graph using iterated Bellman-Ford probing. Today I checked it and my concerns were well founded, so I have removed that.

Wanting to have some way of doing this, I added an example using Floyd-Warshall and found that with negative cycles, `AllShortest` will never complete when a negative cycle exists. So I have fixed that by just not providing a mechanism to obtain the path. This is a bit of a dodge, but we can add it later if we want. The additional cost for the `FloydWashall` is an approximate doubling of time when a negative cycle exists. I think this is OK, but could be convinced otherwise (maybe add an option to retain the data for the call, or add a method to `AllShortest` to sanitise the distance matrix if needed — I think there is an option to do this lazily as well during the weight/paths calls: for each query, check do the work in the k loop in `FloydWarshall` for u and v only, storing the NaN if it's found and returning early if u->v is already NaN).

The use of NaN for undefined path weights reflects the behaviour that already existed in `BellmanFord`/`Shortest`. Other people use `-Inf` for this. I'm open to changing this as well.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
