### PR TITLE
num/dualquat: package for dual quaternion maths

### DIFF
--- a/num/dualquat/doc.go
+++ b/num/dualquat/doc.go
@@ -1,0 +1,9 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package dualquat provides the dual quaternion numeric type and functions.
+package dualquat // imports "gonum.org/v1/gonum/num/dualquat"
+
+// TODO(kortschak): Handle special cases properly.
+//  - Pow

--- a/num/dualquat/doc.go
+++ b/num/dualquat/doc.go
@@ -3,6 +3,10 @@
 // license that can be found in the LICENSE file.
 
 // Package dualquat provides the dual quaternion numeric type and functions.
+//
+// Dual quaternions provide a system for rigid transformation with interpolation
+// and blending in ℝ³. See https://www.cs.utah.edu/~ladislav/kavan06dual/kavan06dual.pdf and
+// https://en.wikipedia.org/wiki/Dual_quaternion for more details.
 package dualquat // imports "gonum.org/v1/gonum/num/dualquat"
 
 // TODO(kortschak): Handle special cases properly.

--- a/num/dualquat/dual.go
+++ b/num/dualquat/dual.go
@@ -12,7 +12,9 @@ import (
 	"gonum.org/v1/gonum/num/quat"
 )
 
-// Number is a float64 precision dual quaternion.
+// Number is a float64 precision dual quaternion. A dual quaternion
+// is a hypercomplex number composed of two quaternions, q₀+q₂ϵ,
+// where ϵ²=0, but ϵ≠0. Here, q₀ is termed the real and q₂ the dual.
 type Number struct {
 	Real, Dual quat.Number
 }
@@ -104,6 +106,14 @@ func Inv(d Number) Number {
 	return Number{
 		Real: quat.Inv(d.Real),
 		Dual: quat.Scale(-1, quat.Mul(d.Dual, quat.Inv(quat.Mul(d.Real, d.Real)))),
+	}
+}
+
+// Conj returns the dual quaternion conjugate of d₁+d₂ϵ, d̅₁-d̅₂ϵ.
+func Conj(d Number) Number {
+	return Number{
+		Real: quat.Conj(d.Real),
+		Dual: quat.Scale(-1, quat.Conj(d.Dual)),
 	}
 }
 

--- a/num/dualquat/dual.go
+++ b/num/dualquat/dual.go
@@ -1,0 +1,157 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dualquat
+
+import (
+	"bytes"
+	"fmt"
+
+	"gonum.org/v1/gonum/num/dual"
+	"gonum.org/v1/gonum/num/quat"
+)
+
+// Number is a float64 precision dual quaternion.
+type Number struct {
+	Real, Dual quat.Number
+}
+
+var (
+	zero     Number
+	zeroQuat quat.Number
+)
+
+// Format implements fmt.Formatter.
+func (d Number) Format(fs fmt.State, c rune) {
+	prec, pOk := fs.Precision()
+	if !pOk {
+		prec = -1
+	}
+	width, wOk := fs.Width()
+	if !wOk {
+		width = -1
+	}
+	switch c {
+	case 'v':
+		if fs.Flag('#') {
+			fmt.Fprintf(fs, "%T{%#v, %#v}", d, d.Real, d.Dual)
+			return
+		}
+		c = 'g'
+		prec = -1
+		fallthrough
+	case 'e', 'E', 'f', 'F', 'g', 'G':
+		fre := fmtString(fs, c, prec, width, false)
+		fim := fmtString(fs, c, prec, width, true)
+		fmt.Fprintf(fs, fmt.Sprintf("(%s+%[2]sϵ)", fre, fim), d.Real, d.Dual)
+	default:
+		fmt.Fprintf(fs, "%%!%c(%T=%[2]v)", c, d)
+		return
+	}
+}
+
+// This is horrible, but it's what we have.
+func fmtString(fs fmt.State, c rune, prec, width int, wantPlus bool) string {
+	// TODO(kortschak) Replace this with strings.Builder
+	// when go1.9 support is dropped from Gonum.
+	var b bytes.Buffer
+	b.WriteByte('%')
+	for _, f := range "0+- " {
+		if fs.Flag(int(f)) || (f == '+' && wantPlus) {
+			b.WriteByte(byte(f))
+		}
+	}
+	if width >= 0 {
+		fmt.Fprint(&b, width)
+	}
+	if prec >= 0 {
+		b.WriteByte('.')
+		if prec > 0 {
+			fmt.Fprint(&b, prec)
+		}
+	}
+	b.WriteRune(c)
+	return b.String()
+}
+
+// Add returns the sum of x and y.
+func Add(x, y Number) Number {
+	return Number{
+		Real: quat.Add(x.Real, y.Real),
+		Dual: quat.Add(x.Dual, y.Dual),
+	}
+}
+
+// Sub returns the difference of x and y, x-y.
+func Sub(x, y Number) Number {
+	return Number{
+		Real: quat.Sub(x.Real, y.Real),
+		Dual: quat.Sub(x.Dual, y.Dual),
+	}
+}
+
+// Mul returns the dual product of x and y.
+func Mul(x, y Number) Number {
+	return Number{
+		Real: quat.Mul(x.Real, y.Real),
+		Dual: quat.Add(quat.Mul(x.Real, y.Dual), quat.Mul(x.Dual, y.Real)),
+	}
+}
+
+// Inv returns the dual inverse of d.
+func Inv(d Number) Number {
+	return Number{
+		Real: quat.Inv(d.Real),
+		Dual: quat.Scale(-1, quat.Mul(d.Dual, quat.Inv(quat.Mul(d.Real, d.Real)))),
+	}
+}
+
+// ConjDual returns the dual conjugate of d₁+d₂ϵ, d₁-d₂ϵ.
+func ConjDual(d Number) Number {
+	return Number{
+		Real: d.Real,
+		Dual: quat.Scale(-1, d.Dual),
+	}
+}
+
+// ConjQuat returns the quaternion conjugate of d₁+d₂ϵ, d̅₁+d̅₂ϵ.
+func ConjQuat(d Number) Number {
+	return Number{
+		Real: quat.Conj(d.Real),
+		Dual: quat.Conj(d.Dual),
+	}
+}
+
+// Scale returns d scaled by f.
+func Scale(f float64, d Number) Number {
+	return Number{Real: quat.Scale(f, d.Real), Dual: quat.Scale(f, d.Dual)}
+}
+
+// Abs returns the absolute value of d.
+func Abs(d Number) dual.Number {
+	return dual.Number{
+		Real: quat.Abs(d.Real),
+		Emag: quat.Abs(d.Dual),
+	}
+}
+
+func addRealQuat(r float64, q quat.Number) quat.Number {
+	q.Real += r
+	return q
+}
+
+func addQuatReal(q quat.Number, r float64) quat.Number {
+	q.Real += r
+	return q
+}
+
+func subRealQuat(r float64, q quat.Number) quat.Number {
+	q.Real = r - q.Real
+	return q
+}
+
+func subQuatReal(q quat.Number, r float64) quat.Number {
+	q.Real -= r
+	return q
+}

