### PR TITLE
graph/iterator: properly test iterator reset

### DIFF
--- a/graph/iterator/edges_test.go
+++ b/graph/iterator/edges_test.go
@@ -30,8 +30,8 @@ var orderedEdgesTests = []struct {
 
 func TestOrderedEdgesIterate(t *testing.T) {
 	for _, test := range orderedEdgesTests {
+		it := iterator.NewOrderedEdges(test.edges)
 		for i := 0; i < 2; i++ {
-			it := iterator.NewOrderedEdges(test.edges)
 			if it.Len() != len(test.edges) {
 				t.Errorf("unexpected iterator length for round %d: got:%d want:%d", i, it.Len(), len(test.edges))
 			}
@@ -50,8 +50,8 @@ func TestOrderedEdgesIterate(t *testing.T) {
 
 func TestOrderedEdgesSlice(t *testing.T) {
 	for _, test := range orderedEdgesTests {
+		it := iterator.NewOrderedEdges(test.edges)
 		for i := 0; i < 2; i++ {
-			it := iterator.NewOrderedEdges(test.edges)
 			got := it.EdgeSlice()
 			want := test.edges
 			if !reflect.DeepEqual(got, want) {
@@ -83,8 +83,8 @@ var orderedWeightedEdgesTests = []struct {
 
 func TestOrderedWeightedEdgesIterate(t *testing.T) {
 	for _, test := range orderedWeightedEdgesTests {
+		it := iterator.NewOrderedWeightedEdges(test.edges)
 		for i := 0; i < 2; i++ {
-			it := iterator.NewOrderedWeightedEdges(test.edges)
 			if it.Len() != len(test.edges) {
 				t.Errorf("unexpected iterator length for round %d: got:%d want:%d", i, it.Len(), len(test.edges))
 			}
@@ -103,8 +103,8 @@ func TestOrderedWeightedEdgesIterate(t *testing.T) {
 
 func TestOrderedWeightedEdgesSlice(t *testing.T) {
 	for _, test := range orderedWeightedEdgesTests {
+		it := iterator.NewOrderedWeightedEdges(test.edges)
 		for i := 0; i < 2; i++ {
-			it := iterator.NewOrderedWeightedEdges(test.edges)
 			got := it.WeightedEdgeSlice()
 			want := test.edges
 			if !reflect.DeepEqual(got, want) {

--- a/graph/iterator/lines_test.go
+++ b/graph/iterator/lines_test.go
@@ -31,8 +31,8 @@ var orderedLinesTests = []struct {
 
 func TestOrderedLinesIterate(t *testing.T) {
 	for _, test := range orderedLinesTests {
+		it := iterator.NewOrderedLines(test.lines)
 		for i := 0; i < 2; i++ {
-			it := iterator.NewOrderedLines(test.lines)
 			if it.Len() != len(test.lines) {
 				t.Errorf("unexpected iterator length for round %d: got:%d want:%d", i, it.Len(), len(test.lines))
 			}
@@ -51,8 +51,8 @@ func TestOrderedLinesIterate(t *testing.T) {
 
 func TestOrderedLinesSlice(t *testing.T) {
 	for _, test := range orderedLinesTests {
+		it := iterator.NewOrderedLines(test.lines)
 		for i := 0; i < 2; i++ {
-			it := iterator.NewOrderedLines(test.lines)
 			got := it.LineSlice()
 			want := test.lines
 			if !reflect.DeepEqual(got, want) {
@@ -85,8 +85,8 @@ var orderedWeightedLinesTests = []struct {
 
 func TestOrderedWeightedLinesIterate(t *testing.T) {
 	for _, test := range orderedWeightedLinesTests {
+		it := iterator.NewOrderedWeightedLines(test.lines)
 		for i := 0; i < 2; i++ {
-			it := iterator.NewOrderedWeightedLines(test.lines)
 			if it.Len() != len(test.lines) {
 				t.Errorf("unexpected iterator length for round %d: got:%d want:%d", i, it.Len(), len(test.lines))
 			}
@@ -105,8 +105,8 @@ func TestOrderedWeightedLinesIterate(t *testing.T) {
 
 func TestOrderedWeightedLinesSlice(t *testing.T) {
 	for _, test := range orderedWeightedLinesTests {
+		it := iterator.NewOrderedWeightedLines(test.lines)
 		for i := 0; i < 2; i++ {
-			it := iterator.NewOrderedWeightedLines(test.lines)
 			got := it.WeightedLineSlice()
 			want := test.lines
 			if !reflect.DeepEqual(got, want) {

--- a/graph/iterator/nodes_test.go
+++ b/graph/iterator/nodes_test.go
@@ -24,8 +24,8 @@ var orderedNodesTests = []struct {
 
 func TestOrderedNodesIterate(t *testing.T) {
 	for _, test := range orderedNodesTests {
+		it := iterator.NewOrderedNodes(test.nodes)
 		for i := 0; i < 2; i++ {
-			it := iterator.NewOrderedNodes(test.nodes)
 			if it.Len() != len(test.nodes) {
 				t.Errorf("unexpected iterator length for round %d: got:%d want:%d", i, it.Len(), len(test.nodes))
 			}
@@ -44,8 +44,8 @@ func TestOrderedNodesIterate(t *testing.T) {
 
 func TestOrderedNodesSlice(t *testing.T) {
 	for _, test := range orderedNodesTests {
+		it := iterator.NewOrderedNodes(test.nodes)
 		for i := 0; i < 2; i++ {
-			it := iterator.NewOrderedNodes(test.nodes)
 			got := it.NodeSlice()
 			want := test.nodes
 			if !reflect.DeepEqual(got, want) {
@@ -81,8 +81,8 @@ func newSimpleNode(id int) graph.Node { return simple.Node(id) }
 
 func TestImplicitNodesIterate(t *testing.T) {
 	for _, test := range implicitNodesTests {
+		it := iterator.NewImplicitNodes(test.beg, test.end, test.new)
 		for i := 0; i < 2; i++ {
-			it := iterator.NewImplicitNodes(test.beg, test.end, test.new)
 			if it.Len() != len(test.want) {
 				t.Errorf("unexpected iterator length for round %d: got:%d want:%d", i, it.Len(), len(test.want))
 			}


### PR DESCRIPTION
Noticed in #1020 that the tests don't actually test the exercise of the `Reset` method.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
