### PR TITLE
graph: make edges and lines reversible

### DIFF
--- a/graph/community/louvain_common.go
+++ b/graph/community/louvain_common.go
@@ -257,10 +257,10 @@ type edge struct {
 	weight   float64
 }
 
-func (e edge) From() graph.Node     { return e.from }
-func (e edge) To() graph.Node       { return e.to }
-func (e edge) Reversed() graph.Edge { e.from, e.to = e.to, e.from; return e }
-func (e edge) Weight() float64      { return e.weight }
+func (e edge) From() graph.Node         { return e.from }
+func (e edge) To() graph.Node           { return e.to }
+func (e edge) ReversedEdge() graph.Edge { e.from, e.to = e.to, e.from; return e }
+func (e edge) Weight() float64          { return e.weight }
 
 // multiplexCommunity is a reduced multiplex graph node describing its membership.
 type multiplexCommunity struct {
@@ -281,10 +281,10 @@ type multiplexEdge struct {
 	weight   float64
 }
 
-func (e multiplexEdge) From() graph.Node     { return e.from }
-func (e multiplexEdge) To() graph.Node       { return e.to }
-func (e multiplexEdge) Reversed() graph.Edge { e.from, e.to = e.to, e.from; return e }
-func (e multiplexEdge) Weight() float64      { return e.weight }
+func (e multiplexEdge) From() graph.Node         { return e.from }
+func (e multiplexEdge) To() graph.Node           { return e.to }
+func (e multiplexEdge) ReversedEdge() graph.Edge { e.from, e.to = e.to, e.from; return e }
+func (e multiplexEdge) Weight() float64          { return e.weight }
 
 // commIdx is an index of a node in a community held by a localMover.
 type commIdx struct {

--- a/graph/community/louvain_common.go
+++ b/graph/community/louvain_common.go
@@ -257,9 +257,10 @@ type edge struct {
 	weight   float64
 }
 
-func (e edge) From() graph.Node { return e.from }
-func (e edge) To() graph.Node   { return e.to }
-func (e edge) Weight() float64  { return e.weight }
+func (e edge) From() graph.Node     { return e.from }
+func (e edge) To() graph.Node       { return e.to }
+func (e edge) Reversed() graph.Edge { e.from, e.to = e.to, e.from; return e }
+func (e edge) Weight() float64      { return e.weight }
 
 // multiplexCommunity is a reduced multiplex graph node describing its membership.
 type multiplexCommunity struct {
@@ -280,9 +281,10 @@ type multiplexEdge struct {
 	weight   float64
 }
 
-func (e multiplexEdge) From() graph.Node { return e.from }
-func (e multiplexEdge) To() graph.Node   { return e.to }
-func (e multiplexEdge) Weight() float64  { return e.weight }
+func (e multiplexEdge) From() graph.Node     { return e.from }
+func (e multiplexEdge) To() graph.Node       { return e.to }
+func (e multiplexEdge) Reversed() graph.Edge { e.from, e.to = e.to, e.from; return e }
+func (e multiplexEdge) Weight() float64      { return e.weight }
 
 // commIdx is an index of a node in a community held by a localMover.
 type commIdx struct {

--- a/graph/encoding/dot/decode.go
+++ b/graph/encoding/dot/decode.go
@@ -240,9 +240,16 @@ func (gen *simpleGraph) addStmt(dst encoding.Builder, stmt ast.Stmt) {
 	}
 }
 
+// basicEdge is an edge without the Reverse method to
+// allow satisfaction by both graph.Edge and graph.Line.
+type basicEdge interface {
+	From() graph.Node
+	To() graph.Node
+}
+
 // applyPortsToEdge applies the available port metadata from an ast.Edge
 // to a graph.Edge
-func applyPortsToEdge(from ast.Vertex, to *ast.Edge, edge graph.Edge) {
+func applyPortsToEdge(from ast.Vertex, to *ast.Edge, edge basicEdge) {
 	if ps, isPortSetter := edge.(PortSetter); isPortSetter {
 		if n, vertexIsNode := from.(*ast.Node); vertexIsNode {
 			if n.Port != nil {
@@ -484,7 +491,7 @@ func (gen *multiGraph) addLine(dst encoding.MultiBuilder, to *ast.Edge, attrs []
 }
 
 // addEdgeAttrs adds the attributes to the given edge.
-func addEdgeAttrs(edge graph.Edge, attrs []*ast.Attr) {
+func addEdgeAttrs(edge basicEdge, attrs []*ast.Attr) {
 	e, ok := edge.(encoding.AttributeSetter)
 	if !ok {
 		return

--- a/graph/encoding/dot/encode_test.go
+++ b/graph/encoding/dot/encode_test.go
@@ -219,7 +219,7 @@ type attrEdge struct {
 
 func (e attrEdge) From() graph.Node                 { return e.from }
 func (e attrEdge) To() graph.Node                   { return e.to }
-func (e attrEdge) Reversed() graph.Edge             { e.from, e.to = e.to, e.from; return e }
+func (e attrEdge) ReversedEdge() graph.Edge         { e.from, e.to = e.to, e.from; return e }
 func (e attrEdge) Weight() float64                  { return 0 }
 func (e attrEdge) Attributes() []encoding.Attribute { return e.attr }
 
@@ -258,7 +258,7 @@ type portedEdge struct {
 
 func (e portedEdge) From() graph.Node { return e.from }
 func (e portedEdge) To() graph.Node   { return e.to }
-func (e portedEdge) Reversed() graph.Edge {
+func (e portedEdge) ReversedEdge() graph.Edge {
 	e.from, e.to = e.to, e.from
 	e.fromPort, e.toPort = e.toPort, e.fromPort
 	e.fromCompass, e.toCompass = e.toCompass, e.fromCompass

--- a/graph/encoding/dot/encode_test.go
+++ b/graph/encoding/dot/encode_test.go
@@ -219,6 +219,7 @@ type attrEdge struct {
 
 func (e attrEdge) From() graph.Node                 { return e.from }
 func (e attrEdge) To() graph.Node                   { return e.to }
+func (e attrEdge) Reversed() graph.Edge             { e.from, e.to = e.to, e.from; return e }
 func (e attrEdge) Weight() float64                  { return 0 }
 func (e attrEdge) Attributes() []encoding.Attribute { return e.attr }
 
@@ -257,7 +258,13 @@ type portedEdge struct {
 
 func (e portedEdge) From() graph.Node { return e.from }
 func (e portedEdge) To() graph.Node   { return e.to }
-func (e portedEdge) Weight() float64  { return 0 }
+func (e portedEdge) Reversed() graph.Edge {
+	e.from, e.to = e.to, e.from
+	e.fromPort, e.toPort = e.toPort, e.fromPort
+	e.fromCompass, e.toCompass = e.toCompass, e.fromCompass
+	return e
+}
+func (e portedEdge) Weight() float64 { return 0 }
 
 func (e portedEdge) FromPort() (port, compass string) {
 	return e.fromPort, e.fromCompass

--- a/graph/encoding/dot/example_test.go
+++ b/graph/encoding/dot/example_test.go
@@ -17,7 +17,7 @@ type edgeWithPorts struct {
 	fromPort, toPort string
 }
 
-func (e edgeWithPorts) Reversed() graph.Edge {
+func (e edgeWithPorts) ReversedEdge() graph.Edge {
 	e.F, e.T = e.T, e.F
 	e.fromPort, e.toPort = e.toPort, e.fromPort
 	return e

--- a/graph/encoding/dot/example_test.go
+++ b/graph/encoding/dot/example_test.go
@@ -7,6 +7,7 @@ package dot_test
 import (
 	"fmt"
 
+	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/encoding/dot"
 	"gonum.org/v1/gonum/graph/simple"
 )
@@ -16,17 +17,23 @@ type edgeWithPorts struct {
 	fromPort, toPort string
 }
 
-func (e *edgeWithPorts) FromPort() (string, string) {
+func (e edgeWithPorts) Reversed() graph.Edge {
+	e.F, e.T = e.T, e.F
+	e.fromPort, e.toPort = e.toPort, e.fromPort
+	return e
+}
+
+func (e edgeWithPorts) FromPort() (string, string) {
 	return e.fromPort, ""
 }
 
-func (e *edgeWithPorts) ToPort() (string, string) {
+func (e edgeWithPorts) ToPort() (string, string) {
 	return e.toPort, ""
 }
 
 func ExamplePorter() {
 	g := simple.NewUndirectedGraph()
-	g.SetEdge(&edgeWithPorts{
+	g.SetEdge(edgeWithPorts{
 		Edge:     simple.Edge{F: simple.Node(1), T: simple.Node(0)},
 		fromPort: "p1",
 		toPort:   "p2",

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -19,9 +19,9 @@ type Edge interface {
 	// To returns the to node of the edge.
 	To() Node
 
-	// Reversed returns an edge that has the
-	// end points of the edge swapped.
-	Reversed() Edge
+	// ReversedEdge returns an edge that has
+	// the end points of the receiver swapped.
+	ReversedEdge() Edge
 }
 
 // WeightedEdge is a weighted graph edge. In directed graphs, the direction

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -13,8 +13,15 @@ type Node interface {
 // edge is given from -> to, otherwise the edge is semantically
 // unordered.
 type Edge interface {
+	// From returns the from node of the edge.
 	From() Node
+
+	// To returns the to node of the edge.
 	To() Node
+
+	// Reversed returns an edge that has the
+	// end points of the edge swapped.
+	Reversed() Edge
 }
 
 // WeightedEdge is a weighted graph edge. In directed graphs, the direction

--- a/graph/iterator/edges_test.go
+++ b/graph/iterator/edges_test.go
@@ -15,9 +15,9 @@ import (
 
 type edge struct{ f, t int }
 
-func (e edge) From() graph.Node     { return simple.Node(e.f) }
-func (e edge) To() graph.Node       { return simple.Node(e.t) }
-func (e edge) Reversed() graph.Edge { return edge{f: e.t, t: e.f} }
+func (e edge) From() graph.Node         { return simple.Node(e.f) }
+func (e edge) To() graph.Node           { return simple.Node(e.t) }
+func (e edge) ReversedEdge() graph.Edge { return edge{f: e.t, t: e.f} }
 
 var orderedEdgesTests = []struct {
 	edges []graph.Edge
@@ -67,10 +67,10 @@ type weightedEdge struct {
 	w    float64
 }
 
-func (e weightedEdge) From() graph.Node     { return simple.Node(e.f) }
-func (e weightedEdge) To() graph.Node       { return simple.Node(e.t) }
-func (e weightedEdge) Reversed() graph.Edge { e.f, e.t = e.t, e.f; return e }
-func (e weightedEdge) Weight() float64      { return e.w }
+func (e weightedEdge) From() graph.Node         { return simple.Node(e.f) }
+func (e weightedEdge) To() graph.Node           { return simple.Node(e.t) }
+func (e weightedEdge) ReversedEdge() graph.Edge { e.f, e.t = e.t, e.f; return e }
+func (e weightedEdge) Weight() float64          { return e.w }
 
 var orderedWeightedEdgesTests = []struct {
 	edges []graph.WeightedEdge

--- a/graph/iterator/edges_test.go
+++ b/graph/iterator/edges_test.go
@@ -15,8 +15,9 @@ import (
 
 type edge struct{ f, t int }
 
-func (e edge) From() graph.Node { return simple.Node(e.f) }
-func (e edge) To() graph.Node   { return simple.Node(e.t) }
+func (e edge) From() graph.Node     { return simple.Node(e.f) }
+func (e edge) To() graph.Node       { return simple.Node(e.t) }
+func (e edge) Reversed() graph.Edge { return edge{f: e.t, t: e.f} }
 
 var orderedEdgesTests = []struct {
 	edges []graph.Edge
@@ -66,9 +67,10 @@ type weightedEdge struct {
 	w    float64
 }
 
-func (e weightedEdge) From() graph.Node { return simple.Node(e.f) }
-func (e weightedEdge) To() graph.Node   { return simple.Node(e.t) }
-func (e weightedEdge) Weight() float64  { return e.w }
+func (e weightedEdge) From() graph.Node     { return simple.Node(e.f) }
+func (e weightedEdge) To() graph.Node       { return simple.Node(e.t) }
+func (e weightedEdge) Reversed() graph.Edge { e.f, e.t = e.t, e.f; return e }
+func (e weightedEdge) Weight() float64      { return e.w }
 
 var orderedWeightedEdgesTests = []struct {
 	edges []graph.WeightedEdge

--- a/graph/iterator/lines_test.go
+++ b/graph/iterator/lines_test.go
@@ -15,10 +15,10 @@ import (
 
 type line struct{ f, t int }
 
-func (l line) From() graph.Node     { return simple.Node(l.f) }
-func (l line) To() graph.Node       { return simple.Node(l.t) }
-func (l line) Reversed() graph.Line { return line{f: l.t, t: l.f} }
-func (l line) ID() int64            { return 1 }
+func (l line) From() graph.Node         { return simple.Node(l.f) }
+func (l line) To() graph.Node           { return simple.Node(l.t) }
+func (l line) ReversedLine() graph.Line { return line{f: l.t, t: l.f} }
+func (l line) ID() int64                { return 1 }
 
 var orderedLinesTests = []struct {
 	lines []graph.Line
@@ -68,11 +68,11 @@ type weightedLine struct {
 	w    float64
 }
 
-func (l weightedLine) From() graph.Node     { return simple.Node(l.f) }
-func (l weightedLine) To() graph.Node       { return simple.Node(l.t) }
-func (l weightedLine) Reversed() graph.Line { l.f, l.t = l.t, l.f; return l }
-func (l weightedLine) Weight() float64      { return l.w }
-func (l weightedLine) ID() int64            { return 1 }
+func (l weightedLine) From() graph.Node         { return simple.Node(l.f) }
+func (l weightedLine) To() graph.Node           { return simple.Node(l.t) }
+func (l weightedLine) ReversedLine() graph.Line { l.f, l.t = l.t, l.f; return l }
+func (l weightedLine) Weight() float64          { return l.w }
+func (l weightedLine) ID() int64                { return 1 }
 
 var orderedWeightedLinesTests = []struct {
 	lines []graph.WeightedLine

--- a/graph/iterator/lines_test.go
+++ b/graph/iterator/lines_test.go
@@ -17,7 +17,7 @@ type line struct{ f, t int }
 
 func (l line) From() graph.Node     { return simple.Node(l.f) }
 func (l line) To() graph.Node       { return simple.Node(l.t) }
-func (l line) Reversed() graph.Edge { return line{f: l.t, t: l.f} }
+func (l line) Reversed() graph.Line { return line{f: l.t, t: l.f} }
 func (l line) ID() int64            { return 1 }
 
 var orderedLinesTests = []struct {
@@ -70,7 +70,7 @@ type weightedLine struct {
 
 func (l weightedLine) From() graph.Node     { return simple.Node(l.f) }
 func (l weightedLine) To() graph.Node       { return simple.Node(l.t) }
-func (l weightedLine) Reversed() graph.Edge { l.f, l.t = l.t, l.f; return l }
+func (l weightedLine) Reversed() graph.Line { l.f, l.t = l.t, l.f; return l }
 func (l weightedLine) Weight() float64      { return l.w }
 func (l weightedLine) ID() int64            { return 1 }
 

--- a/graph/iterator/lines_test.go
+++ b/graph/iterator/lines_test.go
@@ -15,9 +15,10 @@ import (
 
 type line struct{ f, t int }
 
-func (l line) From() graph.Node { return simple.Node(l.f) }
-func (l line) To() graph.Node   { return simple.Node(l.t) }
-func (l line) ID() int64        { return 1 }
+func (l line) From() graph.Node     { return simple.Node(l.f) }
+func (l line) To() graph.Node       { return simple.Node(l.t) }
+func (l line) Reversed() graph.Edge { return line{f: l.t, t: l.f} }
+func (l line) ID() int64            { return 1 }
 
 var orderedLinesTests = []struct {
 	lines []graph.Line
@@ -67,10 +68,11 @@ type weightedLine struct {
 	w    float64
 }
 
-func (l weightedLine) From() graph.Node { return simple.Node(l.f) }
-func (l weightedLine) To() graph.Node   { return simple.Node(l.t) }
-func (l weightedLine) Weight() float64  { return l.w }
-func (l weightedLine) ID() int64        { return 1 }
+func (l weightedLine) From() graph.Node     { return simple.Node(l.f) }
+func (l weightedLine) To() graph.Node       { return simple.Node(l.t) }
+func (l weightedLine) Reversed() graph.Edge { l.f, l.t = l.t, l.f; return l }
+func (l weightedLine) Weight() float64      { return l.w }
+func (l weightedLine) ID() int64            { return 1 }
 
 var orderedWeightedLinesTests = []struct {
 	lines []graph.WeightedLine

--- a/graph/multi/directed_test.go
+++ b/graph/multi/directed_test.go
@@ -17,7 +17,7 @@ import (
 	"gonum.org/v1/gonum/graph/testgraph"
 )
 
-func directedBuilder(nodes []graph.Node, edges []graph.WeightedLine, _, _ float64) (g graph.Graph, n []graph.Node, e []graph.Edge, s, a float64, ok bool) {
+func directedBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, _, _ float64) (g graph.Graph, n []graph.Node, e []testgraph.Edge, s, a float64, ok bool) {
 	seen := make(set.Nodes)
 	dg := multi.NewDirectedGraph()
 	for _, n := range nodes {

--- a/graph/multi/multi.go
+++ b/graph/multi/multi.go
@@ -51,7 +51,7 @@ func (l Line) To() graph.Node { return l.T }
 // swapped. The UID of the new Line is the same as the
 // UID of the receiver. The Lines within the Edge are
 // not altered.
-func (l Line) Reversed() graph.Edge { l.F, l.T = l.T, l.F; return l }
+func (l Line) Reversed() graph.Line { l.F, l.T = l.T, l.F; return l }
 
 // ID returns the ID of the line.
 func (l Line) ID() int64 { return l.UID }
@@ -121,7 +121,7 @@ func (l WeightedLine) To() graph.Node { return l.T }
 // Reversed returns a new Line with the F and T fields
 // swapped. The UID and W of the new Line are the same as the
 // UID and W of the receiver.
-func (l WeightedLine) Reversed() graph.Edge { l.F, l.T = l.T, l.F; return l }
+func (l WeightedLine) Reversed() graph.Line { l.F, l.T = l.T, l.F; return l }
 
 // ID returns the ID of the line.
 func (l WeightedLine) ID() int64 { return l.UID }

--- a/graph/multi/multi.go
+++ b/graph/multi/multi.go
@@ -30,9 +30,9 @@ func (e Edge) From() graph.Node { return e.F }
 // To returns the to-node of the edge.
 func (e Edge) To() graph.Node { return e.T }
 
-// Reversed returns a new Edge with the F and T fields
+// ReversedEdge returns a new Edge with the F and T fields
 // swapped.
-func (e Edge) Reversed() graph.Edge { return Edge{F: e.T, T: e.F} }
+func (e Edge) ReversedEdge() graph.Edge { return Edge{F: e.T, T: e.F} }
 
 // Line is a multigraph edge.
 type Line struct {
@@ -47,11 +47,11 @@ func (l Line) From() graph.Node { return l.F }
 // To returns the to-node of the line.
 func (l Line) To() graph.Node { return l.T }
 
-// Reversed returns a new Line with the F and T fields
+// ReversedLine returns a new Line with the F and T fields
 // swapped. The UID of the new Line is the same as the
 // UID of the receiver. The Lines within the Edge are
 // not altered.
-func (l Line) Reversed() graph.Line { l.F, l.T = l.T, l.F; return l }
+func (l Line) ReversedLine() graph.Line { l.F, l.T = l.T, l.F; return l }
 
 // ID returns the ID of the line.
 func (l Line) ID() int64 { return l.UID }
@@ -80,10 +80,10 @@ func (e WeightedEdge) From() graph.Node { return e.F }
 // To returns the to-node of the edge.
 func (e WeightedEdge) To() graph.Node { return e.T }
 
-// Reversed returns a new Edge with the F and T fields
+// ReversedEdge returns a new Edge with the F and T fields
 // swapped. The Lines within the WeightedEdge are not
 // altered.
-func (e WeightedEdge) Reversed() graph.Edge { e.F, e.T = e.T, e.F; return e }
+func (e WeightedEdge) ReversedEdge() graph.Edge { e.F, e.T = e.T, e.F; return e }
 
 // Weight returns the weight of the edge. Weight uses WeightFunc
 // field to calculate the weight, so the WeightedLines field is
@@ -118,10 +118,10 @@ func (l WeightedLine) From() graph.Node { return l.F }
 // To returns the to-node of the line.
 func (l WeightedLine) To() graph.Node { return l.T }
 
-// Reversed returns a new Line with the F and T fields
+// ReversedLine returns a new Line with the F and T fields
 // swapped. The UID and W of the new Line are the same as the
 // UID and W of the receiver.
-func (l WeightedLine) Reversed() graph.Line { l.F, l.T = l.T, l.F; return l }
+func (l WeightedLine) ReversedLine() graph.Line { l.F, l.T = l.T, l.F; return l }
 
 // ID returns the ID of the line.
 func (l WeightedLine) ID() int64 { return l.UID }

--- a/graph/multi/multi.go
+++ b/graph/multi/multi.go
@@ -30,6 +30,10 @@ func (e Edge) From() graph.Node { return e.F }
 // To returns the to-node of the edge.
 func (e Edge) To() graph.Node { return e.T }
 
+// Reversed returns a new Edge with the F and T fields
+// swapped.
+func (e Edge) Reversed() graph.Edge { return Edge{F: e.T, T: e.F} }
+
 // Line is a multigraph edge.
 type Line struct {
 	F, T graph.Node
@@ -42,6 +46,12 @@ func (l Line) From() graph.Node { return l.F }
 
 // To returns the to-node of the line.
 func (l Line) To() graph.Node { return l.T }
+
+// Reversed returns a new Line with the F and T fields
+// swapped. The UID of the new Line is the same as the
+// UID of the receiver. The Lines within the Edge are
+// not altered.
+func (l Line) Reversed() graph.Edge { l.F, l.T = l.T, l.F; return l }
 
 // ID returns the ID of the line.
 func (l Line) ID() int64 { return l.UID }
@@ -69,6 +79,11 @@ func (e WeightedEdge) From() graph.Node { return e.F }
 
 // To returns the to-node of the edge.
 func (e WeightedEdge) To() graph.Node { return e.T }
+
+// Reversed returns a new Edge with the F and T fields
+// swapped. The Lines within the WeightedEdge are not
+// altered.
+func (e WeightedEdge) Reversed() graph.Edge { e.F, e.T = e.T, e.F; return e }
 
 // Weight returns the weight of the edge. Weight uses WeightFunc
 // field to calculate the weight, so the WeightedLines field is
@@ -102,6 +117,11 @@ func (l WeightedLine) From() graph.Node { return l.F }
 
 // To returns the to-node of the line.
 func (l WeightedLine) To() graph.Node { return l.T }
+
+// Reversed returns a new Line with the F and T fields
+// swapped. The UID and W of the new Line are the same as the
+// UID and W of the receiver.
+func (l WeightedLine) Reversed() graph.Edge { l.F, l.T = l.T, l.F; return l }
 
 // ID returns the ID of the line.
 func (l WeightedLine) ID() int64 { return l.UID }

--- a/graph/multi/undirected.go
+++ b/graph/multi/undirected.go
@@ -143,7 +143,7 @@ func (g *UndirectedGraph) LinesBetween(xid, yid int64) graph.Lines {
 	var lines []graph.Line
 	for _, l := range g.lines[xid][yid] {
 		if l.From().ID() != xid {
-			l = l.Reversed().(graph.Line)
+			l = l.Reversed()
 		}
 		lines = append(lines, l)
 	}

--- a/graph/multi/undirected.go
+++ b/graph/multi/undirected.go
@@ -143,7 +143,7 @@ func (g *UndirectedGraph) LinesBetween(xid, yid int64) graph.Lines {
 	var lines []graph.Line
 	for _, l := range g.lines[xid][yid] {
 		if l.From().ID() != xid {
-			l = l.Reversed()
+			l = l.ReversedLine()
 		}
 		lines = append(lines, l)
 	}

--- a/graph/multi/undirected.go
+++ b/graph/multi/undirected.go
@@ -142,6 +142,9 @@ func (g *UndirectedGraph) LinesBetween(xid, yid int64) graph.Lines {
 	}
 	var lines []graph.Line
 	for _, l := range g.lines[xid][yid] {
+		if l.From().ID() != xid {
+			l = l.Reversed().(graph.Line)
+		}
 		lines = append(lines, l)
 	}
 	return iterator.NewOrderedLines(lines)

--- a/graph/multi/undirected_test.go
+++ b/graph/multi/undirected_test.go
@@ -17,7 +17,7 @@ import (
 	"gonum.org/v1/gonum/graph/testgraph"
 )
 
-func undirectedBuilder(nodes []graph.Node, edges []graph.WeightedLine, _, _ float64) (g graph.Graph, n []graph.Node, e []graph.Edge, s, a float64, ok bool) {
+func undirectedBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, _, _ float64) (g graph.Graph, n []graph.Node, e []testgraph.Edge, s, a float64, ok bool) {
 	seen := make(set.Nodes)
 	ug := multi.NewUndirectedGraph()
 	for _, n := range nodes {

--- a/graph/multi/weighted_directed_test.go
+++ b/graph/multi/weighted_directed_test.go
@@ -16,7 +16,7 @@ import (
 	"gonum.org/v1/gonum/graph/testgraph"
 )
 
-func weightedDirectedBuilder(nodes []graph.Node, edges []graph.WeightedLine, self, absent float64) (g graph.Graph, n []graph.Node, e []graph.Edge, s, a float64, ok bool) {
+func weightedDirectedBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, self, absent float64) (g graph.Graph, n []graph.Node, e []testgraph.Edge, s, a float64, ok bool) {
 	seen := make(set.Nodes)
 	dg := multi.NewWeightedDirectedGraph()
 	dg.EdgeWeightFunc = func(l graph.WeightedLines) float64 {

--- a/graph/multi/weighted_undirected.go
+++ b/graph/multi/weighted_undirected.go
@@ -352,7 +352,7 @@ func (g *WeightedUndirectedGraph) WeightedLinesBetween(xid, yid int64) graph.Wei
 		}
 		seen[lid] = struct{}{}
 		if l.From().ID() != xid {
-			l = l.Reversed().(graph.WeightedLine)
+			l = l.ReversedLine().(graph.WeightedLine)
 		}
 		lines = append(lines, l)
 	}

--- a/graph/multi/weighted_undirected.go
+++ b/graph/multi/weighted_undirected.go
@@ -351,6 +351,9 @@ func (g *WeightedUndirectedGraph) WeightedLinesBetween(xid, yid int64) graph.Wei
 			continue
 		}
 		seen[lid] = struct{}{}
+		if l.From().ID() != xid {
+			l = l.Reversed().(graph.WeightedLine)
+		}
 		lines = append(lines, l)
 	}
 	return iterator.NewOrderedWeightedLines(lines)

--- a/graph/multi/weighted_undirected_test.go
+++ b/graph/multi/weighted_undirected_test.go
@@ -16,7 +16,7 @@ import (
 	"gonum.org/v1/gonum/graph/testgraph"
 )
 
-func weightedUndirectedBuilder(nodes []graph.Node, edges []graph.WeightedLine, self, absent float64) (g graph.Graph, n []graph.Node, e []graph.Edge, s, a float64, ok bool) {
+func weightedUndirectedBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, self, absent float64) (g graph.Graph, n []graph.Node, e []testgraph.Edge, s, a float64, ok bool) {
 	seen := make(set.Nodes)
 	ug := multi.NewWeightedUndirectedGraph()
 	ug.EdgeWeightFunc = func(l graph.WeightedLines) float64 {

--- a/graph/multigraph.go
+++ b/graph/multigraph.go
@@ -13,9 +13,9 @@ type Line interface {
 	// To returns the to node of the edge.
 	To() Node
 
-	// Reversed returns an edge that has the
-	// end points of the edge swapped.
-	Reversed() Line
+	// ReversedLine returns a line that has the
+	// end points of the receiver swapped.
+	ReversedLine() Line
 
 	// ID returns the unique ID for the Line.
 	ID() int64

--- a/graph/multigraph.go
+++ b/graph/multigraph.go
@@ -7,7 +7,17 @@ package graph
 // Line is an edge in a multigraph. A Line returns an ID that must
 // distinguish Lines sharing Node end points.
 type Line interface {
-	Edge
+	// From returns the from node of the edge.
+	From() Node
+
+	// To returns the to node of the edge.
+	To() Node
+
+	// Reversed returns an edge that has the
+	// end points of the edge swapped.
+	Reversed() Line
+
+	// ID returns the unique ID for the Line.
 	ID() int64
 }
 

--- a/graph/path/a_star_test.go
+++ b/graph/path/a_star_test.go
@@ -221,10 +221,10 @@ type weightedEdge struct {
 	cost     float64
 }
 
-func (e weightedEdge) From() graph.Node     { return e.from }
-func (e weightedEdge) To() graph.Node       { return e.to }
-func (e weightedEdge) Reversed() graph.Edge { e.from, e.to = e.to, e.from; return e }
-func (e weightedEdge) Weight() float64      { return e.cost }
+func (e weightedEdge) From() graph.Node         { return e.from }
+func (e weightedEdge) To() graph.Node           { return e.to }
+func (e weightedEdge) ReversedEdge() graph.Edge { e.from, e.to = e.to, e.from; return e }
+func (e weightedEdge) Weight() float64          { return e.cost }
 
 func isMonotonic(g UndirectedWeightLister, h Heuristic) (ok bool, at graph.Edge, goal graph.Node) {
 	for _, goal := range graph.NodesOf(g.Nodes()) {

--- a/graph/path/a_star_test.go
+++ b/graph/path/a_star_test.go
@@ -221,9 +221,10 @@ type weightedEdge struct {
 	cost     float64
 }
 
-func (e weightedEdge) From() graph.Node { return e.from }
-func (e weightedEdge) To() graph.Node   { return e.to }
-func (e weightedEdge) Weight() float64  { return e.cost }
+func (e weightedEdge) From() graph.Node     { return e.from }
+func (e weightedEdge) To() graph.Node       { return e.to }
+func (e weightedEdge) Reversed() graph.Edge { e.from, e.to = e.to, e.from; return e }
+func (e weightedEdge) Weight() float64      { return e.cost }
 
 func isMonotonic(g UndirectedWeightLister, h Heuristic) (ok bool, at graph.Edge, goal graph.Node) {
 	for _, goal := range graph.NodesOf(g.Nodes()) {

--- a/graph/simple/densegraph_test.go
+++ b/graph/simple/densegraph_test.go
@@ -31,7 +31,7 @@ func isZeroContiguousSet(nodes []graph.Node) bool {
 	return true
 }
 
-func directedMatrixBuilder(nodes []graph.Node, edges []graph.WeightedLine, self, absent float64) (g graph.Graph, n []graph.Node, e []graph.Edge, s, a float64, ok bool) {
+func directedMatrixBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, self, absent float64) (g graph.Graph, n []graph.Node, e []testgraph.Edge, s, a float64, ok bool) {
 	if len(nodes) == 0 {
 		return
 	}
@@ -150,7 +150,7 @@ func TestDirectedMatrix(t *testing.T) {
 	})
 }
 
-func directedMatrixFromBuilder(nodes []graph.Node, edges []graph.WeightedLine, self, absent float64) (g graph.Graph, n []graph.Node, e []graph.Edge, s, a float64, ok bool) {
+func directedMatrixFromBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, self, absent float64) (g graph.Graph, n []graph.Node, e []testgraph.Edge, s, a float64, ok bool) {
 	if len(nodes) == 0 {
 		return
 	}
@@ -282,7 +282,7 @@ func (g newEdgeShimDir) NewWeightedEdge(u, v graph.Node, w float64) graph.Weight
 	return simple.WeightedEdge{F: u, T: v, W: w}
 }
 
-func undirectedMatrixBuilder(nodes []graph.Node, edges []graph.WeightedLine, self, absent float64) (g graph.Graph, n []graph.Node, e []graph.Edge, s, a float64, ok bool) {
+func undirectedMatrixBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, self, absent float64) (g graph.Graph, n []graph.Node, e []testgraph.Edge, s, a float64, ok bool) {
 	if len(nodes) == 0 {
 		return
 	}
@@ -401,7 +401,7 @@ func TestUnirectedMatrix(t *testing.T) {
 	})
 }
 
-func undirectedMatrixFromBuilder(nodes []graph.Node, edges []graph.WeightedLine, self, absent float64) (g graph.Graph, n []graph.Node, e []graph.Edge, s, a float64, ok bool) {
+func undirectedMatrixFromBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, self, absent float64) (g graph.Graph, n []graph.Node, e []testgraph.Edge, s, a float64, ok bool) {
 	if len(nodes) == 0 {
 		return
 	}

--- a/graph/simple/directed_test.go
+++ b/graph/simple/directed_test.go
@@ -16,7 +16,7 @@ import (
 	"gonum.org/v1/gonum/graph/testgraph"
 )
 
-func directedBuilder(nodes []graph.Node, edges []graph.WeightedLine, _, _ float64) (g graph.Graph, n []graph.Node, e []graph.Edge, s, a float64, ok bool) {
+func directedBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, _, _ float64) (g graph.Graph, n []graph.Node, e []testgraph.Edge, s, a float64, ok bool) {
 	seen := make(set.Nodes)
 	dg := simple.NewDirectedGraph()
 	for _, n := range nodes {

--- a/graph/simple/simple.go
+++ b/graph/simple/simple.go
@@ -33,9 +33,9 @@ func (e Edge) From() graph.Node { return e.F }
 // To returns the to-node of the edge.
 func (e Edge) To() graph.Node { return e.T }
 
-// Reversed returns a new Edge with the F and T fields
+// ReversedLine returns a new Edge with the F and T fields
 // swapped.
-func (e Edge) Reversed() graph.Edge { return Edge{F: e.T, T: e.F} }
+func (e Edge) ReversedEdge() graph.Edge { return Edge{F: e.T, T: e.F} }
 
 // WeightedEdge is a simple weighted graph edge.
 type WeightedEdge struct {
@@ -49,10 +49,10 @@ func (e WeightedEdge) From() graph.Node { return e.F }
 // To returns the to-node of the edge.
 func (e WeightedEdge) To() graph.Node { return e.T }
 
-// Reversed returns a new Edge with the F and T fields
+// ReversedLine returns a new Edge with the F and T fields
 // swapped. The weight of the new Edge is the same as
 // the weight of the receiver.
-func (e WeightedEdge) Reversed() graph.Edge { return WeightedEdge{F: e.T, T: e.F, W: e.W} }
+func (e WeightedEdge) ReversedEdge() graph.Edge { return WeightedEdge{F: e.T, T: e.F, W: e.W} }
 
 // Weight returns the weight of the edge.
 func (e WeightedEdge) Weight() float64 { return e.W }

--- a/graph/simple/simple.go
+++ b/graph/simple/simple.go
@@ -33,6 +33,10 @@ func (e Edge) From() graph.Node { return e.F }
 // To returns the to-node of the edge.
 func (e Edge) To() graph.Node { return e.T }
 
+// Reversed returns a new Edge with the F and T fields
+// swapped.
+func (e Edge) Reversed() graph.Edge { return Edge{F: e.T, T: e.F} }
+
 // WeightedEdge is a simple weighted graph edge.
 type WeightedEdge struct {
 	F, T graph.Node
@@ -44,6 +48,11 @@ func (e WeightedEdge) From() graph.Node { return e.F }
 
 // To returns the to-node of the edge.
 func (e WeightedEdge) To() graph.Node { return e.T }
+
+// Reversed returns a new Edge with the F and T fields
+// swapped. The weight of the new Edge is the same as
+// the weight of the receiver.
+func (e WeightedEdge) Reversed() graph.Edge { return WeightedEdge{F: e.T, T: e.F, W: e.W} }
 
 // Weight returns the weight of the edge.
 func (e WeightedEdge) Weight() float64 { return e.W }

--- a/graph/simple/undirected.go
+++ b/graph/simple/undirected.go
@@ -66,7 +66,7 @@ func (g *UndirectedGraph) EdgeBetween(xid, yid int64) graph.Edge {
 	if edge.From().ID() == xid {
 		return edge
 	}
-	return edge.Reversed()
+	return edge.ReversedEdge()
 }
 
 // Edges returns all the edges in the graph.

--- a/graph/simple/undirected.go
+++ b/graph/simple/undirected.go
@@ -63,7 +63,10 @@ func (g *UndirectedGraph) EdgeBetween(xid, yid int64) graph.Edge {
 	if !ok {
 		return nil
 	}
-	return edge
+	if edge.From().ID() == xid {
+		return edge
+	}
+	return edge.Reversed()
 }
 
 // Edges returns all the edges in the graph.

--- a/graph/simple/undirected_test.go
+++ b/graph/simple/undirected_test.go
@@ -16,7 +16,7 @@ import (
 	"gonum.org/v1/gonum/graph/testgraph"
 )
 
-func undirectedBuilder(nodes []graph.Node, edges []graph.WeightedLine, _, _ float64) (g graph.Graph, n []graph.Node, e []graph.Edge, s, a float64, ok bool) {
+func undirectedBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, _, _ float64) (g graph.Graph, n []graph.Node, e []testgraph.Edge, s, a float64, ok bool) {
 	seen := make(set.Nodes)
 	ug := simple.NewUndirectedGraph()
 	for _, n := range nodes {

--- a/graph/simple/weighted_directed_test.go
+++ b/graph/simple/weighted_directed_test.go
@@ -16,7 +16,7 @@ import (
 	"gonum.org/v1/gonum/graph/testgraph"
 )
 
-func weightedDirectedBuilder(nodes []graph.Node, edges []graph.WeightedLine, self, absent float64) (g graph.Graph, n []graph.Node, e []graph.Edge, s, a float64, ok bool) {
+func weightedDirectedBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, self, absent float64) (g graph.Graph, n []graph.Node, e []testgraph.Edge, s, a float64, ok bool) {
 	seen := make(set.Nodes)
 	dg := simple.NewWeightedDirectedGraph(self, absent)
 	for _, n := range nodes {

--- a/graph/simple/weighted_undirected.go
+++ b/graph/simple/weighted_undirected.go
@@ -247,7 +247,7 @@ func (g *WeightedUndirectedGraph) WeightedEdgeBetween(xid, yid int64) graph.Weig
 	if edge.From().ID() == xid {
 		return edge
 	}
-	return edge.Reversed().(graph.WeightedEdge)
+	return edge.ReversedEdge().(graph.WeightedEdge)
 }
 
 // WeightedEdges returns all the weighted edges in the graph.

--- a/graph/simple/weighted_undirected.go
+++ b/graph/simple/weighted_undirected.go
@@ -244,7 +244,10 @@ func (g *WeightedUndirectedGraph) WeightedEdgeBetween(xid, yid int64) graph.Weig
 	if !ok {
 		return nil
 	}
-	return edge
+	if edge.From().ID() == xid {
+		return edge
+	}
+	return edge.Reversed().(graph.WeightedEdge)
 }
 
 // WeightedEdges returns all the weighted edges in the graph.

--- a/graph/simple/weighted_undirected_test.go
+++ b/graph/simple/weighted_undirected_test.go
@@ -16,7 +16,7 @@ import (
 	"gonum.org/v1/gonum/graph/testgraph"
 )
 
-func weightedUndirectedBuilder(nodes []graph.Node, edges []graph.WeightedLine, self, absent float64) (g graph.Graph, n []graph.Node, e []graph.Edge, s, a float64, ok bool) {
+func weightedUndirectedBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, self, absent float64) (g graph.Graph, n []graph.Node, e []testgraph.Edge, s, a float64, ok bool) {
 	seen := make(set.Nodes)
 	ug := simple.NewWeightedUndirectedGraph(self, absent)
 	for _, n := range nodes {

--- a/graph/testgraph/testcases.go
+++ b/graph/testgraph/testcases.go
@@ -25,11 +25,11 @@ type line struct {
 	W    float64
 }
 
-func (e line) From() graph.Node     { return e.F }
-func (e line) To() graph.Node       { return e.T }
-func (e line) Reversed() graph.Edge { e.F, e.T = e.T, e.F; return e }
-func (e line) ID() int64            { return e.UID }
-func (e line) Weight() float64      { return e.W }
+func (e line) From() graph.Node         { return e.F }
+func (e line) To() graph.Node           { return e.T }
+func (e line) ReversedEdge() graph.Edge { e.F, e.T = e.T, e.F; return e }
+func (e line) ID() int64                { return e.UID }
+func (e line) Weight() float64          { return e.W }
 
 var testCases = []struct {
 	// name is the name of the test.

--- a/graph/testgraph/testcases.go
+++ b/graph/testgraph/testcases.go
@@ -41,7 +41,7 @@ var testCases = []struct {
 
 	// edges is the set of edges that should be used
 	// to construct the graph.
-	edges []graph.WeightedLine
+	edges []WeightedLine
 
 	// nonexist is a set of nodes that should not be
 	// found within the graph.
@@ -87,7 +87,7 @@ var testCases = []struct {
 	{
 		name:     "one - self loop",
 		nodes:    []graph.Node{node(0)},
-		edges:    []graph.WeightedLine{line{F: node(0), T: node(0), UID: 0, W: 0.5}},
+		edges:    []WeightedLine{line{F: node(0), T: node(0), UID: 0, W: 0.5}},
 		nonexist: []graph.Node{node(-1), node(1)},
 		self:     0,
 		absent:   math.Inf(1),
@@ -96,7 +96,7 @@ var testCases = []struct {
 	{
 		name:     "two - positive",
 		nodes:    []graph.Node{node(1), node(2)},
-		edges:    []graph.WeightedLine{line{F: node(1), T: node(2), UID: 0, W: 0.5}},
+		edges:    []WeightedLine{line{F: node(1), T: node(2), UID: 0, W: 0.5}},
 		nonexist: []graph.Node{node(-1), node(0)},
 		self:     0,
 		absent:   math.Inf(1),
@@ -104,7 +104,7 @@ var testCases = []struct {
 	{
 		name:     "two - negative",
 		nodes:    []graph.Node{node(-1), node(-2)},
-		edges:    []graph.WeightedLine{line{F: node(-1), T: node(-2), UID: 0, W: 0.5}},
+		edges:    []WeightedLine{line{F: node(-1), T: node(-2), UID: 0, W: 0.5}},
 		nonexist: []graph.Node{node(0), node(-3)},
 		self:     0,
 		absent:   math.Inf(1),
@@ -112,7 +112,7 @@ var testCases = []struct {
 	{
 		name:     "two - zero spanning",
 		nodes:    []graph.Node{node(-1), node(1)},
-		edges:    []graph.WeightedLine{line{F: node(-1), T: node(1), UID: 0, W: 0.5}},
+		edges:    []WeightedLine{line{F: node(-1), T: node(1), UID: 0, W: 0.5}},
 		nonexist: []graph.Node{node(0), node(2)},
 		self:     0,
 		absent:   math.Inf(1),
@@ -120,7 +120,7 @@ var testCases = []struct {
 	{
 		name:     "two - zero contiguous",
 		nodes:    []graph.Node{node(0), node(1)},
-		edges:    []graph.WeightedLine{line{F: node(0), T: node(1), UID: 0, W: 0.5}},
+		edges:    []WeightedLine{line{F: node(0), T: node(1), UID: 0, W: 0.5}},
 		nonexist: []graph.Node{node(-1), node(2)},
 		self:     0,
 		absent:   math.Inf(1),
@@ -129,7 +129,7 @@ var testCases = []struct {
 	{
 		name:     "three - positive",
 		nodes:    []graph.Node{node(1), node(2), node(3)},
-		edges:    []graph.WeightedLine{line{F: node(1), T: node(2), UID: 0, W: 0.5}},
+		edges:    []WeightedLine{line{F: node(1), T: node(2), UID: 0, W: 0.5}},
 		nonexist: []graph.Node{node(-1), node(0)},
 		self:     0,
 		absent:   math.Inf(1),
@@ -137,7 +137,7 @@ var testCases = []struct {
 	{
 		name:     "three - negative",
 		nodes:    []graph.Node{node(-1), node(-2), node(-3)},
-		edges:    []graph.WeightedLine{line{F: node(-1), T: node(-2), UID: 0, W: 0.5}},
+		edges:    []WeightedLine{line{F: node(-1), T: node(-2), UID: 0, W: 0.5}},
 		nonexist: []graph.Node{node(0), node(1)},
 		self:     0,
 		absent:   math.Inf(1),
@@ -145,7 +145,7 @@ var testCases = []struct {
 	{
 		name:     "three - zero spanning",
 		nodes:    []graph.Node{node(-1), node(0), node(1)},
-		edges:    []graph.WeightedLine{line{F: node(-1), T: node(1), UID: 0, W: 0.5}},
+		edges:    []WeightedLine{line{F: node(-1), T: node(1), UID: 0, W: 0.5}},
 		nonexist: []graph.Node{node(-2), node(2)},
 		self:     0,
 		absent:   math.Inf(1),
@@ -153,7 +153,7 @@ var testCases = []struct {
 	{
 		name:     "three - zero contiguous",
 		nodes:    []graph.Node{node(0), node(1), node(2)},
-		edges:    []graph.WeightedLine{line{F: node(0), T: node(1), UID: 0, W: 0.5}},
+		edges:    []WeightedLine{line{F: node(0), T: node(1), UID: 0, W: 0.5}},
 		nonexist: []graph.Node{node(-1), node(3)},
 		self:     0,
 		absent:   math.Inf(1),
@@ -161,10 +161,10 @@ var testCases = []struct {
 
 	{
 		name: "4-clique - single(non-prepared)",
-		edges: func() []graph.WeightedLine {
+		edges: func() []WeightedLine {
 			const n = 4
 			var uid int64
-			var edges []graph.WeightedLine
+			var edges []WeightedLine
 			for i := 0; i < n; i++ {
 				for j := i + 1; j < 4; j++ {
 					edges = append(edges, line{F: node(i), T: node(j), UID: uid, W: 0.5})
@@ -179,10 +179,10 @@ var testCases = []struct {
 	},
 	{
 		name: "4-clique+ - single(non-prepared)",
-		edges: func() []graph.WeightedLine {
+		edges: func() []WeightedLine {
 			const n = 4
 			var uid int64
-			var edges []graph.WeightedLine
+			var edges []WeightedLine
 			for i := 0; i < n; i++ {
 				for j := i; j < 4; j++ {
 					edges = append(edges, line{F: node(i), T: node(j), UID: uid, W: 0.5})
@@ -205,10 +205,10 @@ var testCases = []struct {
 			}
 			return nodes
 		}(),
-		edges: func() []graph.WeightedLine {
+		edges: func() []WeightedLine {
 			const n = 4
 			var uid int64
-			var edges []graph.WeightedLine
+			var edges []WeightedLine
 			for i := 0; i < n; i++ {
 				for j := i + 1; j < n; j++ {
 					edges = append(edges, line{F: node(i), T: node(j), UID: uid, W: 0.5})
@@ -231,10 +231,10 @@ var testCases = []struct {
 			}
 			return nodes
 		}(),
-		edges: func() []graph.WeightedLine {
+		edges: func() []WeightedLine {
 			const n = 4
 			var uid int64
-			var edges []graph.WeightedLine
+			var edges []WeightedLine
 			for i := 0; i < n; i++ {
 				for j := i; j < n; j++ {
 					edges = append(edges, line{F: node(i), T: node(j), UID: uid, W: 0.5})
@@ -250,10 +250,10 @@ var testCases = []struct {
 
 	{
 		name: "4-clique - double(non-prepared)",
-		edges: func() []graph.WeightedLine {
+		edges: func() []WeightedLine {
 			const n = 4
 			var uid int64
-			var edges []graph.WeightedLine
+			var edges []WeightedLine
 			for i := 0; i < n; i++ {
 				for j := i + 1; j < n; j++ {
 					edges = append(edges, line{F: node(i), T: node(j), UID: uid, W: 0.5})
@@ -270,10 +270,10 @@ var testCases = []struct {
 	},
 	{
 		name: "4-clique+ - double(non-prepared)",
-		edges: func() []graph.WeightedLine {
+		edges: func() []WeightedLine {
 			const n = 4
 			var uid int64
-			var edges []graph.WeightedLine
+			var edges []WeightedLine
 			for i := 0; i < n; i++ {
 				for j := i; j < n; j++ {
 					edges = append(edges, line{F: node(i), T: node(j), UID: uid, W: 0.5})
@@ -298,10 +298,10 @@ var testCases = []struct {
 			}
 			return nodes
 		}(),
-		edges: func() []graph.WeightedLine {
+		edges: func() []WeightedLine {
 			const n = 4
 			var uid int64
-			var edges []graph.WeightedLine
+			var edges []WeightedLine
 			for i := 0; i < n; i++ {
 				for j := i + 1; j < n; j++ {
 					edges = append(edges, line{F: node(i), T: node(j), UID: uid, W: 0.5})
@@ -326,10 +326,10 @@ var testCases = []struct {
 			}
 			return nodes
 		}(),
-		edges: func() []graph.WeightedLine {
+		edges: func() []WeightedLine {
 			const n = 4
 			var uid int64
-			var edges []graph.WeightedLine
+			var edges []WeightedLine
 			for i := 0; i < n; i++ {
 				for j := i; j < n; j++ {
 					edges = append(edges, line{F: node(i), T: node(j), UID: uid, W: 0.5})

--- a/graph/testgraph/testcases.go
+++ b/graph/testgraph/testcases.go
@@ -25,10 +25,11 @@ type line struct {
 	W    float64
 }
 
-func (e line) From() graph.Node { return e.F }
-func (e line) To() graph.Node   { return e.T }
-func (e line) ID() int64        { return e.UID }
-func (e line) Weight() float64  { return e.W }
+func (e line) From() graph.Node     { return e.F }
+func (e line) To() graph.Node       { return e.T }
+func (e line) Reversed() graph.Edge { e.F, e.T = e.T, e.F; return e }
+func (e line) ID() int64            { return e.UID }
+func (e line) Weight() float64      { return e.W }
 
 var testCases = []struct {
 	// name is the name of the test.

--- a/graph/topo/clique_graph.go
+++ b/graph/topo/clique_graph.go
@@ -101,10 +101,10 @@ func (e CliqueGraphEdge) From() graph.Node { return e.from }
 // To returns the to node of the edge.
 func (e CliqueGraphEdge) To() graph.Node { return e.to }
 
-// Reversed returns a new CliqueGraphEdge with
+// ReversedEdge returns a new CliqueGraphEdge with
 // the edge end points swapped. The nodes of the
 // new edge are shared with the receiver.
-func (e CliqueGraphEdge) Reversed() graph.Edge { e.from, e.to = e.to, e.from; return e }
+func (e CliqueGraphEdge) ReversedEdge() graph.Edge { e.from, e.to = e.to, e.from; return e }
 
 // Nodes returns the common nodes in the cliques of the underlying graph
 // corresponding to the from and to nodes in the clique graph.

--- a/graph/topo/clique_graph.go
+++ b/graph/topo/clique_graph.go
@@ -101,6 +101,11 @@ func (e CliqueGraphEdge) From() graph.Node { return e.from }
 // To returns the to node of the edge.
 func (e CliqueGraphEdge) To() graph.Node { return e.to }
 
+// Reversed returns a new CliqueGraphEdge with
+// the edge end points swapped. The nodes of the
+// new edge are shared with the receiver.
+func (e CliqueGraphEdge) Reversed() graph.Edge { e.from, e.to = e.to, e.from; return e }
+
 // Nodes returns the common nodes in the cliques of the underlying graph
 // corresponding to the from and to nodes in the clique graph.
 func (e CliqueGraphEdge) Nodes() []graph.Node { return e.nodes }

--- a/graph/undirect.go
+++ b/graph/undirect.go
@@ -190,14 +190,14 @@ func (e EdgePair) To() Node {
 	return nil
 }
 
-// Reversed returns a new Edge with the end point of the
+// ReversedEdge returns a new Edge with the end point of the
 // edges in the pair swapped.
-func (e EdgePair) Reversed() Edge {
+func (e EdgePair) ReversedEdge() Edge {
 	if e[0] != nil {
-		e[0] = e[0].Reversed()
+		e[0] = e[0].ReversedEdge()
 	}
 	if e[1] != nil {
-		e[1] = e[1].Reversed()
+		e[1] = e[1].ReversedEdge()
 	}
 	return e
 }
@@ -206,6 +206,13 @@ func (e EdgePair) Reversed() Edge {
 type WeightedEdgePair struct {
 	EdgePair
 	W float64
+}
+
+// ReversedEdge returns a new Edge with the end point of the
+// edges in the pair swapped.
+func (e WeightedEdgePair) ReversedEdge() Edge {
+	e.EdgePair = e.EdgePair.ReversedEdge().(EdgePair)
+	return e
 }
 
 // Weight returns the merged edge weights of the two edges.

--- a/graph/undirect.go
+++ b/graph/undirect.go
@@ -190,6 +190,18 @@ func (e EdgePair) To() Node {
 	return nil
 }
 
+// Reversed returns a new Edge with the end point of the
+// edges in the pair swapped.
+func (e EdgePair) Reversed() Edge {
+	if e[0] != nil {
+		e[0] = e[0].Reversed()
+	}
+	if e[1] != nil {
+		e[1] = e[1].Reversed()
+	}
+	return e
+}
+
 // WeightedEdgePair is an opposed pair of directed edges.
 type WeightedEdgePair struct {
 	EdgePair


### PR DESCRIPTION
I'm sending this as a candidate implementation addressing #825. After having sat on this for a while, I'm fairly convinced this is the right thing to do; if fixes unfortunate subtleties and an otherwise insoluble bug (~~#417~~#824) at the cost of requiring an extra method on edge and line types.

I am not convinced of my approach to naming the methods because, as it stands (the two versions here), either a type assertion is needed for lines, or edges and lines are not interchangeable without wrapping. I think that probably the method names should be `ReversedEdge` and `ReversedLine` to avoid this collision.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
