### PR TITLE
all: fix "the the" typo in comments

### DIFF
--- a/graph/community/louvain_common.go
+++ b/graph/community/louvain_common.go
@@ -311,7 +311,7 @@ type dense struct {
 
 // TakeMin mimics intsets.Sparse TakeMin for dense sets. If the dense
 // iterator position is less than the iterator size, TakeMin sets *p
-// to the the iterator position and increments the position and returns
+// to the iterator position and increments the position and returns
 // true.
 // Otherwise, it returns false and *p is undefined.
 func (d *dense) TakeMin(p *int) bool {
@@ -341,7 +341,7 @@ func newSlice(s set.Ints) *slice {
 
 // TakeMin mimics intsets.Sparse TakeMin for a sorted set. If the set
 // iterator position is less than the iterator size, TakeMin sets *p
-// to the the iterator position's element and increments the position
+// to the iterator position's element and increments the position
 // and returns true.
 // Otherwise, it returns false and *p is undefined.
 func (s *slice) TakeMin(p *int) bool {

--- a/graph/encoding/dot/encode.go
+++ b/graph/encoding/dot/encode.go
@@ -40,15 +40,15 @@ type Attributers interface {
 
 // Porter defines the behavior of graph.Edge values that can specify
 // connection ports for their end points. The returned port corresponds
-// to the the DOT node port to be used by the edge, compass corresponds
+// to the DOT node port to be used by the edge, compass corresponds
 // to DOT compass point to which the edge will be aimed.
 type Porter interface {
-	// FromPort returns the port and compass for the
-	// From node of a graph.Edge.
+	// FromPort returns the port and compass for
+	// the From node of a graph.Edge.
 	FromPort() (port, compass string)
 
-	// ToPort returns the port and compass for the
-	// To node of a graph.Edge.
+	// ToPort returns the port and compass for
+	// the To node of a graph.Edge.
 	ToPort() (port, compass string)
 }
 

--- a/graph/encoding/graphql/decode.go
+++ b/graph/encoding/graphql/decode.go
@@ -14,7 +14,7 @@ import (
 	"gonum.org/v1/gonum/graph/encoding"
 )
 
-// Unmarshal parses the the JSON-encoded data and stores the result in dst.
+// Unmarshal parses the JSON-encoded data and stores the result in dst.
 // Node IDs are obtained from the JSON fields identified by the uid parameter.
 // UIDs obtained from the JSON encoding must map to unique node ID values
 // consistently across the JSON-encoded spanning tree.

--- a/graph/traverse/traverse.go
+++ b/graph/traverse/traverse.go
@@ -20,8 +20,8 @@ type Graph interface {
 
 	// Edge returns the edge from u to v, with IDs uid and vid,
 	// if such an edge exists and nil otherwise. The node v
-	// must be directly reachable from u as defined by the
-	// From method.
+	// must be directly reachable from u as defined by
+	// the From method.
 	Edge(uid, vid int64) graph.Edge
 }
 
@@ -34,8 +34,8 @@ type BreadthFirst struct {
 	// during the walk. This includes edges that would hop to
 	// an already visited node.
 	//
-	// The value returned by Traverse determines whether an
-	// edge can be traversed during the walk.
+	// The value returned by Traverse determines whether
+	// an edge can be traversed during the walk.
 	Traverse func(graph.Edge) bool
 
 	queue   linear.NodeQueue
@@ -43,8 +43,8 @@ type BreadthFirst struct {
 }
 
 // Walk performs a breadth-first traversal of the graph g starting from the given node,
-// depending on the the Traverse field and the until parameter if they are non-nil. The
-// traversal follows edges for which Traverse(edge) is true and returns the first node
+// depending on the Traverse field and the until parameter if they are non-nil.
+// The traversal follows edges for which Traverse(edge) is true and returns the first node
 // for which until(node, depth) is true. During the traversal, if the Visit field is
 // non-nil, it is called with each node the first time it is visited.
 func (b *BreadthFirst) Walk(g Graph, from graph.Node, until func(n graph.Node, d int) bool) graph.Node {
@@ -151,8 +151,8 @@ type DepthFirst struct {
 }
 
 // Walk performs a depth-first traversal of the graph g starting from the given node,
-// depending on the the Traverse field and the until parameter if they are non-nil. The
-// traversal follows edges for which Traverse(edge) is true and returns the first node
+// depending on the Traverse field and the until parameter if they are non-nil.
+// The traversal follows edges for which Traverse(edge) is true and returns the first node
 // for which until(node) is true. During the traversal, if the Visit field is non-nil, it
 // is called with each node the first time it is visited.
 func (d *DepthFirst) Walk(g Graph, from graph.Node, until func(graph.Node) bool) graph.Node {

--- a/lapack/gonum/dlaqr04.go
+++ b/lapack/gonum/dlaqr04.go
@@ -443,7 +443,7 @@ func (impl Implementation) Dlaqr04(wantt, wantz bool, n, ilo, ihi int, h []float
 			}
 		}
 
-		// Use up to ns of the the smallest magnitude shifts. If there
+		// Use up to ns of the smallest magnitude shifts. If there
 		// aren't ns shifts available, then use them all, possibly
 		// dropping one to make the number of shifts even.
 		ns = min(ns, kbot-ks+1) &^ 1

--- a/lapack/gonum/dsytd2.go
+++ b/lapack/gonum/dsytd2.go
@@ -9,15 +9,15 @@ import (
 	"gonum.org/v1/gonum/blas/blas64"
 )
 
-// Dsytd2 reduces a symmetric n×n matrix A to symmetric tridiagonal form T by an
-// orthogonal similarity transformation
+// Dsytd2 reduces a symmetric n×n matrix A to symmetric tridiagonal form T by
+// an orthogonal similarity transformation
 //  Q^T * A * Q = T
 // On entry, the matrix is contained in the specified triangle of a. On exit,
 // if uplo == blas.Upper, the diagonal and first super-diagonal of a are
 // overwritten with the elements of T. The elements above the first super-diagonal
-// are overwritten with the the elementary reflectors that are used with the
-// elements written to tau in order to construct Q. If uplo == blas.Lower, the
-// elements are written in the lower triangular region.
+// are overwritten with the elementary reflectors that are used with
+// the elements written to tau in order to construct Q. If uplo == blas.Lower,
+// the elements are written in the lower triangular region.
 //
 // d must have length at least n. e and tau must have length at least n-1. Dsytd2
 // will panic if these sizes are not met.

--- a/optimize/functions/functions.go
+++ b/optimize/functions/functions.go
@@ -98,7 +98,7 @@ func (Beale) Minima() []Minimum {
 	}
 }
 
-// BiggsEXP2 implements the the Biggs' EXP2 function.
+// BiggsEXP2 implements the Biggs' EXP2 function.
 //
 // Standard starting point:
 //  [1, 2]
@@ -160,7 +160,7 @@ func (BiggsEXP2) Minima() []Minimum {
 	}
 }
 
-// BiggsEXP3 implements the the Biggs' EXP3 function.
+// BiggsEXP3 implements the Biggs' EXP3 function.
 //
 // Standard starting point:
 //  [1, 2, 1]
@@ -224,7 +224,7 @@ func (BiggsEXP3) Minima() []Minimum {
 	}
 }
 
-// BiggsEXP4 implements the the Biggs' EXP4 function.
+// BiggsEXP4 implements the Biggs' EXP4 function.
 //
 // Standard starting point:
 //  [1, 2, 1, 1]
@@ -290,7 +290,7 @@ func (BiggsEXP4) Minima() []Minimum {
 	}
 }
 
-// BiggsEXP5 implements the the Biggs' EXP5 function.
+// BiggsEXP5 implements the Biggs' EXP5 function.
 //
 // Standard starting point:
 //  [1, 2, 1, 1, 1]
@@ -358,7 +358,7 @@ func (BiggsEXP5) Minima() []Minimum {
 	}
 }
 
-// BiggsEXP6 implements the the Biggs' EXP6 function.
+// BiggsEXP6 implements the Biggs' EXP6 function.
 //
 // Standard starting point:
 //  [1, 2, 1, 1, 1, 1]


### PR DESCRIPTION
At a couple of places I also moved the article from the end of a line to the beginning of the next one.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
