### PR TITLE
graph/testgraph: test for missing From and To paths

### DIFF
--- a/graph/testgraph/testcases.go
+++ b/graph/testgraph/testcases.go
@@ -160,6 +160,31 @@ var testCases = []struct {
 	},
 
 	{
+		name:  "three in only",
+		nodes: []graph.Node{node(0), node(1), node(2), node(3)},
+		edges: []WeightedLine{
+			line{F: node(1), T: node(0), UID: 0, W: 0.5},
+			line{F: node(2), T: node(0), UID: 1, W: 0.5},
+			line{F: node(3), T: node(0), UID: 2, W: 0.5},
+		},
+		nonexist: []graph.Node{node(-1), node(4)},
+		self:     0,
+		absent:   math.Inf(1),
+	},
+	{
+		name:  "three out only",
+		nodes: []graph.Node{node(0), node(1), node(2), node(3)},
+		edges: []WeightedLine{
+			line{F: node(0), T: node(1), UID: 0, W: 0.5},
+			line{F: node(0), T: node(2), UID: 1, W: 0.5},
+			line{F: node(0), T: node(3), UID: 2, W: 0.5},
+		},
+		nonexist: []graph.Node{node(-1), node(4)},
+		self:     0,
+		absent:   math.Inf(1),
+	},
+
+	{
 		name: "4-clique - single(non-prepared)",
 		edges: func() []WeightedLine {
 			const n = 4

--- a/graph/testgraph/testgraph.go
+++ b/graph/testgraph/testgraph.go
@@ -953,6 +953,9 @@ func ReturnAdjacentNodes(t *testing.T, b Builder, useEmpty bool) {
 		want := make(map[edge]bool)
 		for _, e := range edges {
 			want[edge{f: e.From().ID(), t: e.To().ID()}] = true
+			if g.From(e.From().ID()).Len() == 0 {
+				t.Errorf("missing path from node %v with outbound edge %v", e.From().ID(), e)
+			}
 		}
 		for _, x := range nodes {
 			switch g := g.(type) {
@@ -1026,6 +1029,11 @@ func ReturnAdjacentNodes(t *testing.T, b Builder, useEmpty bool) {
 					}
 					if !want[edge{f: u.ID(), t: v.ID()}] {
 						t.Errorf("unexpected edge for test %q: (%v)->(%v)", test.name, u.ID(), v.ID())
+					}
+				}
+				for _, e := range edges {
+					if g.To(e.To().ID()).Len() == 0 {
+						t.Errorf("missing path to node %v with inbound edge %v", e.To().ID(), e)
 					}
 				}
 


### PR DESCRIPTION
It turns out the implementations were correctly behaving, but I think this was more fortuitous than by design.

I'm interested to know how @yinyanghu found the bug. I don't think it was from the behaviour, but if it was, can you show me the case that was failing and I will add it here.

Please take a look.

Fixes #1030.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
