### PR TITLE
travis: check that we work with modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,13 @@ go:
  - master
 
 env:
- - TAGS=""
- - TAGS="-tags bounds"
- - TAGS="-tags noasm"
- - TAGS="-tags appengine"
+ global:
+  - GO111MODULE=on
+ matrix:
+  - TAGS=""
+  - TAGS="-tags bounds"
+  - TAGS="-tags noasm"
+  - TAGS="-tags appengine"
 
 cache:
  directories:

--- a/.travis/check-generate.sh
+++ b/.travis/check-generate.sh
@@ -4,8 +4,13 @@ go generate gonum.org/v1/gonum/blas
 go generate gonum.org/v1/gonum/blas/gonum
 go generate gonum.org/v1/gonum/unit
 go generate gonum.org/v1/gonum/graph/formats/dot
-if [ -n "$(git diff)" ]; then
-	git checkout -- go.mod # Discard changes to go.mod that have been made.
+
+# Discard changes to go.mod that have been made.
+# FIXME(kortschak): Sort out a policy of what we should do with go.mod changes.
+# If we want to check changes we should set `GOFLAGS=-mod=readonly` in .travis.yml.
+git checkout -- go.mod
+
+if [ -n "$(git diff)" ]; then	
 	git diff
 	exit 1
 fi

--- a/.travis/install-gocc.sh
+++ b/.travis/install-gocc.sh
@@ -4,6 +4,7 @@ set -ex
 
 # TODO(kortschak): Replace this with versioned go get when
 # all our supported versions of Go support it.
+export GO111MODULE=auto
 mkdir -p $GOPATH/src/github.com/goccmack
 git clone https://github.com/goccmack/gocc.git $GOPATH/src/github.com/goccmack/gocc
 cd $GOPATH/src/github.com/goccmack/gocc


### PR DESCRIPTION
At the moment, I am doing a nasty (but now correct) git workaround to get rid of changes to `go.mod`. These changes come about because the go tool finds the latest versions of the pre-installed tools specified in the `before_install` yaml stanza. To get these to install at the appropriate version, we need to be in the gonum/gonum directory so the go tool can see go.mod, but I don't think this is where travis is by the time that stanza is run.

I think in the long run (once modules are supported by all the versions of Go we support), we can `cd gonum/gonum && go get ./...` in `before_install` to get our dependencies.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
