### PR TITLE
graph/{multi,simple}: fix empty To optimisation

### DIFF
--- a/graph/multi/directed.go
+++ b/graph/multi/directed.go
@@ -261,7 +261,7 @@ func (g *DirectedGraph) SetLine(l graph.Line) {
 
 // To returns all nodes in g that can reach directly to n.
 func (g *DirectedGraph) To(id int64) graph.Nodes {
-	if _, ok := g.from[id]; !ok {
+	if _, ok := g.to[id]; !ok {
 		return graph.Empty
 	}
 

--- a/graph/multi/weighted_directed.go
+++ b/graph/multi/weighted_directed.go
@@ -270,7 +270,7 @@ func (g *WeightedDirectedGraph) SetWeightedLine(l graph.WeightedLine) {
 
 // To returns all nodes in g that can reach directly to n.
 func (g *WeightedDirectedGraph) To(id int64) graph.Nodes {
-	if _, ok := g.from[id]; !ok {
+	if _, ok := g.to[id]; !ok {
 		return graph.Empty
 	}
 

--- a/graph/simple/directed.go
+++ b/graph/simple/directed.go
@@ -218,7 +218,7 @@ func (g *DirectedGraph) SetEdge(e graph.Edge) {
 
 // To returns all nodes in g that can reach directly to n.
 func (g *DirectedGraph) To(id int64) graph.Nodes {
-	if _, ok := g.from[id]; !ok {
+	if _, ok := g.to[id]; !ok {
 		return graph.Empty
 	}
 

--- a/graph/simple/weighted_directed.go
+++ b/graph/simple/weighted_directed.go
@@ -222,7 +222,7 @@ func (g *WeightedDirectedGraph) SetWeightedEdge(e graph.WeightedEdge) {
 
 // To returns all nodes in g that can reach directly to n.
 func (g *WeightedDirectedGraph) To(id int64) graph.Nodes {
-	if _, ok := g.from[id]; !ok {
+	if _, ok := g.to[id]; !ok {
 		return graph.Empty
 	}
 


### PR DESCRIPTION
This fixes an incorrect optimisation in the directed graph implementations found by @yinyanghu.

Please take a look.

Closes #1026.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
