### PR TITLE
spatial/barneshut: catch finitely too far points

### DIFF
--- a/spatial/barneshut/barneshut2_test.go
+++ b/spatial/barneshut/barneshut2_test.go
@@ -353,7 +353,11 @@ func TestPlane(t *testing.T) {
 			particles[i] = p
 		}
 
-		got := NewPlane(particles)
+		got, err := NewPlane(particles)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			continue
+		}
 
 		if test.want != nil && !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexpected result for %q: got:%v want:%v", test.name, got, test.want)
@@ -426,7 +430,11 @@ func TestPlaneForceOn(t *testing.T) {
 			moved[i] = p.Coord2().Add(v)
 		}
 
-		plane := NewPlane(particles)
+		plane, err := NewPlane(particles)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			continue
+		}
 		for _, theta := range []float64{0, 0.3, 0.6, 0.9} {
 			t.Run(fmt.Sprintf("%d-body/theta=%v", len(particles), theta), func(t *testing.T) {
 				var ssd, sd float64
@@ -465,9 +473,13 @@ func BenchmarkNewPlane(b *testing.B) {
 			particles[i] = particle2{x: rnd.Float64(), y: rnd.Float64(), m: 1}
 		}
 		b.ResetTimer()
+		var err error
 		b.Run(fmt.Sprintf("%d-body", len(particles)), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				planeSink = NewPlane(particles)
+				planeSink, err = NewPlane(particles)
+				if err != nil {
+					b.Fatalf("unexpected error: %v", err)
+				}
 			}
 		})
 	}
@@ -485,7 +497,10 @@ func BenchmarkPlaneForceOn(b *testing.B) {
 			for i := range particles {
 				particles[i] = particle2{x: rnd.Float64(), y: rnd.Float64(), m: 1}
 			}
-			plane := NewPlane(particles)
+			plane, err := NewPlane(particles)
+			if err != nil {
+				b.Fatalf("unexpected error: %v", err)
+			}
 			b.ResetTimer()
 			b.Run(fmt.Sprintf("%d-body/theta=%v", len(particles), theta), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
@@ -513,7 +528,10 @@ func BenchmarkPlaneFull(b *testing.B) {
 			b.ResetTimer()
 			b.Run(fmt.Sprintf("%d-body/theta=%v", len(particles), theta), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					plane := NewPlane(particles)
+					plane, err := NewPlane(particles)
+					if err != nil {
+						b.Fatalf("unexpected error: %v", err)
+					}
 					for _, p := range particles {
 						fv2sink = plane.ForceOn(p, theta, Gravity2)
 					}

--- a/spatial/barneshut/barneshut3_test.go
+++ b/spatial/barneshut/barneshut3_test.go
@@ -348,7 +348,11 @@ func TestVolume(t *testing.T) {
 			particles[i] = p
 		}
 
-		got := NewVolume(particles)
+		got, err := NewVolume(particles)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			continue
+		}
 
 		if test.want != nil && !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexpected result for %q: got:%v want:%v", test.name, got, test.want)
@@ -423,7 +427,11 @@ func TestVolumeForceOn(t *testing.T) {
 			moved[i] = p.Coord3().Add(v)
 		}
 
-		volume := NewVolume(particles)
+		volume, err := NewVolume(particles)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			continue
+		}
 		for _, theta := range []float64{0, 0.3, 0.6, 0.9} {
 			t.Run(fmt.Sprintf("%d-body/theta=%v", len(particles), theta), func(t *testing.T) {
 				var ssd, sd float64
@@ -462,9 +470,13 @@ func BenchmarkNewVolume(b *testing.B) {
 			particles[i] = particle3{x: rnd.Float64(), y: rnd.Float64(), z: rnd.Float64(), m: 1}
 		}
 		b.ResetTimer()
+		var err error
 		b.Run(fmt.Sprintf("%d-body", len(particles)), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				volumeSink = NewVolume(particles)
+				volumeSink, err = NewVolume(particles)
+				if err != nil {
+					b.Fatalf("unexpected error: %v", err)
+				}
 			}
 		})
 	}
@@ -482,7 +494,10 @@ func BenchmarkVolumeForceOn(b *testing.B) {
 			for i := range particles {
 				particles[i] = particle3{x: rnd.Float64(), y: rnd.Float64(), z: rnd.Float64(), m: 1}
 			}
-			volume := NewVolume(particles)
+			volume, err := NewVolume(particles)
+			if err != nil {
+				b.Fatalf("unexpected error: %v", err)
+			}
 			b.ResetTimer()
 			b.Run(fmt.Sprintf("%d-body/theta=%v", len(particles), theta), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
@@ -510,7 +525,10 @@ func BenchmarkVolumeFull(b *testing.B) {
 			b.ResetTimer()
 			b.Run(fmt.Sprintf("%d-body/theta=%v", len(particles), theta), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					volume := NewVolume(particles)
+					volume, err := NewVolume(particles)
+					if err != nil {
+						b.Fatalf("unexpected error: %v", err)
+					}
 					for _, p := range particles {
 						fv3sink = volume.ForceOn(p, theta, Gravity3)
 					}


### PR DESCRIPTION
It turns out the previous check was not strict enough. When the quadrants and octants are being subdeivided, if the box is large enough the midpoint will be numerically identical to one of the bounds. This results in an infinite recursion down the tree, overflowing the stack.

The approach here is to restrict the area/volume to within sqrt(maxfloat) of the origin as a heuristic and then check for non-progression during tree construction.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
