### PR TITLE
mat: add fast paths to matrix sum function

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -46,6 +46,7 @@ Jeremy Atkinson <jchatkinson@gmail.com>
 Jonas Kahler <jonas@derkahler.de>
 Jonas Schulze <jonas.schulze@ovgu.de>
 Jonathan J Lawlor <jonathan.lawlor@gmail.com>
+Jonathan Reiter <jonreiter@gmail.com>
 Jonathan Schroeder <jd.schroeder@gmail.com>
 Joseph Watson <jtwatson@linux-consulting.us>
 Josh Wilson <josh.craig.wilson@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -52,6 +52,7 @@ Jeremy Atkinson <jchatkinson@gmail.com>
 Jonas Kahler <jonas@derkahler.de>
 Jonas Schulze <jonas.schulze@ovgu.de>
 Jonathan J Lawlor <jonathan.lawlor@gmail.com>
+Jonathan Reiter <jonreiter@gmail.com>
 Jonathan Schroeder <jd.schroeder@gmail.com>
 Joseph Watson <jtwatson@linux-consulting.us>
 Josh Wilson <josh.craig.wilson@gmail.com>

--- a/mat/dense_test.go
+++ b/mat/dense_test.go
@@ -2093,3 +2093,15 @@ func denseMulTransSymBench(b *testing.B, size int, rho float64) {
 		wd = &n
 	}
 }
+
+func BenchmarkDenseSum1000(b *testing.B) { denseSumBench(b, 1000) }
+
+var denseSumForBench float64
+
+func denseSumBench(b *testing.B, size int) {
+	a, _ := randDense(size, 1.0, rand.NormFloat64)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		denseSumForBench = Sum(a)
+	}
+}

--- a/mat/matrix.go
+++ b/mat/matrix.go
@@ -848,12 +848,43 @@ func normLapack(norm float64, aTrans bool) lapack.MatrixNorm {
 
 // Sum returns the sum of the elements of the matrix.
 func Sum(a Matrix) float64 {
-	// TODO(btracey): Add a fast path for the other supported matrix types.
 
-	r, c := a.Dims()
 	var sum float64
 	aU, _ := untranspose(a)
-	if rma, ok := aU.(RawMatrixer); ok {
+	switch rma := aU.(type) {
+	case RawSymmetricer:
+		rm := rma.RawSymmetric()
+		for i := 0; i < rm.N; i++ {
+			// Diagonals count once while off-diagonals count twice.
+			sum += rm.Data[i*rm.Stride+i]
+			var s float64
+			for _, v := range rm.Data[i*rm.Stride+i+1 : i*rm.Stride+rm.N] {
+				s += v
+			}
+			sum += 2 * s
+		}
+		return sum
+	case RawTriangular:
+		rm := rma.RawTriangular()
+		var startIdx, endIdx int
+		for i := 0; i < rm.N; i++ {
+			// Start and end index for this triangle-row.
+			switch rm.Uplo {
+			case blas.Upper:
+				startIdx = i
+				endIdx = rm.N
+			case blas.Lower:
+				startIdx = 0
+				endIdx = i + 1
+			default:
+				panic(badTriangle)
+			}
+			for _, v := range rm.Data[i*rm.Stride+startIdx : i*rm.Stride+endIdx] {
+				sum += v
+			}
+		}
+		return sum
+	case RawMatrixer:
 		rm := rma.RawMatrix()
 		for i := 0; i < rm.Rows; i++ {
 			for _, v := range rm.Data[i*rm.Stride : i*rm.Stride+rm.Cols] {
@@ -861,13 +892,21 @@ func Sum(a Matrix) float64 {
 			}
 		}
 		return sum
-	}
-	for i := 0; i < r; i++ {
-		for j := 0; j < c; j++ {
-			sum += a.At(i, j)
+	case *VecDense:
+		rm := rma.RawVector()
+		for i := 0; i < rm.N; i++ {
+			sum += rm.Data[i*rm.Inc]
 		}
+		return sum
+	default:
+		r, c := a.Dims()
+		for i := 0; i < r; i++ {
+			for j := 0; j < c; j++ {
+				sum += a.At(i, j)
+			}
+		}
+		return sum
 	}
-	return sum
 }
 
 // A Tracer can compute the trace of the matrix. Trace must panic if the

--- a/mat/symmetric_test.go
+++ b/mat/symmetric_test.go
@@ -735,3 +735,29 @@ func TestPowPSD(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkSymSum1000(b *testing.B) { symSumBench(b, 1000) }
+
+var symSumForBench float64
+
+func symSumBench(b *testing.B, size int) {
+	a := randSymDense(size)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		symSumForBench = Sum(a)
+	}
+}
+
+func randSymDense(size int) *SymDense {
+	backData := make([]float64, size*size)
+	for i := 0; i < size; i++ {
+		backData[i*size+i] = rand.Float64()
+		for j := i + 1; j < size; j++ {
+			v := rand.Float64()
+			backData[i*size+j] = v
+			backData[j*size+i] = v
+		}
+	}
+	s := NewSymDense(size, backData)
+	return s
+}

--- a/mat/triangular_test.go
+++ b/mat/triangular_test.go
@@ -512,3 +512,25 @@ func TestCopySymIntoTriangle(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkTriSum1000(b *testing.B) { triSumBench(b, 1000) }
+
+var triSumForBench float64
+
+func triSumBench(b *testing.B, size int) {
+	a := randTriDense(size)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		triSumForBench = Sum(a)
+	}
+}
+
+func randTriDense(size int) *TriDense {
+	t := NewTriDense(size, Upper, nil)
+	for i := 0; i < size; i++ {
+		for j := i; j < size; j++ {
+			t.SetTri(i, j, rand.Float64())
+		}
+	}
+	return t
+}

--- a/mat/vector_test.go
+++ b/mat/vector_test.go
@@ -561,3 +561,15 @@ func randVecDense(size, inc int, rho float64, rnd func() float64) *VecDense {
 		},
 	}
 }
+
+func BenchmarkVectorSum100000(b *testing.B) { vectorSumBench(b, 100000) }
+
+var vectorSumForBench float64
+
+func vectorSumBench(b *testing.B, size int) {
+	a := randVecDense(size, 1, 1.0, rand.NormFloat64)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		vectorSumForBench = Sum(a)
+	}
+}


### PR DESCRIPTION
Please take a look. Should be #946 committed correctly.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
