### PR TITLE
travis: fix gocc installation

### DIFF
--- a/.travis/install-gocc.sh
+++ b/.travis/install-gocc.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-go get github.com/goccmack/gocc
+set -ex
+
+# TODO(kortschak): Replace this with versioned go get when
+# all our supported versions of Go support it.
+mkdir -p $GOPATH/src/github.com/goccmack
+git clone https://github.com/goccmack/gocc.git $GOPATH/src/github.com/goccmack/gocc
 cd $GOPATH/src/github.com/goccmack/gocc
 git checkout $1
 go install

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gonum.org/v1/gonum
 
 require (
-	golang.org/x/exp v0.0.0-20180321215751-8460e604b9de
-	golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b
+	golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2
+	golang.org/x/tools v0.0.0-20190206041539-40960b6deb8e
 )


### PR DESCRIPTION
It looks like Travis have set `GO111MODULE=on`, breaking our approach to versioning gocc for the code generation checks for graph/format/dot. This gets rid of the use of go get for this pull.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
