### PR TITLE
all: fix repeated word typos in comments

### DIFF
--- a/fourier/fourier.go
+++ b/fourier/fourier.go
@@ -230,11 +230,11 @@ func (t *CmplxFFT) Freq(i int) float64 {
 	return step * float64(i-t.Len())
 }
 
-// ShiftIdx returns returns a shifted index into a slice of
-// coefficients returned by the CmplxFFT so that indexing
-// into the coefficients places the zero frequency component
-// at the center of the spectrum. ShiftIdx will panic if i is
-// negative or greater than or equal to t.Len().
+// ShiftIdx returns a shifted index into a slice of coefficients
+// returned by the CmplxFFT so that indexing into the coefficients
+// places the zero frequency component at the center of the spectrum.
+// ShiftIdx will panic if i is negative or greater than or equal to
+// t.Len().
 func (t *CmplxFFT) ShiftIdx(i int) int {
 	if i < 0 || t.Len() <= i {
 		panic("fourier: index out of range")

--- a/graph/network/page.go
+++ b/graph/network/page.go
@@ -379,7 +379,7 @@ func (r *compressedRow) addTo(j int, v float64) {
 }
 
 // dotUnitary performs a simplified scatter-based Ddot operations on
-// v and the receiver. v must have have a unitary vector increment.
+// v and the receiver. v must have a unitary vector increment.
 func (r compressedRow) dotUnitary(v *mat.VecDense) float64 {
 	var sum float64
 	vec := v.RawVector().Data
@@ -396,8 +396,8 @@ type sparseElement struct {
 }
 
 // onesDotUnitary performs the equivalent of a Ddot of v with
-// a ones vector of equal length. v must have have a unitary
-// vector increment.
+// a ones vector of equal length. v must have a unitary vector
+// increment.
 func onesDotUnitary(alpha float64, v *mat.VecDense) float64 {
 	var sum float64
 	for _, f := range v.RawVector().Data {

--- a/integrate/quad/hermite.go
+++ b/integrate/quad/hermite.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Hermite generates sample locations and weights for performing quadrature with
-// with a squared-exponential weight
+// a squared-exponential weight
 //  int_-inf^inf e^(-x^2) f(x) dx .
 type Hermite struct{}
 

--- a/lapack/gonum/dlaqr5.go
+++ b/lapack/gonum/dlaqr5.go
@@ -348,7 +348,7 @@ func (impl Implementation) Dlaqr5(wantt, wantz bool, kacc22 int, n, ktop, kbot, 
 					h[j*ldh+k+3] -= refsum * v[m*ldv+2]
 				}
 				if accum {
-					// Accumulate U. (If necessary, update Z later with with an
+					// Accumulate U. (If necessary, update Z later with an
 					// efficient matrix-matrix multiply.)
 					kms := k - incol
 					for j := max(0, ktop-incol-1); j < kdu; j++ {

--- a/lapack/gonum/dlatrs.go
+++ b/lapack/gonum/dlatrs.go
@@ -18,7 +18,7 @@ import (
 // where the scale s is set for numeric stability.
 //
 // A is an n×n triangular matrix. On entry, the slice x contains the values of
-// of b, and on exit it contains the solution vector x.
+// b, and on exit it contains the solution vector x.
 //
 // If normin == true, cnorm is an input and cnorm[j] contains the norm of the off-diagonal
 // part of the j^th column of A. If trans == blas.NoTrans, cnorm[j] must be greater

--- a/lapack/gonum/doc.go
+++ b/lapack/gonum/doc.go
@@ -16,7 +16,7 @@
 // Most LAPACK functions are built on top the routines defined in the BLAS API,
 // and as such the computation time for many LAPACK functions is
 // dominated by BLAS calls. Here, BLAS is accessed through the
-// the blas64 package (https://godoc.org/golang.org/v1/gonum/blas/blas64). In particular,
+// blas64 package (https://godoc.org/golang.org/v1/gonum/blas/blas64). In particular,
 // this implies that an external BLAS library will be used if it is
 // registered in blas64.
 //

--- a/mat/format.go
+++ b/mat/format.go
@@ -66,7 +66,7 @@ func (f formatter) Format(fs fmt.State, c rune) {
 }
 
 // format prints a pretty representation of m to the fs io.Writer. The format character c
-// specifies the numerical representation of of elements; valid values are those for float64
+// specifies the numerical representation of elements; valid values are those for float64
 // specified in the fmt package, with their associated flags. In addition to this, a space
 // preceding a verb indicates that zero values should be represented by the dot character.
 // The printed range of the matrix can be limited by specifying a positive value for margin;

--- a/mat/hogsvd_test.go
+++ b/mat/hogsvd_test.go
@@ -48,7 +48,7 @@ func TestHOGSVD(t *testing.T) {
 					}
 				} else {
 					if ok {
-						t.Errorf("HOGSVD factorization unexpectedly succeeded for for %d %d×%d matrices", n, r, c)
+						t.Errorf("HOGSVD factorization unexpectedly succeeded for %d %d×%d matrices", n, r, c)
 					}
 					continue
 				}

--- a/stat/distuv/categorical.go
+++ b/stat/distuv/categorical.go
@@ -24,8 +24,8 @@ type Categorical struct {
 	//
 	// Each element holds the sum of weights for
 	// the corresponding index, plus the sum of
-	// of its children's weights; the children
-	// of an element i can be found at positions
+	// its children's weights; the children of
+	// an element i can be found at positions
 	// 2*(i+1)-1 and 2*(i+1). The root of the
 	// weight heap is at element 0.
 	//

--- a/stat/sampleuv/weighted.go
+++ b/stat/sampleuv/weighted.go
@@ -22,8 +22,8 @@ type Weighted struct {
 	//
 	// Each element holds the sum of weights for
 	// the corresponding index, plus the sum of
-	// of its children's weights; the children
-	// of an element i can be found at positions
+	// its children's weights; the children of
+	// an element i can be found at positions
 	// 2*(i+1)-1 and 2*(i+1). The root of the
 	// weight heap is at element 0.
 	//

--- a/stat/spatial/spatial.go
+++ b/stat/spatial/spatial.go
@@ -13,7 +13,7 @@ import (
 
 // TODO(kortschak): Implement weighted routines.
 
-// GetisOrdGStar returns the Local Getis-Ord G*i statistic for element of of the
+// GetisOrdGStar returns the Local Getis-Ord G*i statistic for element of the
 // weighted data using the provided locality matrix. The returned value is a z-score.
 //
 //  G^*_i = num_i / den_i


### PR DESCRIPTION
Prompted by #930.

This was done on `fix-the-the` and then cherry picked to here to avoid conflicts.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
