### PR TITLE
travis: preparatory changes for Go modules in builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ language: go
 # Do not move these lines; they are referred to by README.md.
 # Versions of go that are explicitly supported by gonum plus go tip.
 go:
- - 1.9.x
- - 1.10.x
  - 1.11.x
+ - 1.10.x
+ - 1.9.x
  - master
 
 env:

--- a/.travis/check-generate.sh
+++ b/.travis/check-generate.sh
@@ -5,6 +5,7 @@ go generate gonum.org/v1/gonum/blas/gonum
 go generate gonum.org/v1/gonum/unit
 go generate gonum.org/v1/gonum/graph/formats/dot
 if [ -n "$(git diff)" ]; then
+	git checkout -- go.mod # Discard changes to go.mod that have been made.
 	git diff
 	exit 1
 fi

--- a/.travis/install-gocc.sh
+++ b/.travis/install-gocc.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-go get github.com/goccmack/gocc
+set -ex
+
+# TODO(kortschak): Replace this with versioned go get when
+# all our supported versions of Go support it.
+mkdir -p $GOPATH/src/github.com/goccmack
+git clone https://github.com/goccmack/gocc.git $GOPATH/src/github.com/goccmack/gocc
 cd $GOPATH/src/github.com/goccmack/gocc
 git checkout $1
 go install

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gonum.org/v1/gonum
 
 require (
-	golang.org/x/exp v0.0.0-20180321215751-8460e604b9de
-	golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b
+	golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2
+	golang.org/x/tools v0.0.0-20190206041539-40960b6deb8e
 )

--- a/unit/generate_unit.go
+++ b/unit/generate_unit.go
@@ -11,7 +11,6 @@ import (
 	"go/format"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 	"text/template"
 )
@@ -194,18 +193,6 @@ var Units = []Unit{
 	},
 }
 
-var gopath string
-var unitPkgPath string
-
-func init() {
-	gopath = os.Getenv("GOPATH")
-	if gopath == "" {
-		log.Fatal("no gopath")
-	}
-
-	unitPkgPath = filepath.Join(gopath, "src", "gonum.org", "v1", "gonum", "unit")
-}
-
 // Generate generates a file for each of the units
 func main() {
 	for _, unit := range Units {
@@ -307,7 +294,7 @@ var form = template.Must(template.New("format").Parse(formatTemplate))
 
 func generate(unit Unit) {
 	lowerName := strings.ToLower(unit.Name)
-	filename := filepath.Join(unitPkgPath, lowerName+".go")
+	filename := lowerName + ".go"
 	f, err := os.Create(filename)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
See #838 for background.

This makes some preparatory changes for using Go modules and for the most part works around the changes that transiently happened to travis' behaviour when a go.mod file existed. It did not completely fix that, but that is not longer necessary.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
