### PR TITLE
graph/traverse: reduce edge confusion

### DIFF
--- a/graph/community/k_communities.go
+++ b/graph/community/k_communities.go
@@ -88,7 +88,7 @@ func kConnectedComponents(k int, cg graph.Undirected) [][]graph.Node {
 		c = c[:0]
 	}
 	w := traverse.DepthFirst{
-		EdgeFilter: func(e graph.Edge) bool {
+		Traverse: func(e graph.Edge) bool {
 			return len(e.(topo.CliqueGraphEdge).Nodes()) >= k-1
 		},
 	}

--- a/graph/traverse/traverse.go
+++ b/graph/traverse/traverse.go
@@ -30,21 +30,21 @@ type BreadthFirst struct {
 	// Visit is called on all nodes on their first visit.
 	Visit func(graph.Node)
 
-	// EdgeFilter is called on all edges that may be traversed
+	// Traverse is called on all edges that may be traversed
 	// during the walk. This includes edges that would hop to
 	// an already visited node.
 	//
 	// The value returned by EdgeFulter determines whether an
 	// edge can be traverse during the walk.
-	EdgeFilter func(graph.Edge) bool
+	Traverse func(graph.Edge) bool
 
 	queue   linear.NodeQueue
 	visited set.Int64s
 }
 
 // Walk performs a breadth-first traversal of the graph g starting from the given node,
-// depending on the the EdgeFilter field and the until parameter if they are non-nil. The
-// traversal follows edges for which EdgeFilter(edge) is true and returns the first node
+// depending on the the Traverse field and the until parameter if they are non-nil. The
+// traversal follows edges for which Traverse(edge) is true and returns the first node
 // for which until(node, depth) is true. During the traversal, if the Visit field is
 // non-nil, it is called with each node the first time it is visited.
 func (b *BreadthFirst) Walk(g Graph, from graph.Node, until func(n graph.Node, d int) bool) graph.Node {
@@ -72,7 +72,7 @@ func (b *BreadthFirst) Walk(g Graph, from graph.Node, until func(n graph.Node, d
 		for to.Next() {
 			n := to.Node()
 			nid := n.ID()
-			if b.EdgeFilter != nil && !b.EdgeFilter(g.Edge(tid, nid)) {
+			if b.Traverse != nil && !b.Traverse(g.Edge(tid, nid)) {
 				continue
 			}
 			if b.visited.Has(nid) {
@@ -138,21 +138,21 @@ type DepthFirst struct {
 	// Visit is called on all nodes on their first visit.
 	Visit func(graph.Node)
 
-	// EdgeFilter is called on all edges that may be traversed
+	// Traverse is called on all edges that may be traversed
 	// during the walk. This includes edges that would hop to
 	// an already visited node.
 	//
 	// The value returned by EdgeFulter determines whether an
 	// edge can be traverse during the walk.
-	EdgeFilter func(graph.Edge) bool
+	Traverse func(graph.Edge) bool
 
 	stack   linear.NodeStack
 	visited set.Int64s
 }
 
 // Walk performs a depth-first traversal of the graph g starting from the given node,
-// depending on the the EdgeFilter field and the until parameter if they are non-nil. The
-// traversal follows edges for which EdgeFilter(edge) is true and returns the first node
+// depending on the the Traverse field and the until parameter if they are non-nil. The
+// traversal follows edges for which Traverse(edge) is true and returns the first node
 // for which until(node) is true. During the traversal, if the Visit field is non-nil, it
 // is called with each node the first time it is visited.
 func (d *DepthFirst) Walk(g Graph, from graph.Node, until func(graph.Node) bool) graph.Node {
@@ -175,7 +175,7 @@ func (d *DepthFirst) Walk(g Graph, from graph.Node, until func(graph.Node) bool)
 		for to.Next() {
 			n := to.Node()
 			nid := n.ID()
-			if d.EdgeFilter != nil && !d.EdgeFilter(g.Edge(tid, nid)) {
+			if d.Traverse != nil && !d.Traverse(g.Edge(tid, nid)) {
 				continue
 			}
 			if d.visited.Has(nid) {

--- a/graph/traverse/traverse.go
+++ b/graph/traverse/traverse.go
@@ -34,8 +34,8 @@ type BreadthFirst struct {
 	// during the walk. This includes edges that would hop to
 	// an already visited node.
 	//
-	// The value returned by EdgeFulter determines whether an
-	// edge can be traverse during the walk.
+	// The value returned by Traverse determines whether an
+	// edge can be traversed during the walk.
 	Traverse func(graph.Edge) bool
 
 	queue   linear.NodeQueue
@@ -142,8 +142,8 @@ type DepthFirst struct {
 	// during the walk. This includes edges that would hop to
 	// an already visited node.
 	//
-	// The value returned by EdgeFulter determines whether an
-	// edge can be traverse during the walk.
+	// The value returned by Traverse determines whether an
+	// edge can be traversed during the walk.
 	Traverse func(graph.Edge) bool
 
 	stack   linear.NodeStack

--- a/graph/traverse/traverse_test.go
+++ b/graph/traverse/traverse_test.go
@@ -144,7 +144,7 @@ func TestBreadthFirst(t *testing.T) {
 			}
 		}
 		w := BreadthFirst{
-			EdgeFilter: test.edge,
+			Traverse: test.edge,
 		}
 		var got [][]int64
 		final := w.Walk(g, test.from, func(n graph.Node, d int) bool {
@@ -232,7 +232,7 @@ func TestDepthFirst(t *testing.T) {
 			}
 		}
 		w := DepthFirst{
-			EdgeFilter: test.edge,
+			Traverse: test.edge,
 		}
 		var got []int64
 		final := w.Walk(g, test.from, func(n graph.Node) bool {
@@ -308,9 +308,9 @@ func TestWalkAll(t *testing.T) {
 			)
 			switch w := w.(type) {
 			case *BreadthFirst:
-				w.EdgeFilter = test.edge
+				w.Traverse = test.edge
 			case *DepthFirst:
-				w.EdgeFilter = test.edge
+				w.Traverse = test.edge
 			default:
 				panic(fmt.Sprintf("bad walker type: %T", w))
 			}


### PR DESCRIPTION
Please take a look.

It could be argued that the `Visit` could go away completely, since the `until` parameter can now be used to do the same thing. However, `until` differs between `BreadthFirst` and `DepthFirst` so that BF can stop after a certain depth. This means that a visitors for `BreadthFirst` and `DepthFirst` would not be interchangeable. For this reason I have kept it.

Fixes #913.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
