### PR TITLE
spatial/{barneshut,vptree}: refuse points at infinity

### DIFF
--- a/spatial/barneshut/barneshut2.go
+++ b/spatial/barneshut/barneshut2.go
@@ -47,10 +47,21 @@ type Plane struct {
 }
 
 // NewPlane returns a new Plane.
+//
+// Points in p must not be infinitely distant, otherwise NewPlane will panic.
 func NewPlane(p []Particle2) *Plane {
+	for _, l := range p {
+		if isInfR2(l.Coord2()) {
+			panic("barneshut: point at infinity")
+		}
+	}
 	q := Plane{Particles: p}
 	q.Reset()
 	return &q
+}
+
+func isInfR2(v r2.Vec) bool {
+	return math.IsInf(v.X, 0) || math.IsInf(v.Y, 0)
 }
 
 // Reset reconstructs the Barnes-Hut tree. Reset must be called if the

--- a/spatial/barneshut/barneshut3.go
+++ b/spatial/barneshut/barneshut3.go
@@ -47,10 +47,21 @@ type Volume struct {
 }
 
 // NewVolume returns a new Volume.
+//
+// Points in p must not be infinitely distant, otherwise NewVolume will panic.
 func NewVolume(p []Particle3) *Volume {
+	for _, l := range p {
+		if isInfR3(l.Coord3()) {
+			panic("barneshut: point at infinity")
+		}
+	}
 	q := Volume{Particles: p}
 	q.Reset()
 	return &q
+}
+
+func isInfR3(v r3.Vec) bool {
+	return math.IsInf(v.X, 0) || math.IsInf(v.Y, 0) || math.IsInf(v.Z, 0)
 }
 
 // Reset reconstructs the Barnes-Hut tree. Reset must be called if the


### PR DESCRIPTION
Please take a look.

Fixes #1004.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
