### PR TITLE
set Stride in mat.Dense.Slice

### DIFF
--- a/mat/dense.go
+++ b/mat/dense.go
@@ -305,6 +305,7 @@ func (m *Dense) Slice(i, k, j, l int) Matrix {
 	t.mat.Data = t.mat.Data[i*t.mat.Stride+j : (k-1)*t.mat.Stride+l]
 	t.mat.Rows = k - i
 	t.mat.Cols = l - j
+	t.mat.Stride = m.mat.Stride
 	t.capRows -= i
 	t.capCols -= j
 	return &t


### PR DESCRIPTION
Hi,
using result of Slice casted as (*mat.Dense) currently fails because Stride isn't set

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
