### PR TITLE
modules: add gonum.org/v1/netlib to go.mod and commit go.sum

### DIFF
--- a/.travis/check-generate.sh
+++ b/.travis/check-generate.sh
@@ -8,7 +8,7 @@ go generate gonum.org/v1/gonum/graph/formats/dot
 # Discard changes to go.mod that have been made.
 # FIXME(kortschak): Sort out a policy of what we should do with go.mod changes.
 # If we want to check changes we should set `GOFLAGS=-mod=readonly` in .travis.yml.
-git checkout -- go.mod
+git checkout -- go.{mod,sum}
 
 if [ -n "$(git diff)" ]; then	
 	git diff

--- a/go.mod
+++ b/go.mod
@@ -3,4 +3,5 @@ module gonum.org/v1/gonum
 require (
 	golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2
 	golang.org/x/tools v0.0.0-20190206041539-40960b6deb8e
+	gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2 h1:y102fOLFqhV41b+4GPiJoa0k/x+pJcEi2/HB1Y5T6fU=
+golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/tools v0.0.0-20190206041539-40960b6deb8e h1:Io7mpb+aUAGF0MKxbyQ7HQl1VgB+cL6ZJZUFaFNqVV4=
+golang.org/x/tools v0.0.0-20190206041539-40960b6deb8e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0 h1:OE9mWmgKkjJyEmDAAtGMPjXu+YNeGvK9VTSHY6+Qihc=
+gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=


### PR DESCRIPTION
Including netlib since the tests can be run with it and it now tests correctly.

go.sum included since that appears to be preferred practice.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
