### PR TITLE
graph/{multi,simple}: don't allocate edge maps before they are needed

### DIFF
--- a/graph/multi/directed.go
+++ b/graph/multi/directed.go
@@ -53,8 +53,6 @@ func (g *DirectedGraph) AddNode(n graph.Node) {
 		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
 	}
 	g.nodes[n.ID()] = n
-	g.from[n.ID()] = make(map[int64]map[int64]graph.Line)
-	g.to[n.ID()] = make(map[int64]map[int64]graph.Line)
 	g.nodeIDs.Use(n.ID())
 }
 
@@ -242,20 +240,29 @@ func (g *DirectedGraph) SetLine(l graph.Line) {
 	} else {
 		g.nodes[fid] = from
 	}
-	if g.from[fid][tid] == nil {
-		g.from[fid][tid] = make(map[int64]graph.Line)
-	}
 	if _, ok := g.nodes[tid]; !ok {
 		g.AddNode(to)
 	} else {
 		g.nodes[tid] = to
 	}
-	if g.to[tid][fid] == nil {
-		g.to[tid][fid] = make(map[int64]graph.Line)
+
+	switch {
+	case g.from[fid] == nil:
+		g.from[fid] = map[int64]map[int64]graph.Line{tid: map[int64]graph.Line{lid: l}}
+	case g.from[fid][tid] == nil:
+		g.from[fid][tid] = map[int64]graph.Line{lid: l}
+	default:
+		g.from[fid][tid][lid] = l
+	}
+	switch {
+	case g.to[tid] == nil:
+		g.to[tid] = map[int64]map[int64]graph.Line{fid: map[int64]graph.Line{lid: l}}
+	case g.to[tid][fid] == nil:
+		g.to[tid][fid] = map[int64]graph.Line{lid: l}
+	default:
+		g.to[tid][fid][lid] = l
 	}
 
-	g.from[fid][tid][lid] = l
-	g.to[tid][fid][lid] = l
 	g.lineIDs.Use(lid)
 }
 

--- a/graph/multi/undirected.go
+++ b/graph/multi/undirected.go
@@ -51,7 +51,6 @@ func (g *UndirectedGraph) AddNode(n graph.Node) {
 		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
 	}
 	g.nodes[n.ID()] = n
-	g.lines[n.ID()] = make(map[int64]map[int64]graph.Line)
 	g.nodeIDs.Use(n.ID())
 }
 
@@ -242,19 +241,28 @@ func (g *UndirectedGraph) SetLine(l graph.Line) {
 	} else {
 		g.nodes[fid] = from
 	}
-	if g.lines[fid][tid] == nil {
-		g.lines[fid][tid] = make(map[int64]graph.Line)
-	}
 	if _, ok := g.nodes[tid]; !ok {
 		g.AddNode(to)
 	} else {
 		g.nodes[tid] = to
 	}
-	if g.lines[tid][fid] == nil {
-		g.lines[tid][fid] = make(map[int64]graph.Line)
+
+	switch {
+	case g.lines[fid] == nil:
+		g.lines[fid] = map[int64]map[int64]graph.Line{tid: map[int64]graph.Line{lid: l}}
+	case g.lines[fid][tid] == nil:
+		g.lines[fid][tid] = map[int64]graph.Line{lid: l}
+	default:
+		g.lines[fid][tid][lid] = l
+	}
+	switch {
+	case g.lines[tid] == nil:
+		g.lines[tid] = map[int64]map[int64]graph.Line{fid: map[int64]graph.Line{lid: l}}
+	case g.lines[tid][fid] == nil:
+		g.lines[tid][fid] = map[int64]graph.Line{lid: l}
+	default:
+		g.lines[tid][fid][lid] = l
 	}
 
-	g.lines[fid][tid][lid] = l
-	g.lines[tid][fid][lid] = l
 	g.lineIDs.Use(lid)
 }

--- a/graph/multi/weighted_directed.go
+++ b/graph/multi/weighted_directed.go
@@ -62,8 +62,6 @@ func (g *WeightedDirectedGraph) AddNode(n graph.Node) {
 		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
 	}
 	g.nodes[n.ID()] = n
-	g.from[n.ID()] = make(map[int64]map[int64]graph.WeightedLine)
-	g.to[n.ID()] = make(map[int64]map[int64]graph.WeightedLine)
 	g.nodeIDs.Use(n.ID())
 }
 
