### PR TITLE
graph/iterator: guard against iteration panic

### DIFF
--- a/graph/iterator/nodes_unordered.go
+++ b/graph/iterator/nodes_unordered.go
@@ -41,6 +41,9 @@ func (n *Nodes) Len() int {
 
 // Next returns whether the next call of Node will return a valid node.
 func (n *Nodes) Next() bool {
+	if n.pos >= n.nodes.Len() {
+		return false
+	}
 	ok := n.iter.Next()
 	if ok {
 		n.pos++

--- a/graph/iterator/nodes_unordered_test.go
+++ b/graph/iterator/nodes_unordered_test.go
@@ -49,6 +49,15 @@ func TestNodesIterate(t *testing.T) {
 			if !reflect.DeepEqual(got, want) {
 				t.Errorf("unexpected iterator output for round %d: got:%#v want:%#v", i, got, want)
 			}
+			func() {
+				defer func() {
+					r := recover()
+					if r != nil {
+						t.Errorf("unexpected panic: %v", r)
+					}
+				}()
+				it.Next()
+			}()
 			it.Reset()
 		}
 	}


### PR DESCRIPTION
I missed an edge case.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