--- a/num/dualquat/dual_example_test.go
+++ b/num/dualquat/dual_example_test.go
@@ -1,0 +1,148 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dualquat_test
+
+import (
+	"fmt"
+	"math"
+
+	"gonum.org/v1/gonum/floats"
+	"gonum.org/v1/gonum/num/dualquat"
+	"gonum.org/v1/gonum/num/quat"
+)
+
+// point is a 3-dimensional point/vector.
+type point struct {
+	x, y, z float64
+}
+
+// raise raises the dimensionality of a point to a quaternion.
+func raise(p point) quat.Number {
+	return quat.Number{Imag: p.x, Jmag: p.y, Kmag: p.z}
+}
+
+// raiseDual raises the dimensionality of a point to a dual quaternion.
+func raiseDual(p point) dualquat.Number {
+	return dualquat.Number{
+		Real: quat.Number{Real: 1},
+		Dual: raise(p),
+	}
+}
+
+// transform performs the quaternion rotation of p by the given quaternion
+// and scaling by the scale factor. The rotations are normalized to unit
+// vectors.
+func transform(p point, by ...dualquat.Number) point {
+	if len(by) == 0 {
+		return p
+	}
+
+	// Ensure the modulus of by is correctly scaled.
+	for i := range by {
+		if len := quat.Abs(by[i].Real); len != 1 {
+			by[i].Real = quat.Scale(1/len, by[i].Real)
+		}
+	}
+
+	// Perform the transformations.
+	q := by[0]
+	for _, o := range by[1:] {
+		q = dualquat.Mul(o, q)
+	}
+	pp := dualquat.Mul(dualquat.Mul(q, raiseDual(p)), dualquat.ConjDual(dualquat.ConjQuat(q)))
+
+	// Extract the point.
+	return point{x: pp.Dual.Imag, y: pp.Dual.Jmag, z: pp.Dual.Kmag}
+}
+
+func Example() {
+	// Translate a 1×1×1 cube [3, 4, 5] and rotate it 120° around the
+	// diagonal vector [1, 1, 1].
+	fmt.Println("cube:")
+
+	// Construct a displacement.
+	displace := dualquat.Number{
+		Real: quat.Number{Real: 1},
+		Dual: quat.Scale(0.5, raise(point{3, 4, 5})),
+	}
+
+	// Construct a rotations.
+	alpha := 2 * math.Pi / 3
+	axis := raise(point{1, 1, 1})
+	rotate := dualquat.Number{Real: axis}
+	rotate.Real = quat.Scale(math.Sin(alpha/2)/quat.Abs(rotate.Real), rotate.Real)
+	rotate.Real.Real += math.Cos(alpha / 2)
+
+	for i, p := range []point{
+		{x: 0, y: 0, z: 0},
+		{x: 0, y: 0, z: 1},
+		{x: 0, y: 1, z: 0},
+		{x: 0, y: 1, z: 1},
+		{x: 1, y: 0, z: 0},
+		{x: 1, y: 0, z: 1},
+		{x: 1, y: 1, z: 0},
+		{x: 1, y: 1, z: 1},
+	} {
+		pp := transform(p,
+			displace, rotate,
+		)
+
+		// Clean up floating point error for clarity.
+		pp.x = floats.Round(pp.x, 2)
+		pp.y = floats.Round(pp.y, 2)
+		pp.z = floats.Round(pp.z, 2)
+
+		fmt.Printf(" %d %+v -> %+v\n", i, p, pp)
+	}
+
+	// Rotate a line segment from [2, 1, 1] to [2, 1, 2] 120° around
+	// the diagonal vector [1, 1, 1] at its lower end.
+	fmt.Println("\nline segment:")
+
+	// Construct an displacement to the origin from the lower end...
+	origin := dualquat.Number{
+		Real: quat.Number{Real: 1},
+		Dual: quat.Scale(0.5, raise(point{-2, -1, -1})),
+	}
+	// ... and back from the origin to the lower end.
+	replace := dualquat.Number{
+		Real: quat.Number{Real: 1},
+		Dual: quat.Scale(-1, origin.Dual),
+	}
+
+	for i, p := range []point{
+		{x: 2, y: 1, z: 1},
+		{x: 2, y: 1, z: 2},
+	} {
+		pp := transform(p,
+			origin,  // Displace to origin.
+			rotate,  // Rotate around axis.
+			replace, // Displace back to original location.
+		)
+
+		// Clean up floating point error for clarity.
+		pp.x = floats.Round(pp.x, 2)
+		pp.y = floats.Round(pp.y, 2)
+		pp.z = floats.Round(pp.z, 2)
+
+		fmt.Printf(" %d %+v -> %+v\n", i, p, pp)
+	}
+
+	// Output:
+	//
+	// cube:
+	//  0 {x:0 y:0 z:0} -> {x:5 y:3 z:4}
+	//  1 {x:0 y:0 z:1} -> {x:6 y:3 z:4}
+	//  2 {x:0 y:1 z:0} -> {x:5 y:3 z:5}
+	//  3 {x:0 y:1 z:1} -> {x:6 y:3 z:5}
+	//  4 {x:1 y:0 z:0} -> {x:5 y:4 z:4}
+	//  5 {x:1 y:0 z:1} -> {x:6 y:4 z:4}
+	//  6 {x:1 y:1 z:0} -> {x:5 y:4 z:5}
+	//  7 {x:1 y:1 z:1} -> {x:6 y:4 z:5}
+	//
+	// line segment:
+	//  0 {x:2 y:1 z:1} -> {x:2 y:1 z:1}
+	//  1 {x:2 y:1 z:2} -> {x:3 y:1 z:1}
+}