@@ -251,20 +249,29 @@ func (g *WeightedDirectedGraph) SetWeightedLine(l graph.WeightedLine) {
 	} else {
 		g.nodes[fid] = from
 	}
-	if g.from[fid][tid] == nil {
-		g.from[fid][tid] = make(map[int64]graph.WeightedLine)
-	}
 	if _, ok := g.nodes[tid]; !ok {
 		g.AddNode(to)
 	} else {
 		g.nodes[tid] = to
 	}
-	if g.to[tid][fid] == nil {
-		g.to[tid][fid] = make(map[int64]graph.WeightedLine)
+
+	switch {
+	case g.from[fid] == nil:
+		g.from[fid] = map[int64]map[int64]graph.WeightedLine{tid: map[int64]graph.WeightedLine{lid: l}}
+	case g.from[fid][tid] == nil:
+		g.from[fid][tid] = map[int64]graph.WeightedLine{lid: l}
+	default:
+		g.from[fid][tid][lid] = l
+	}
+	switch {
+	case g.to[tid] == nil:
+		g.to[tid] = map[int64]map[int64]graph.WeightedLine{fid: map[int64]graph.WeightedLine{lid: l}}
+	case g.to[tid][fid] == nil:
+		g.to[tid][fid] = map[int64]graph.WeightedLine{lid: l}
+	default:
+		g.to[tid][fid][lid] = l
 	}
 
-	g.from[fid][tid][lid] = l
-	g.to[tid][fid][lid] = l
 	g.lineIDs.Use(l.ID())
 }
 

--- a/graph/multi/weighted_undirected.go
+++ b/graph/multi/weighted_undirected.go
@@ -60,7 +60,6 @@ func (g *WeightedUndirectedGraph) AddNode(n graph.Node) {
 		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
 	}
 	g.nodes[n.ID()] = n
-	g.lines[n.ID()] = make(map[int64]map[int64]graph.WeightedLine)
 	g.nodeIDs.Use(n.ID())
 }
 
@@ -252,20 +251,29 @@ func (g *WeightedUndirectedGraph) SetWeightedLine(l graph.WeightedLine) {
 	} else {
 		g.nodes[fid] = from
 	}
-	if g.lines[fid][tid] == nil {
-		g.lines[fid][tid] = make(map[int64]graph.WeightedLine)
-	}
 	if _, ok := g.nodes[tid]; !ok {
 		g.AddNode(to)
 	} else {
 		g.nodes[tid] = to
 	}
-	if g.lines[tid][fid] == nil {
-		g.lines[tid][fid] = make(map[int64]graph.WeightedLine)
+
+	switch {
+	case g.lines[fid] == nil:
+		g.lines[fid] = map[int64]map[int64]graph.WeightedLine{tid: map[int64]graph.WeightedLine{lid: l}}
+	case g.lines[fid][tid] == nil:
+		g.lines[fid][tid] = map[int64]graph.WeightedLine{lid: l}
+	default:
+		g.lines[fid][tid][lid] = l
+	}
+	switch {
+	case g.lines[tid] == nil:
+		g.lines[tid] = map[int64]map[int64]graph.WeightedLine{fid: map[int64]graph.WeightedLine{lid: l}}
+	case g.lines[tid][fid] == nil:
+		g.lines[tid][fid] = map[int64]graph.WeightedLine{lid: l}
+	default:
+		g.lines[tid][fid][lid] = l
 	}
 
-	g.lines[fid][tid][lid] = l
-	g.lines[tid][fid][lid] = l
 	g.lineIDs.Use(lid)
 }
 

--- a/graph/simple/directed.go
+++ b/graph/simple/directed.go
@@ -49,8 +49,6 @@ func (g *DirectedGraph) AddNode(n graph.Node) {
 		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
 	}
 	g.nodes[n.ID()] = n
-	g.from[n.ID()] = make(map[int64]graph.Edge)
-	g.to[n.ID()] = make(map[int64]graph.Edge)
 	g.nodeIDs.Use(n.ID())
 }
 
@@ -212,8 +210,16 @@ func (g *DirectedGraph) SetEdge(e graph.Edge) {
 		g.nodes[tid] = to
 	}
 
