### PR TITLE
mat: optimize multri

### DIFF
--- a/mat/diagonal_test.go
+++ b/mat/diagonal_test.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"testing"
 
+	"golang.org/x/exp/rand"
+
 	"gonum.org/v1/gonum/blas/blas64"
 )
 
@@ -457,4 +459,12 @@ func TestDiagonalAtSet(t *testing.T) {
 			}
 		}
 	}
+}
+
+func randDiagDense(size int, rnd *rand.Rand) *DiagDense {
+	t := NewDiagDense(size, nil)
+	for i := 0; i < size; i++ {
+		t.SetDiag(i, rnd.Float64())
+	}
+	return t
 }

--- a/mat/triangular.go
+++ b/mat/triangular.go
@@ -452,15 +452,39 @@ func (t *TriDense) MulTri(a, b Triangular) {
 		defer restore()
 	}
 
-	// TODO(btracey): Improve the set of fast-paths.
+	// Inspect types here, helps keep the loops later clean(er).
+	_, aDiag := aU.(Diagonal)
+	_, bDiag := bU.(Diagonal)
+	// If they are both diagonal only need 1 loop.
+	// All diagonal matrices are Upper.
+	// TODO: Add fast paths for DiagDense.
+	if aDiag && bDiag {
+		t.Zero()
+		for i := 0; i < n; i++ {
+			t.SetTri(i, i, a.At(i, i)*b.At(i, i))
+		}
+		return
+	}
+
+	// Now we know at least one matrix is non-diagonal.
+	// And all diagonal matrices are all Upper.
+	// The both-diagonal case is handled above.
+	// TODO: Add fast paths for Dense variants.
 	if kind == Upper {
 		for i := 0; i < n; i++ {
 			for j := i; j < n; j++ {
-				var v float64
-				for k := i; k <= j; k++ {
-					v += a.At(i, k) * b.At(k, j)
+				switch {
+				case aDiag:
+					t.SetTri(i, j, a.At(i, i)*b.At(i, j))
+				case bDiag:
+					t.SetTri(i, j, a.At(i, j)*b.At(j, j))
+				default:
+					var v float64
+					for k := i; k <= j; k++ {
+						v += a.At(i, k) * b.At(k, j)
+					}
+					t.SetTri(i, j, v)
 				}
-				t.SetTri(i, j, v)
 			}
 		}
 		return

--- a/mat/triangular_test.go
+++ b/mat/triangular_test.go
@@ -5,6 +5,7 @@
 package mat
 
 import (
+	"fmt"
 	"math"
 	"reflect"
 	"testing"
@@ -513,23 +514,69 @@ func TestCopySymIntoTriangle(t *testing.T) {
 	}
 }
 
-func BenchmarkTriSum1000(b *testing.B) { triSumBench(b, 1000) }
-
 var triSumForBench float64
 
-func triSumBench(b *testing.B, size int) {
-	a := randTriDense(size)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		triSumForBench = Sum(a)
+func BenchmarkTriSum(b *testing.B) {
+	rnd := rand.New(rand.NewSource(1))
+	for n := 100; n <= 1600; n *= 2 {
+		a := randTriDense(n, rnd)
+		b.Run(fmt.Sprintf("BenchmarkTriSum%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				triSumForBench = Sum(a)
+			}
+		})
 	}
 }
 
-func randTriDense(size int) *TriDense {
+var triProductForBench *TriDense
+
+func BenchmarkTriMul(b *testing.B) {
+	rnd := rand.New(rand.NewSource(1))
+	for n := 100; n <= 1600; n *= 2 {
+		triProductForBench = NewTriDense(n, Upper, nil)
+		a := randTriDense(n, rnd)
+		c := randTriDense(n, rnd)
+		b.Run(fmt.Sprintf("BenchmarkTriMul%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				triProductForBench.MulTri(a, c)
+			}
+		})
+	}
+}
+
+func BenchmarkTriMulDiag(b *testing.B) {
+	rnd := rand.New(rand.NewSource(1))
+	for n := 100; n <= 1600; n *= 2 {
+		triProductForBench = NewTriDense(n, Upper, nil)
+		a := randTriDense(n, rnd)
+		c := randDiagDense(n, rnd)
+		b.Run(fmt.Sprintf("BenchmarkTriMulDiag%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				triProductForBench.MulTri(a, c)
+			}
+		})
+	}
+}
+
+func BenchmarkTriMul2Diag(b *testing.B) {
+	rnd := rand.New(rand.NewSource(1))
+	for n := 100; n <= 1600; n *= 2 {
+		triProductForBench = NewTriDense(n, Upper, nil)
+		a := randDiagDense(n, rnd)
+		c := randDiagDense(n, rnd)
+		b.Run(fmt.Sprintf("BenchmarkTriMul2Diag%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				triProductForBench.MulTri(a, c)
+			}
+		})
+	}
+}
+
+func randTriDense(size int, rnd *rand.Rand) *TriDense {
 	t := NewTriDense(size, Upper, nil)
 	for i := 0; i < size; i++ {
 		for j := i; j < size; j++ {
-			t.SetTri(i, j, rand.Float64())
+			t.SetTri(i, j, rnd.Float64())
 		}
 	}
 	return t


### PR DESCRIPTION
optimize the paths for diagonal matrices in MulTri.  there was a TODO and i use tri*diag a lot.
add benchmarks for multri

the performance improvement is pretty ridiculous as it cuts 1 or 2 dimensions out of the problem.

<table class='benchstat oldnew'>
<tr class='configs'><th><th>old.txt<th>new.txt
<tbody>
<tr><th><th colspan='2' class='metric'>time/op<th>delta
<tr class='unchanged'><td>TriMul1000-4<td>2.77s ± 6%<td>2.79s ± 3%<td class='nodelta'>~<td class='note'>(p=0.549 n=10&#43;9)
<tr class='better'><td>TriMulDiag1000-4<td>1.71s ± 6%<td>0.01s ± 3%<td class='delta'>−99.53%<td class='note'>(p=0.000 n=9&#43;9)
<tr class='better'><td>TriMul2Diag1000-4<td>1.30s ± 2%<td>0.00s ±15%<td class='delta'>−99.96%<td class='note'>(p=0.000 n=9&#43;10)
<tr><td>&nbsp;
</tbody>
</table>

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
