### PR TITLE
graph/iterator: add unordered node iterator

### DIFF
--- a/graph/iterator/nodes_unordered.go
+++ b/graph/iterator/nodes_unordered.go
@@ -1,0 +1,63 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.12
+
+// TODO(kortschak): Merge this into nodes.go when go1.11 is no longer supported.
+
+package iterator
+
+import (
+	"reflect"
+
+	"gonum.org/v1/gonum/graph"
+)
+
+// Nodes implements the graph.Nodes interfaces.
+// The iteration order of Nodes is randomized.
+type Nodes struct {
+	nodes reflect.Value
+	iter  *reflect.MapIter
+	pos   int
+	curr  graph.Node
+}
+
+// NewNodes returns a Nodes initialized with the provided nodes, a
+// map of node IDs to graph.Nodes. No check is made that the keys
+// match the graph.Node IDs, and the map keys are not used.
+//
+// Behavior of the Nodes is unspecified if nodes is mutated after
+// the call the NewNodes.
+func NewNodes(nodes map[int64]graph.Node) *Nodes {
+	rv := reflect.ValueOf(nodes)
+	return &Nodes{nodes: rv, iter: rv.MapRange()}
+}
+
+// Len returns the remaining number of nodes to be iterated over.
+func (n *Nodes) Len() int {
+	return n.nodes.Len() - n.pos
+}
+
+// Next returns whether the next call of Node will return a valid node.
+func (n *Nodes) Next() bool {
+	ok := n.iter.Next()
+	if ok {
+		n.pos++
+		n.curr = n.iter.Value().Interface().(graph.Node)
+	}
+	return ok
+}
+
+// Node returns the current node of the iterator. Next must have been
+// called prior to a call to Node.
+func (n *Nodes) Node() graph.Node {
+	return n.curr
+}
+
+// Reset returns the iterator to its initial state.
+func (n *Nodes) Reset() {
+	n.curr = nil
+	n.pos = 0
+	n.iter = n.nodes.MapRange()
+}

--- a/graph/iterator/nodes_unordered_test.go
+++ b/graph/iterator/nodes_unordered_test.go
@@ -1,0 +1,55 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.12
+
+// TODO(kortschak): Merge this into nodes_test.go when go1.11 is no longer supported.
+
+package iterator_test
+
+import (
+	"reflect"
+	"testing"
+
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/iterator"
+	"gonum.org/v1/gonum/graph/simple"
+)
+
+var nodesTests = []struct {
+	nodes map[int64]graph.Node
+}{
+	{nodes: nil},
+	{nodes: make(map[int64]graph.Node)},
+	{nodes: map[int64]graph.Node{1: simple.Node(1)}},
+	{nodes: map[int64]graph.Node{1: simple.Node(1), 2: simple.Node(2), 3: simple.Node(3), 5: simple.Node(5)}},
+	{nodes: map[int64]graph.Node{5: simple.Node(5), 3: simple.Node(3), 2: simple.Node(2), 1: simple.Node(1)}},
+}
+
+func TestNodesIterate(t *testing.T) {
+	for _, test := range nodesTests {
+		it := iterator.NewNodes(test.nodes)
+		for i := 0; i < 2; i++ {
+			if it.Len() != len(test.nodes) {
+				t.Errorf("unexpected iterator length for round %d: got:%d want:%d", i, it.Len(), len(test.nodes))
+			}
+			var got map[int64]graph.Node
+			if test.nodes != nil {
+				got = make(map[int64]graph.Node)
+			}
+			for it.Next() {
+				n := it.Node()
+				got[n.ID()] = n
+				if len(got)+it.Len() != len(test.nodes) {
+					t.Errorf("unexpected iterator length during iteration for round %d: got:%d want:%d", i, it.Len(), len(test.nodes))
+				}
+			}
+			want := test.nodes
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("unexpected iterator output for round %d: got:%#v want:%#v", i, got, want)
+			}
+			it.Reset()
+		}
+	}
+}


### PR DESCRIPTION
Please take a look.

This is mainly a reminder for me to ensure that I implement the remainder and the unsafe version when I can. In the meantime it can be used by clients using go1.12+ in their implementations.

Updates #1019.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