-	g.from[fid][tid] = e
-	g.to[tid][fid] = e
+	if fm, ok := g.from[fid]; ok {
+		fm[tid] = e
+	} else {
+		g.from[fid] = map[int64]graph.Edge{tid: e}
+	}
+	if tm, ok := g.to[tid]; ok {
+		tm[fid] = e
+	} else {
+		g.to[tid] = map[int64]graph.Edge{fid: e}
+	}
 }
 
 // To returns all nodes in g that can reach directly to n.

--- a/graph/simple/undirected.go
+++ b/graph/simple/undirected.go
@@ -47,7 +47,6 @@ func (g *UndirectedGraph) AddNode(n graph.Node) {
 		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
 	}
 	g.nodes[n.ID()] = n
-	g.edges[n.ID()] = make(map[int64]graph.Edge)
 	g.nodeIDs.Use(n.ID())
 }
 
@@ -211,6 +210,14 @@ func (g *UndirectedGraph) SetEdge(e graph.Edge) {
 		g.nodes[tid] = to
 	}
 
-	g.edges[fid][tid] = e
-	g.edges[tid][fid] = e
+	if fm, ok := g.edges[fid]; ok {
+		fm[tid] = e
+	} else {
+		g.edges[fid] = map[int64]graph.Edge{tid: e}
+	}
+	if tm, ok := g.edges[tid]; ok {
+		tm[fid] = e
+	} else {
+		g.edges[tid] = map[int64]graph.Edge{fid: e}
+	}
 }

--- a/graph/simple/weighted_directed.go
+++ b/graph/simple/weighted_directed.go
@@ -57,8 +57,6 @@ func (g *WeightedDirectedGraph) AddNode(n graph.Node) {
 		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
 	}
 	g.nodes[n.ID()] = n
-	g.from[n.ID()] = make(map[int64]graph.WeightedEdge)
-	g.to[n.ID()] = make(map[int64]graph.WeightedEdge)
 	g.nodeIDs.Use(n.ID())
 }
 
@@ -143,7 +141,7 @@ func (g *WeightedDirectedGraph) Node(id int64) graph.Node {
 
 // Nodes returns all the nodes in the graph.
 func (g *WeightedDirectedGraph) Nodes() graph.Nodes {
-	if len(g.from) == 0 {
+	if len(g.nodes) == 0 {
 		return graph.Empty
 	}
 	nodes := make([]graph.Node, len(g.nodes))
@@ -216,8 +214,16 @@ func (g *WeightedDirectedGraph) SetWeightedEdge(e graph.WeightedEdge) {
 		g.nodes[tid] = to
 	}
 
-	g.from[fid][tid] = e
-	g.to[tid][fid] = e
+	if fm, ok := g.from[fid]; ok {
+		fm[tid] = e
+	} else {
+		g.from[fid] = map[int64]graph.WeightedEdge{tid: e}
+	}
+	if tm, ok := g.to[tid]; ok {
+		tm[fid] = e
+	} else {
+		g.to[tid] = map[int64]graph.WeightedEdge{fid: e}
+	}
 }
 
 // To returns all nodes in g that can reach directly to n.

--- a/graph/simple/weighted_undirected.go
+++ b/graph/simple/weighted_undirected.go
@@ -55,7 +55,6 @@ func (g *WeightedUndirectedGraph) AddNode(n graph.Node) {
 		panic(fmt.Sprintf("simple: node ID collision: %d", n.ID()))
 	}
 	g.nodes[n.ID()] = n
-	g.edges[n.ID()] = make(map[int64]graph.WeightedEdge)
 	g.nodeIDs.Use(n.ID())
 }
 
@@ -212,8 +211,16 @@ func (g *WeightedUndirectedGraph) SetWeightedEdge(e graph.WeightedEdge) {
 		g.nodes[tid] = to
 	}
 
-	g.edges[fid][tid] = e
-	g.edges[tid][fid] = e
+	if fm, ok := g.edges[fid]; ok {
+		fm[tid] = e
+	} else {
+		g.edges[fid] = map[int64]graph.WeightedEdge{tid: e}
+	}
+	if tm, ok := g.edges[tid]; ok {
+		tm[fid] = e
+	} else {
+		g.edges[tid] = map[int64]graph.WeightedEdge{fid: e}
+	}
 }
 
 // Weight returns the weight for the edge between x and y if Edge(x, y) returns a non-nil Edge.


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
