### PR TITLE
mat: rename SliceSquare=>SliceSym and GrowSquare=>GrowSym and return Symmetric

### DIFF
--- a/mat/cholesky_test.go
+++ b/mat/cholesky_test.go
@@ -488,7 +488,7 @@ func TestCholeskyExtendVecSym(t *testing.T) {
 		},
 	} {
 		n := test.a.Symmetric()
-		as := test.a.SliceSquare(0, n-1).(*SymDense)
+		as := test.a.SliceSym(0, n-1).(*SymDense)
 
 		// Compute the full factorization to use later (do the full factorization
 		// first to ensure the matrix is positive definite).

--- a/mat/symmetric.go
+++ b/mat/symmetric.go
@@ -497,12 +497,12 @@ func (s *SymDense) SubsetSym(a Symmetric, set []int) {
 	}
 }
 
-// SliceSquare returns a new Matrix that shares backing data with the receiver.
+// SliceSym returns a new Matrix that shares backing data with the receiver.
 // The returned matrix starts at {i,i} of the receiver and extends k-i rows
 // and columns. The final row and column in the resulting matrix is k-1.
-// SliceSquare panics with ErrIndexOutOfRange if the slice is outside the capacity
-// of the receiver.
-func (s *SymDense) SliceSquare(i, k int) Matrix {
+// SliceSym panics with ErrIndexOutOfRange if the slice is outside the
+// capacity of the receiver.
+func (s *SymDense) SliceSym(i, k int) Symmetric {
 	sz := s.cap
 	if i < 0 || sz < i || k < i || sz < k {
 		panic(ErrIndexOutOfRange)
@@ -514,11 +514,11 @@ func (s *SymDense) SliceSquare(i, k int) Matrix {
 	return &v
 }
 
-// GrowSquare returns the receiver expanded by n rows and n columns. If the
+// GrowSym returns the receiver expanded by n rows and n columns. If the
 // dimensions of the expanded matrix are outside the capacity of the receiver
 // a new allocation is made, otherwise not. Note that the receiver itself is
 // not modified during the call to GrowSquare.
-func (s *SymDense) GrowSquare(n int) Matrix {
+func (s *SymDense) GrowSym(n int) Symmetric {
 	if n < 0 {
 		panic(ErrIndexOutOfRange)
 	}

--- a/mat/symmetric_test.go
+++ b/mat/symmetric_test.go
@@ -608,7 +608,7 @@ func TestViewGrowSquare(t *testing.T) {
 		// Take a subset and check the view matches.
 		start1 := test.start1
 		span1 := test.span1
-		v := s.SliceSquare(start1, start1+span1).(*SymDense)
+		v := s.SliceSym(start1, start1+span1).(*SymDense)
 		for i := 0; i < span1; i++ {
 			for j := i; j < span1; j++ {
 				if v.At(i, j) != s.At(start1+i, start1+j) {
@@ -619,7 +619,7 @@ func TestViewGrowSquare(t *testing.T) {
 
 		start2 := test.start2
 		span2 := test.span2
-		v2 := v.SliceSquare(start2, start2+span2).(*SymDense)
+		v2 := v.SliceSym(start2, start2+span2).(*SymDense)
 
 		for i := 0; i < span2; i++ {
 			for j := i; j < span2; j++ {
@@ -637,7 +637,7 @@ func TestViewGrowSquare(t *testing.T) {
 
 		// Grow the matrix back to the original view
 		gn := n - start1 - start2
-		g := v2.GrowSquare(gn - v2.Symmetric()).(*SymDense)
+		g := v2.GrowSym(gn - v2.Symmetric()).(*SymDense)
 		g.SetSym(1, 1, 2.2)
 
 		for i := 0; i < gn; i++ {
@@ -653,9 +653,9 @@ func TestViewGrowSquare(t *testing.T) {
 		}
 
 		// View g, then grow it and make sure all the elements were copied.
-		gv := g.SliceSquare(0, gn-1).(*SymDense)
+		gv := g.SliceSym(0, gn-1).(*SymDense)
 
-		gg := gv.GrowSquare(2)
+		gg := gv.GrowSym(2)
 		for i := 0; i < gn; i++ {
 			for j := 0; j < gn; j++ {
 				if g.At(i, j) != gg.At(i, j) {

--- a/stat/distmv/dirichlet.go
+++ b/stat/distmv/dirichlet.go
@@ -66,7 +66,7 @@ func (d *Dirichlet) CovarianceMatrix(cov *mat.SymDense) *mat.SymDense {
 	if cov == nil {
 		cov = mat.NewSymDense(d.Dim(), nil)
 	} else if cov.Symmetric() == 0 {
-		*cov = *(cov.GrowSquare(d.dim).(*mat.SymDense))
+		*cov = *(cov.GrowSym(d.dim).(*mat.SymDense))
 	} else if cov.Symmetric() != d.dim {
 		panic("normal: input matrix size mismatch")
 	}


### PR DESCRIPTION
The `Sym` suffix implies the square, and allows the `Tri` and banded API extensions when they are needed. It's also shorter.

Please take a look.

Closes #174.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
