### PR TITLE
ci: use GOPROXY from proxy.golang.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ os:
 env:
  global:
   - GO111MODULE=on
+  - GOPROXY="https://proxy.golang.org"
   - GOFLAGS="-mod=readonly"
  matrix:
   - TAGS=""


### PR DESCRIPTION
Using this proxy allows to push and then use the latest Gonum version
from the playground.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
