### PR TITLE
appveyor: comment out go1.12 until appveyor update

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
   matrix:
     - GOROOT: 'c:\go110'
     - GOROOT: 'c:\go111'
-    - GOROOT: 'c:\go112'
+    # - GOROOT: 'c:\go112' TODO: Uncomment with appveyor do an update containing go1.12.
   GOPATH: c:\gopath
   GOTOOLDIR: '%GOROOT%\pkg\tool\windows_amd64'
   PATH: '%GOPATH%\bin;%GOROOT%\bin;%PATH%'


### PR DESCRIPTION
AppVeyor are taking too long, so comment out the go1.12 line.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
