### PR TITLE
modules: prevent go tool mutating go.mod to add a go version line

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module gonum.org/v1/gonum
 
+go 1.10
+
 require (
 	golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2
 	golang.org/x/tools v0.0.0-20190206041539-40960b6deb8e


### PR DESCRIPTION
Please take a look.

I don't see any documentation about this, but the change here fixes the problem. Confirming that this is a fix requires that the reviewer check the "Allowed Failures" master branch tests on travis.

See golang/go#32147.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
