### PR TITLE
spatial/r1: import and rename from bound

### DIFF
--- a/spatial/r1/bound.go
+++ b/spatial/r1/bound.go
@@ -4,7 +4,7 @@
 
 package r1
 
-// Bound represents [Min, Max] bounds.
-type Bound struct {
+// Interval represents [Min, Max] bounds.
+type Interval struct {
 	Min, Max float64
 }

--- a/spatial/r1/bound.go
+++ b/spatial/r1/bound.go
@@ -2,5 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package bound provides types for bounded data.
-package bound // import "gonum.org/v1/gonum/bound"
+package r1
+
+// Bound represents [Min, Max] bounds.
+type Bound struct {
+	Min, Max float64
+}

--- a/spatial/r1/doc.go
+++ b/spatial/r1/doc.go
@@ -2,5 +2,5 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package r1 provides 1D vectors and boxes and operations on them.
+// Package r1 provides 1D vectors and intervals and operations on them.
 package r1 // import "gonum.org/v1/gonum/spatial/r1"

--- a/spatial/r1/doc.go
+++ b/spatial/r1/doc.go
@@ -2,9 +2,5 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package bound
-
-// Bound represents [Min, Max] bounds.
-type Bound struct {
-	Min, Max float64
-}
+// Package r1 provides 1D vectors and boxes and operations on them.
+package r1 // import "gonum.org/v1/gonum/spatial/r1"

--- a/spatial/r1/interval.go
+++ b/spatial/r1/interval.go
@@ -4,7 +4,7 @@
 
 package r1
 
-// Interval represents [Min, Max] bounds.
+// Interval represents an interval.
 type Interval struct {
 	Min, Max float64
 }

--- a/stat/distmv/statdist.go
+++ b/stat/distmv/statdist.go
@@ -76,7 +76,7 @@ func (Bhattacharyya) DistUniform(l, r *Uniform) float64 {
 
 // unifLogVolOverlap computes the log of the volume of the hyper-rectangle where
 // both uniform distributions have positive probability.
-func unifLogVolOverlap(b1, b2 []r1.Bound) float64 {
+func unifLogVolOverlap(b1, b2 []r1.Interval) float64 {
 	var logVolOverlap float64
 	for dim, v1 := range b1 {
 		v2 := b2[dim]

--- a/stat/distmv/statdist.go
+++ b/stat/distmv/statdist.go
@@ -7,10 +7,10 @@ package distmv
 import (
 	"math"
 
-	"gonum.org/v1/gonum/bound"
 	"gonum.org/v1/gonum/floats"
 	"gonum.org/v1/gonum/mat"
 	"gonum.org/v1/gonum/mathext"
+	"gonum.org/v1/gonum/spatial/r1"
 	"gonum.org/v1/gonum/stat"
 )
 
@@ -76,7 +76,7 @@ func (Bhattacharyya) DistUniform(l, r *Uniform) float64 {
 
 // unifLogVolOverlap computes the log of the volume of the hyper-rectangle where
 // both uniform distributions have positive probability.
-func unifLogVolOverlap(b1, b2 []bound.Bound) float64 {
+func unifLogVolOverlap(b1, b2 []r1.Bound) float64 {
 	var logVolOverlap float64
 	for dim, v1 := range b1 {
 		v2 := b2[dim]

--- a/stat/distmv/statdist_test.go
+++ b/stat/distmv/statdist_test.go
@@ -10,9 +10,9 @@ import (
 
 	"golang.org/x/exp/rand"
 
-	"gonum.org/v1/gonum/bound"
 	"gonum.org/v1/gonum/floats"
 	"gonum.org/v1/gonum/mat"
+	"gonum.org/v1/gonum/spatial/r1"
 )
 
 func TestBhattacharyyaNormal(t *testing.T) {
@@ -62,14 +62,14 @@ func TestBhattacharyyaUniform(t *testing.T) {
 		tol     float64
 	}{
 		{
-			a:       NewUniform([]bound.Bound{{-3, 2}, {-5, 8}}, rnd),
-			b:       NewUniform([]bound.Bound{{-4, 1}, {-7, 10}}, rnd),
+			a:       NewUniform([]r1.Bound{{-3, 2}, {-5, 8}}, rnd),
+			b:       NewUniform([]r1.Bound{{-4, 1}, {-7, 10}}, rnd),
 			samples: 100000,
 			tol:     1e-2,
 		},
 		{
-			a:       NewUniform([]bound.Bound{{-3, 2}, {-5, 8}}, rnd),
-			b:       NewUniform([]bound.Bound{{-5, -4}, {-7, 10}}, rnd),
+			a:       NewUniform([]r1.Bound{{-3, 2}, {-5, 8}}, rnd),
+			b:       NewUniform([]r1.Bound{{-5, -4}, {-7, 10}}, rnd),
 			samples: 100000,
 			tol:     1e-2,
 		},
@@ -257,14 +257,14 @@ func TestKullbackLeiblerUniform(t *testing.T) {
 		tol     float64
 	}{
 		{
-			a:       NewUniform([]bound.Bound{{-5, 2}, {-7, 12}}, rnd),
-			b:       NewUniform([]bound.Bound{{-4, 1}, {-7, 10}}, rnd),
+			a:       NewUniform([]r1.Bound{{-5, 2}, {-7, 12}}, rnd),
+			b:       NewUniform([]r1.Bound{{-4, 1}, {-7, 10}}, rnd),
 			samples: 100000,
 			tol:     1e-2,
 		},
 		{
-			a:       NewUniform([]bound.Bound{{-5, 2}, {-7, 12}}, rnd),
-			b:       NewUniform([]bound.Bound{{-9, -6}, {-7, 10}}, rnd),
+			a:       NewUniform([]r1.Bound{{-5, 2}, {-7, 12}}, rnd),
+			b:       NewUniform([]r1.Bound{{-9, -6}, {-7, 10}}, rnd),
 			samples: 100000,
 			tol:     1e-2,
 		},

--- a/stat/distmv/statdist_test.go
+++ b/stat/distmv/statdist_test.go
@@ -62,14 +62,14 @@ func TestBhattacharyyaUniform(t *testing.T) {
 		tol     float64
 	}{
 		{
-			a:       NewUniform([]r1.Bound{{-3, 2}, {-5, 8}}, rnd),
-			b:       NewUniform([]r1.Bound{{-4, 1}, {-7, 10}}, rnd),
+			a:       NewUniform([]r1.Interval{{-3, 2}, {-5, 8}}, rnd),
+			b:       NewUniform([]r1.Interval{{-4, 1}, {-7, 10}}, rnd),
 			samples: 100000,
 			tol:     1e-2,
 		},
 		{
-			a:       NewUniform([]r1.Bound{{-3, 2}, {-5, 8}}, rnd),
-			b:       NewUniform([]r1.Bound{{-5, -4}, {-7, 10}}, rnd),
+			a:       NewUniform([]r1.Interval{{-3, 2}, {-5, 8}}, rnd),
+			b:       NewUniform([]r1.Interval{{-5, -4}, {-7, 10}}, rnd),
 			samples: 100000,
 			tol:     1e-2,
 		},
@@ -257,14 +257,14 @@ func TestKullbackLeiblerUniform(t *testing.T) {
 		tol     float64
 	}{
 		{
-			a:       NewUniform([]r1.Bound{{-5, 2}, {-7, 12}}, rnd),
-			b:       NewUniform([]r1.Bound{{-4, 1}, {-7, 10}}, rnd),
+			a:       NewUniform([]r1.Interval{{-5, 2}, {-7, 12}}, rnd),
+			b:       NewUniform([]r1.Interval{{-4, 1}, {-7, 10}}, rnd),
 			samples: 100000,
 			tol:     1e-2,
 		},
 		{
-			a:       NewUniform([]r1.Bound{{-5, 2}, {-7, 12}}, rnd),
-			b:       NewUniform([]r1.Bound{{-9, -6}, {-7, 10}}, rnd),
+			a:       NewUniform([]r1.Interval{{-5, 2}, {-7, 12}}, rnd),
+			b:       NewUniform([]r1.Interval{{-9, -6}, {-7, 10}}, rnd),
 			samples: 100000,
 			tol:     1e-2,
 		},

--- a/stat/distmv/uniform.go
+++ b/stat/distmv/uniform.go
@@ -8,18 +8,18 @@ import (
 	"math"
 
 	"golang.org/x/exp/rand"
-	"gonum.org/v1/gonum/bound"
+	"gonum.org/v1/gonum/spatial/r1"
 )
 
 // Uniform represents a multivariate uniform distribution.
 type Uniform struct {
-	bounds []bound.Bound
+	bounds []r1.Bound
 	dim    int
 	rnd    *rand.Rand
 }
 
 // NewUniform creates a new uniform distribution with the given bounds.
-func NewUniform(bnds []bound.Bound, src rand.Source) *Uniform {
+func NewUniform(bnds []r1.Bound, src rand.Source) *Uniform {
 	dim := len(bnds)
 	if dim == 0 {
 		panic(badZeroDimension)
@@ -30,7 +30,7 @@ func NewUniform(bnds []bound.Bound, src rand.Source) *Uniform {
 		}
 	}
 	u := &Uniform{
-		bounds: make([]bound.Bound, dim),
+		bounds: make([]r1.Bound, dim),
 		dim:    dim,
 	}
 	if src != nil {
@@ -50,7 +50,7 @@ func NewUnitUniform(dim int, src rand.Source) *Uniform {
 	if dim <= 0 {
 		panic(nonPosDimension)
 	}
-	bounds := make([]bound.Bound, dim)
+	bounds := make([]r1.Bound, dim)
 	for i := range bounds {
 		bounds[i].Min = 0
 		bounds[i].Max = 1
@@ -69,9 +69,9 @@ func NewUnitUniform(dim int, src rand.Source) *Uniform {
 // is nil, a new slice is allocated and returned. If the input is non-nil, then
 // the bounds are stored in-place into the input argument, and Bounds will panic
 // if len(bounds) != u.Dim().
-func (u *Uniform) Bounds(bounds []bound.Bound) []bound.Bound {
+func (u *Uniform) Bounds(bounds []r1.Bound) []r1.Bound {
 	if bounds == nil {
-		bounds = make([]bound.Bound, u.Dim())
+		bounds = make([]r1.Bound, u.Dim())
 	}
 	if len(bounds) != u.Dim() {
 		panic(badInputLength)

--- a/stat/distmv/uniform.go
+++ b/stat/distmv/uniform.go
@@ -13,13 +13,13 @@ import (
 
 // Uniform represents a multivariate uniform distribution.
 type Uniform struct {
-	bounds []r1.Bound
+	bounds []r1.Interval
 	dim    int
 	rnd    *rand.Rand
 }
 
 // NewUniform creates a new uniform distribution with the given bounds.
-func NewUniform(bnds []r1.Bound, src rand.Source) *Uniform {
+func NewUniform(bnds []r1.Interval, src rand.Source) *Uniform {
 	dim := len(bnds)
 	if dim == 0 {
 		panic(badZeroDimension)
@@ -30,7 +30,7 @@ func NewUniform(bnds []r1.Bound, src rand.Source) *Uniform {
 		}
 	}
 	u := &Uniform{
-		bounds: make([]r1.Bound, dim),
+		bounds: make([]r1.Interval, dim),
 		dim:    dim,
 	}
 	if src != nil {
@@ -50,7 +50,7 @@ func NewUnitUniform(dim int, src rand.Source) *Uniform {
 	if dim <= 0 {
 		panic(nonPosDimension)
 	}
-	bounds := make([]r1.Bound, dim)
+	bounds := make([]r1.Interval, dim)
 	for i := range bounds {
 		bounds[i].Min = 0
 		bounds[i].Max = 1
@@ -69,9 +69,9 @@ func NewUnitUniform(dim int, src rand.Source) *Uniform {
 // is nil, a new slice is allocated and returned. If the input is non-nil, then
 // the bounds are stored in-place into the input argument, and Bounds will panic
 // if len(bounds) != u.Dim().
-func (u *Uniform) Bounds(bounds []r1.Bound) []r1.Bound {
+func (u *Uniform) Bounds(bounds []r1.Interval) []r1.Interval {
 	if bounds == nil {
-		bounds = make([]r1.Bound, u.Dim())
+		bounds = make([]r1.Interval, u.Dim())
 	}
 	if len(bounds) != u.Dim() {
 		panic(badInputLength)

--- a/stat/distmv/uniform_test.go
+++ b/stat/distmv/uniform_test.go
@@ -17,11 +17,11 @@ func TestUniformEntropy(t *testing.T) {
 		Entropy float64
 	}{
 		{
-			NewUniform([]r1.Bound{{0, 1}, {0, 1}}, nil),
+			NewUniform([]r1.Interval{{0, 1}, {0, 1}}, nil),
 			0,
 		},
 		{
-			NewUniform([]r1.Bound{{-1, 3}, {2, 8}, {-5, -3}}, nil),
+			NewUniform([]r1.Interval{{-1, 3}, {2, 8}, {-5, -3}}, nil),
 			math.Log(48),
 		},
 	} {

--- a/stat/distmv/uniform_test.go
+++ b/stat/distmv/uniform_test.go
@@ -8,7 +8,7 @@ import (
 	"math"
 	"testing"
 
-	"gonum.org/v1/gonum/bound"
+	"gonum.org/v1/gonum/spatial/r1"
 )
 
 func TestUniformEntropy(t *testing.T) {
@@ -17,11 +17,11 @@ func TestUniformEntropy(t *testing.T) {
 		Entropy float64
 	}{
 		{
-			NewUniform([]bound.Bound{{0, 1}, {0, 1}}, nil),
+			NewUniform([]r1.Bound{{0, 1}, {0, 1}}, nil),
 			0,
 		},
 		{
-			NewUniform([]bound.Bound{{-1, 3}, {2, 8}, {-5, -3}}, nil),
+			NewUniform([]r1.Bound{{-1, 3}, {2, 8}, {-5, -3}}, nil),
 			math.Log(48),
 		},
 	} {

--- a/stat/samplemv/sample_test.go
+++ b/stat/samplemv/sample_test.go
@@ -27,8 +27,8 @@ func TestLatinHypercube(t *testing.T) {
 	src := rand.New(rand.NewSource(1))
 	for _, nSamples := range []int{1, 2, 5, 10, 20} {
 		for _, dist := range []lhDist{
-			distmv.NewUniform([]r1.Bound{{Min: 0, Max: 3}}, src),
-			distmv.NewUniform([]r1.Bound{{Min: 0, Max: 3}, {Min: -1, Max: 5}, {Min: -4, Max: -1}}, src),
+			distmv.NewUniform([]r1.Interval{{Min: 0, Max: 3}}, src),
+			distmv.NewUniform([]r1.Interval{{Min: 0, Max: 3}, {Min: -1, Max: 5}, {Min: -4, Max: -1}}, src),
 		} {
 			dim := dist.Dim()
 			batch := mat.NewDense(nSamples, dim, nil)
@@ -93,7 +93,7 @@ func TestRejection(t *testing.T) {
 	src := rand.New(rand.NewSource(1))
 	// Test by finding the expected value of a uniform.
 	dim := 3
-	bounds := make([]r1.Bound, dim)
+	bounds := make([]r1.Interval, dim)
 	for i := 0; i < dim; i++ {
 		min := src.NormFloat64()
 		max := src.NormFloat64()

--- a/stat/samplemv/sample_test.go
+++ b/stat/samplemv/sample_test.go
@@ -10,9 +10,9 @@ import (
 
 	"golang.org/x/exp/rand"
 
-	"gonum.org/v1/gonum/bound"
 	"gonum.org/v1/gonum/floats"
 	"gonum.org/v1/gonum/mat"
+	"gonum.org/v1/gonum/spatial/r1"
 	"gonum.org/v1/gonum/stat"
 	"gonum.org/v1/gonum/stat/distmv"
 )
@@ -27,8 +27,8 @@ func TestLatinHypercube(t *testing.T) {
 	src := rand.New(rand.NewSource(1))
 	for _, nSamples := range []int{1, 2, 5, 10, 20} {
 		for _, dist := range []lhDist{
-			distmv.NewUniform([]bound.Bound{{Min: 0, Max: 3}}, src),
-			distmv.NewUniform([]bound.Bound{{Min: 0, Max: 3}, {Min: -1, Max: 5}, {Min: -4, Max: -1}}, src),
+			distmv.NewUniform([]r1.Bound{{Min: 0, Max: 3}}, src),
+			distmv.NewUniform([]r1.Bound{{Min: 0, Max: 3}, {Min: -1, Max: 5}, {Min: -4, Max: -1}}, src),
 		} {
 			dim := dist.Dim()
 			batch := mat.NewDense(nSamples, dim, nil)
@@ -93,7 +93,7 @@ func TestRejection(t *testing.T) {
 	src := rand.New(rand.NewSource(1))
 	// Test by finding the expected value of a uniform.
 	dim := 3
-	bounds := make([]bound.Bound, dim)
+	bounds := make([]r1.Bound, dim)
 	for i := 0; i < dim; i++ {
 		min := src.NormFloat64()
 		max := src.NormFloat64()


### PR DESCRIPTION
Mechanically generated with:

```
$> gomvpkg -from gonum.org/v1/gonum/bound -to gonum.org/v1/gonum/spatial/r1 -vcs_mv_cmd "git mv {{.Src}} {{.Dst}}"
```

Fixes gonum/gonum#956.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
