### PR TITLE
stat: define ROC cutoffs instead of using number of cutoffs

### DIFF
--- a/stat/roc.go
+++ b/stat/roc.go
@@ -99,13 +99,8 @@ func ROC(cutoffs, y []float64, classes []bool, weights []float64) (tpr, fpr []fl
 		}
 	}
 
-	var invNeg, invPos float64
-	if nNeg != 0 {
-		invNeg = 1 / nNeg
-	}
-	if nPos != 0 {
-		invPos = 1 / nPos
-	}
+	invNeg := 1 / nNeg
+	invPos := 1 / nPos
 	for i := range tpr {
 		tpr[i] *= invPos
 		fpr[i] *= invNeg

--- a/stat/roc_example_test.go
+++ b/stat/roc_example_test.go
@@ -15,67 +15,83 @@ import (
 
 func ExampleROC_weighted() {
 	y := []float64{0, 3, 5, 6, 7.5, 8}
-	classes := []bool{true, false, true, false, false, false}
+	classes := []bool{false, true, false, true, true, true}
 	weights := []float64{4, 1, 6, 3, 2, 2}
 
-	tpr, fpr := stat.ROC(nil, y, classes, weights)
+	tpr, fpr, _ := stat.ROC(nil, y, classes, weights)
 	fmt.Printf("true  positive rate: %v\n", tpr)
 	fmt.Printf("false positive rate: %v\n", fpr)
 
 	// Output:
-	// true  positive rate: [0 0.4 0.4 1 1 1 1]
-	// false positive rate: [0 0 0.125 0.125 0.5 0.75 1]
+	// true  positive rate: [0 0.25 0.5 0.875 0.875 1 1]
+	// false positive rate: [0 0 0 0 0.6 0.6 1]
 }
 
 func ExampleROC_unweighted() {
 	y := []float64{0, 3, 5, 6, 7.5, 8}
-	classes := []bool{true, false, true, false, false, false}
+	classes := []bool{false, true, false, true, true, true}
 
-	tpr, fpr := stat.ROC(nil, y, classes, nil)
+	tpr, fpr, _ := stat.ROC(nil, y, classes, nil)
 	fmt.Printf("true  positive rate: %v\n", tpr)
 	fmt.Printf("false positive rate: %v\n", fpr)
 
 	// Output:
-	// true  positive rate: [0 0.5 0.5 1 1 1 1]
-	// false positive rate: [0 0 0.25 0.25 0.5 0.75 1]
+	// true  positive rate: [0 0.25 0.5 0.75 0.75 1 1]
+	// false positive rate: [0 0 0 0 0.5 0.5 1]
+}
+
+func ExampleROC_threshold() {
+	y := []float64{0.1, 0.4, 0.35, 0.8}
+	classes := []bool{false, false, true, true}
+	stat.SortWeightedLabeled(y, classes, nil)
+
+	tpr, fpr, thresh := stat.ROC(nil, y, classes, nil)
+	fmt.Printf("true  positive rate: %v\n", tpr)
+	fmt.Printf("false positive rate: %v\n", fpr)
+	fmt.Printf("cutoff thresholds: %v\n", thresh)
+
+	// Output:
+	// true  positive rate: [0 0.5 0.5 1 1]
+	// false positive rate: [0 0 0.5 0.5 1]
+	// cutoff thresholds: [+Inf 0.8 0.4 0.35 0.1]
 }
 
 func ExampleROC_unsorted() {
 	y := []float64{8, 7.5, 6, 5, 3, 0}
-	classes := []bool{false, false, false, true, false, true}
+	classes := []bool{true, true, true, false, true, false}
 	weights := []float64{2, 2, 3, 6, 1, 4}
 
 	stat.SortWeightedLabeled(y, classes, weights)
 
-	tpr, fpr := stat.ROC(nil, y, classes, weights)
+	tpr, fpr, _ := stat.ROC(nil, y, classes, weights)
 	fmt.Printf("true  positive rate: %v\n", tpr)
 	fmt.Printf("false positive rate: %v\n", fpr)
 
 	// Output:
-	// true  positive rate: [0 0.4 0.4 1 1 1 1]
-	// false positive rate: [0 0 0.125 0.125 0.5 0.75 1]
+	// true  positive rate: [0 0.25 0.5 0.875 0.875 1 1]
+	// false positive rate: [0 0 0 0 0.6 0.6 1]
 }
 
 func ExampleROC_knownCutoffs() {
 	y := []float64{8, 7.5, 6, 5, 3, 0}
-	classes := []bool{false, false, false, true, false, true}
+	classes := []bool{true, true, true, false, true, false}
 	weights := []float64{2, 2, 3, 6, 1, 4}
 	cutoffs := []float64{-1, 3, 4}
 
 	stat.SortWeightedLabeled(y, classes, weights)
 
-	tpr, fpr := stat.ROC(cutoffs, y, classes, weights)
+	tpr, fpr, _ := stat.ROC(cutoffs, y, classes, weights)
 	fmt.Printf("true  positive rate: %v\n", tpr)
 	fmt.Printf("false positive rate: %v\n", fpr)
 
 	// Output:
-	// true  positive rate: [0 0.4 0.4]
-	// false positive rate: [0 0.125 0.125]
+	// true  positive rate: [0.875 0.875 1]
+	// false positive rate: [0.6 0.6 1]
 }
 
 func ExampleROC_equallySpacedCutoffs() {
 	y := []float64{8, 7.5, 6, 5, 3, 0}
-	classes := []bool{false, false, false, true, false, true}
+	classes := []bool{true, true, true, false, true, true}
 	weights := []float64{2, 2, 3, 6, 1, 4}
 	n := 9
 
@@ -83,20 +99,20 @@ func ExampleROC_equallySpacedCutoffs() {
 	cutoffs := make([]float64, n)
 	floats.Span(cutoffs, math.Nextafter(y[0], y[0]-1), y[len(y)-1])
 
-	tpr, fpr := stat.ROC(cutoffs, y, classes, weights)
-	fmt.Printf("true  positive rate: %v\n", tpr)
-	fmt.Printf("false positive rate: %v\n", fpr)
+	tpr, fpr, _ := stat.ROC(cutoffs, y, classes, weights)
+	fmt.Printf("true  positive rate: %.3v\n", tpr)
+	fmt.Printf("false positive rate: %.3v\n", fpr)
 
 	// Output:
-	// true  positive rate: [0 0.4 0.4 0.4 0.4 1 1 1 1]
-	// false positive rate: [0 0 0 0.125 0.125 0.125 0.5 0.5 1]
+	// true  positive rate: [0 0.333 0.333 0.583 0.583 0.583 0.667 0.667 1]
+	// false positive rate: [0 0 0 0 1 1 1 1 1]
 }
 
 func ExampleROC_aUC() {
 	y := []float64{0.1, 0.35, 0.4, 0.8}
 	classes := []bool{true, false, true, false}
 
-	tpr, fpr := stat.ROC(nil, y, classes, nil)
+	tpr, fpr, _ := stat.ROC(nil, y, classes, nil)
 
 	// Compute Area Under Curve.
 	auc := integrate.Trapezoidal(fpr, tpr)
@@ -105,7 +121,7 @@ func ExampleROC_aUC() {
 	fmt.Printf("auc: %v\n", auc)
 
 	// Output:
-	// true  positive rate: [0 0.5 0.5 1 1]
-	// false positive rate: [0 0 0.5 0.5 1]
-	// auc: 0.75
+	// true  positive rate: [0 0 0.5 0.5 1]
+	// false positive rate: [0 0.5 0.5 1 1]
+	// auc: 0.25
 }

--- a/stat/roc_example_test.go
+++ b/stat/roc_example_test.go
@@ -6,7 +6,9 @@ package stat_test
 
 import (
 	"fmt"
+	"math"
 
+	"gonum.org/v1/gonum/floats"
 	"gonum.org/v1/gonum/integrate"
 	"gonum.org/v1/gonum/stat"
 )
@@ -16,7 +18,7 @@ func ExampleROC_weighted() {
 	classes := []bool{true, false, true, false, false, false}
 	weights := []float64{4, 1, 6, 3, 2, 2}
 
-	tpr, fpr := stat.ROC(0, y, classes, weights)
+	tpr, fpr := stat.ROC(nil, y, classes, weights)
 	fmt.Printf("true  positive rate: %v\n", tpr)
 	fmt.Printf("false positive rate: %v\n", fpr)
 
@@ -29,7 +31,7 @@ func ExampleROC_unweighted() {
 	y := []float64{0, 3, 5, 6, 7.5, 8}
 	classes := []bool{true, false, true, false, false, false}
 
-	tpr, fpr := stat.ROC(0, y, classes, nil)
+	tpr, fpr := stat.ROC(nil, y, classes, nil)
 	fmt.Printf("true  positive rate: %v\n", tpr)
 	fmt.Printf("false positive rate: %v\n", fpr)
 
@@ -38,12 +40,65 @@ func ExampleROC_unweighted() {
 	// false positive rate: [0 0 0.25 0.25 0.5 0.75 1]
 }
 
+func ExampleROC_unsorted() {
+	y := []float64{8, 7.5, 6, 5, 3, 0}
+	classes := []bool{false, false, false, true, false, true}
+	weights := []float64{2, 2, 3, 6, 1, 4}
+
+	stat.SortWeightedLabeled(y, classes, weights)
+
+	tpr, fpr := stat.ROC(nil, y, classes, weights)
+	fmt.Printf("true  positive rate: %v\n", tpr)
+	fmt.Printf("false positive rate: %v\n", fpr)
+
+	// Output:
+	// true  positive rate: [0 0.4 0.4 1 1 1 1]
+	// false positive rate: [0 0 0.125 0.125 0.5 0.75 1]
+}
+
+func ExampleROC_knownCutoffs() {
+	y := []float64{8, 7.5, 6, 5, 3, 0}
+	classes := []bool{false, false, false, true, false, true}
+	weights := []float64{2, 2, 3, 6, 1, 4}
+	cutoffs := []float64{-1, 3, 4}
+
+	stat.SortWeightedLabeled(y, classes, weights)
+
+	tpr, fpr := stat.ROC(cutoffs, y, classes, weights)
+	fmt.Printf("true  positive rate: %v\n", tpr)
+	fmt.Printf("false positive rate: %v\n", fpr)
+
+	// Output:
+	// true  positive rate: [0 0.4 0.4]
+	// false positive rate: [0 0.125 0.125]
+}
+
+func ExampleROC_equallySpacedCutoffs() {
+	y := []float64{8, 7.5, 6, 5, 3, 0}
+	classes := []bool{false, false, false, true, false, true}
+	weights := []float64{2, 2, 3, 6, 1, 4}
+	n := 9
+
+	stat.SortWeightedLabeled(y, classes, weights)
+	cutoffs := make([]float64, n)
+	floats.Span(cutoffs, math.Nextafter(y[0], y[0]-1), y[len(y)-1])
+
+	tpr, fpr := stat.ROC(cutoffs, y, classes, weights)
+	fmt.Printf("true  positive rate: %v\n", tpr)
+	fmt.Printf("false positive rate: %v\n", fpr)
+
+	// Output:
+	// true  positive rate: [0 0.4 0.4 0.4 0.4 1 1 1 1]
+	// false positive rate: [0 0 0 0.125 0.125 0.125 0.5 0.5 1]
+}
+
 func ExampleROC_aUC() {
 	y := []float64{0.1, 0.35, 0.4, 0.8}
 	classes := []bool{true, false, true, false}
 
-	tpr, fpr := stat.ROC(0, y, classes, nil)
-	// compute Area Under Curve
+	tpr, fpr := stat.ROC(nil, y, classes, nil)
+
+	// Compute Area Under Curve.
 	auc := integrate.Trapezoidal(fpr, tpr)
 	fmt.Printf("true  positive rate: %v\n", tpr)
 	fmt.Printf("false positive rate: %v\n", fpr)

--- a/stat/roc_test.go
+++ b/stat/roc_test.go
@@ -10,164 +10,164 @@ import (
 	"gonum.org/v1/gonum/floats"
 )
 
-// Test cases where calculated manually.
+// Test cases were calculated manually.
 func TestROC(t *testing.T) {
 	cases := []struct {
 		y       []float64
 		c       []bool
 		w       []float64
-		n       int
+		cutoffs []float64
 		wantTPR []float64
 		wantFPR []float64
 	}{
-		{
+		{ // 0
 			y:       []float64{0, 3, 5, 6, 7.5, 8},
 			c:       []bool{true, false, true, false, false, false},
 			wantTPR: []float64{0, 0.5, 0.5, 1, 1, 1, 1},
 			wantFPR: []float64{0, 0, 0.25, 0.25, 0.5, 0.75, 1},
 		},
-		{
+		{ // 1
 			y:       []float64{0, 3, 5, 6, 7.5, 8},
 			c:       []bool{true, false, true, false, false, false},
 			w:       []float64{4, 1, 6, 3, 2, 2},
 			wantTPR: []float64{0, 0.4, 0.4, 1, 1, 1, 1},
 			wantFPR: []float64{0, 0, 0.125, 0.125, 0.5, 0.75, 1},
 		},
-		{
+		{ // 2
 			y:       []float64{0, 3, 5, 6, 7.5, 8},
 			c:       []bool{true, false, true, false, false, false},
-			n:       int(5),
+			cutoffs: []float64{-1, 2, 4, 6, 8},
 			wantTPR: []float64{0, 0.5, 0.5, 1, 1},
 			wantFPR: []float64{0, 0, 0.25, 0.5, 1},
 		},
-		{
+		{ // 3
 			y:       []float64{0, 3, 5, 6, 7.5, 8},
 			c:       []bool{true, false, true, false, false, false},
-			n:       int(9),
+			cutoffs: []float64{-1, 1, 2, 3, 4, 5, 6, 7, 8},
 			wantTPR: []float64{0, 0.5, 0.5, 0.5, 0.5, 1, 1, 1, 1},
 			wantFPR: []float64{0, 0, 0, 0.25, 0.25, 0.25, 0.5, 0.5, 1},
 		},
-		{
+		{ // 4
 			y:       []float64{0, 3, 5, 6, 7.5, 8},
 			c:       []bool{true, false, true, false, false, false},
 			w:       []float64{4, 1, 6, 3, 2, 2},
-			n:       int(5),
+			cutoffs: []float64{-1, 2, 4, 6, 8},
 			wantTPR: []float64{0, 0.4, 0.4, 1, 1},
 			wantFPR: []float64{0, 0, 0.125, 0.5, 1},
 		},
-		{
+		{ // 5
 			y:       []float64{0, 3, 5, 6, 7.5, 8},
 			c:       []bool{true, false, true, false, false, false},
 			w:       []float64{4, 1, 6, 3, 2, 2},
-			n:       int(9),
+			cutoffs: []float64{-1, 1, 2, 3, 4, 5, 6, 7, 8},
 			wantTPR: []float64{0, 0.4, 0.4, 0.4, 0.4, 1, 1, 1, 1},
 			wantFPR: []float64{0, 0, 0, 0.125, 0.125, 0.125, 0.5, 0.5, 1},
 		},
-		{
+		{ // 6
 			y:       []float64{0, 3, 6, 6, 6, 8},
 			c:       []bool{true, false, true, false, false, false},
 			wantTPR: []float64{0, 0.5, 0.5, 1, 1},
 			wantFPR: []float64{0, 0, 0.25, 0.75, 1},
 		},
-		{
+		{ // 7
 			y:       []float64{0, 3, 6, 6, 6, 8},
 			c:       []bool{true, false, true, false, false, false},
 			w:       []float64{4, 1, 6, 3, 2, 2},
 			wantTPR: []float64{0, 0.4, 0.4, 1, 1},
 			wantFPR: []float64{0, 0, 0.125, 0.75, 1},
 		},
-		{
+		{ // 8
 			y:       []float64{0, 3, 6, 6, 6, 8},
 			c:       []bool{true, false, true, false, false, false},
-			n:       int(5),
+			cutoffs: []float64{-1, 2, 4, 6, 8},
 			wantTPR: []float64{0, 0.5, 0.5, 1, 1},
 			wantFPR: []float64{0, 0, 0.25, 0.75, 1},
 		},
-		{
+		{ // 9
 			y:       []float64{0, 3, 6, 6, 6, 8},
 			c:       []bool{true, false, true, false, false, false},
-			n:       int(9),
+			cutoffs: []float64{-1, 1, 2, 3, 4, 5, 6, 7, 8},
 			wantTPR: []float64{0, 0.5, 0.5, 0.5, 0.5, 0.5, 1, 1, 1},
 			wantFPR: []float64{0, 0, 0, 0.25, 0.25, 0.25, 0.75, 0.75, 1},
 		},
-		{
+		{ // 10
 			y:       []float64{0, 3, 6, 6, 6, 8},
 			c:       []bool{true, false, true, false, false, false},
 			w:       []float64{4, 1, 6, 3, 2, 2},
-			n:       int(5),
+			cutoffs: []float64{-1, 2, 4, 6, 8},
 			wantTPR: []float64{0, 0.4, 0.4, 1, 1},
 			wantFPR: []float64{0, 0, 0.125, 0.75, 1},
 		},
-		{
+		{ // 11
 			y:       []float64{0, 3, 6, 6, 6, 8},
 			c:       []bool{true, false, true, false, false, false},
 			w:       []float64{4, 1, 6, 3, 2, 2},
-			n:       int(9),
+			cutoffs: []float64{-1, 1, 2, 3, 4, 5, 6, 7, 8},
 			wantTPR: []float64{0, 0.4, 0.4, 0.4, 0.4, 0.4, 1, 1, 1},
 			wantFPR: []float64{0, 0, 0, 0.125, 0.125, 0.125, 0.75, 0.75, 1},
 		},
-		{
+		{ // 12
 			y:       []float64{1, 2},
 			c:       []bool{true, true},
 			wantTPR: []float64{0, 0.5, 1},
-			wantFPR: []float64{0, 0, 1},
+			wantFPR: []float64{0, 0, 0},
 		},
-		{
+		{ // 13
 			y:       []float64{1, 2},
 			c:       []bool{true, true},
-			n:       int(2),
+			cutoffs: []float64{-1, 2},
 			wantTPR: []float64{0, 1},
-			wantFPR: []float64{0, 1},
+			wantFPR: []float64{0, 0},
 		},
-		{
+		{ // 14
 			y:       []float64{1, 2},
 			c:       []bool{true, true},
-			n:       int(7),
-			wantTPR: []float64{0, 0.5, 0.5, 0.5, 0.5, 0.5, 1},
-			wantFPR: []float64{0, 0, 0, 0, 0, 0, 1},
+			cutoffs: []float64{0, 1.2, 1.4, 1.6, 1.8, 2},
+			wantTPR: []float64{0, 0.5, 0.5, 0.5, 0.5, 1},
+			wantFPR: []float64{0, 0, 0, 0, 0, 0},
 		},
-		{
+		{ // 15
 			y:       []float64{1},
 			c:       []bool{true},
 			wantTPR: []float64{0, 1},
-			wantFPR: []float64{0, 1},
+			wantFPR: []float64{0, 0},
 		},
-		{
+		{ // 16
 			y:       []float64{1},
 			c:       []bool{true},
-			n:       int(2),
+			cutoffs: []float64{-1, 1},
 			wantTPR: []float64{0, 1},
-			wantFPR: []float64{0, 1},
+			wantFPR: []float64{0, 0},
 		},
-		{
+		{ // 17
 			y:       []float64{1},
 			c:       []bool{false},
-			wantTPR: []float64{0, 1},
+			wantTPR: []float64{0, 0},
 			wantFPR: []float64{0, 1},
 		},
-		{
+		{ // 18
 			y:       []float64{0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 10},
 			c:       []bool{true, false, true, true, false, false, true},
-			n:       int(5),
+			cutoffs: []float64{-1, 2.5, 5, 7.5, 10},
 			wantTPR: []float64{0, 0.75, 0.75, 0.75, 1},
 			wantFPR: []float64{0, 1, 1, 1, 1},
 		},
-		{
+		{ // 19
 			y:       []float64{},
 			c:       []bool{},
 			wantTPR: nil,
 			wantFPR: nil,
 		},
-		{
+		{ // 20
 			y:       []float64{},
 			c:       []bool{},
-			n:       int(5),
+			cutoffs: []float64{-1, 2.5, 5, 7.5, 10},
 			wantTPR: nil,
 			wantFPR: nil,
 		},
 	}
 	for i, test := range cases {
-		gotTPR, gotFPR := ROC(test.n, test.y, test.c, test.w)
+		gotTPR, gotFPR := ROC(test.cutoffs, test.y, test.c, test.w)
 		if !floats.Same(gotTPR, test.wantTPR) {
 			t.Errorf("%d: unexpected TPR got:%v want:%v", i, gotTPR, test.wantTPR)
 		}

--- a/stat/roc_test.go
+++ b/stat/roc_test.go
@@ -5,6 +5,7 @@
 package stat
 
 import (
+	"math"
 	"testing"
 
 	"gonum.org/v1/gonum/floats"
@@ -110,39 +111,39 @@ func TestROC(t *testing.T) {
 			y:       []float64{1, 2},
 			c:       []bool{true, true},
 			wantTPR: []float64{0, 0.5, 1},
-			wantFPR: []float64{0, 0, 0},
+			wantFPR: []float64{math.NaN(), math.NaN(), math.NaN()},
 		},
 		{ // 13
 			y:       []float64{1, 2},
 			c:       []bool{true, true},
 			cutoffs: []float64{-1, 2},
 			wantTPR: []float64{0, 1},
-			wantFPR: []float64{0, 0},
+			wantFPR: []float64{math.NaN(), math.NaN()},
 		},
 		{ // 14
 			y:       []float64{1, 2},
 			c:       []bool{true, true},
 			cutoffs: []float64{0, 1.2, 1.4, 1.6, 1.8, 2},
 			wantTPR: []float64{0, 0.5, 0.5, 0.5, 0.5, 1},
-			wantFPR: []float64{0, 0, 0, 0, 0, 0},
+			wantFPR: []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()},
 		},
 		{ // 15
 			y:       []float64{1},
 			c:       []bool{true},
 			wantTPR: []float64{0, 1},
-			wantFPR: []float64{0, 0},
+			wantFPR: []float64{math.NaN(), math.NaN()},
 		},
 		{ // 16
 			y:       []float64{1},
 			c:       []bool{true},
 			cutoffs: []float64{-1, 1},
 			wantTPR: []float64{0, 1},
-			wantFPR: []float64{0, 0},
+			wantFPR: []float64{math.NaN(), math.NaN()},
 		},
 		{ // 17
 			y:       []float64{1},
 			c:       []bool{false},
-			wantTPR: []float64{0, 0},
+			wantTPR: []float64{math.NaN(), math.NaN()},
 			wantFPR: []float64{0, 1},
 		},
 		{ // 18

--- a/stat/roc_test.go
+++ b/stat/roc_test.go
@@ -11,169 +11,214 @@ import (
 	"gonum.org/v1/gonum/floats"
 )
 
-// Test cases were calculated manually.
 func TestROC(t *testing.T) {
 	cases := []struct {
-		y       []float64
-		c       []bool
-		w       []float64
-		cutoffs []float64
-		wantTPR []float64
-		wantFPR []float64
+		y          []float64
+		c          []bool
+		w          []float64
+		cutoffs    []float64
+		wantTPR    []float64
+		wantFPR    []float64
+		wantThresh []float64
 	}{
+		// Test cases were calculated using sklearn metrics.roc_curve when
+		// cutoffs is nil. Where cutoffs is not nil, a visual inspection is
+		// used.
+		// Some differences exist between unweighted ROCs from our function
+		// and metrics.roc_curve which appears to use integer cutoffs in that
+		// case. sklearn also appears to do some magic that trims leading zeros
+		// sometimes.
 		{ // 0
-			y:       []float64{0, 3, 5, 6, 7.5, 8},
-			c:       []bool{true, false, true, false, false, false},
-			wantTPR: []float64{0, 0.5, 0.5, 1, 1, 1, 1},
-			wantFPR: []float64{0, 0, 0.25, 0.25, 0.5, 0.75, 1},
+			y:          []float64{0, 3, 5, 6, 7.5, 8},
+			c:          []bool{false, true, false, true, true, true},
+			wantTPR:    []float64{0, 0.25, 0.5, 0.75, 0.75, 1, 1},
+			wantFPR:    []float64{0, 0, 0, 0, 0.5, 0.5, 1},
+			wantThresh: []float64{math.Inf(1), 8, 7.5, 6, 5, 3, 0},
 		},
 		{ // 1
-			y:       []float64{0, 3, 5, 6, 7.5, 8},
-			c:       []bool{true, false, true, false, false, false},
-			w:       []float64{4, 1, 6, 3, 2, 2},
-			wantTPR: []float64{0, 0.4, 0.4, 1, 1, 1, 1},
-			wantFPR: []float64{0, 0, 0.125, 0.125, 0.5, 0.75, 1},
+			y:          []float64{0, 3, 5, 6, 7.5, 8},
+			c:          []bool{false, true, false, true, true, true},
+			w:          []float64{4, 1, 6, 3, 2, 2},
+			wantTPR:    []float64{0, 0.25, 0.5, 0.875, 0.875, 1, 1},
+			wantFPR:    []float64{0, 0, 0, 0, 0.6, 0.6, 1},
+			wantThresh: []float64{math.Inf(1), 8, 7.5, 6, 5, 3, 0},
 		},
 		{ // 2
-			y:       []float64{0, 3, 5, 6, 7.5, 8},
-			c:       []bool{true, false, true, false, false, false},
-			cutoffs: []float64{-1, 2, 4, 6, 8},
-			wantTPR: []float64{0, 0.5, 0.5, 1, 1},
-			wantFPR: []float64{0, 0, 0.25, 0.5, 1},
+			y:          []float64{0, 3, 5, 6, 7.5, 8},
+			c:          []bool{false, true, false, true, true, true},
+			cutoffs:    []float64{-1, 2, 4, 6, 8},
+			wantTPR:    []float64{0, 0.5, 0.75, 1, 1},
+			wantFPR:    []float64{0, 0, 0.5, 0.5, 1},
+			wantThresh: []float64{math.Inf(1), 8, 6, 4, 2},
 		},
 		{ // 3
-			y:       []float64{0, 3, 5, 6, 7.5, 8},
-			c:       []bool{true, false, true, false, false, false},
-			cutoffs: []float64{-1, 1, 2, 3, 4, 5, 6, 7, 8},
-			wantTPR: []float64{0, 0.5, 0.5, 0.5, 0.5, 1, 1, 1, 1},
-			wantFPR: []float64{0, 0, 0, 0.25, 0.25, 0.25, 0.5, 0.5, 1},
+			y:          []float64{0, 3, 5, 6, 7.5, 8},
+			c:          []bool{false, true, false, true, true, true},
+			cutoffs:    []float64{-1, 1, 2, 3, 4, 5, 6, 7, 8},
+			wantTPR:    []float64{0, 0.5, 0.5, 0.75, 0.75, 0.75, 1, 1, 1},
+			wantFPR:    []float64{0, 0, 0, 0, 0.5, 0.5, 0.5, 0.5, 1},
+			wantThresh: []float64{math.Inf(1), 8, 7, 6, 5, 4, 3, 2, 1},
 		},
 		{ // 4
-			y:       []float64{0, 3, 5, 6, 7.5, 8},
-			c:       []bool{true, false, true, false, false, false},
-			w:       []float64{4, 1, 6, 3, 2, 2},
-			cutoffs: []float64{-1, 2, 4, 6, 8},
-			wantTPR: []float64{0, 0.4, 0.4, 1, 1},
-			wantFPR: []float64{0, 0, 0.125, 0.5, 1},
+			y:          []float64{0, 3, 5, 6, 7.5, 8},
+			c:          []bool{false, true, false, true, true, true},
+			w:          []float64{4, 1, 6, 3, 2, 2},
+			cutoffs:    []float64{-1, 2, 4, 6, 8},
+			wantTPR:    []float64{0, 0.5, 0.875, 1, 1},
+			wantFPR:    []float64{0, 0, 0.6, 0.6, 1},
+			wantThresh: []float64{math.Inf(1), 8, 6, 4, 2},
 		},
 		{ // 5
-			y:       []float64{0, 3, 5, 6, 7.5, 8},
-			c:       []bool{true, false, true, false, false, false},
-			w:       []float64{4, 1, 6, 3, 2, 2},
-			cutoffs: []float64{-1, 1, 2, 3, 4, 5, 6, 7, 8},
-			wantTPR: []float64{0, 0.4, 0.4, 0.4, 0.4, 1, 1, 1, 1},
-			wantFPR: []float64{0, 0, 0, 0.125, 0.125, 0.125, 0.5, 0.5, 1},
+			y:          []float64{0, 3, 5, 6, 7.5, 8},
+			c:          []bool{false, true, false, true, true, true},
+			w:          []float64{4, 1, 6, 3, 2, 2},
+			cutoffs:    []float64{-1, 1, 2, 3, 4, 5, 6, 7, 8},
+			wantTPR:    []float64{0, 0.5, 0.5, 0.875, 0.875, 0.875, 1, 1, 1},
+			wantFPR:    []float64{0, 0, 0, 0, 0.6, 0.6, 0.6, 0.6, 1},
+			wantThresh: []float64{math.Inf(1), 8, 7, 6, 5, 4, 3, 2, 1},
 		},
 		{ // 6
-			y:       []float64{0, 3, 6, 6, 6, 8},
-			c:       []bool{true, false, true, false, false, false},
-			wantTPR: []float64{0, 0.5, 0.5, 1, 1},
-			wantFPR: []float64{0, 0, 0.25, 0.75, 1},
+			y:          []float64{0, 3, 6, 6, 6, 8},
+			c:          []bool{false, true, false, true, true, true},
+			wantTPR:    []float64{0, 0.25, 0.75, 1, 1},
+			wantFPR:    []float64{0, 0, 0.5, 0.5, 1},
+			wantThresh: []float64{math.Inf(1), 8, 6, 3, 0},
 		},
 		{ // 7
-			y:       []float64{0, 3, 6, 6, 6, 8},
-			c:       []bool{true, false, true, false, false, false},
-			w:       []float64{4, 1, 6, 3, 2, 2},
-			wantTPR: []float64{0, 0.4, 0.4, 1, 1},
-			wantFPR: []float64{0, 0, 0.125, 0.75, 1},
+			y:          []float64{0, 3, 6, 6, 6, 8},
+			c:          []bool{false, true, false, true, true, true},
+			w:          []float64{4, 1, 6, 3, 2, 2},
+			wantTPR:    []float64{0, 0.25, 0.875, 1, 1},
+			wantFPR:    []float64{0, 0, 0.6, 0.6, 1},
+			wantThresh: []float64{math.Inf(1), 8, 6, 3, 0},
 		},
 		{ // 8
-			y:       []float64{0, 3, 6, 6, 6, 8},
-			c:       []bool{true, false, true, false, false, false},
-			cutoffs: []float64{-1, 2, 4, 6, 8},
-			wantTPR: []float64{0, 0.5, 0.5, 1, 1},
-			wantFPR: []float64{0, 0, 0.25, 0.75, 1},
+			y:          []float64{0, 3, 6, 6, 6, 8},
+			c:          []bool{false, true, false, true, true, true},
+			cutoffs:    []float64{-1, 2, 4, 6, 8},
+			wantTPR:    []float64{0, 0.25, 0.75, 1, 1},
+			wantFPR:    []float64{0, 0, 0.5, 0.5, 1},
+			wantThresh: []float64{math.Inf(1), 8, 6, 4, 2},
 		},
 		{ // 9
-			y:       []float64{0, 3, 6, 6, 6, 8},
-			c:       []bool{true, false, true, false, false, false},
-			cutoffs: []float64{-1, 1, 2, 3, 4, 5, 6, 7, 8},
-			wantTPR: []float64{0, 0.5, 0.5, 0.5, 0.5, 0.5, 1, 1, 1},
-			wantFPR: []float64{0, 0, 0, 0.25, 0.25, 0.25, 0.75, 0.75, 1},
+			y:          []float64{0, 3, 6, 6, 6, 8},
+			c:          []bool{false, true, false, true, true, true},
+			cutoffs:    []float64{-1, 1, 2, 3, 4, 5, 6, 7, 8},
+			wantTPR:    []float64{0, 0.25, 0.25, 0.75, 0.75, 0.75, 1, 1, 1},
+			wantFPR:    []float64{0, 0, 0, 0.5, 0.5, 0.5, 0.5, 0.5, 1},
+			wantThresh: []float64{math.Inf(1), 8, 7, 6, 5, 4, 3, 2, 1},
 		},
 		{ // 10
-			y:       []float64{0, 3, 6, 6, 6, 8},
-			c:       []bool{true, false, true, false, false, false},
-			w:       []float64{4, 1, 6, 3, 2, 2},
-			cutoffs: []float64{-1, 2, 4, 6, 8},
-			wantTPR: []float64{0, 0.4, 0.4, 1, 1},
-			wantFPR: []float64{0, 0, 0.125, 0.75, 1},
+			y:          []float64{0, 3, 6, 6, 6, 8},
+			c:          []bool{false, true, false, true, true, true},
+			w:          []float64{4, 1, 6, 3, 2, 2},
+			cutoffs:    []float64{-1, 2, 4, 6, 8},
+			wantTPR:    []float64{0, 0.25, 0.875, 1, 1},
+			wantFPR:    []float64{0, 0, 0.6, 0.6, 1},
+			wantThresh: []float64{math.Inf(1), 8, 6, 4, 2},
 		},
 		{ // 11
-			y:       []float64{0, 3, 6, 6, 6, 8},
-			c:       []bool{true, false, true, false, false, false},
-			w:       []float64{4, 1, 6, 3, 2, 2},
-			cutoffs: []float64{-1, 1, 2, 3, 4, 5, 6, 7, 8},
-			wantTPR: []float64{0, 0.4, 0.4, 0.4, 0.4, 0.4, 1, 1, 1},
-			wantFPR: []float64{0, 0, 0, 0.125, 0.125, 0.125, 0.75, 0.75, 1},
+			y:          []float64{0, 3, 6, 6, 6, 8},
+			c:          []bool{false, true, false, true, true, true},
+			w:          []float64{4, 1, 6, 3, 2, 2},
+			cutoffs:    []float64{-1, 1, 2, 3, 4, 5, 6, 7, 8},
+			wantTPR:    []float64{0, 0.25, 0.25, 0.875, 0.875, 0.875, 1, 1, 1},
+			wantFPR:    []float64{0, 0, 0, 0.6, 0.6, 0.6, 0.6, 0.6, 1},
+			wantThresh: []float64{math.Inf(1), 8, 7, 6, 5, 4, 3, 2, 1},
 		},
 		{ // 12
-			y:       []float64{1, 2},
-			c:       []bool{true, true},
-			wantTPR: []float64{0, 0.5, 1},
-			wantFPR: []float64{math.NaN(), math.NaN(), math.NaN()},
+			y:          []float64{0.1, 0.35, 0.4, 0.8},
+			c:          []bool{true, false, true, false},
+			wantTPR:    []float64{0, 0, 0.5, 0.5, 1},
+			wantFPR:    []float64{0, 0.5, 0.5, 1, 1},
+			wantThresh: []float64{math.Inf(1), 0.8, 0.4, 0.35, 0.1},
 		},
 		{ // 13
-			y:       []float64{1, 2},
-			c:       []bool{true, true},
-			cutoffs: []float64{-1, 2},
-			wantTPR: []float64{0, 1},
-			wantFPR: []float64{math.NaN(), math.NaN()},
+			y:          []float64{0.1, 0.35, 0.4, 0.8},
+			c:          []bool{false, false, true, true},
+			wantTPR:    []float64{0, 0.5, 1, 1, 1},
+			wantFPR:    []float64{0, 0, 0, 0.5, 1},
+			wantThresh: []float64{math.Inf(1), 0.8, 0.4, 0.35, 0.1},
 		},
 		{ // 14
-			y:       []float64{1, 2},
-			c:       []bool{true, true},
-			cutoffs: []float64{0, 1.2, 1.4, 1.6, 1.8, 2},
-			wantTPR: []float64{0, 0.5, 0.5, 0.5, 0.5, 1},
-			wantFPR: []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()},
+			y:          []float64{0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 10},
+			c:          []bool{false, true, false, false, true, true, false},
+			cutoffs:    []float64{-1, 2.5, 5, 7.5, 10},
+			wantTPR:    []float64{0, 0, 0, 0, 1},
+			wantFPR:    []float64{0, 0.25, 0.25, 0.25, 1},
+			wantThresh: []float64{math.Inf(1), 10, 7.5, 5, 2.5},
 		},
 		{ // 15
-			y:       []float64{1},
-			c:       []bool{true},
-			wantTPR: []float64{0, 1},
-			wantFPR: []float64{math.NaN(), math.NaN()},
+			y:          []float64{1, 2},
+			c:          []bool{false, false},
+			wantTPR:    []float64{math.NaN(), math.NaN(), math.NaN()},
+			wantFPR:    []float64{0, 0.5, 1},
+			wantThresh: []float64{math.Inf(1), 2, 1},
 		},
 		{ // 16
-			y:       []float64{1},
-			c:       []bool{true},
-			cutoffs: []float64{-1, 1},
-			wantTPR: []float64{0, 1},
-			wantFPR: []float64{math.NaN(), math.NaN()},
+			y:          []float64{1, 2},
+			c:          []bool{false, false},
+			cutoffs:    []float64{-1, 2},
+			wantTPR:    []float64{math.NaN(), math.NaN()},
+			wantFPR:    []float64{0, 1},
+			wantThresh: []float64{math.Inf(1), 2},
 		},
 		{ // 17
-			y:       []float64{1},
-			c:       []bool{false},
-			wantTPR: []float64{math.NaN(), math.NaN()},
-			wantFPR: []float64{0, 1},
+			y:          []float64{1, 2},
+			c:          []bool{false, false},
+			cutoffs:    []float64{0, 1.2, 1.4, 1.6, 1.8, 2},
+			wantTPR:    []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()},
+			wantFPR:    []float64{0, 0.5, 0.5, 0.5, 0.5, 1},
+			wantThresh: []float64{math.Inf(1), 2, 1.8, 1.6, 1.4, 1.2},
 		},
 		{ // 18
-			y:       []float64{0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 10},
-			c:       []bool{true, false, true, true, false, false, true},
-			cutoffs: []float64{-1, 2.5, 5, 7.5, 10},
-			wantTPR: []float64{0, 0.75, 0.75, 0.75, 1},
-			wantFPR: []float64{0, 1, 1, 1, 1},
+			y:          []float64{1},
+			c:          []bool{false},
+			wantTPR:    []float64{math.NaN(), math.NaN()},
+			wantFPR:    []float64{0, 1},
+			wantThresh: []float64{math.Inf(1), 1},
 		},
 		{ // 19
-			y:       []float64{},
-			c:       []bool{},
-			wantTPR: nil,
-			wantFPR: nil,
+			y:          []float64{1},
+			c:          []bool{false},
+			cutoffs:    []float64{-1, 1},
+			wantTPR:    []float64{math.NaN(), math.NaN()},
+			wantFPR:    []float64{0, 1},
+			wantThresh: []float64{math.Inf(1), 1},
 		},
 		{ // 20
-			y:       []float64{},
-			c:       []bool{},
-			cutoffs: []float64{-1, 2.5, 5, 7.5, 10},
-			wantTPR: nil,
-			wantFPR: nil,
+			y:          []float64{1},
+			c:          []bool{true},
+			wantTPR:    []float64{0, 1},
+			wantFPR:    []float64{math.NaN(), math.NaN()},
+			wantThresh: []float64{math.Inf(1), 1},
+		},
+		{ // 21
+			y:          []float64{},
+			c:          []bool{},
+			wantTPR:    nil,
+			wantFPR:    nil,
+			wantThresh: nil,
+		},
+		{ // 22
+			y:          []float64{},
+			c:          []bool{},
+			cutoffs:    []float64{-1, 2.5, 5, 7.5, 10},
+			wantTPR:    nil,
+			wantFPR:    nil,
+			wantThresh: nil,
 		},
 	}
 	for i, test := range cases {
-		gotTPR, gotFPR := ROC(test.cutoffs, test.y, test.c, test.w)
+		gotTPR, gotFPR, gotThresh := ROC(test.cutoffs, test.y, test.c, test.w)
 		if !floats.Same(gotTPR, test.wantTPR) {
 			t.Errorf("%d: unexpected TPR got:%v want:%v", i, gotTPR, test.wantTPR)
 		}
 		if !floats.Same(gotFPR, test.wantFPR) {
 			t.Errorf("%d: unexpected FPR got:%v want:%v", i, gotFPR, test.wantFPR)
+		}
+		if !floats.Same(gotThresh, test.wantThresh) {
+			t.Errorf("%d: unexpected thresholds got:%#v want:%v", i, gotThresh, test.wantThresh)
 		}
 	}
 }


### PR DESCRIPTION
Please take a look.

Closes #708.
Fixes #316.
Closes #960.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
