### PR TITLE
 graph/encoding/{,di}graph6: add support for digraph6- and graph6-encoded graphs

### DIFF
--- a/graph/encoding/digraph6/digraph6.go
+++ b/graph/encoding/digraph6/digraph6.go
@@ -1,0 +1,338 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package digraph6 implements graphs specified by digraph6 strings.
+package digraph6 // import "gonum.org/v1/gonum/graph/encoding/digraph6"
+
+import (
+	"fmt"
+	"math/big"
+	"sort"
+	"strings"
+
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/internal/ordered"
+	"gonum.org/v1/gonum/graph/iterator"
+	"gonum.org/v1/gonum/graph/simple"
+)
+
+// Graph is a digraph6-represented directed graph.
+//
+// See https://users.cecs.anu.edu.au/~bdm/data/formats.txt for details.
+//
+// Note that the digraph6 format specifies that the first character of the graph
+// string is a '&'. This character must be present for use in the digraph6 package.
+// A Graph without this prefix is treated as the null graph.
+type Graph string
+
+var (
+	d6 Graph
+
+	_ graph.Graph    = d6
+	_ graph.Directed = d6
+)
+
+// Encode returns a graph6 encoding of the topology of the given graph using a
+// lexical ordering of the nodes by ID to map them to [0, n).
+func Encode(g graph.Graph) Graph {
+	nodes := graph.NodesOf(g.Nodes())
+	n := len(nodes)
+	sort.Sort(ordered.ByID(nodes))
+	indexOf := make(map[int64]int, n)
+	for i, n := range nodes {
+		indexOf[n.ID()] = i
+	}
+
+	size := n * n
+	var b big.Int
+	for i, u := range nodes {
+		it := g.From(u.ID())
+		for it.Next() {
+			vid := it.Node().ID()
+			j := indexOf[vid]
+			b.SetBit(&b, bitFor(int64(i), int64(j), int64(n)), 1)
+		}
+	}
+
+	var buf strings.Builder
+	buf.WriteByte('&')
+	switch {
+	case n < 63:
+		buf.WriteByte(byte(n) + 63)
+	case n < 258048:
+		buf.Write([]byte{126, byte(n>>12) + 63, byte(n>>6) + 63, byte(n) + 63})
+	case n < 68719476736:
+		buf.Write([]byte{126, 126, byte(n>>30) + 63, byte(n>>24) + 63, byte(n>>18) + 63, byte(n>>12) + 63, byte(n>>6) + 63, byte(n) + 63})
+	default:
+		panic("digraph6: too large")
+	}
+
+	var c byte
+	for i := 0; i < size; i++ {
+		bit := i % 6
+		c |= byte(b.Bit(i)) << uint(5-bit)
+		if bit == 5 {
+			buf.WriteByte(c + 63)
+			c = 0
+		}
+	}
+	if size%6 != 0 {
+		buf.WriteByte(c + 63)
+	}
+
+	return Graph(buf.String())
+}
+
+// IsValid returns whether the graph is a valid digraph6 encoding. An invalid Graph
+// behaves as the null graph.
+func IsValid(g Graph) bool {
+	n := int(numberOf(g))
+	if n < 0 {
+		return false
+	}
+	size := (n*n + 5) / 6 // ceil(n^2 / 6)
+	g = g[1:]
+	switch {
+	case g[0] != 126:
+		return len(g[1:]) == size
+	case g[1] != 126:
+		return len(g[4:]) == size
+	default:
+		return len(g[8:]) == size
+	}
+}
+
+// Edge returns the edge from u to v, with IDs uid and vid, if such an edge
+// exists and nil otherwise. The node v must be directly reachable from u as
+// defined by the From method.
+func (g Graph) Edge(uid, vid int64) graph.Edge {
+	if !IsValid(g) {
+		return nil
+	}
+	if !g.HasEdgeFromTo(uid, vid) {
+		return nil
+	}
+	return simple.Edge{simple.Node(uid), simple.Node(vid)}
+}
+
+// From returns all nodes that can be reached directly from the node with the
+// given ID.
+func (g Graph) From(id int64) graph.Nodes {
+	if !IsValid(g) {
+		return graph.Empty
+	}
+	if g.Node(id) == nil {
+		return nil
+	}
+	return &d6ForwardIterator{g: g, from: id, to: -1}
+}
+
+// HasEdgeBetween returns whether an edge exists between nodes with IDs xid
+// and yid without considering direction.
+func (g Graph) HasEdgeBetween(xid, yid int64) bool {
+	if !IsValid(g) {
+		return false
+	}
+	return g.HasEdgeFromTo(xid, yid) || g.HasEdgeFromTo(yid, xid)
+}
+
+// HasEdgeFromTo returns whether an edge exists in the graph from u to v with
+// IDs uid and vid.
+func (g Graph) HasEdgeFromTo(uid, vid int64) bool {
+	if !IsValid(g) {
+		return false
+	}
+	if uid == vid {
+		return false
+	}
+	n := numberOf(g)
+	if uid < 0 || n <= uid {
+		return false
+	}
+	if vid < 0 || n <= vid {
+		return false
+	}
+	return isSet(bitFor(uid, vid, n), g)
+}
+
+// Node returns the node with the given ID if it exists in the graph, and nil
+// otherwise.
+func (g Graph) Node(id int64) graph.Node {
+	if !IsValid(g) {
+		return nil
+	}
+	if id < 0 || numberOf(g) <= id {
+		return nil
+	}
+	return simple.Node(id)
+}
+
+// Nodes returns all the nodes in the graph.
+func (g Graph) Nodes() graph.Nodes {
+	if !IsValid(g) {
+		return graph.Empty
+	}
+	return iterator.NewImplicitNodes(0, int(numberOf(g)), func(id int) graph.Node { return simple.Node(id) })
+}
+
+// To returns all nodes that can reach directly to the node with the given ID.
+func (g Graph) To(id int64) graph.Nodes {
+	if !IsValid(g) || g.Node(id) == nil {
+		return graph.Empty
+	}
+	return &d6ReverseIterator{g: g, from: -1, to: id}
+}
+
+// d6ForwardIterator is a graph.Nodes for digraph6 graph edges for forward hops.
+type d6ForwardIterator struct {
+	g    Graph
+	from int64
+	to   int64
+}
+
+var _ graph.Nodes = (*d6ForwardIterator)(nil)
+
+func (i *d6ForwardIterator) Next() bool {
+	n := numberOf(i.g)
+	for i.to < n-1 {
+		i.to++
+		if i.to != i.from && isSet(bitFor(i.from, i.to, n), i.g) {
+			return true
+		}
+	}
+	return false
+}
+
+func (i *d6ForwardIterator) Len() int {
+	var cnt int
+	n := numberOf(i.g)
+	for to := i.to; to < n-1; {
+		to++
+		if to != i.from && isSet(bitFor(i.from, to, n), i.g) {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func (i *d6ForwardIterator) Reset() { i.to = -1 }
+
+func (i *d6ForwardIterator) Node() graph.Node { return simple.Node(i.to) }
+
+// d6ReverseIterator is a graph.Nodes for digraph6 graph edges for reverse hops.
+type d6ReverseIterator struct {
+	g    Graph
+	from int64
+	to   int64
+}
+
+var _ graph.Nodes = (*d6ReverseIterator)(nil)
+
+func (i *d6ReverseIterator) Next() bool {
+	n := numberOf(i.g)
+	for i.from < n-1 {
+		i.from++
+		if i.to != i.from && isSet(bitFor(i.from, i.to, n), i.g) {
+			return true
+		}
+	}
+	return false
+}
+
+func (i *d6ReverseIterator) Len() int {
+	var cnt int
+	n := numberOf(i.g)
+	for from := i.from; from < n-1; {
+		from++
+		if from != i.to && isSet(bitFor(from, i.to, n), i.g) {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func (i *d6ReverseIterator) Reset() { i.from = -1 }
+
+func (i *d6ReverseIterator) Node() graph.Node { return simple.Node(i.from) }
+
+// numberOf returns the digraph6-encoded number corresponding to g.
+func numberOf(g Graph) int64 {
+	if len(g) < 2 {
+		return -1
+	}
+	if g[0] != '&' {
+		return -1
+	}
+	g = g[1:]
+	if g[0] != 126 {
+		return int64(g[0] - 63)
+	}
+	if len(g) < 4 {
+		return -1
+	}
+	if g[1] != 126 {
+		return int64(g[1]-63)<<12 | int64(g[2]-63)<<6 | int64(g[3]-63)
+	}
+	if len(g) < 8 {
+		return -1
+	}
+	return int64(g[2]-63)<<30 | int64(g[3]-63)<<24 | int64(g[4]-63)<<18 | int64(g[5]-63)<<12 | int64(g[6]-63)<<6 | int64(g[7]-63)
+}
+
+// bitFor returns the index into the digraph6 adjacency matrix for uid->vid in a graph
+// order n.
+func bitFor(uid, vid, n int64) int {
+	return int(uid*n + vid)
+}
+
+// isSet returns whether the given bit of the adjacency matrix is set.
+func isSet(bit int, g Graph) bool {
+	g = g[1:]
+	switch {
+	case g[0] != 126:
+		g = g[1:]
+	case g[1] != 126:
+		g = g[4:]
+	default:
+		g = g[8:]
+	}
+	if bit/6 >= len(g) {
+		panic("digraph6: index out of range")
+	}
+	return (g[bit/6]-63)&(1<<uint(5-bit%6)) != 0
+}
+
+func (g Graph) GoString() string {
+	if !IsValid(g) {
+		return ""
+	}
+	bin, m6 := binary(g)
+	format := fmt.Sprintf("%%d:%%0%db", m6)
+	return fmt.Sprintf(format, numberOf(g), bin)
+}
+
+func binary(g Graph) (b *big.Int, l int) {
+	n := int(numberOf(g))
+	g = g[1:]
+	switch {
+	case g[0] != 126:
+		g = g[1:]
+	case g[1] != 126:
+		g = g[4:]
+	default:
+		g = g[8:]
+	}
+	b = &big.Int{}
+	var c big.Int
+	for i := range g {
+		c.SetUint64(uint64(g[len(g)-i-1] - 63))
+		c.Lsh(&c, uint(6*i))
+		b.Or(b, &c)
+	}
+
+	// Truncate to only the relevant parts of the bit vector.
+	b.Rsh(b, uint(len(g)*6-(n*n)))
+
+	return b, n * n
+}

--- a/graph/encoding/digraph6/digraph6_test.go
+++ b/graph/encoding/digraph6/digraph6_test.go
@@ -1,0 +1,280 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package digraph6
+
+import (
+	"reflect"
+	"testing"
+
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/simple"
+)
+
+var testGraphs = []struct {
+	g    string
+	bin  string
+	want []set
+}{
+	// Wanted graphs were obtained from showg using the input graph string.
+	// The showg output is included for comparison.
+	//
+	// showg with dgraph6 support, in nauty v2.7, is available here: http://pallini.di.uniroma1.it/
+	{
+		// Graph 1, order 0.
+		g:    "&?",
+		bin:  "0:0",
+		want: []set{},
+	},
+	{
+		// Graph 1, order 5.
+		//   0 : 2 4;
+		//   1 : ;
+		//   2 : ;
+		//   3 : 1 4;
+		//   4 : ;
+		g:   "&DI?AO?",
+		bin: "5:0010100000000000100100000",
+		want: []set{
+			0: linksToInt(2, 4),
+			1: linksToInt(),
+			2: linksToInt(),
+			3: linksToInt(1, 4),
+			4: linksToInt(),
+		},
+	},
+	{
+		// Graph 1, order 5.
+		//   0 : 1 3;
+		//   1 : 0 2 3 4;
+		//   2 : 0 1 3 4;
+		//   3 : 0 2;
+		//   4 : 0 1 2 3;
+		g:   "&DT^\\N?",
+		bin: "5:0101010111110111010011110",
+		want: []set{
+			0: linksToInt(1, 3),
+			1: linksToInt(0, 2, 3, 4),
+			2: linksToInt(0, 1, 3, 4),
+			3: linksToInt(0, 2),
+			4: linksToInt(0, 1, 2, 3),
+		},
+	},
+	{
+		// Graph 1, order 5.
+		//   0 : ;
+		//   1 : 3;
+		//   2 : 0;
+		//   3 : ;
+		//   4 : 0 3;
+		g:   "&D?I?H?",
+		bin: "5:0000000010100000000010010",
+		want: []set{
+			0: linksToInt(),
+			1: linksToInt(3),
+			2: linksToInt(0),
+			3: linksToInt(),
+			4: linksToInt(0, 3),
+		},
+	},
+	{
+		// Graph 1, order 6.
+		//   0 : 1 2 5;
+		//   1 : 2 3 4 5;
+		//   2 : 3 4;
+		//   3 : 0 4 5;
+		//   4 : 0 5;
+		//   5 : 2;
+		g:   "&EXNEb`G",
+		bin: "6:011001001111000110100011100001001000",
+		want: []set{
+			0: linksToInt(1, 2, 5),
+			1: linksToInt(2, 3, 4, 5),
+			2: linksToInt(3, 4),
+			3: linksToInt(0, 4, 5),
+			4: linksToInt(0, 5),
+			5: linksToInt(2),
+		},
+	},
+	{
+		// Graph 1, order 9.
+		//   0 : 1 3 5 7 8;
+		//   1 : 2 3 4 7 8;
+		//   2 : 0 3 4;
+		//   3 : 4 5 6 7 8;
+		//   4 : 0 5 6 8;
+		//   5 : 1 2 6 7 8;
+		//   6 : 0 1 2 7 8;
+		//   7 : 2 4 8;
+		//   8 : 2;
+		g:   "&HTXre?^`jFwXPG?",
+		bin: "9:010101011001110011100110000000011111100001101011000111111000011001010001001000000",
+		want: []set{
+			0: linksToInt(1, 3, 5, 7, 8),
+			1: linksToInt(2, 3, 4, 7, 8),
+			2: linksToInt(0, 3, 4),
+			3: linksToInt(4, 5, 6, 7, 8),
+			4: linksToInt(0, 5, 6, 8),
+			5: linksToInt(1, 2, 6, 7, 8),
+			6: linksToInt(0, 1, 2, 7, 8),
+			7: linksToInt(2, 4, 8),
+			8: linksToInt(2),
+		},
+	},
+	{
+		// Graph 1, order 12.
+		//   0 : 1 2 3 4 5 6 7 8 9 10 11;
+		//   1 : 2 3 4 5 6 7 8 11;
+		//   2 : 3 4 5 6 7 8 9 11;
+		//   3 : 4 5 6 7 8 10 11;
+		//   4 : 5 6 7 8 9 11;
+		//   5 : 6 7 9 10;
+		//   6 : 7 8 9 10 11;
+		//   7 : 8 9 10 11;
+		//   8 : 5 9 10;
+		//   9 : 1 3 10;
+		//  10 : 1 2 4 11;
+		//  11 : 5 8 9;
+		g:   "&K^~NxF|Bz@|?u?^?N@ESAY@@K",
+		bin: "12:011111111111001111111001000111111101000011111011000001111101000000110110000000011111000000001111000001000110010100000010011010000001000001001100",
+		want: []set{
+			0:  linksToInt(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			1:  linksToInt(2, 3, 4, 5, 6, 7, 8, 11),
+			2:  linksToInt(3, 4, 5, 6, 7, 8, 9, 11),
+			3:  linksToInt(4, 5, 6, 7, 8, 10, 11),
+			4:  linksToInt(5, 6, 7, 8, 9, 11),
+			5:  linksToInt(6, 7, 9, 10),
+			6:  linksToInt(7, 8, 9, 10, 11),
+			7:  linksToInt(8, 9, 10, 11),
+			8:  linksToInt(5, 9, 10),
+			9:  linksToInt(1, 3, 10),
+			10: linksToInt(1, 2, 4, 11),
+			11: linksToInt(5, 8, 9),
+		},
+	},
+	{
+		// Graph 1, order 17.
+		//   0 : 1 2 3 4 5 6 7 8 9 10 11 12 14 15 16;
+		//   1 : 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16;
+		//   2 : 3 4 5 6 7 8 9 10 11 12 13 14 16;
+		//   3 : 4 5 6 7 8 9 10 11 12 13 14 15 16;
+		//   4 : 5 6 7 8 9 10 11 12 13 14 15 16;
+		//   5 : 6 7 8 9 10 11 12 13 14 15 16;
+		//   6 : 7 8 9 10 11 12 13 14 15;
+		//   7 : 8 9 10 11 12 13 14 15 16;
+		//   8 : 9 10 11 12 13 15 16;
+		//   9 : 10 11 12 13 14 15 16;
+		//  10 : 11 12 13 14 16;
+		//  11 : 12 13 14 15 16;
+		//  12 : 13 14 15 16;
+		//  13 : 0 14 15 16;
+		//  14 : 8 15;
+		//  15 : 2 10 16;
+		//  16 : 6 14;
+		g:   "&P^~m^~{^~g^~o^~_^~?^{?^{?^W?^o?]_?^??^??[?_P?OOGA?",
+		bin: "17:0111111111111011100111111111111111000111111111111010000111111111111100000111111111111000000111111111110000000111111111000000000111111111000000000111110110000000000111111100000000000111101000000000000111110000000000000111110000000000000111000000001000000100010000000100000100000010000000100",
+		want: []set{
+			0:  linksToInt(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16),
+			1:  linksToInt(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16),
+			2:  linksToInt(3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16),
+			3:  linksToInt(4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16),
+			4:  linksToInt(5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16),
+			5:  linksToInt(6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16),
+			6:  linksToInt(7, 8, 9, 10, 11, 12, 13, 14, 15),
+			7:  linksToInt(8, 9, 10, 11, 12, 13, 14, 15, 16),
+			8:  linksToInt(9, 10, 11, 12, 13, 15, 16),
+			9:  linksToInt(10, 11, 12, 13, 14, 15, 16),
+			10: linksToInt(11, 12, 13, 14, 16),
+			11: linksToInt(12, 13, 14, 15, 16),
+			12: linksToInt(13, 14, 15, 16),
+			13: linksToInt(0, 14, 15, 16),
+			14: linksToInt(8, 15),
+			15: linksToInt(2, 10, 16),
+			16: linksToInt(6, 14),
+		},
+	},
+}
+
+func TestNumberOf(t *testing.T) {
+	for _, test := range testGraphs {
+		n := numberOf(Graph(test.g))
+		if n != int64(len(test.want)) {
+			t.Errorf("unexpected graph n: got:%d want:%d", n, len(test.want))
+		}
+	}
+}
+
+func TestGoString(t *testing.T) {
+	for _, test := range testGraphs {
+		gosyntax := Graph(test.g).GoString()
+		if gosyntax != test.bin {
+			t.Errorf("unexpected graph string: got:%s want:%s", gosyntax, test.bin)
+		}
+	}
+}
+
+func TestGraph(t *testing.T) {
+	for _, test := range testGraphs {
+		g := Graph(test.g)
+		if !IsValid(g) {
+			t.Errorf("unexpected invalid graph %q", g)
+		}
+		nodes := g.Nodes()
+		if nodes.Len() != len(test.want) {
+			t.Errorf("unexpected graph n: got:%d want:%d", nodes.Len(), len(test.want))
+		}
+		got := make([]set, nodes.Len())
+		for nodes.Next() {
+			n := nodes.Node()
+			got[n.ID()] = linksTo(graph.NodesOf(g.From(n.ID()))...)
+		}
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("unexpected graph:\ngot: %v\nwant:%v", got, test.want)
+		}
+		reverse := make([]set, len(got))
+		for i := range reverse {
+			reverse[i] = make(set)
+		}
+		for i, s := range got {
+			for j := range s {
+				reverse[j][i] = struct{}{}
+			}
+		}
+		for i, s := range got {
+			from := g.From(int64(i)).Len()
+			if from != len(s) {
+				t.Errorf("unexpected number of nodes from %d: got:%d want:%d", i, from, len(s))
+			}
+			to := g.To(int64(i)).Len()
+			if to != len(reverse[i]) {
+				t.Errorf("unexpected number of nodes to %d: got:%d want:%d", i, to, len(reverse))
+			}
+		}
+
+		dst := simple.NewDirectedGraph()
+		graph.Copy(dst, g)
+		enc := Encode(dst)
+		if enc != g {
+			t.Errorf("unexpected round trip: got:%q want:%q", enc, g)
+		}
+	}
+}
+
+type set map[int]struct{}
+
+func linksToInt(nodes ...int) map[int]struct{} {
+	s := make(map[int]struct{})
+	for _, n := range nodes {
+		s[n] = struct{}{}
+	}
+	return s
+}
+
+func linksTo(nodes ...graph.Node) map[int]struct{} {
+	s := make(map[int]struct{})
+	for _, n := range nodes {
+		s[int(n.ID())] = struct{}{}
+	}
+	return s
+}

--- a/graph/encoding/graph6/graph6.go
+++ b/graph/encoding/graph6/graph6.go
@@ -1,0 +1,283 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package graph6 implements graphs specified by graph6 strings.
+package graph6 // import "gonum.org/v1/gonum/graph/encoding/graph6"
+
+import (
+	"fmt"
+	"math/big"
+	"sort"
+	"strings"
+
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/internal/ordered"
+	"gonum.org/v1/gonum/graph/iterator"
+	"gonum.org/v1/gonum/graph/simple"
+)
+
+// Graph is a graph6-represented undirected graph.
+//
+// See https://users.cecs.anu.edu.au/~bdm/data/formats.txt for details
+// and https://hog.grinvin.org/ for a source of interesting graphs in graph6
+// format.
+type Graph string
+
+var (
+	g6 Graph
+
+	_ graph.Graph      = g6
+	_ graph.Undirected = g6
+)
+
+// Encode returns a graph6 encoding of the topology of the given graph using a
+// lexical ordering of the nodes by ID to map them to [0, n).
+func Encode(g graph.Graph) Graph {
+	nodes := graph.NodesOf(g.Nodes())
+	n := len(nodes)
+	sort.Sort(ordered.ByID(nodes))
+	indexOf := make(map[int64]int, n)
+	for i, n := range nodes {
+		indexOf[n.ID()] = i
+	}
+
+	size := (n*n - n) / 2
+	var b big.Int
+	for i, u := range nodes {
+		uid := u.ID()
+		it := g.From(uid)
+		for it.Next() {
+			vid := it.Node().ID()
+			if vid < uid {
+				continue
+			}
+			j := indexOf[vid]
+			b.SetBit(&b, bitFor(int64(i), int64(j)), 1)
+		}
+	}
+
+	var buf strings.Builder
+	switch {
+	case n < 63:
+		buf.WriteByte(byte(n) + 63)
+	case n < 258048:
+		buf.Write([]byte{126, byte(n>>12) + 63, byte(n>>6) + 63, byte(n) + 63})
+	case n < 68719476736:
+		buf.Write([]byte{126, 126, byte(n>>30) + 63, byte(n>>24) + 63, byte(n>>18) + 63, byte(n>>12) + 63, byte(n>>6) + 63, byte(n) + 63})
+	default:
+		panic("graph6: too large")
+	}
+
+	var c byte
+	for i := 0; i < size; i++ {
+		bit := i % 6
+		c |= byte(b.Bit(i)) << uint(5-bit)
+		if bit == 5 {
+			buf.WriteByte(c + 63)
+			c = 0
+		}
+	}
+	if size%6 != 0 {
+		buf.WriteByte(c + 63)
+	}
+
+	return Graph(buf.String())
+}
+
+// IsValid returns whether the graph is a valid graph6 encoding. An invalid Graph
+// behaves as the null graph.
+func IsValid(g Graph) bool {
+	n := int(numberOf(g))
+	if n < 0 {
+		return false
+	}
+	size := ((n*n-n)/2 + 5) / 6 // ceil(((n*n-n)/2) / 6)
+	switch {
+	case g[0] != 126:
+		return len(g[1:]) == size
+	case g[1] != 126:
+		return len(g[4:]) == size
+	default:
+		return len(g[8:]) == size
+	}
+}
+
+// Edge returns the edge from u to v, with IDs uid and vid, if such an edge
+// exists and nil otherwise. The node v must be directly reachable from u as
+// defined by the From method.
+func (g Graph) Edge(uid, vid int64) graph.Edge {
+	if !IsValid(g) {
+		return nil
+	}
+	if !g.HasEdgeBetween(uid, vid) {
+		return nil
+	}
+	return simple.Edge{simple.Node(uid), simple.Node(vid)}
+}
+
+// EdgeBetween returns the edge between nodes x and y with IDs xid and yid.
+func (g Graph) EdgeBetween(xid, yid int64) graph.Edge {
+	return g.Edge(xid, yid)
+}
+
+// From returns all nodes that can be reached directly from the node with the
+// given ID.
+func (g Graph) From(id int64) graph.Nodes {
+	if !IsValid(g) {
+		return graph.Empty
+	}
+	if g.Node(id) == nil {
+		return nil
+	}
+	return &g6Iterator{g: g, from: id, to: -1}
+}
+
+// HasEdgeBetween returns whether an edge exists between nodes with IDs xid
+// and yid without considering direction.
+func (g Graph) HasEdgeBetween(xid, yid int64) bool {
+	if !IsValid(g) {
+		return false
+	}
+	if xid == yid {
+		return false
+	}
+	if xid < 0 || numberOf(g) <= xid {
+		return false
+	}
+	if yid < 0 || numberOf(g) <= yid {
+		return false
+	}
+	return isSet(bitFor(xid, yid), g)
+}
+
+// Node returns the node with the given ID if it exists in the graph, and nil
+// otherwise.
+func (g Graph) Node(id int64) graph.Node {
+	if !IsValid(g) {
+		return nil
+	}
+	if id < 0 || numberOf(g) <= id {
+		return nil
+	}
+	return simple.Node(id)
+}
+
+// Nodes returns all the nodes in the graph.
+func (g Graph) Nodes() graph.Nodes {
+	if !IsValid(g) {
+		return graph.Empty
+	}
+	return iterator.NewImplicitNodes(0, int(numberOf(g)), func(id int) graph.Node { return simple.Node(id) })
+}
+
+// g6Iterator is a graph.Nodes for graph6 graph edges.
+type g6Iterator struct {
+	g    Graph
+	from int64
+	to   int64
+}
+
+var _ graph.Nodes = (*g6Iterator)(nil)
+
+func (i *g6Iterator) Next() bool {
+	n := numberOf(i.g)
+	for i.to < n-1 {
+		i.to++
+		if i.to != i.from && isSet(bitFor(i.from, i.to), i.g) {
+			return true
+		}
+	}
+	return false
+}
+
+func (i *g6Iterator) Len() int {
+	var cnt int
+	n := numberOf(i.g)
+	for to := i.to; to < n-1; {
+		to++
+		if to != i.from && isSet(bitFor(i.from, to), i.g) {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func (i *g6Iterator) Reset() { i.to = -1 }
+
+func (i *g6Iterator) Node() graph.Node { return simple.Node(i.to) }
+
+// numberOf returns the graph6-encoded number corresponding to g.
+func numberOf(g Graph) int64 {
+	if len(g) < 1 {
+		return -1
+	}
+	if g[0] != 126 {
+		return int64(g[0] - 63)
+	}
+	if len(g) < 4 {
+		return -1
+	}
+	if g[1] != 126 {
+		return int64(g[1]-63)<<12 | int64(g[2]-63)<<6 | int64(g[3]-63)
+	}
+	if len(g) < 8 {
+		return -1
+	}
+	return int64(g[2]-63)<<30 | int64(g[3]-63)<<24 | int64(g[4]-63)<<18 | int64(g[5]-63)<<12 | int64(g[6]-63)<<6 | int64(g[7]-63)
+}
+
+// bitFor returns the index into the graph6 adjacency matrix for xid--yid.
+func bitFor(xid, yid int64) int {
+	if xid < yid {
+		xid, yid = yid, xid
+	}
+	return int((xid*xid-xid)/2 + yid)
+}
+
+// isSet returns whether the given bit of the adjacency matrix is set.
+func isSet(bit int, g Graph) bool {
+	switch {
+	case g[0] != 126:
+		g = g[1:]
+	case g[1] != 126:
+		g = g[4:]
+	default:
+		g = g[8:]
+	}
+	if bit/6 >= len(g) {
+		panic("g6: index out of range")
+	}
+	return (g[bit/6]-63)&(1<<uint(5-bit%6)) != 0
+}
+
+func (g Graph) GoString() string {
+	bin, m6 := binary(g)
+	format := fmt.Sprintf("%%d:%%0%db", m6)
+	return fmt.Sprintf(format, numberOf(g), bin)
+}
+
+func binary(g Graph) (b *big.Int, l int) {
+	n := int(numberOf(g))
+
+	switch {
+	case g[0] != 126:
+		g = g[1:]
+	case g[1] != 126:
+		g = g[4:]
+	default:
+		g = g[8:]
+	}
+	b = &big.Int{}
+	var c big.Int
+	for i := range g {
+		c.SetUint64(uint64(g[len(g)-i-1] - 63))
+		c.Lsh(&c, uint(6*i))
+		b.Or(b, &c)
+	}
+
+	// Truncate to only the relevant parts of the bit vector.
+	b.Rsh(b, uint(len(g)*6-(n*n-n)/2))
+
+	return b, (n*n - n) / 2
+}

--- a/graph/encoding/graph6/graph6_example_test.go
+++ b/graph/encoding/graph6/graph6_example_test.go
@@ -1,0 +1,41 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package graph6_test
+
+import (
+	"fmt"
+
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/encoding/graph6"
+)
+
+func ExampleGraph() {
+	// Construct a graph from HOG graph 32194.
+	// https://hog.grinvin.org/ViewGraphInfo.action?id=32194
+	g := graph6.Graph("H@BQPS^")
+
+	// Get the nodes of the graph and print
+	// an adjacency list.
+	nodes := g.Nodes()
+	fmt.Printf("Number of nodes: %d\n", nodes.Len())
+	fmt.Println("Adjacency:")
+	for nodes.Next() {
+		fmt.Printf("\t%d: %d\n", nodes.Node().ID(), graph.NodesOf(g.From(nodes.Node().ID())))
+	}
+
+	// Output:
+	//
+	// Number of nodes: 9
+	// Adjacency:
+	// 	0: [5]
+	// 	1: [5 6]
+	// 	2: [3 7]
+	// 	3: [2 5 8]
+	// 	4: [6 7 8]
+	// 	5: [0 1 3 8]
+	// 	6: [1 4 7 8]
+	// 	7: [2 4 6 8]
+	// 	8: [3 4 5 6 7]
+}

--- a/graph/encoding/graph6/graph6_test.go
+++ b/graph/encoding/graph6/graph6_test.go
@@ -1,0 +1,219 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package graph6
+
+import (
+	"reflect"
+	"testing"
+
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/simple"
+)
+
+var testGraphs = []struct {
+	g    string
+	bin  string
+	want []set
+}{
+	// Wanted graphs were obtained from showg using the input graph string.
+	// The showg output is included for comparison.
+	//
+	// showg is available here: https://hog.grinvin.org/data/generators/decoders/showg
+	{
+		// Graph 1, order 0.
+		g:    "?",
+		bin:  "0:0",
+		want: []set{},
+	},
+	{
+		// Graph 1, order 5.
+		//   0 : 2 4;
+		//   1 : 3;
+		//   2 : 0;
+		//   3 : 1 4;
+		//   4 : 0 3;
+		g:   "DQc",
+		bin: "5:0100101001",
+		want: []set{
+			0: linksToInt(2, 4),
+			1: linksToInt(3),
+			2: linksToInt(0),
+			3: linksToInt(1, 4),
+			4: linksToInt(0, 3),
+		},
+	},
+	{
+		// Graph 1, order 4.
+		//   0 : 1 2 3;
+		//   1 : 0 2 3;
+		//   2 : 0 1 3;
+		//   3 : 0 1 2;
+		g:   "C~",
+		bin: "4:111111",
+		want: []set{
+			0: linksToInt(1, 2, 3),
+			1: linksToInt(0, 2, 3),
+			2: linksToInt(0, 1, 3),
+			3: linksToInt(0, 1, 2),
+		},
+	},
+	{
+		// Graph 1, order 6.
+		//   0 : 1 3 4;
+		//   1 : 0 2 5;
+		//   2 : 1 3 4;
+		//   3 : 0 2 5;
+		//   4 : 0 2 5;
+		//   5 : 1 3 4;
+		g:   "ElhW",
+		bin: "6:101101101001011",
+		want: []set{
+			0: linksToInt(1, 3, 4),
+			1: linksToInt(0, 2, 5),
+			2: linksToInt(1, 3, 4),
+			3: linksToInt(0, 2, 5),
+			4: linksToInt(0, 2, 5),
+			5: linksToInt(1, 3, 4),
+		},
+	},
+	{
+		// Graph 1, order 10.
+		//   0 : 1 2 3;
+		//   1 : 0 4 5;
+		//   2 : 0 6 7;
+		//   3 : 0 8 9;
+		//   4 : 1 6 8;
+		//   5 : 1 7 9;
+		//   6 : 2 4 9;
+		//   7 : 2 5 8;
+		//   8 : 3 4 7;
+		//   9 : 3 5 6;
+		g:   "IsP@PGXD_",
+		bin: "10:110100010001000001010001001000011001000101100",
+		want: []set{
+			0: linksToInt(1, 2, 3),
+			1: linksToInt(0, 4, 5),
+			2: linksToInt(0, 6, 7),
+			3: linksToInt(0, 8, 9),
+			4: linksToInt(1, 6, 8),
+			5: linksToInt(1, 7, 9),
+			6: linksToInt(2, 4, 9),
+			7: linksToInt(2, 5, 8),
+			8: linksToInt(3, 4, 7),
+			9: linksToInt(3, 5, 6),
+		},
+	},
+	{
+		// Graph 1, order 17.
+		//   0 : 1 15 16;
+		//   1 : 0 2 5;
+		//   2 : 1 3 14;
+		//   3 : 2 4 16;
+		//   4 : 3 5 15;
+		//   5 : 1 4 6;
+		//   6 : 5 7 16;
+		//   7 : 6 8 11;
+		//   8 : 7 9 13;
+		//   9 : 8 10 16;
+		//  10 : 9 11 14;
+		//  11 : 7 10 12;
+		//  12 : 11 13 16;
+		//  13 : 8 12 14;
+		//  14 : 2 10 13 15;
+		//  15 : 0 4 14;
+		//  16 : 0 3 6 9 12;
+		g:   "PhDGGC@?G?_H?@?Gc@KO@cc_",
+		bin: "17:1010010001010010000010000001000000010000000010000000001000000010010000000000010000000010001001000000010011000100000000011001001001001000",
+		want: []set{
+			0:  linksToInt(1, 15, 16),
+			1:  linksToInt(0, 2, 5),
+			2:  linksToInt(1, 3, 14),
+			3:  linksToInt(2, 4, 16),
+			4:  linksToInt(3, 5, 15),
+			5:  linksToInt(1, 4, 6),
+			6:  linksToInt(5, 7, 16),
+			7:  linksToInt(6, 8, 11),
+			8:  linksToInt(7, 9, 13),
+			9:  linksToInt(8, 10, 16),
+			10: linksToInt(9, 11, 14),
+			11: linksToInt(7, 10, 12),
+			12: linksToInt(11, 13, 16),
+			13: linksToInt(8, 12, 14),
+			14: linksToInt(2, 10, 13, 15),
+			15: linksToInt(0, 4, 14),
+			16: linksToInt(0, 3, 6, 9, 12),
+		},
+	},
+}
+
+func TestNumberOf(t *testing.T) {
+	for _, test := range testGraphs {
+		n := numberOf(Graph(test.g))
+		if n != int64(len(test.want)) {
+			t.Errorf("unexpected graph n: got:%d want:%d", n, len(test.want))
+		}
+	}
+}
+
+func TestGoString(t *testing.T) {
+	for _, test := range testGraphs {
+		gosyntax := Graph(test.g).GoString()
+		if gosyntax != test.bin {
+			t.Errorf("unexpected graph string: got:%s want:%s", gosyntax, test.bin)
+		}
+	}
+}
+
+func TestGraph(t *testing.T) {
+	for _, test := range testGraphs {
+		g := Graph(test.g)
+		if !IsValid(g) {
+			t.Errorf("unexpected invalid graph %q", g)
+		}
+		nodes := g.Nodes()
+		if nodes.Len() != len(test.want) {
+			t.Errorf("unexpected graph n: got:%d want:%d", nodes.Len(), len(test.want))
+		}
+		got := make([]set, nodes.Len())
+		for nodes.Next() {
+			n := nodes.Node()
+			got[n.ID()] = linksTo(graph.NodesOf(g.From(n.ID()))...)
+		}
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("unexpected graph: got:%v want:%v", got, test.want)
+		}
+		for i, s := range got {
+			f := g.From(int64(i)).Len()
+			if f != len(s) {
+				t.Errorf("unexpected number of nodes from %d: got:%d want:%d", i, f, len(s))
+			}
+		}
+
+		dst := simple.NewUndirectedGraph()
+		graph.Copy(dst, g)
+		enc := Encode(dst)
+		if enc != g {
+			t.Errorf("unexpected round trip: got:%q want:%q", enc, g)
+		}
+	}
+}
+
+type set map[int]struct{}
+
+func linksToInt(nodes ...int) map[int]struct{} {
+	s := make(map[int]struct{})
+	for _, n := range nodes {
+		s[n] = struct{}{}
+	}
+	return s
+}
+
+func linksTo(nodes ...graph.Node) map[int]struct{} {
+	s := make(map[int]struct{})
+	for _, n := range nodes {
+		s[int(n.ID())] = struct{}{}
+	}
+	return s
+}


### PR DESCRIPTION
Please take a look.

Note that the copyright date is last year because that's when it was written.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
