### PR TITLE
spatial/vptree: return error rather than panic

### DIFF
--- a/spatial/vptree/vptree_simple_example_test.go
+++ b/spatial/vptree/vptree_simple_example_test.go
@@ -6,6 +6,7 @@ package vptree_test
 
 import (
 	"fmt"
+	"log"
 
 	"gonum.org/v1/gonum/spatial/vptree"
 )
@@ -21,7 +22,10 @@ func ExampleTree() {
 		vptree.Point{7, 2},
 	}
 
-	t := vptree.New(points, 3, nil)
+	t, err := vptree.New(points, 3, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
 	q := vptree.Point{8, 7}
 	p, d := t.Nearest(q)
 	fmt.Printf("%v is closest point to %v, d=%f\n", p, q, d)
@@ -41,7 +45,10 @@ func ExampleTree_Do() {
 	}
 
 	// Print all points in the data set within 3 of (3, 5).
-	t := vptree.New(points, 0, nil)
+	t, err := vptree.New(points, 0, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
 	q := vptree.Point{3, 5}
 	t.Do(func(c vptree.Comparable, _ int) (done bool) {
 		// Compare each distance and output points

--- a/spatial/vptree/vptree_user_type_example_test.go
+++ b/spatial/vptree/vptree_user_type_example_test.go
@@ -6,6 +6,7 @@ package vptree_test
 
 import (
 	"fmt"
+	"log"
 	"math"
 
 	"gonum.org/v1/gonum/spatial/vptree"
@@ -15,7 +16,10 @@ func Example_accessiblePublicTransport() {
 	// Construct a vp tree of train station locations
 	// to identify accessible public transport for the
 	// elderly.
-	t := vptree.New(stations, 5, nil)
+	t, err := vptree.New(stations, 5, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Residence.
 	q := place{lat: 51.501476, lon: -0.140634}


### PR DESCRIPTION
Addresses https://github.com/gonum/gonum/pull/1009#issuecomment-506244683.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
