### PR TITLE
 graph/internal/set: make complex set operations pure functions 

### DIFF
--- a/graph/community/k_communities_test.go
+++ b/graph/community/k_communities_test.go
@@ -5,6 +5,7 @@
 package community
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -43,11 +44,13 @@ var batageljZaversnikGraph = []intset{
 }
 
 var kCliqueCommunitiesTests = []struct {
+	name string
 	g    []intset
 	k    int
 	want [][]graph.Node
 }{
 	{
+		name: "simple",
 		g: []intset{
 			0: linksTo(1, 2, 4, 6),
 			1: linksTo(2, 4, 6),
@@ -65,8 +68,9 @@ var kCliqueCommunitiesTests = []struct {
 		},
 	},
 	{
-		g: batageljZaversnikGraph,
-		k: 3,
+		name: "Batagelj-Zaversnik Graph",
+		g:    batageljZaversnikGraph,
+		k:    3,
 		want: [][]graph.Node{
 			{simple.Node(0)},
 			{simple.Node(1)},
@@ -84,8 +88,9 @@ var kCliqueCommunitiesTests = []struct {
 		},
 	},
 	{
-		g: batageljZaversnikGraph,
-		k: 4,
+		name: "Batagelj-Zaversnik Graph",
+		g:    batageljZaversnikGraph,
+		k:    4,
 		want: [][]graph.Node{
 			{simple.Node(0)},
 			{simple.Node(1)},
@@ -126,7 +131,32 @@ func TestKCliqueCommunities(t *testing.T) {
 		sort.Sort(ordered.BySliceIDs(got))
 
 		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("unexpected k-connected components:\ngot: %v\nwant:%v", got, test.want)
+			t.Errorf("unexpected k-connected components for %q k=%d:\ngot: %v\nwant:%v", test.name, test.k, got, test.want)
 		}
+	}
+}
+
+func BenchmarkKCliqueCommunities(b *testing.B) {
+	for _, test := range kCliqueCommunitiesTests {
+		g := simple.NewUndirectedGraph()
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if g.Node(int64(u)) == nil {
+				g.AddNode(simple.Node(u))
+			}
+			for v := range e {
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
+			}
+		}
+
+		b.Run(fmt.Sprintf("%s-k=%d", test.name, test.k), func(b *testing.B) {
+			var got [][]graph.Node
+			for i := 0; i < b.N; i++ {
+				got = KCliqueCommunities(test.k, g)
+			}
+			if len(got) != len(test.want) {
+				b.Errorf("unexpected k-connected components for %q k=%d:\ngot: %v\nwant:%v", test.name, test.k, got, test.want)
+			}
+		})
 	}
 }

--- a/graph/graphs/gen/batagelj_brandes_test.go
+++ b/graph/graphs/gen/batagelj_brandes_test.go
@@ -293,8 +293,8 @@ func TestBipartitePowerLawUndirected(t *testing.T) {
 			for _, u := range p2 {
 				p2s.Add(u)
 			}
-			o := set.NewNodes()
-			if o.Intersect(p1s, p2s); len(o) != 0 {
+			o := set.IntersectionOfNodes(p1s, p2s)
+			if len(o) != 0 {
 				t.Errorf("unexpected overlap in partition membership: n=%d, d=%d: got:%d", n, d, len(o))
 			}
 
@@ -342,8 +342,8 @@ func TestBipartitePowerLawDirected(t *testing.T) {
 			for _, u := range p2 {
 				p2s.Add(u)
 			}
-			o := set.NewNodes()
-			if o.Intersect(p1s, p2s); len(o) != 0 {
+			o := set.IntersectionOfNodes(p1s, p2s)
+			if len(o) != 0 {
 				t.Errorf("unexpected overlap in partition membership: n=%d, d=%d: got:%d", n, d, len(o))
 			}
 

--- a/graph/internal/set/set.go
+++ b/graph/internal/set/set.go
@@ -126,37 +126,23 @@ func (s Nodes) Remove(e graph.Node) {
 	delete(s, e.ID())
 }
 
-// Has reports the existence of the element in the set.
+// Count returns the number of element in the set.
+func (s Nodes) Count() int {
+	return len(s)
+}
+
+// Has reports the existence of the elements in the set.
 func (s Nodes) Has(n graph.Node) bool {
 	_, ok := s[n.ID()]
 	return ok
 }
 
-// clear clears the set, possibly using the same backing store.
-func (s *Nodes) clear() {
-	if len(*s) != 0 {
-		*s = make(Nodes)
-	}
-}
-
-// Copy performs a perfect copy from src to dst returning the result.
-// If len(dst) is not 0, a new Nodes is made and returned.
-func (dst Nodes) Copy(src Nodes) Nodes {
-	// FIXME(kortschak): The behaviour is this method is very surprising.
-	// Whether the return is required or not depends on len(dst).
-
-	if same(src, dst) {
-		return dst
-	}
-
-	if len(dst) != 0 {
-		dst = make(Nodes, len(src))
-	}
-
+// CloneNodes returns a clone of src.
+func CloneNodes(src Nodes) Nodes {
+	dst := make(Nodes, len(src))
 	for e, n := range src {
 		dst[e] = n
 	}
-
 	return dst
 }
 
@@ -180,7 +166,7 @@ func Equal(a, b Nodes) bool {
 	return true
 }
 
-// Union takes the union of a and b, and stores it in dst.
+// UnionOfNodes returns the union of a and b.
 //
 // The union of two sets, a and b, is the set containing all the
 // elements of each, for instance:
@@ -192,31 +178,23 @@ func Equal(a, b Nodes) bool {
 //
 //     {a,b,c} UNION {b,c,d} = {a,b,c,d}
 //
-func (dst Nodes) Union(a, b Nodes) Nodes {
+func UnionOfNodes(a, b Nodes) Nodes {
 	if same(a, b) {
-		return dst.Copy(a)
+		return CloneNodes(a)
 	}
 
-	if !same(a, dst) && !same(b, dst) {
-		dst.clear()
+	dst := make(Nodes)
+	for e, n := range a {
+		dst[e] = n
 	}
-
-	if !same(dst, a) {
-		for e, n := range a {
-			dst[e] = n
-		}
-	}
-
-	if !same(dst, b) {
-		for e, n := range b {
-			dst[e] = n
-		}
+	for e, n := range b {
+		dst[e] = n
 	}
 
 	return dst
 }
 
-// Intersect takes the intersection of a and b, and stores it in dst.
+// IntersectionOfNodes returns the intersection of a and b.
 //
 // The intersection of two sets, a and b, is the set containing all
 // the elements shared between the two sets, for instance:
@@ -233,35 +211,18 @@ func (dst Nodes) Union(a, b Nodes) Nodes {
 //
 //     {a,b,c} INTERSECT {d,e,f} = {}
 //
-func (dst Nodes) Intersect(a, b Nodes) Nodes {
+func IntersectionOfNodes(a, b Nodes) Nodes {
 	if same(a, b) {
-		return dst.Copy(a)
+		return CloneNodes(a)
 	}
-
-	var swap Nodes
-	switch {
-	default:
-		dst.clear()
-		if len(a) > len(b) {
-			a, b = b, a
-		}
-		for e, n := range a {
-			if _, ok := b[e]; ok {
-				dst[e] = n
-			}
-		}
-		return dst
-
-	case same(a, dst):
-		swap = b
-	case same(b, dst):
-		swap = a
+	dst := make(Nodes)
+	if len(a) > len(b) {
+		a, b = b, a
 	}
-	for e := range dst {
-		if _, ok := swap[e]; !ok {
-			delete(dst, e)
+	for e, n := range a {
+		if _, ok := b[e]; ok {
+			dst[e] = n
 		}
 	}
-
 	return dst
 }

--- a/graph/internal/set/set_test.go
+++ b/graph/internal/set/set_test.go
@@ -329,7 +329,7 @@ func TestAddNodes(t *testing.T) {
 		t.Fatal("Set cannot be created successfully")
 	}
 
-	if s.count() != 0 {
+	if s.Count() != 0 {
 		t.Error("Set somehow contains new elements upon creation")
 	}
 
@@ -337,7 +337,7 @@ func TestAddNodes(t *testing.T) {
 	s.Add(node(3))
 	s.Add(node(5))
 
-	if s.count() != 3 {
+	if s.Count() != 3 {
 		t.Error("Incorrect number of set elements after adding")
 	}
 
@@ -347,9 +347,9 @@ func TestAddNodes(t *testing.T) {
 
 	s.Add(node(1))
 
-	if s.count() > 3 {
+	if s.Count() > 3 {
 		t.Error("Set double-adds element (element not unique)")
-	} else if s.count() < 3 {
+	} else if s.Count() < 3 {
 		t.Error("Set double-add lowered len")
 	}
 
@@ -377,7 +377,7 @@ func TestRemoveNodes(t *testing.T) {
 
 	s.Remove(node(1))
 
-	if s.count() != 2 {
+	if s.Count() != 2 {
 		t.Error("Incorrect number of set elements after removing an element")
 	}
 
@@ -391,28 +391,14 @@ func TestRemoveNodes(t *testing.T) {
 
 	s.Remove(node(1))
 
-	if s.count() != 2 || s.Has(node(1)) {
+	if s.Count() != 2 || s.Has(node(1)) {
 		t.Error("Double set remove does something strange")
 	}
 
 	s.Add(node(1))
 
-	if s.count() != 3 || !s.Has(node(1)) {
+	if s.Count() != 3 || !s.Has(node(1)) {
 		t.Error("Cannot add element after removal")
-	}
-}
-
-func TestClearNodes(t *testing.T) {
-	s := NewNodes()
-
-	s.Add(node(8))
-	s.Add(node(9))
-	s.Add(node(10))
-
-	s.clear()
-
-	if s.count() != 0 {
-		t.Error("clear did not properly reset set to size 0")
 	}
 }
 
@@ -457,13 +443,12 @@ func TestEqualNodes(t *testing.T) {
 
 func TestCopyNodes(t *testing.T) {
 	a := NewNodes()
-	b := NewNodes()
 
 	a.Add(node(1))
 	a.Add(node(2))
 	a.Add(node(3))
 
-	b.Copy(a)
+	b := CloneNodes(a)
 
 	if !Equal(a, b) {
 		t.Fatalf("Two sets not equal after copy: %v != %v", a, b)
@@ -474,31 +459,11 @@ func TestCopyNodes(t *testing.T) {
 	if Equal(a, b) {
 		t.Errorf("Mutating one set mutated another after copy: %v == %v", a, b)
 	}
-
-	b = b.Copy(a) // Assignment is needed because b is not empty.
-
-	if !Equal(a, b) {
-		t.Fatalf("Two sets not equal after second copy: %v != %v", a, b)
-	}
-}
-
-func TestSelfCopyNodes(t *testing.T) {
-	a := NewNodes()
-
-	a.Add(node(1))
-	a.Add(node(2))
-
-	a.Copy(a)
-
-	if a.count() != 2 {
-		t.Error("Something strange happened when copying into self")
-	}
 }
 
 func TestUnionSameNodes(t *testing.T) {
 	a := NewNodes()
 	b := NewNodes()
-	c := NewNodes()
 
 	a.Add(node(1))
 	a.Add(node(2))
@@ -506,9 +471,9 @@ func TestUnionSameNodes(t *testing.T) {
 	b.Add(node(1))
 	b.Add(node(2))
 
-	c.Union(a, b)
+	c := UnionOfNodes(a, b)
 
-	if c.count() != 2 {
+	if c.Count() != 2 {
 		t.Error("Union of same sets yields set with wrong len")
 	}
 
@@ -528,16 +493,15 @@ func TestUnionSameNodes(t *testing.T) {
 func TestUnionDiffNodes(t *testing.T) {
 	a := NewNodes()
 	b := NewNodes()
-	c := NewNodes()
 
 	a.Add(node(1))
 	a.Add(node(2))
 
 	b.Add(node(3))
 
-	c.Union(a, b)
+	c := UnionOfNodes(a, b)
 
-	if c.count() != 3 {
+	if c.Count() != 3 {
 		t.Error("Union of different sets yields set with wrong len")
 	}
 
@@ -545,11 +509,11 @@ func TestUnionDiffNodes(t *testing.T) {
 		t.Error("Union of different sets yields set with wrong elements")
 	}
 
-	if a.Has(node(3)) || !a.Has(node(2)) || !a.Has(node(1)) || a.count() != 2 {
+	if a.Has(node(3)) || !a.Has(node(2)) || !a.Has(node(1)) || a.Count() != 2 {
 		t.Error("Union of sets mutates non-destination set (argument 1)")
 	}
 
-	if !b.Has(node(3)) || b.Has(node(1)) || b.Has(node(2)) || b.count() != 1 {
+	if !b.Has(node(3)) || b.Has(node(1)) || b.Has(node(2)) || b.Count() != 1 {
 		t.Error("Union of sets mutates non-destination set (argument 2)")
 	}
 
@@ -561,7 +525,7 @@ func TestUnionDiffNodes(t *testing.T) {
 		}
 	}
 
-	c = c.Union(a, a) // Assignment is necessary because c is not empty.
+	c = UnionOfNodes(a, a)
 	if !reflect.DeepEqual(c, a) {
 		t.Errorf("Union of equal sets not equal to sets: %v != %v", c, a)
 	}
@@ -570,7 +534,6 @@ func TestUnionDiffNodes(t *testing.T) {
 func TestUnionOverlappingNodes(t *testing.T) {
 	a := NewNodes()
 	b := NewNodes()
-	c := NewNodes()
 
 	a.Add(node(1))
 	a.Add(node(2))
@@ -578,9 +541,9 @@ func TestUnionOverlappingNodes(t *testing.T) {
 	b.Add(node(2))
 	b.Add(node(3))
 
-	c.Union(a, b)
+	c := UnionOfNodes(a, b)
 
-	if c.count() != 3 {
+	if c.Count() != 3 {
 		t.Error("Union of overlapping sets yields set with wrong len")
 	}
 
@@ -588,11 +551,11 @@ func TestUnionOverlappingNodes(t *testing.T) {
 		t.Error("Union of overlapping sets yields set with wrong elements")
 	}
 
-	if a.Has(node(3)) || !a.Has(node(2)) || !a.Has(node(1)) || a.count() != 2 {
+	if a.Has(node(3)) || !a.Has(node(2)) || !a.Has(node(1)) || a.Count() != 2 {
 		t.Error("Union of sets mutates non-destination set (argument 1)")
 	}
 
-	if !b.Has(node(3)) || b.Has(node(1)) || !b.Has(node(2)) || b.count() != 2 {
+	if !b.Has(node(3)) || b.Has(node(1)) || !b.Has(node(2)) || b.Count() != 2 {
 		t.Error("Union of sets mutates non-destination set (argument 2)")
 	}
 
@@ -604,7 +567,7 @@ func TestUnionOverlappingNodes(t *testing.T) {
 		}
 	}
 
-	c = c.Intersect(a, a) // Assignment is necessary because c is not empty.
+	c = IntersectionOfNodes(a, a)
 	if !reflect.DeepEqual(c, a) {
 		t.Errorf("Intersection of equal sets not equal to sets: %v != %v", c, a)
 	}
@@ -613,7 +576,6 @@ func TestUnionOverlappingNodes(t *testing.T) {
 func TestIntersectSameNodes(t *testing.T) {
 	a := NewNodes()
 	b := NewNodes()
-	c := NewNodes()
 
 	a.Add(node(2))
 	a.Add(node(3))
@@ -621,9 +583,9 @@ func TestIntersectSameNodes(t *testing.T) {
 	b.Add(node(2))
 	b.Add(node(3))
 
-	c.Intersect(a, b)
+	c := IntersectionOfNodes(a, b)
 
-	if card := c.count(); card != 2 {
+	if card := c.Count(); card != 2 {
 		t.Errorf("Intersection of identical sets yields set of wrong len %d", card)
 	}
 
@@ -643,7 +605,6 @@ func TestIntersectSameNodes(t *testing.T) {
 func TestIntersectDiffNodes(t *testing.T) {
 	a := NewNodes()
 	b := NewNodes()
-	c := NewNodes()
 
 	a.Add(node(2))
 	a.Add(node(3))
@@ -651,17 +612,17 @@ func TestIntersectDiffNodes(t *testing.T) {
 	b.Add(node(1))
 	b.Add(node(4))
 
-	c.Intersect(a, b)
+	c := IntersectionOfNodes(a, b)
 
-	if card := c.count(); card != 0 {
+	if card := c.Count(); card != 0 {
 		t.Errorf("Intersection of different yields non-empty set %d", card)
 	}
 
-	if !a.Has(node(2)) || !a.Has(node(3)) || a.Has(node(1)) || a.Has(node(4)) || a.count() != 2 {
+	if !a.Has(node(2)) || !a.Has(node(3)) || a.Has(node(1)) || a.Has(node(4)) || a.Count() != 2 {
 		t.Error("Intersection of sets mutates non-destination set (argument 1)")
 	}
 
-	if b.Has(node(2)) || b.Has(node(3)) || !b.Has(node(1)) || !b.Has(node(4)) || b.count() != 2 {
+	if b.Has(node(2)) || b.Has(node(3)) || !b.Has(node(1)) || !b.Has(node(4)) || b.Count() != 2 {
 		t.Error("Intersection of sets mutates non-destination set (argument 1)")
 	}
 
@@ -677,7 +638,6 @@ func TestIntersectDiffNodes(t *testing.T) {
 func TestIntersectOverlappingNodes(t *testing.T) {
 	a := NewNodes()
 	b := NewNodes()
-	c := NewNodes()
 
 	a.Add(node(2))
 	a.Add(node(3))
@@ -685,9 +645,9 @@ func TestIntersectOverlappingNodes(t *testing.T) {
 	b.Add(node(3))
 	b.Add(node(4))
 
-	c.Intersect(a, b)
+	c := IntersectionOfNodes(a, b)
 
-	if card := c.count(); card != 1 {
+	if card := c.Count(); card != 1 {
 		t.Errorf("Intersection of overlapping sets yields set of incorrect len %d", card)
 	}
 
@@ -695,11 +655,11 @@ func TestIntersectOverlappingNodes(t *testing.T) {
 		t.Errorf("Intersection of overlapping sets yields set with wrong element")
 	}
 
-	if !a.Has(node(2)) || !a.Has(node(3)) || a.Has(node(4)) || a.count() != 2 {
+	if !a.Has(node(2)) || !a.Has(node(3)) || a.Has(node(4)) || a.Count() != 2 {
 		t.Error("Intersection of sets mutates non-destination set (argument 1)")
 	}
 
-	if b.Has(node(2)) || !b.Has(node(3)) || !b.Has(node(4)) || b.count() != 2 {
+	if b.Has(node(2)) || !b.Has(node(3)) || !b.Has(node(4)) || b.Count() != 2 {
 		t.Error("Intersection of sets mutates non-destination set (argument 1)")
 	}
 
@@ -711,12 +671,12 @@ func TestIntersectOverlappingNodes(t *testing.T) {
 		}
 	}
 
-	c = c.Intersect(c, a) // Assignment is necessary because c is not empty.
+	c = IntersectionOfNodes(c, a)
 	want := Nodes{3: node(3)}
 	if !reflect.DeepEqual(c, want) {
 		t.Errorf("Intersection of sets with dst equal to a not equal: %v != %v", c, want)
 	}
-	c = c.Intersect(a, c) // Assignment is necessary because c is not empty.
+	c = IntersectionOfNodes(a, c)
 	if !reflect.DeepEqual(c, want) {
 		t.Errorf("Intersection of sets with dst equal to a not equal: %v != %v", c, want)
 	}

--- a/graph/topo/bron_kerbosch.go
+++ b/graph/topo/bron_kerbosch.go
@@ -152,7 +152,7 @@ func BronKerbosch(g graph.Undirected) [][]graph.Node {
 		for _, n := range neighbours {
 			nv.Add(n)
 		}
-		bk.maximalCliquePivot(g, []graph.Node{v}, set.NewNodes().Intersect(p, nv), set.NewNodes().Intersect(x, nv))
+		bk.maximalCliquePivot(g, []graph.Node{v}, set.IntersectionOfNodes(p, nv), set.IntersectionOfNodes(x, nv))
 		p.Remove(v)
 		x.Add(v)
 	}
@@ -195,7 +195,7 @@ func (bk *bronKerbosch) maximalCliquePivot(g graph.Undirected, r []graph.Node, p
 			sr = append(r[:len(r):len(r)], v)
 		}
 
-		bk.maximalCliquePivot(g, sr, set.NewNodes().Intersect(p, nv), set.NewNodes().Intersect(x, nv))
+		bk.maximalCliquePivot(g, sr, set.IntersectionOfNodes(p, nv), set.IntersectionOfNodes(x, nv))
 		p.Remove(v)
 		x.Add(v)
 	}

--- a/graph/topo/bron_kerbosch_test.go
+++ b/graph/topo/bron_kerbosch_test.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"testing"
 
+	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
 )
@@ -126,12 +127,14 @@ func TestKCore(t *testing.T) {
 }
 
 var bronKerboschTests = []struct {
+	name string
 	g    []intset
 	want [][]int64
 }{
 	{
 		// This is the example given in the Bron-Kerbosch article on wikipedia (renumbered).
 		// http://en.wikipedia.org/w/index.php?title=Bron%E2%80%93Kerbosch_algorithm&oldid=656805858
+		name: "wikipedia example",
 		g: []intset{
 			0: linksTo(1, 4),
 			1: linksTo(2, 4),
@@ -149,7 +152,8 @@ var bronKerboschTests = []struct {
 		},
 	},
 	{
-		g: batageljZaversnikGraph,
+		name: "Batagelj-Zaversnik Graph",
+		g:    batageljZaversnikGraph,
 		want: [][]int64{
 			{0},
 			{1, 2},
@@ -171,7 +175,7 @@ var bronKerboschTests = []struct {
 }
 
 func TestBronKerbosch(t *testing.T) {
-	for i, test := range bronKerboschTests {
+	for _, test := range bronKerboschTests {
 		g := simple.NewUndirectedGraph()
 		for u, e := range test.g {
 			// Add nodes that are not defined by an edge.
@@ -194,7 +198,32 @@ func TestBronKerbosch(t *testing.T) {
 		}
 		sort.Sort(ordered.BySliceValues(got))
 		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("unexpected cliques for test %d:\ngot: %v\nwant:%v", i, got, test.want)
+			t.Errorf("unexpected cliques for test %q:\ngot: %v\nwant:%v", test.name, got, test.want)
 		}
+	}
+}
+
+func BenchmarkBronKerbosch(b *testing.B) {
+	for _, test := range bronKerboschTests {
+		g := simple.NewUndirectedGraph()
+		for u, e := range test.g {
+			// Add nodes that are not defined by an edge.
+			if g.Node(int64(u)) == nil {
+				g.AddNode(simple.Node(u))
+			}
+			for v := range e {
+				g.SetEdge(simple.Edge{F: simple.Node(u), T: simple.Node(v)})
+			}
+		}
+
+		b.Run(test.name, func(b *testing.B) {
+			var got [][]graph.Node
+			for i := 0; i < b.N; i++ {
+				got = BronKerbosch(g)
+			}
+			if len(got) != len(test.want) {
+				b.Errorf("unexpected cliques for test %q:\ngot: %v\nwant:%v", test.name, got, test.want)
+			}
+		})
 	}
 }

--- a/graph/topo/clique_graph.go
+++ b/graph/topo/clique_graph.go
@@ -58,7 +58,7 @@ func CliqueGraph(dst Builder, g graph.Undirected) {
 				case len(vc.Clique.nodes):
 					edgeNodes = []graph.Node{vc.Clique.nodes[0]}
 				default:
-					for _, n := range set.NewNodes().Intersect(uc.nodes, vc.nodes) {
+					for _, n := range set.IntersectionOfNodes(uc.nodes, vc.nodes) {
 						edgeNodes = append(edgeNodes, n)
 					}
 					sort.Sort(ordered.ByID(edgeNodes))


### PR DESCRIPTION
Looking at the benchmarks for this approach, we have a better outcome than the original code for `community.KCliqueCommunities` and a better outcome than the pointer approach in #900 for `topo.BronKerbosch` and `topo.CliqueGraph`.

### Original versus this approach

<table class='benchstat'>
<tr><th>name</th><th>original time/op</th><th>pure function time/op</th><th>delta</th>
<tr><td>KCliqueCommunities/simple-k=3-8</td><td>76.1µs ± 2%</td><td>61.1µs ± 3%</td><td>-19.81%</td><td>(p=0.000 n=17+20)</td>
<tr><td>KCliqueCommunities/Batagelj-Zaversnik_Graph-k=3-8</td><td>230µs ± 3%</td><td>184µs ± 1%</td><td>-19.83%</td><td>(p=0.000 n=20+17)</td>
<tr><td>KCliqueCommunities/Batagelj-Zaversnik_Graph-k=4-8</td><td>229µs ± 2%</td><td>183µs ± 1%</td><td>-20.02%</td><td>(p=0.000 n=19+18)</td>
<tr><td>BronKerbosch/wikipedia_example-8</td><td>19.0µs ± 2%</td><td>21.4µs ± 3%</td><td>+12.39%</td><td>(p=0.000 n=20+20)</td>
<tr><td>BronKerbosch/Batagelj-Zaversnik_Graph-8</td><td>106µs ± 6%</td><td>111µs ± 6%</td><td>+4.62%</td><td>(p=0.000 n=20+20)</td>
<tr><td>CliqueGraph/simple-8</td><td>54.5µs ± 3%</td><td>58.1µs ± 2%</td><td>+6.52%</td><td>(p=0.000 n=20+20)</td>
<tr><td>CliqueGraph/Batagelj-Zaversnik_Graph-8</td><td>149µs ± 6%</td><td>156µs ± 1%</td><td>+4.75%</td><td>(p=0.000 n=20+16)</td>
</table>

### Pointer method approach versus this approach

<table class='benchstat'>
<tr><th>name</th><th>pointer method time/op</th><th>pure function time/op</th><th>delta</th>
<tr><td>BronKerbosch/wikipedia_example-8</td><td>24.7µs ± 6%</td><td>21.4µs ± 3%</td><td>-13.22%</td><td>(p=0.000 n=20+20)</td>
<tr><td>BronKerbosch/Batagelj-Zaversnik_Graph-8</td><td>123µs ± 5%</td><td>111µs ± 6%</td><td>-9.78%</td><td>(p=0.000 n=20+20)</td>
<tr><td>CliqueGraph/simple-8</td><td>62.1µs ± 1%</td><td>58.1µs ± 2%</td><td>-6.53%</td><td>(p=0.000 n=18+20)</td>
<tr><td>CliqueGraph/Batagelj-Zaversnik_Graph-8</td><td>167µs ± 4%</td><td>156µs ± 1%</td><td>-6.18%</td><td>(p=0.000 n=20+16)</td>
</table>

I also think the clarity of the calls is not bad (surprisingly to me).

Finally, the purity of the functions means that other potentially surprising behaviours that I did not notice previously are now not possible.

All up I think this is the correct approach.

Please take a look.

Fixes #863.
Closes #900.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