--- a/num/dualquat/dual_example_test.go
+++ b/num/dualquat/dual_example_test.go
@@ -51,14 +51,14 @@ func transform(p point, by ...dualquat.Number) point {
 	for _, o := range by[1:] {
 		q = dualquat.Mul(o, q)
 	}
-	pp := dualquat.Mul(dualquat.Mul(q, raiseDual(p)), dualquat.ConjDual(dualquat.ConjQuat(q)))
+	pp := dualquat.Mul(dualquat.Mul(q, raiseDual(p)), dualquat.Conj(q))
 
 	// Extract the point.
 	return point{x: pp.Dual.Imag, y: pp.Dual.Jmag, z: pp.Dual.Kmag}
 }
 
 func Example() {
-	// Translate a 1×1×1 cube [3, 4, 5] and rotate it 120° around the
+	// Translate a 1×1×1 cube by [3, 4, 5] and rotate it 120° around the
 	// diagonal vector [1, 1, 1].
 	fmt.Println("cube:")
 
@@ -97,7 +97,7 @@ func Example() {
 		fmt.Printf(" %d %+v -> %+v\n", i, p, pp)
 	}
 
-	// Rotate a line segment from [2, 1, 1] to [2, 1, 2] 120° around
+	// Rotate a line segment from {[2, 1, 1], [2, 1, 2]} 120° around
 	// the diagonal vector [1, 1, 1] at its lower end.
 	fmt.Println("\nline segment:")
 

--- a/num/dualquat/dual_fike.go
+++ b/num/dualquat/dual_fike.go
@@ -1,0 +1,152 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Derived from code by Jeffrey A. Fike at http://adl.stanford.edu/hyperdual/
+
+// The MIT License (MIT)
+//
+// Copyright (c) 2006 Jeffrey A. Fike
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dualquat
+
+import (
+	"math"
+
+	"gonum.org/v1/gonum/num/quat"
+)
+
+// PowReal returns d**p, the base-d exponential of p.
+//
+// Special cases are (in order):
+//	PowReal(NaN+xϵ, ±0) = 1+NaNϵ for any x
+//	PowReal(x, ±0) = 1 for any x
+//	PowReal(1+xϵ, y) = 1+xyϵ for any y
+//	PowReal(x, 1) = x for any x
+//	PowReal(NaN+xϵ, y) = NaN+NaNϵ
+//	PowReal(x, NaN) = NaN+NaNϵ
+//	PowReal(±0, y) = ±Inf for y an odd integer < 0
+//	PowReal(±0, -Inf) = +Inf
+//	PowReal(±0, +Inf) = +0
+//	PowReal(±0, y) = +Inf for finite y < 0 and not an odd integer
+//	PowReal(±0, y) = ±0 for y an odd integer > 0
+//	PowReal(±0, y) = +0 for finite y > 0 and not an odd integer
+//	PowReal(-1, ±Inf) = 1
+//	PowReal(x+0ϵ, +Inf) = +Inf+NaNϵ for |x| > 1
+//	PowReal(x+yϵ, +Inf) = +Inf for |x| > 1
+//	PowReal(x, -Inf) = +0+NaNϵ for |x| > 1
+//	PowReal(x, +Inf) = +0+NaNϵ for |x| < 1
+//	PowReal(x+0ϵ, -Inf) = +Inf+NaNϵ for |x| < 1
+//	PowReal(x, -Inf) = +Inf-Infϵ for |x| < 1
+//	PowReal(+Inf, y) = +Inf for y > 0
+//	PowReal(+Inf, y) = +0 for y < 0
+//	PowReal(-Inf, y) = Pow(-0, -y)
+func PowReal(d Number, p float64) Number {
+	switch {
+	case p == 0:
+		switch {
+		case quat.IsNaN(d.Real):
+			return Number{Real: quat.Number{Real: 1}, Dual: quat.NaN()}
+		case d.Real == zeroQuat, quat.IsInf(d.Real):
+			return Number{Real: quat.Number{Real: 1}}
+		}
+	case p == 1:
+		return d
+	case math.IsInf(p, 1):
+		if Abs(d).Real > 1 {
+			if d.Dual == zeroQuat {
+				return Number{Real: quat.Inf(), Dual: quat.NaN()}
+			}
+			return Number{Real: quat.Inf(), Dual: quat.Inf()}
+		}
+		return Number{Real: zeroQuat, Dual: quat.NaN()}
+	case math.IsInf(p, -1):
+		if Abs(d).Real > 1 {
+			return Number{Real: zeroQuat, Dual: quat.NaN()}
+		}
+		if d.Dual == zeroQuat {
+			return Number{Real: quat.Inf(), Dual: quat.NaN()}
+		}
+		return Number{Real: quat.Inf(), Dual: quat.Inf()}
+	}
+	deriv := quat.Mul(quat.Number{Real: p}, quat.Pow(d.Real, quat.Number{Real: p - 1}))
+	return Number{
+		Real: quat.Pow(d.Real, quat.Number{Real: p}),
+		Dual: quat.Mul(d.Dual, deriv),
+	}
+}
+
+// Pow return d**p, the base-d exponential of p.
+func Pow(d, p Number) Number {
+	return Exp(Mul(p, Log(d)))
+}
+
+// Sqrt returns the square root of d
+//
+// Special cases are:
+//	Sqrt(+Inf) = +Inf
+//	Sqrt(±0) = (±0+Infϵ)
+//	Sqrt(x < 0) = NaN
+//	Sqrt(NaN) = NaN
+func Sqrt(d Number) Number {
+	return PowReal(d, 0.5)
+}
+
+// Exp returns e**d, the base-e exponential of d.
+//
+// Special cases are:
+//	Exp(+Inf) = +Inf
+//	Exp(NaN) = NaN
+// Very large values overflow to 0 or +Inf.
+// Very small values underflow to 1.
+func Exp(d Number) Number {
+	fnDeriv := quat.Exp(d.Real)
+	return Number{
+		Real: fnDeriv,
+		Dual: quat.Mul(fnDeriv, d.Dual),
+	}
+}
+
+// Log returns the natural logarithm of d.
+//
+// Special cases are:
+//	Log(+Inf) = (+Inf+0ϵ)
+//	Log(0) = (-Inf±Infϵ)
+//	Log(x < 0) = NaN
+//	Log(NaN) = NaN
+func Log(d Number) Number {
+	switch {
+	case d.Real == zeroQuat:
+		return Number{
+			Real: quat.Log(d.Real),
+			Dual: quat.Inf(),
+		}
+	case quat.IsInf(d.Real):
+		return Number{
+			Real: quat.Log(d.Real),
+			Dual: zeroQuat,
+		}
+	}
+	return Number{
+		Real: quat.Log(d.Real),
+		Dual: quat.Mul(d.Dual, quat.Inv(d.Real)),
+	}
+}

--- a/num/dualquat/dual_simple_example_test.go
+++ b/num/dualquat/dual_simple_example_test.go
@@ -11,11 +11,9 @@ import (
 	"gonum.org/v1/gonum/num/quat"
 )
 
-// Example point, displacement and rotation from Euclidean Space Dual Quaternions page:
-// http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/other/dualQuaternion/index.htm
-
 func Example_displace() {
 	// Displace a point [3, 4, 5] by [4, 2, 6].
+	// See http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/other/dualQuaternion/index.htm
 
 	// Point to be transformed in the dual imaginary vector.
 	p := dualquat.Number{Real: quat.Number{Real: 1}, Dual: quat.Number{Imag: 3, Jmag: 4, Kmag: 5}}
@@ -23,7 +21,7 @@ func Example_displace() {
 	// Displacement vector, half [4, 2, 6], in the dual imaginary vector.
 	d := dualquat.Number{Real: quat.Number{Real: 1}, Dual: quat.Number{Imag: 2, Jmag: 1, Kmag: 3}}
 
-	fmt.Println(dualquat.Mul(dualquat.Mul(d, p), dualquat.ConjDual(dualquat.ConjQuat(d))).Dual)
+	fmt.Println(dualquat.Mul(dualquat.Mul(d, p), dualquat.Conj(d)).Dual)
 
 	// Output:
 	//
@@ -32,6 +30,7 @@ func Example_displace() {
 
 func Example_rotate() {
 	// Rotate a point [3, 4, 5] by 180° around the x axis.
+	// See http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/other/dualQuaternion/index.htm
 
 	// Point to be transformed in the dual imaginary vector.
 	p := dualquat.Number{Real: quat.Number{Real: 1}, Dual: quat.Number{Imag: 3, Jmag: 4, Kmag: 5}}
@@ -39,7 +38,7 @@ func Example_rotate() {
 	// Rotation in the real quaternion.
 	r := dualquat.Number{Real: quat.Number{Real: 0, Imag: 1}}
 
-	fmt.Println(dualquat.Mul(dualquat.Mul(r, p), dualquat.ConjDual(dualquat.ConjQuat(r))).Dual)
+	fmt.Println(dualquat.Mul(dualquat.Mul(r, p), dualquat.Conj(r)).Dual)
 
 	// Output:
 	//
@@ -49,6 +48,7 @@ func Example_rotate() {
 func Example_displaceAndRotate() {
 	// Displace a point [3, 4, 5] by [4, 2, 6] and then rotate
 	// by 180° around the x axis.
+	// See http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/other/dualQuaternion/index.htm
 
 	// Point to be transformed in the dual imaginary vector.
 	p := dualquat.Number{Real: quat.Number{Real: 1}, Dual: quat.Number{Imag: 3, Jmag: 4, Kmag: 5}}
@@ -63,7 +63,7 @@ func Example_displaceAndRotate() {
 	// the displacement is performed first.
 	q := dualquat.Mul(r, d)
 
-	fmt.Println(dualquat.Mul(dualquat.Mul(q, p), dualquat.ConjDual(dualquat.ConjQuat(q))).Dual)
+	fmt.Println(dualquat.Mul(dualquat.Mul(q, p), dualquat.Conj(q)).Dual)
 
 	// Output:
 	//
@@ -87,7 +87,7 @@ func Example_rotateAndDisplace() {
 	// the rotations is performed first.
 	q := dualquat.Mul(d, r)
 
-	fmt.Println(dualquat.Mul(dualquat.Mul(q, p), dualquat.ConjDual(dualquat.ConjQuat(q))).Dual)
+	fmt.Println(dualquat.Mul(dualquat.Mul(q, p), dualquat.Conj(q)).Dual)
 
 	// Output:
 	//

--- a/num/dualquat/dual_simple_example_test.go
+++ b/num/dualquat/dual_simple_example_test.go
@@ -1,0 +1,95 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dualquat_test
+
+import (
+	"fmt"
+
+	"gonum.org/v1/gonum/num/dualquat"
+	"gonum.org/v1/gonum/num/quat"
+)
+
+// Example point, displacement and rotation from Euclidean Space Dual Quaternions page:
+// http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/other/dualQuaternion/index.htm
+
+func Example_displace() {
+	// Displace a point [3, 4, 5] by [4, 2, 6].
+
+	// Point to be transformed in the dual imaginary vector.
+	p := dualquat.Number{Real: quat.Number{Real: 1}, Dual: quat.Number{Imag: 3, Jmag: 4, Kmag: 5}}
+
+	// Displacement vector, half [4, 2, 6], in the dual imaginary vector.
+	d := dualquat.Number{Real: quat.Number{Real: 1}, Dual: quat.Number{Imag: 2, Jmag: 1, Kmag: 3}}
+
+	fmt.Println(dualquat.Mul(dualquat.Mul(d, p), dualquat.ConjDual(dualquat.ConjQuat(d))).Dual)
+
+	// Output:
+	//
+	// (0+7i+6j+11k)
+}
+
+func Example_rotate() {
+	// Rotate a point [3, 4, 5] by 180° around the x axis.
+
+	// Point to be transformed in the dual imaginary vector.
+	p := dualquat.Number{Real: quat.Number{Real: 1}, Dual: quat.Number{Imag: 3, Jmag: 4, Kmag: 5}}
+
+	// Rotation in the real quaternion.
+	r := dualquat.Number{Real: quat.Number{Real: 0, Imag: 1}}
+
+	fmt.Println(dualquat.Mul(dualquat.Mul(r, p), dualquat.ConjDual(dualquat.ConjQuat(r))).Dual)
+
+	// Output:
+	//
+	// (0+3i-4j-5k)
+}
+
+func Example_displaceAndRotate() {
+	// Displace a point [3, 4, 5] by [4, 2, 6] and then rotate
+	// by 180° around the x axis.
+
+	// Point to be transformed in the dual imaginary vector.
+	p := dualquat.Number{Real: quat.Number{Real: 1}, Dual: quat.Number{Imag: 3, Jmag: 4, Kmag: 5}}
+
+	// Displacement vector, half [4, 2, 6], in the dual imaginary vector.
+	d := dualquat.Number{Real: quat.Number{Real: 1}, Dual: quat.Number{Imag: 2, Jmag: 1, Kmag: 3}}
+
+	// Rotation in the real quaternion.
+	r := dualquat.Number{Real: quat.Number{Real: 0, Imag: 1}}
+
+	// Combine the rotation and displacement so
+	// the displacement is performed first.
+	q := dualquat.Mul(r, d)
+
+	fmt.Println(dualquat.Mul(dualquat.Mul(q, p), dualquat.ConjDual(dualquat.ConjQuat(q))).Dual)
+
+	// Output:
+	//
+	// (0+7i-6j-11k)
+}
+
+func Example_rotateAndDisplace() {
+	// Rotate a point [3, 4, 5] by 180° around the x axis and then
+	// displace by [4, 2, 6]
+
+	// Point to be transformed in the dual imaginary vector.
+	p := dualquat.Number{Real: quat.Number{Real: 1}, Dual: quat.Number{Imag: 3, Jmag: 4, Kmag: 5}}
+
+	// Displacement vector, half [4, 2, 6], in the dual imaginary vector.
+	d := dualquat.Number{Real: quat.Number{Real: 1}, Dual: quat.Number{Imag: 2, Jmag: 1, Kmag: 3}}
+
+	// Rotation in the real quaternion.
+	r := dualquat.Number{Real: quat.Number{Real: 0, Imag: 1}}
+
+	// Combine the rotation and displacement so
+	// the rotations is performed first.
+	q := dualquat.Mul(d, r)
+
+	fmt.Println(dualquat.Mul(dualquat.Mul(q, p), dualquat.ConjDual(dualquat.ConjQuat(q))).Dual)
+
+	// Output:
+	//
+	// (0+7i-2j+1k)
+}

--- a/num/dualquat/dual_test.go
+++ b/num/dualquat/dual_test.go
@@ -1,0 +1,273 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dualquat
+
+import (
+	"math"
+	"testing"
+
+	"gonum.org/v1/gonum/floats"
+	"gonum.org/v1/gonum/num/quat"
+)
+
+// First derivatives:
+
+func dPowReal(x quat.Number, y float64) quat.Number {
+	return quat.Mul(quat.Number{Real: y}, quat.Pow(x, quat.Number{Real: y - 1}))
+}
+func dExp(x quat.Number) quat.Number { return quat.Exp(x) }
+func dLog(x quat.Number) quat.Number {
+	switch {
+	case x == zeroQuat:
+		return quat.Inf()
+	case quat.IsInf(x):
+		return zeroQuat
+	}
+	return quat.Inv(x)
+}
+func dPow(x, y quat.Number) quat.Number { return quat.Mul(y, quat.Pow(x, subQuatReal(y, 1))) }
+func dSqrt(x quat.Number) quat.Number   { return quat.Scale(0.5, quat.Inv(quat.Sqrt(x))) }
+func dInv(x quat.Number) quat.Number    { return quat.Scale(-1, quat.Inv(quat.Mul(x, x))) }
+
+var (
+	negZero     = math.Copysign(0, -1)
+	oneReal     = quat.Number{Real: 1}
+	negZeroQuat = quat.Scale(-1, zeroQuat)
+	one         = quat.Number{1, 1, 1, 1}
+	negOne      = quat.Scale(-1, one)
+	half        = quat.Scale(0.5, one)
+	negHalf     = quat.Scale(-1, half)
+	two         = quat.Scale(2, one)
+	negTwo      = quat.Scale(-1, two)
+	three       = quat.Scale(3, one)
+	negThree    = quat.Scale(-1, three)
+	four        = quat.Scale(4, one)
+	six         = quat.Scale(6, one)
+)
+
+var dualTests = []struct {
+	name   string
+	x      []quat.Number
+	fnDual func(x Number) Number
+	fn     func(x quat.Number) quat.Number
+	dFn    func(x quat.Number) quat.Number
+}{
+	{
+		name:   "exp",
+		x:      []quat.Number{quat.NaN(), quat.Inf(), negThree, negTwo, negOne, negHalf, negZeroQuat, zeroQuat, half, one, two, three},
+		fnDual: Exp,
+		fn:     quat.Exp,
+		dFn:    dExp,
+	},
+	{
+		name:   "log",
+		x:      []quat.Number{quat.NaN(), quat.Inf(), negThree, negTwo, negOne, negHalf, negZeroQuat, zeroQuat, half, one, two, three},
+		fnDual: Log,
+		fn:     quat.Log,
+		dFn:    dLog,
+	},
+	{
+		name:   "inv",
+		x:      []quat.Number{quat.NaN(), quat.Inf(), negThree, negTwo, negOne, negHalf, negZeroQuat, zeroQuat, half, one, two, three},
+		fnDual: Inv,
+		fn:     quat.Inv,
+		dFn:    dInv,
+	},
+	{
+		name:   "sqrt",
+		x:      []quat.Number{quat.NaN(), quat.Inf(), negThree, negTwo, negOne, negHalf, negZeroQuat, zeroQuat, half, one, two, three},
+		fnDual: Sqrt,
+		fn:     quat.Sqrt,
+		dFn:    dSqrt,
+	},
+}
+
+func TestNumber(t *testing.T) {
+	const tol = 1e-15
+	for _, test := range dualTests {
+		for _, x := range test.x {
+			fxDual := test.fnDual(Number{Real: x, Dual: oneReal})
+			fx := test.fn(x)
+			dFx := test.dFn(x)
+			if !same(fxDual.Real, fx, tol) {
+				t.Errorf("unexpected %s(%v): got:%v want:%v", test.name, x, fxDual.Real, fx)
+			}
+			if !same(fxDual.Dual, dFx, tol) {
+				t.Errorf("unexpected %s'(%v): got:%v want:%v", test.name, x, fxDual.Dual, dFx)
+			}
+		}
+	}
+}
+
+var invTests = []Number{
+	{Real: quat.Number{Real: 1}},
+	{Real: quat.Number{Real: 1}, Dual: quat.Number{Real: 1}},
+	{Real: quat.Number{Imag: 1}, Dual: quat.Number{Real: 1}},
+	{Real: quat.Number{Real: 1}, Dual: quat.Number{Real: 1, Imag: 1}},
+	{Real: quat.Number{Real: 1, Imag: 1}, Dual: quat.Number{Real: 1, Imag: 1}},
+	{Real: quat.Number{Real: 1, Imag: 10}, Dual: quat.Number{Real: 1, Imag: 5}},
+	{Real: quat.Number{Real: 10, Imag: 1}, Dual: quat.Number{Real: 5, Imag: 1}},
+	{Real: quat.Number{Real: 1}, Dual: quat.Number{Real: 1, Imag: 1, Kmag: 1}},
+	{Real: quat.Number{Real: 12, Imag: 1}, Dual: quat.Number{Real: 1, Imag: 1}},
+	{Real: quat.Number{Real: 12, Imag: 1, Jmag: 3}},
+}
+
+func TestInv(t *testing.T) {
+	const tol = 1e-15
+	for _, x := range invTests {
+		got := Mul(x, Inv(x))
+		want := Number{Real: quat.Number{Real: 1}}
+		if !sameDual(got, want, tol) {
+			t.Errorf("unexpected Mul(%[1]v, Inv(%[1]v)): got:%v want:%v", x, got, want)
+		}
+	}
+}
+
+var powRealTests = []struct {
+	d    Number
+	p    float64
+	want Number
+}{
+	// PowReal(NaN+xϵ, ±0) = 1+NaNϵ for any x
+	{d: Number{Real: quat.NaN(), Dual: zeroQuat}, p: 0, want: Number{Real: oneReal, Dual: quat.NaN()}},
+	{d: Number{Real: quat.NaN(), Dual: zeroQuat}, p: negZero, want: Number{Real: oneReal, Dual: quat.NaN()}},
+	{d: Number{Real: quat.NaN(), Dual: one}, p: 0, want: Number{Real: oneReal, Dual: quat.NaN()}},
+	{d: Number{Real: quat.NaN(), Dual: two}, p: negZero, want: Number{Real: oneReal, Dual: quat.NaN()}},
+	{d: Number{Real: quat.NaN(), Dual: three}, p: 0, want: Number{Real: oneReal, Dual: quat.NaN()}},
+	{d: Number{Real: quat.NaN(), Dual: one}, p: negZero, want: Number{Real: oneReal, Dual: quat.NaN()}},
+	{d: Number{Real: quat.NaN(), Dual: two}, p: 0, want: Number{Real: oneReal, Dual: quat.NaN()}},
+	{d: Number{Real: quat.NaN(), Dual: three}, p: negZero, want: Number{Real: oneReal, Dual: quat.NaN()}},
+
+	// PowReal(x, ±0) = 1 for any x
+	{d: Number{Real: zeroQuat, Dual: zeroQuat}, p: 0, want: Number{Real: oneReal, Dual: zeroQuat}},
+	{d: Number{Real: negZeroQuat, Dual: zeroQuat}, p: negZero, want: Number{Real: oneReal, Dual: zeroQuat}},
+	{d: Number{Real: quat.Inf(), Dual: zeroQuat}, p: 0, want: Number{Real: oneReal, Dual: zeroQuat}},
+	{d: Number{Real: quat.Inf(), Dual: zeroQuat}, p: negZero, want: Number{Real: oneReal, Dual: zeroQuat}},
+	{d: Number{Real: zeroQuat, Dual: one}, p: 0, want: Number{Real: oneReal, Dual: zeroQuat}},
+	{d: Number{Real: negZeroQuat, Dual: one}, p: negZero, want: Number{Real: oneReal, Dual: zeroQuat}},
+	{d: Number{Real: quat.Inf(), Dual: one}, p: 0, want: Number{Real: oneReal, Dual: zeroQuat}},
+	{d: Number{Real: quat.Inf(), Dual: one}, p: negZero, want: Number{Real: oneReal, Dual: zeroQuat}},
+
+	// PowReal(1+xϵ, y) = (1+xyϵ) for any y
+	{d: Number{Real: oneReal, Dual: zeroQuat}, p: 0, want: Number{Real: oneReal, Dual: zeroQuat}},
+	{d: Number{Real: oneReal, Dual: zeroQuat}, p: 1, want: Number{Real: oneReal, Dual: zeroQuat}},
+	{d: Number{Real: oneReal, Dual: zeroQuat}, p: 2, want: Number{Real: oneReal, Dual: zeroQuat}},
+	{d: Number{Real: oneReal, Dual: zeroQuat}, p: 3, want: Number{Real: oneReal, Dual: zeroQuat}},
+	{d: Number{Real: oneReal, Dual: one}, p: 0, want: Number{Real: oneReal, Dual: zeroQuat}},
+	{d: Number{Real: oneReal, Dual: one}, p: 1, want: Number{Real: oneReal, Dual: one}},
+	{d: Number{Real: oneReal, Dual: one}, p: 2, want: Number{Real: oneReal, Dual: two}},
+	{d: Number{Real: oneReal, Dual: one}, p: 3, want: Number{Real: oneReal, Dual: three}},
+	{d: Number{Real: oneReal, Dual: two}, p: 0, want: Number{Real: oneReal, Dual: zeroQuat}},
+	{d: Number{Real: oneReal, Dual: two}, p: 1, want: Number{Real: oneReal, Dual: two}},
+	{d: Number{Real: oneReal, Dual: two}, p: 2, want: Number{Real: oneReal, Dual: four}},
+	{d: Number{Real: oneReal, Dual: two}, p: 3, want: Number{Real: oneReal, Dual: six}},
+
+	// PowReal(x, 1) = x for any x
+	{d: Number{Real: zeroQuat, Dual: zeroQuat}, p: 1, want: Number{Real: zeroQuat, Dual: zeroQuat}},
+	{d: Number{Real: negZeroQuat, Dual: zeroQuat}, p: 1, want: Number{Real: negZeroQuat, Dual: zeroQuat}},
+	{d: Number{Real: zeroQuat, Dual: one}, p: 1, want: Number{Real: zeroQuat, Dual: one}},
+	{d: Number{Real: negZeroQuat, Dual: one}, p: 1, want: Number{Real: negZeroQuat, Dual: one}},
+	{d: Number{Real: quat.NaN(), Dual: zeroQuat}, p: 1, want: Number{Real: quat.NaN(), Dual: zeroQuat}},
+	{d: Number{Real: quat.NaN(), Dual: one}, p: 1, want: Number{Real: quat.NaN(), Dual: one}},
+	{d: Number{Real: quat.NaN(), Dual: two}, p: 1, want: Number{Real: quat.NaN(), Dual: two}},
+
+	// PowReal(NaN+xϵ, y) = NaN+NaNϵ
+	{d: Number{Real: quat.NaN(), Dual: zeroQuat}, p: 2, want: Number{Real: quat.NaN(), Dual: quat.NaN()}},
+	{d: Number{Real: quat.NaN(), Dual: zeroQuat}, p: 3, want: Number{Real: quat.NaN(), Dual: quat.NaN()}},
+	{d: Number{Real: quat.NaN(), Dual: one}, p: 2, want: Number{Real: quat.NaN(), Dual: quat.NaN()}},
+	{d: Number{Real: quat.NaN(), Dual: one}, p: 3, want: Number{Real: quat.NaN(), Dual: quat.NaN()}},
+	{d: Number{Real: quat.NaN(), Dual: two}, p: 2, want: Number{Real: quat.NaN(), Dual: quat.NaN()}},
+	{d: Number{Real: quat.NaN(), Dual: two}, p: 3, want: Number{Real: quat.NaN(), Dual: quat.NaN()}},
+
+	// PowReal(x, NaN) = NaN+NaNϵ
+	{d: Number{Real: zeroQuat, Dual: zeroQuat}, p: math.NaN(), want: Number{Real: quat.NaN(), Dual: quat.NaN()}},
+	{d: Number{Real: two, Dual: zeroQuat}, p: math.NaN(), want: Number{Real: quat.NaN(), Dual: quat.NaN()}},
+	{d: Number{Real: three, Dual: zeroQuat}, p: math.NaN(), want: Number{Real: quat.NaN(), Dual: quat.NaN()}},
+	{d: Number{Real: zeroQuat, Dual: one}, p: math.NaN(), want: Number{Real: quat.NaN(), Dual: quat.NaN()}},
+	{d: Number{Real: two, Dual: one}, p: math.NaN(), want: Number{Real: quat.NaN(), Dual: quat.NaN()}},
+	{d: Number{Real: three, Dual: one}, p: math.NaN(), want: Number{Real: quat.NaN(), Dual: quat.NaN()}},
+	{d: Number{Real: zeroQuat, Dual: two}, p: math.NaN(), want: Number{Real: quat.NaN(), Dual: quat.NaN()}},
+	{d: Number{Real: two, Dual: two}, p: math.NaN(), want: Number{Real: quat.NaN(), Dual: quat.NaN()}},
+	{d: Number{Real: three, Dual: two}, p: math.NaN(), want: Number{Real: quat.NaN(), Dual: quat.NaN()}},
+
+	// Handled by quat.Pow tests:
+	//
+	// Pow(±0, y) = ±Inf for y an odd integer < 0
+	// Pow(±0, -Inf) = +Inf
+	// Pow(±0, +Inf) = +0
+	// Pow(±0, y) = +Inf for finite y < 0 and not an odd integer
+	// Pow(±0, y) = ±0 for y an odd integer > 0
+	// Pow(±0, y) = +0 for finite y > 0 and not an odd integer
+	// Pow(-1, ±Inf) = 1
+
+	// PowReal(x+0ϵ, +Inf) = +Inf+NaNϵ for |x| > 1
+	{d: Number{Real: two, Dual: zeroQuat}, p: math.Inf(1), want: Number{Real: quat.Inf(), Dual: quat.NaN()}},
+	{d: Number{Real: three, Dual: zeroQuat}, p: math.Inf(1), want: Number{Real: quat.Inf(), Dual: quat.NaN()}},
+
+	// PowReal(x+yϵ, +Inf) = +Inf for |x| > 1
+	{d: Number{Real: two, Dual: one}, p: math.Inf(1), want: Number{Real: quat.Inf(), Dual: quat.Inf()}},
+	{d: Number{Real: three, Dual: one}, p: math.Inf(1), want: Number{Real: quat.Inf(), Dual: quat.Inf()}},
+	{d: Number{Real: two, Dual: two}, p: math.Inf(1), want: Number{Real: quat.Inf(), Dual: quat.Inf()}},
+	{d: Number{Real: three, Dual: two}, p: math.Inf(1), want: Number{Real: quat.Inf(), Dual: quat.Inf()}},
+
+	// PowReal(x, -Inf) = +0+NaNϵ for |x| > 1
+	{d: Number{Real: two, Dual: zeroQuat}, p: math.Inf(-1), want: Number{Real: zeroQuat, Dual: quat.NaN()}},
+	{d: Number{Real: three, Dual: zeroQuat}, p: math.Inf(-1), want: Number{Real: zeroQuat, Dual: quat.NaN()}},
+	{d: Number{Real: two, Dual: one}, p: math.Inf(-1), want: Number{Real: zeroQuat, Dual: quat.NaN()}},
+	{d: Number{Real: three, Dual: one}, p: math.Inf(-1), want: Number{Real: zeroQuat, Dual: quat.NaN()}},
+	{d: Number{Real: two, Dual: two}, p: math.Inf(-1), want: Number{Real: zeroQuat, Dual: quat.NaN()}},
+	{d: Number{Real: three, Dual: two}, p: math.Inf(-1), want: Number{Real: zeroQuat, Dual: quat.NaN()}},
+
+	// PowReal(x+yϵ, +Inf) = +0+NaNϵ for |x| < 1
+	{d: Number{Real: quat.Scale(0.1, one), Dual: zeroQuat}, p: math.Inf(1), want: Number{Real: zeroQuat, Dual: quat.NaN()}},
+	{d: Number{Real: quat.Scale(0.1, one), Dual: quat.Scale(0.1, one)}, p: math.Inf(1), want: Number{Real: zeroQuat, Dual: quat.NaN()}},
+	{d: Number{Real: quat.Scale(0.2, one), Dual: quat.Scale(0.2, one)}, p: math.Inf(1), want: Number{Real: zeroQuat, Dual: quat.NaN()}},
+	{d: Number{Real: quat.Scale(0.5, one), Dual: quat.Scale(0.5, one)}, p: math.Inf(1), want: Number{Real: zeroQuat, Dual: quat.NaN()}},
+
+	// PowReal(x+0ϵ, -Inf) = +Inf+NaNϵ for |x| < 1
+	{d: Number{Real: quat.Scale(0.1, one), Dual: zeroQuat}, p: math.Inf(-1), want: Number{Real: quat.Inf(), Dual: quat.NaN()}},
+	{d: Number{Real: quat.Scale(0.2, one), Dual: zeroQuat}, p: math.Inf(-1), want: Number{Real: quat.Inf(), Dual: quat.NaN()}},
+
+	// PowReal(x, -Inf) = +Inf-Infϵ for |x| < 1
+	{d: Number{Real: quat.Scale(0.1, one), Dual: quat.Scale(0.1, one)}, p: math.Inf(-1), want: Number{Real: quat.Inf(), Dual: quat.Inf()}},
+	{d: Number{Real: quat.Scale(0.2, one), Dual: quat.Scale(0.1, one)}, p: math.Inf(-1), want: Number{Real: quat.Inf(), Dual: quat.Inf()}},
+	{d: Number{Real: quat.Scale(0.1, one), Dual: quat.Scale(0.2, one)}, p: math.Inf(-1), want: Number{Real: quat.Inf(), Dual: quat.Inf()}},
+	{d: Number{Real: quat.Scale(0.2, one), Dual: quat.Scale(0.2, one)}, p: math.Inf(-1), want: Number{Real: quat.Inf(), Dual: quat.Inf()}},
+	{d: Number{Real: quat.Scale(0.1, one), Dual: one}, p: math.Inf(-1), want: Number{Real: quat.Inf(), Dual: quat.Inf()}},
+	{d: Number{Real: quat.Scale(0.2, one), Dual: one}, p: math.Inf(-1), want: Number{Real: quat.Inf(), Dual: quat.Inf()}},
+	{d: Number{Real: quat.Scale(0.1, one), Dual: two}, p: math.Inf(-1), want: Number{Real: quat.Inf(), Dual: quat.Inf()}},
+	{d: Number{Real: quat.Scale(0.2, one), Dual: two}, p: math.Inf(-1), want: Number{Real: quat.Inf(), Dual: quat.Inf()}},
+
+	// Handled by quat.Pow tests:
+	//
+	// Pow(+Inf, y) = +Inf for y > 0
+	// Pow(+Inf, y) = +0 for y < 0
+	// Pow(-Inf, y) = Pow(-0, -y)
+}
+
+func TestPowReal(t *testing.T) {
+	const tol = 1e-15
+	for _, test := range powRealTests {
+		got := PowReal(test.d, test.p)
+		if !sameDual(got, test.want, tol) {
+			t.Errorf("unexpected PowReal(%v, %v): got:%v want:%v", test.d, test.p, got, test.want)
+		}
+	}
+}
+
+func sameDual(a, b Number, tol float64) bool {
+	return same(a.Real, b.Real, tol) && same(a.Dual, b.Dual, tol)
+}
+
+func same(a, b quat.Number, tol float64) bool {
+	return (quat.IsNaN(a) && quat.IsNaN(b)) || (quat.IsInf(a) && quat.IsInf(b)) || equalApprox(a, b, tol)
+}
+
+func equalApprox(a, b quat.Number, tol float64) bool {
+	return floats.EqualWithinAbsOrRel(a.Real, b.Real, tol, tol) &&
+		floats.EqualWithinAbsOrRel(a.Imag, b.Imag, tol, tol) &&
+		floats.EqualWithinAbsOrRel(a.Jmag, b.Jmag, tol, tol) &&
+		floats.EqualWithinAbsOrRel(a.Kmag, b.Kmag, tol, tol)
+}

--- a/num/quat/conj.go
+++ b/num/quat/conj.go
@@ -15,6 +15,9 @@ func Conj(q Number) Number {
 
 // Inv returns the quaternion inverse of q.
 func Inv(q Number) Number {
+	if IsInf(q) {
+		return zero
+	}
 	a := Abs(q)
 	return Scale(1/(a*a), Conj(q))
 }


### PR DESCRIPTION
I have struggled with getting the trig functions to work with these packages and this has prevented me from sending this. Given that the primary use for these types of numbers is to allow 2D and 3D translations and rotations, something that doesn't require trig in this number space, I have decided that discretion is the better part of valor and have removed them. The problems I was facing were compounded (but not entirely caused) by the odd behaviour of "math/cmplx" for some of these functions. If people want trig functions for these, they can file an issue and then I can look at it again (the almost working code is in dualquat-full).

~There is one issue that I am not entirely sure of yet, and I think stems from the commutativity of complex numbers when quaternions are not commutative (this shows up in the different behaviours of the rotate and translate examples of the two packages). I would like to sort this out, but am sending this now.~

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
