### PR TITLE
Move EigenvectorsSym to VectorsTo

### DIFF
--- a/mat/eigen_example_test.go
+++ b/mat/eigen_example_test.go
@@ -25,9 +25,8 @@ func ExampleEigenSym() {
 	}
 	fmt.Printf("Eigenvalues of A:\n%1.3f\n\n", eigsym.Values(nil))
 
-	var ev mat.Dense
-	ev.EigenvectorsSym(&eigsym)
-	fmt.Printf("Eigenvectors of A:\n%1.3f\n\n", mat.Formatted(&ev))
+	ev := eigsym.VectorsTo(nil)
+	fmt.Printf("Eigenvectors of A:\n%1.3f\n\n", mat.Formatted(ev))
 
 	// Output:
 	// A = ⎡  7  0.5⎤

--- a/mat/symmetric.go
+++ b/mat/symmetric.go
@@ -577,14 +577,13 @@ func (s *SymDense) PowPSD(a Symmetric, pow float64) error {
 		}
 		values[i] = math.Pow(v, pow)
 	}
-	var u Dense
-	u.EigenvectorsSym(&eigen)
+	u := eigen.VectorsTo(nil)
 
 	s.SymOuterK(values[0], u.ColView(0))
 
 	var v VecDense
 	for i := 1; i < dim; i++ {
-		v.ColViewOf(&u, i)
+		v.ColViewOf(u, i)
 		s.SymRankOne(s, values[i], &v)
 	}
 	return nil

--- a/stat/mds/mds.go
+++ b/stat/mds/mds.go
@@ -59,7 +59,7 @@ func TorgersonScaling(dst *mat.Dense, eigdst []float64, dis mat.Symmetric) (k in
 	if !ok {
 		return 0, dst, eigdst
 	}
-	dst.EigenvectorsSym(&ed)
+	ed.VectorsTo(dst)
 	vals := ed.Values(nil)
 	reverse(vals, dst.RawMatrix())
 	copy(eigdst, vals)


### PR DESCRIPTION
This is in line with the other factorization extraction methods.

Fixes #847.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
