### PR TITLE
Convert two files from ISO-8859-1 to UTF-8

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -81,6 +81,7 @@ Takeshi Yoneda <cz.rk.t0415y.g@gmail.com>
 The University of Adelaide
 The University of Minnesota
 The University of Washington
+Thomas Berg <tomfuture@gmail.com>
 Tobin Harding <me@tobin.cc>
 Vincent Thiery <vjmthiery@gmail.com>
 Vladimír Chalupecký <vladimir.chalupecky@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -83,6 +83,7 @@ Spencer Lyon <spencerlyon2@gmail.com>
 Steve McCoy <mccoyst@gmail.com>
 Taesu Pyo <pyotaesu@gmail.com>
 Takeshi Yoneda <cz.rk.t0415y.g@gmail.com>
+Thomas Berg <tomfuture@gmail.com>
 Tobin Harding <me@tobin.cc>
 Vincent Thiery <vjmthiery@gmail.com>
 Vladimír Chalupecký <vladimir.chalupecky@gmail.com>

--- a/integrate/quad/internal/PrintGoSlice.m
+++ b/integrate/quad/internal/PrintGoSlice.m
@@ -1,4 +1,4 @@
-% Copyright ©2016 The Gonum Authors. All rights reserved.
+% Copyright Â©2016 The Gonum Authors. All rights reserved.
 % Use of this source code is governed by a BSD-style
 % license that can be found in the LICENSE file.
 

--- a/integrate/quad/internal/genherm.m
+++ b/integrate/quad/internal/genherm.m
@@ -1,4 +1,4 @@
-% Copyright ©2016 The Gonum Authors. All rights reserved.
+% Copyright Â©2016 The Gonum Authors. All rights reserved.
 % Use of this source code is governed by a BSD-style
 % license that can be found in the LICENSE file.
 


### PR DESCRIPTION
There are just a couple source files that are encoded as  ISO-8859-1 instead of UTF-8.  Let's make them UTF-8, unless there's a reason for them not to be.
