### PR TITLE
stat/combin: Fix CombinationGenerator comment

### DIFF
--- a/stat/combin/combin.go
+++ b/stat/combin/combin.go
@@ -119,7 +119,7 @@ func (c *CombinationGenerator) Next() bool {
 	return true
 }
 
-// Combination generates the next combination. If next is non-nil, it must have
+// Combination generates the current combination. If next is non-nil, it must have
 // length k and the result will be stored in-place into combination. If combination
 // is nil a new slice will be allocated and returned. If all of the combinations
 // have already been constructed (Next() returns false), Combination will panic.


### PR DESCRIPTION
It's confusing to say that Combination generates the next combination, when really it generates the current one with Next doing the advancing.

