### PR TITLE
travis: only run coverage when secure and on master

### DIFF
--- a/.travis/script.d/test-coverage.sh
+++ b/.travis/script.d/test-coverage.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+if [[ "${TRAVIS_SECURE_ENV_VARS}" != true ]]; then
+	echo "skipping coverage - no secure environment"
+	exit 0
+fi
+
+ORIGIN_MASTER="$(git ls-remote origin master | cut -f1)"
+CURRENT="$(git rev-parse HEAD)"
+if [[ ${ORIGIN_MASTER} != ${CURRENT} ]]; then
+	echo "skipping coverage - not merged into master"
+	exit 0
+fi
+
 MODE=set
 PROFILE_OUT="${PWD}/profile.out"
 ACC_OUT="${PWD}/coverage.txt"


### PR DESCRIPTION
This got lost in the multi-os testing system.

Please take a look.

TBR

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
