### PR TITLE
lapack/gonum: add Dlatbs

### DIFF
--- a/lapack/gonum/dlatbs.go
+++ b/lapack/gonum/dlatbs.go
@@ -31,7 +31,7 @@ import (
 // non-trivial solution to A*x = 0 is returned.
 //
 // Dlatbs is an internal routine. It is exported for testing purposes.
-func (Implementation) Dlatbs(uplo blas.Uplo, trans blas.Transpose, diag blas.Diag, normin bool, n, kd int, ab []float64, ldab int, x []float64, cnorm []float64) (scale float64) {
+func (Implementation) Dlatbs(uplo blas.Uplo, trans blas.Transpose, diag blas.Diag, normin bool, n, kd int, ab []float64, ldab int, x, cnorm []float64) (scale float64) {
 	noTran := trans == blas.NoTrans
 	switch {
 	case uplo != blas.Upper && uplo != blas.Lower:
@@ -298,7 +298,8 @@ skipComputeGrow:
 
 			// Scale x if necessary to avoid overflow when adding a multiple of
 			// column j of A.
-			if xj > 1 {
+			switch {
+			case xj > 1:
 				rec := 1 / xj
 				if cnorm[j] > (bignum-xMax)*rec {
 					// Scale x by 1/(2*abs(x[j])).
@@ -306,7 +307,7 @@ skipComputeGrow:
 					bi.Dscal(n, rec, x, 1)
 					scale *= rec
 				}
-			} else if xj*cnorm[j] > bignum-xMax {
+			case xj*cnorm[j] > bignum-xMax:
 				// Scale x by 1/2.
 				bi.Dscal(n, 0.5, x, 1)
 				scale *= 0.5

--- a/lapack/gonum/dlatbs.go
+++ b/lapack/gonum/dlatbs.go
@@ -1,0 +1,449 @@
+// Copyright ©2019 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+import (
+	"math"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/blas64"
+)
+
+// Dlatbs solves a triangular banded system of equations
+//  A * x = s*b    if trans == blas.NoTrans
+//  A^T * x = s*b  if trans == blas.Trans or blas.ConjTrans
+// where A is an upper or lower triangular band matrix, x and b are n-element
+// vectors, and s is a scaling factor chosen so that the components of x will be
+// less than the overflow threshold.
+//
+// On entry, x contains the right-hand side b of the triangular system.
+// On return, x is overwritten by the solution vector x.
+//
+// normin specifies whether the cnorm parameter contains the column norms of A on
+// entry. If it is true, cnorm[j] contains the norm of the off-diagonal part of
+// the j-th column of A. If it is false, the norms will be computed and stored
+// in cnorm.
+//
+// Dlatbs returns the scaling factor s for the triangular system. If the matrix
+// A is singular (A[j,j]==0 for some j), then scale is set to 0 and a
+// non-trivial solution to A*x = 0 is returned.
+//
+// Dlatbs is an internal routine. It is exported for testing purposes.
+func (Implementation) Dlatbs(uplo blas.Uplo, trans blas.Transpose, diag blas.Diag, normin bool, n, kd int, ab []float64, ldab int, x []float64, cnorm []float64) (scale float64) {
+	noTran := trans == blas.NoTrans
+	switch {
+	case uplo != blas.Upper && uplo != blas.Lower:
+		panic(badUplo)
+	case !noTran && trans != blas.Trans && trans != blas.ConjTrans:
+		panic(badTrans)
+	case diag != blas.NonUnit && diag != blas.Unit:
+		panic(badDiag)
+	case n < 0:
+		panic(nLT0)
+	case kd < 0:
+		panic(kdLT0)
+	case ldab < kd+1:
+		panic(badLdA)
+	}
+
+	// Quick return if possible.
+	if n == 0 {
+		return 0
+	}
+
+	switch {
+	case len(ab) < (n-1)*ldab+kd:
+		panic(shortAB)
+	case len(x) < n:
+		panic(shortX)
+	case len(cnorm) < n:
+		panic(shortCNorm)
+	}
+
+	// Parameters to control overflow.
+	smlnum := dlamchS / dlamchP
+	bignum := 1 / smlnum
+
+	bi := blas64.Implementation()
+	kld := max(1, ldab-1)
+	if !normin {
+		// Compute the 1-norm of each column, not including the diagonal.
+		if uplo == blas.Upper {
+			for j := 0; j < n; j++ {
+				jlen := min(j, kd)
+				if jlen > 0 {
+					cnorm[j] = bi.Dasum(jlen, ab[(j-jlen)*ldab+jlen:], kld)
+				} else {
+					cnorm[j] = 0
+				}
+			}
+		} else {
+			for j := 0; j < n; j++ {
+				jlen := min(n-j-1, kd)
+				if jlen > 0 {
+					cnorm[j] = bi.Dasum(jlen, ab[(j+1)*ldab+kd-1:], kld)
+				} else {
+					cnorm[j] = 0
+				}
+			}
+		}
+	}
+
+	// Set up indices and increments for loops below.
+	var (
+		jFirst, jLast, jInc int
+		maind               int
+	)
+	if noTran {
+		if uplo == blas.Upper {
+			jFirst = n - 1
+			jLast = -1
+			jInc = -1
+			maind = 0
+		} else {
+			jFirst = 0
+			jLast = n
+			jInc = 1
+			maind = kd
+		}
+	} else {
+		if uplo == blas.Upper {
+			jFirst = 0
+			jLast = n
+			jInc = 1
+			maind = 0
+		} else {
+			jFirst = n - 1
+			jLast = -1
+			jInc = -1
+			maind = kd
+		}
+	}
+
+	// Scale the column norms by tscal if the maximum element in cnorm is
+	// greater than bignum.
+	tmax := cnorm[bi.Idamax(n, cnorm, 1)]
+	tscal := 1.0
+	if tmax > bignum {
+		tscal = 1 / (smlnum * tmax)
+		bi.Dscal(n, tscal, cnorm, 1)
+	}
+
+	// Compute a bound on the computed solution vector to see if the Level 2
+	// BLAS routine Dtbsv can be used.
+
+	xMax := math.Abs(x[bi.Idamax(n, x, 1)])
+	xBnd := xMax
+	grow := 0.0
+	// Compute the growth only if the maximum element in cnorm is NOT greater
+	// than bignum.
+	if tscal != 1 {
+		goto skipComputeGrow
+	}
+	if noTran {
+		// Compute the growth in A * x = b.
+		if diag == blas.NonUnit {
+			// A is non-unit triangular.
+			//
+			// Compute grow = 1/G_j and xBnd = 1/M_j.
+			// Initially, G_0 = max{x(i), i=1,...,n}.
+			grow = 1 / math.Max(xBnd, smlnum)
+			xBnd = grow
+			for j := jFirst; j != jLast; j += jInc {
+				if grow <= smlnum {
+					// Exit the loop because the growth factor is too small.
+					goto skipComputeGrow
+				}
+				// M_j = G_{j-1} / abs(A[j,j])
+				tjj := math.Abs(ab[j*ldab+maind])
+				xBnd = math.Min(xBnd, math.Min(1, tjj)*grow)
+				if tjj+cnorm[j] >= smlnum {
+					// G_j = G_{j-1}*( 1 + cnorm[j] / abs(A[j,j]) )
+					grow *= tjj / (tjj + cnorm[j])
+				} else {
+					// G_j could overflow, set grow to 0.
+					grow = 0
+				}
+			}
+			grow = xBnd
+		} else {
+			// A is unit triangular.
+			//
+			// Compute grow = 1/G_j, where G_0 = max{x(i), i=1,...,n}.
+			grow = math.Min(1, 1/math.Max(xBnd, smlnum))
+			for j := jFirst; j != jLast; j += jInc {
+				if grow <= smlnum {
+					// Exit the loop because the growth factor is too small.
+					goto skipComputeGrow
+				}
+				// G_j = G_{j-1}*( 1 + cnorm[j] )
+				grow /= 1 + cnorm[j]
+			}
+		}
+	} else {
+		// Compute the growth in A^T * x = b.
+		if diag == blas.NonUnit {
+			// A is non-unit triangular.
+			//
+			// Compute grow = 1/G_j and xBnd = 1/M_j.
+			// Initially, G_0 = max{x(i), i=1,...,n}.
+			grow = 1 / math.Max(xBnd, smlnum)
+			xBnd = grow
+			for j := jFirst; j != jLast; j += jInc {
+				if grow <= smlnum {
+					// Exit the loop because the growth factor is too small.
+					goto skipComputeGrow
+				}
+				// G_j = max( G_{j-1}, M_{j-1}*( 1 + cnorm[j] ) )
+				xj := 1 + cnorm[j]
+				grow = math.Min(grow, xBnd/xj)
+				// M_j = M_{j-1}*( 1 + cnorm[j] ) / abs(A[j,j])
+				tjj := math.Abs(ab[j*ldab+maind])
+				if xj > tjj {
+					xBnd *= tjj / xj
+				}
+			}
+			grow = math.Min(grow, xBnd)
+		} else {
+			// A is unit triangular.
+			//
+			// Compute grow = 1/G_j, where G_0 = max{x(i), i=1,...,n}.
+			grow = math.Min(1, 1/math.Max(xBnd, smlnum))
+			for j := jFirst; j != jLast; j += jInc {
+				if grow <= smlnum {
+					// Exit the loop because the growth factor is too small.
+					goto skipComputeGrow
+				}
+				// G_j = G_{j-1}*( 1 + cnorm[j] )
+				grow /= 1 + cnorm[j]
+			}
+		}
+	}
+skipComputeGrow:
+
+	if grow*tscal > smlnum {
+		// The reciprocal of the bound on elements of X is not too small, use
+		// the Level 2 BLAS solve.
+		bi.Dtbsv(uplo, trans, diag, n, kd, ab, ldab, x, 1)
+		// Scale the column norms by 1/tscal for return.
+		if tscal != 1 {
+			bi.Dscal(n, 1/tscal, cnorm, 1)
+		}
+		return 1
+	}
+
+	// Use a Level 1 BLAS solve, scaling intermediate results.
+
+	scale = 1
+	if xMax > bignum {
+		// Scale x so that its components are less than or equal to bignum in
+		// absolute value.
+		scale = bignum / xMax
+		bi.Dscal(n, scale, x, 1)
+		xMax = bignum
+	}
+
+	if noTran {
+		// Solve A * x = b.
+		for j := jFirst; j != jLast; j += jInc {
+			// Compute x[j] = b[j] / A[j,j], scaling x if necessary.
+			xj := math.Abs(x[j])
+			tjjs := tscal
+			if diag == blas.NonUnit {
+				tjjs *= ab[j*ldab+maind]
+			}
+			tjj := math.Abs(tjjs)
+			switch {
+			case tjj > smlnum:
+				// smlnum < abs(A[j,j])
+				if tjj < 1 && xj > tjj*bignum {
+					// Scale x by 1/b[j].
+					rec := 1 / xj
+					bi.Dscal(n, rec, x, 1)
+					scale *= rec
+					xMax *= rec
+				}
+				x[j] /= tjjs
+				xj = math.Abs(x[j])
+			case tjj > 0:
+				// 0 < abs(A[j,j]) <= smlnum
+				if xj > tjj*bignum {
+					// Scale x by (1/abs(x[j]))*abs(A[j,j])*bignum to avoid
+					// overflow when dividing by A[j,j].
+					rec := tjj * bignum / xj
+					if cnorm[j] > 1 {
+						// Scale by 1/cnorm[j] to avoid overflow when
+						// multiplying x[j] times column j.
+						rec /= cnorm[j]
+					}
+					bi.Dscal(n, rec, x, 1)
+					scale *= rec
+					xMax *= rec
+				}
+				x[j] /= tjjs
+				xj = math.Abs(x[j])
+			default:
+				// A[j,j] == 0: Set x[0:n] = 0, x[j] = 1, and scale = 0, and
+				// compute a solution to A*x = 0.
+				for i := range x[:n] {
+					x[i] = 0
+				}
+				x[j] = 1
+				xj = 1
+				scale = 0
+				xMax = 0
+			}
+
+			// Scale x if necessary to avoid overflow when adding a multiple of
+			// column j of A.
+			if xj > 1 {
+				rec := 1 / xj
+				if cnorm[j] > (bignum-xMax)*rec {
+					// Scale x by 1/(2*abs(x[j])).
+					rec *= 0.5
+					bi.Dscal(n, rec, x, 1)
+					scale *= rec
+				}
+			} else if xj*cnorm[j] > bignum-xMax {
+				// Scale x by 1/2.
+				bi.Dscal(n, 0.5, x, 1)
+				scale *= 0.5
+			}
+
+			if uplo == blas.Upper {
+				if j > 0 {
+					// Compute the update
+					//  x[max(0,j-kd):j] := x[max(0,j-kd):j] - x[j] * A[max(0,j-kd):j,j]
+					jlen := min(j, kd)
+					if jlen > 0 {
+						bi.Daxpy(jlen, -x[j]*tscal, ab[(j-jlen)*ldab+jlen:], kld, x[j-jlen:], 1)
+					}
+					i := bi.Idamax(j, x, 1)
+					xMax = math.Abs(x[i])
+				}
+			} else if j < n-1 {
+				// Compute the update
+				//  x[j+1:min(j+kd,n)] := x[j+1:min(j+kd,n)] - x[j] * A[j+1:min(j+kd,n),j]
+				jlen := min(kd, n-j-1)
+				if jlen > 0 {
+					bi.Daxpy(jlen, -x[j]*tscal, ab[(j+1)*ldab+kd-1:], kld, x[j+1:], 1)
+				}
+				i := j + 1 + bi.Idamax(n-j-1, x[j+1:], 1)
+				xMax = math.Abs(x[i])
+			}
+		}
+	} else {
+		// Solve A^T * x = b.
+		for j := jFirst; j != jLast; j += jInc {
+			// Compute x[j] = b[j] - sum A[k,j]*x[k].
+			//                       k!=j
+			xj := math.Abs(x[j])
+			tjjs := tscal
+			if diag == blas.NonUnit {
+				tjjs *= ab[j*ldab+maind]
+			}
+			tjj := math.Abs(tjjs)
+			rec := 1 / math.Max(1, xMax)
+			uscal := tscal
+			if cnorm[j] > (bignum-xj)*rec {
+				// If x[j] could overflow, scale x by 1/(2*xMax).
+				rec *= 0.5
+				if tjj > 1 {
+					// Divide by A[j,j] when scaling x if A[j,j] > 1.
+					rec = math.Min(1, rec*tjj)
+					uscal /= tjjs
+				}
+				if rec < 1 {
+					bi.Dscal(n, rec, x, 1)
+					scale *= rec
+					xMax *= rec
+				}
+			}
+
+			var sumj float64
+			if uscal == 1 {
+				// If the scaling needed for A in the dot product is 1, call
+				// Ddot to perform the dot product...
+				if uplo == blas.Upper {
+					jlen := min(j, kd)
+					if jlen > 0 {
+						sumj = bi.Ddot(jlen, ab[(j-jlen)*ldab+jlen:], kld, x[j-jlen:], 1)
+					}
+				} else {
+					jlen := min(n-j-1, kd)
+					if jlen > 0 {
+						sumj = bi.Ddot(jlen, ab[(j+1)*ldab+kd-1:], kld, x[j+1:], 1)
+					}
+				}
+			} else {
+				// ...otherwise, use in-line code for the dot product.
+				if uplo == blas.Upper {
+					jlen := min(j, kd)
+					for i := 0; i < jlen; i++ {
+						sumj += (ab[(j-jlen+i)*ldab+jlen-i] * uscal) * x[j-jlen+i]
+					}
+				} else {
+					jlen := min(n-j-1, kd)
+					for i := 0; i < jlen; i++ {
+						sumj += (ab[(j+1+i)*ldab+kd-1-i] * uscal) * x[j+i+1]
+					}
+				}
+			}
+
+			if uscal == tscal {
+				// Compute x[j] := ( x[j] - sumj ) / A[j,j]
+				// if 1/A[j,j] was not used to scale the dot product.
+				x[j] -= sumj
+				xj = math.Abs(x[j])
+				if diag == blas.NonUnit {
+					// Compute x[j] = x[j] / A[j,j], scaling if necessary.
+					switch {
+					case tjj > smlnum:
+						// smlnum < abs(A[j,j]):
+						if tjj < 1 && xj > tjj*bignum {
+							// Scale x by 1/abs(x[j]).
+							rec := 1 / xj
+							bi.Dscal(n, rec, x, 1)
+							scale *= rec
+							xMax *= rec
+						}
+						x[j] /= tjjs
+					case tjj > 0:
+						// 0 < abs(A[j,j]) <= smlnum:
+						if xj > tjj*bignum {
+							// Scale x by (1/abs(x[j]))*abs(A[j,j])*bignum.
+							rec := (tjj * bignum) / xj
+							bi.Dscal(n, rec, x, 1)
+							scale *= rec
+							xMax *= rec
+						}
+						x[j] /= tjjs
+					default:
+						// A[j,j] == 0: Set x[0:n] = 0, x[j] = 1, and scale = 0, and
+						// compute a solution A^T * x = 0.
+						for i := range x[:n] {
+							x[i] = 0
+						}
+						x[j] = 1
+						scale = 0
+						xMax = 0
+					}
+				}
+			} else {
+				// Compute x[j] := x[j] / A[j,j] - sumj
+				// if the dot product has already been divided by 1/A[j,j].
+				x[j] = x[j]/tjjs - sumj
+			}
+			xMax = math.Max(xMax, math.Abs(x[j]))
+		}
+		scale /= tscal
+	}
+
+	// Scale the column norms by 1/tscal for return.
+	if tscal != 1 {
+		bi.Dscal(n, 1/tscal, cnorm, 1)
+	}
+	return scale
+}

--- a/lapack/gonum/lapack_test.go
+++ b/lapack/gonum/lapack_test.go
@@ -289,6 +289,10 @@ func TestDlasv2(t *testing.T) {
 	testlapack.Dlasv2Test(t, impl)
 }
 
+func TestDlatbs(t *testing.T) {
+	testlapack.DlatbsTest(t, impl)
+}
+
 func TestDlatrd(t *testing.T) {
 	testlapack.DlatrdTest(t, impl)
 }

--- a/lapack/testlapack/dlatbs.go
+++ b/lapack/testlapack/dlatbs.go
@@ -1,0 +1,166 @@
+// Copyright ©2019 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"golang.org/x/exp/rand"
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/blas64"
+	"gonum.org/v1/gonum/floats"
+)
+
+type Dlatbser interface {
+	Dlatbs(uplo blas.Uplo, trans blas.Transpose, diag blas.Diag, normin bool, n, kd int, ab []float64, ldab int, x []float64, cnorm []float64) float64
+}
+
+// DlatbsTest tests Dlatbs by generating a random triangular band system and
+// checking that a residual for the computed solution is small.
+func DlatbsTest(t *testing.T, impl Dlatbser) {
+	rnd := rand.New(rand.NewSource(1))
+	for _, n := range []int{0, 1, 2, 3, 4, 5, 10, 50} {
+		for _, kd := range []int{0, (n + 1) / 4, (3*n - 1) / 4, (5*n + 1) / 4} {
+			for _, uplo := range []blas.Uplo{blas.Upper, blas.Lower} {
+				for _, trans := range []blas.Transpose{blas.NoTrans, blas.Trans, blas.ConjTrans} {
+					for _, ldab := range []int{kd + 1, kd + 1 + 7} {
+						for _, kind := range []int{6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17, 18} {
+							dlatbsTest(t, impl, rnd, kind, uplo, trans, n, kd, ldab)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func dlatbsTest(t *testing.T, impl Dlatbser, rnd *rand.Rand, kind int, uplo blas.Uplo, trans blas.Transpose, n, kd, ldab int) {
+	const eps = 1e-15
+
+	// Allocate a triangular band matrix.
+	ab := make([]float64, n*ldab)
+	for i := range ab {
+		ab[i] = rnd.NormFloat64()
+	}
+
+	// Generate a triangular test matrix and the right-hand side.
+	diag, b := dlattb(kind, uplo, trans, n, kd, ab, ldab, rnd)
+
+	// Make a copy of AB to make sure that it is not modified in Dlatbs.
+	abCopy := make([]float64, len(ab))
+	copy(abCopy, ab)
+
+	// Allocate cnorm and fill it with impossible result to make sure that it
+	// _is_ updated in the first Dlatbs call below.
+	cnorm := make([]float64, n)
+	for i := range cnorm {
+		cnorm[i] = -1
+	}
+
+	// Solve the system op(A)*x = b.
+	x := make([]float64, n)
+	copy(x, b)
+	scale := impl.Dlatbs(uplo, trans, diag, false, n, kd, ab, ldab, x, cnorm)
+
+	name := fmt.Sprintf("kind=%v,uplo=%v,trans=%v,diag=%v,n=%v,kd=%v,ldab=%v",
+		kind, string(uplo), string(trans), string(diag), n, kd, ldab)
+
+	if !floats.Equal(ab, abCopy) {
+		t.Errorf("%v: unexpected modification of ab", name)
+	}
+	if floats.Count(func(v float64) bool { return v == -1 }, cnorm) > 0 {
+		t.Errorf("%v: expected modification of cnorm", name)
+	}
+
+	resid := dlatbsResidual(uplo, trans, diag, n, kd, ab, ldab, scale, cnorm, b, x)
+	if resid >= eps {
+		t.Errorf("%v: unexpected result when normin=false. residual=%v", name, resid)
+	}
+
+	// Make a copy of cnorm to check that it is _not_ modified.
+	cnormCopy := make([]float64, len(cnorm))
+	copy(cnormCopy, cnorm)
+	// Restore x.
+	copy(x, b)
+	// Solve the system op(A)*x = b again with normin = true.
+	scale = impl.Dlatbs(uplo, trans, diag, true, n, kd, ab, ldab, x, cnorm)
+
+	// Cannot test for exact equality because Dlatbs may scale cnorm by s and
+	// then by 1/s before return.
+	if !floats.EqualApprox(cnorm, cnormCopy, 1e-15) {
+		t.Errorf("%v: unexpected modification of cnorm", name)
+	}
+
+	resid = dlatbsResidual(uplo, trans, diag, n, kd, ab, ldab, scale, cnorm, b, x)
+	if resid >= eps {
+		t.Errorf("%v: unexpected result when normin=true. residual=%v", name, resid)
+	}
+}
+
+// dlatbsResidual returns the residual for the solution to a scaled triangular
+// system of equations  A*x = s*b  or  A^T*x = s*b  when A is an n×n triangular
+// band matrix with kd super- or sub-diagonals. The residual is computed as
+//  norm( op(A)*x - scale*b ) / ( norm(op(A)) * norm(x) ).
+//
+// This function corresponds to DTBT03 in Reference LAPACK.
+func dlatbsResidual(uplo blas.Uplo, trans blas.Transpose, diag blas.Diag, n, kd int, ab []float64, ldab int, scale float64, cnorm, b, x []float64) float64 {
+	if n == 0 {
+		return 0
+	}
+
+	// Compute the norm of the triangular matrix A using the columns norms
+	// already computed by Dlatbs.
+	var tnorm float64
+	if diag == blas.NonUnit {
+		if uplo == blas.Upper {
+			for j := 0; j < n; j++ {
+				tnorm = math.Max(tnorm, math.Abs(ab[j*ldab])+cnorm[j])
+			}
+		} else {
+			for j := 0; j < n; j++ {
+				tnorm = math.Max(tnorm, math.Abs(ab[j*ldab+kd])+cnorm[j])
+			}
+		}
+	} else {
+		for j := 0; j < n; j++ {
+			tnorm = math.Max(tnorm, 1+cnorm[j])
+		}
+	}
+
+	bi := blas64.Implementation()
+	eps := dlamchE
+	smlnum := dlamchS
+
+	ix := bi.Idamax(n, x, 1)
+	xNorm := math.Max(1, math.Abs(x[ix]))
+	xScal := (1 / xNorm) / float64(kd+1)
+
+	resid := make([]float64, len(x))
+	copy(resid, x)
+	bi.Dscal(n, xScal, resid, 1)
+	bi.Dtbmv(uplo, trans, diag, n, kd, ab, ldab, resid, 1)
+	bi.Daxpy(n, -scale*xScal, b, 1, resid, 1)
+
+	ix = bi.Idamax(n, resid, 1)
+	residNorm := math.Abs(resid[ix])
+	if residNorm*smlnum <= xNorm {
+		if xNorm > 0 {
+			residNorm /= xNorm
+		}
+	} else if residNorm > 0 {
+		residNorm = 1 / eps
+	}
+	if residNorm*smlnum <= tnorm {
+		if tnorm > 0 {
+			residNorm /= tnorm
+		}
+	} else if residNorm > 0 {
+		residNorm = 1 / eps
+	}
+
+	return residNorm
+}

--- a/lapack/testlapack/matgen.go
+++ b/lapack/testlapack/matgen.go
@@ -832,8 +832,8 @@ func dlattb(kind int, uplo blas.Uplo, trans blas.Transpose, n, kd int, ab []floa
 		// Matrix is the identity.
 		if uplo == blas.Upper {
 			for i := 0; i < n; i++ {
-				// Fill the diagonal with random numbers.
-				ab[i*ldab] = rnd.NormFloat64()
+				// Fill the diagonal with non-unit numbers.
+				ab[i*ldab] = float64(i + 2)
 				for j := 1; j < min(n-i, kd+1); j++ {
 					ab[i*ldab+j] = 0
 				}
@@ -843,8 +843,8 @@ func dlattb(kind int, uplo blas.Uplo, trans blas.Transpose, n, kd int, ab []floa
 				for j := max(0, kd-i); j < kd; j++ {
 					ab[i*ldab+j] = 0
 				}
-				// Fill the diagonal with random numbers.
-				ab[i*ldab+kd] = rnd.NormFloat64()
+				// Fill the diagonal with non-unit numbers.
+				ab[i*ldab+kd] = float64(i + 2)
 			}
 		}
 
@@ -860,8 +860,8 @@ func dlattb(kind int, uplo blas.Uplo, trans blas.Transpose, n, kd int, ab []floa
 		// Initialize AB to zero.
 		if uplo == blas.Upper {
 			for i := 0; i < n; i++ {
-				// Fill the diagonal with random numbers.
-				ab[i*ldab] = rnd.NormFloat64()
+				// Fill the diagonal with non-unit numbers.
+				ab[i*ldab] = float64(i + 2)
 				for j := 1; j < min(n-i, kd+1); j++ {
 					ab[i*ldab+j] = 0
 				}
@@ -871,8 +871,8 @@ func dlattb(kind int, uplo blas.Uplo, trans blas.Transpose, n, kd int, ab []floa
 				for j := max(0, kd-i); j < kd; j++ {
 					ab[i*ldab+j] = 0
 				}
-				// Fill the diagonal with random numbers.
-				ab[i*ldab+kd] = rnd.NormFloat64()
+				// Fill the diagonal with non-unit numbers.
+				ab[i*ldab+kd] = float64(i + 2)
 			}
 		}
 
@@ -1133,6 +1133,7 @@ func dlattb(kind int, uplo blas.Uplo, trans blas.Transpose, n, kd int, ab []floa
 		bi.Dscal(n, 2, b, 1)
 
 		// case 16:
+		// TODO(vladimir-ch)
 		// Make the off-diagonal elements large to cause overflow when adding a
 		// column of T. In the non-transposed case, the matrix is constructed to
 		// cause overflow when adding a column in every other step.

--- a/lapack/testlapack/matgen.go
+++ b/lapack/testlapack/matgen.go
@@ -738,3 +738,505 @@ func applyReflector(qh blas64.General, q blas64.General, v []float64) {
 		}
 	}
 }
+
+func dlattb(kind int, uplo blas.Uplo, trans blas.Transpose, n, kd int, ab []float64, ldab int, rnd *rand.Rand) (diag blas.Diag, b []float64) {
+	switch {
+	case kind < 1 || 18 < kind:
+		panic("bad matrix kind")
+	case (6 <= kind && kind <= 9) || kind == 17:
+		diag = blas.Unit
+	default:
+		diag = blas.NonUnit
+	}
+
+	if n == 0 {
+		return
+	}
+
+	const (
+		unfl   = dlamchS
+		ulp    = dlamchE * dlamchB
+		smlnum = unfl
+		bignum = (1 - ulp) / smlnum
+
+		eps   = dlamchP
+		small = 0.25 * (dlamchS / eps)
+		large = 1 / small
+		badc2 = 0.1 / eps
+	)
+	badc1 := math.Sqrt(badc2)
+
+	var cndnum float64
+	switch {
+	case kind == 2 || kind == 8:
+		cndnum = badc1
+	case kind == 3 || kind == 9:
+		cndnum = badc2
+	default:
+		cndnum = 2
+	}
+
+	uniformM11 := func() float64 {
+		return 2*rnd.Float64() - 1
+	}
+
+	// Allocate the right-hand side and fill it with random numbers.
+	// The pathological matrix types below overwrite it with their
+	// custom vector.
+	b = make([]float64, n)
+	for i := range b {
+		b[i] = uniformM11()
+	}
+
+	bi := blas64.Implementation()
+	switch kind {
+	default:
+		panic("test matrix type not implemented")
+
+	case 1, 2, 3, 4, 5:
+		// Non-unit triangular matrix
+		// TODO(vladimir-ch)
+		var kl, ku int
+		switch uplo {
+		case blas.Upper:
+			ku = kd
+			kl = 0
+			// IOFF = 1 + MAX( 0, KD-N+1 )
+			// PACKIT = 'Q'
+			// 'Q' => store the upper triangle in band storage scheme
+			//        (only if matrix symmetric or upper triangular)
+		case blas.Lower:
+			ku = 0
+			kl = kd
+			// IOFF = 1
+			// PACKIT = 'B'
+			// 'B' => store the lower triangle in band storage scheme
+			//        (only if matrix symmetric or lower triangular)
+		}
+		anorm := 1.0
+		switch kind {
+		case 4:
+			anorm = small
+		case 5:
+			anorm = large
+		}
+		_, _, _ = kl, ku, anorm
+		// // DIST = 'S' // UNIFORM(-1, 1)
+		// // MODE = 3   // MODE = 3 sets D(I)=CNDNUM**(-(I-1)/(N-1))
+		// // TYPE = 'N' // If TYPE='N', the generated matrix is nonsymmetric
+		// CALL DLATMS( N, N, DIST, ISEED, TYPE, B, MODE, CNDNUM, ANORM,
+		// $            KL, KU, PACKIT, AB( IOFF, 1 ), LDAB, WORK, INFO )
+		panic("test matrix type not implemented")
+
+	case 6:
+		// Matrix is the identity.
+		if uplo == blas.Upper {
+			for i := 0; i < n; i++ {
+				// Fill the diagonal with random numbers.
+				ab[i*ldab] = rnd.NormFloat64()
+				for j := 1; j < min(n-i, kd+1); j++ {
+					ab[i*ldab+j] = 0
+				}
+			}
+		} else {
+			for i := 0; i < n; i++ {
+				for j := max(0, kd-i); j < kd; j++ {
+					ab[i*ldab+j] = 0
+				}
+				// Fill the diagonal with random numbers.
+				ab[i*ldab+kd] = rnd.NormFloat64()
+			}
+		}
+
+	case 7, 8, 9:
+		// Non-trivial unit triangular matrix
+		//
+		// A unit triangular matrix T with condition cndnum is formed.
+		// In this version, T only has bandwidth 2, the rest of it is
+		// zero.
+
+		tnorm := math.Sqrt(cndnum)
+
+		// Initialize AB to zero.
+		if uplo == blas.Upper {
+			for i := 0; i < n; i++ {
+				// Fill the diagonal with random numbers.
+				ab[i*ldab] = rnd.NormFloat64()
+				for j := 1; j < min(n-i, kd+1); j++ {
+					ab[i*ldab+j] = 0
+				}
+			}
+		} else {
+			for i := 0; i < n; i++ {
+				for j := max(0, kd-i); j < kd; j++ {
+					ab[i*ldab+j] = 0
+				}
+				// Fill the diagonal with random numbers.
+				ab[i*ldab+kd] = rnd.NormFloat64()
+			}
+		}
+
+		switch kd {
+		case 0:
+			// Unit diagonal matrix, nothing else to do.
+		case 1:
+			// Special case: T is tridiagonal. Set every other
+			// off-diagonal so that the matrix has norm tnorm+1.
+			if n > 1 {
+				if uplo == blas.Upper {
+					ab[1] = math.Copysign(tnorm, uniformM11())
+					for i := 2; i < n-1; i += 2 {
+						ab[i*ldab+1] = tnorm * uniformM11()
+					}
+				} else {
+					ab[ldab] = math.Copysign(tnorm, uniformM11())
+					for i := 3; i < n; i += 2 {
+						ab[i*ldab] = tnorm * uniformM11()
+					}
+				}
+			}
+		default:
+			// Form a unit triangular matrix T with condition cndnum. T is given
+			// by
+			//      | 1   +   *                      |
+			//      |     1   +                      |
+			//  T = |         1   +   *              |
+			//      |             1   +              |
+			//      |                 1   +   *      |
+			//      |                     1   +      |
+			//      |                          . . . |
+			// Each element marked with a '*' is formed by taking the product of
+			// the adjacent elements marked with '+'. The '*'s can be chosen
+			// freely, and the '+'s are chosen so that the inverse of T will
+			// have elements of the same magnitude as T.
+			work1 := make([]float64, n)
+			work2 := make([]float64, n)
+			star1 := math.Copysign(tnorm, uniformM11())
+			sfac := math.Sqrt(tnorm)
+			plus1 := math.Copysign(sfac, uniformM11())
+			for i := 0; i < n; i += 2 {
+				work1[i] = plus1
+				work2[i] = star1
+				if i+1 == n {
+					continue
+				}
+				plus2 := star1 / plus1
+				work1[i+1] = plus2
+				plus1 = star1 / plus2
+				// Generate a new *-value with norm between sqrt(tnorm)
+				// and tnorm.
+				rexp := uniformM11()
+				if rexp < 0 {
+					star1 = -math.Pow(sfac, 1-rexp)
+				} else {
+					star1 = math.Pow(sfac, 1+rexp)
+				}
+			}
+			// Copy the diagonal to AB.
+			if uplo == blas.Upper {
+				bi.Dcopy(n-1, work1, 1, ab[1:], ldab)
+				if n > 2 {
+					bi.Dcopy(n-2, work2, 1, ab[2:], ldab)
+				}
+			} else {
+				bi.Dcopy(n-1, work1, 1, ab[ldab+kd-1:], ldab)
+				if n > 2 {
+					bi.Dcopy(n-2, work2, 1, ab[2*ldab+kd-2:], ldab)
+				}
+			}
+		}
+
+	// Pathological test cases 10-18: these triangular matrices are badly
+	// scaled or badly conditioned, so when used in solving a triangular
+	// system they may cause overflow in the solution vector.
+
+	case 10:
+		// Generate a triangular matrix with elements between -1 and 1.
+		// Give the diagonal norm 2 to make it well-conditioned.
+		// Make the right hand side large so that it requires scaling.
+		if uplo == blas.Upper {
+			for i := 0; i < n; i++ {
+				for j := 0; j < min(n-j, kd+1); j++ {
+					ab[i*ldab+j] = uniformM11()
+				}
+				ab[i*ldab] = math.Copysign(2, ab[i*ldab])
+			}
+		} else {
+			for i := 0; i < n; i++ {
+				for j := max(0, kd-i); j < kd+1; j++ {
+					ab[i*ldab+j] = uniformM11()
+				}
+				ab[i*ldab+kd] = math.Copysign(2, ab[i*ldab+kd])
+			}
+		}
+		// Set the right hand side so that the largest value is bignum.
+		bnorm := math.Abs(b[bi.Idamax(n, b, 1)])
+		bscal := bignum / math.Max(1, bnorm)
+		bi.Dscal(n, bscal, b, 1)
+
+	case 11:
+		// Make the first diagonal element in the solve small to cause
+		// immediate overflow when dividing by T[j,j].
+		// The offdiagonal elements are small (cnorm[j] < 1).
+		tscal := 1 / float64(kd+1)
+		if uplo == blas.Upper {
+			for i := 0; i < n; i++ {
+				jlen := min(n-i, kd+1)
+				arow := ab[i*ldab : i*ldab+jlen]
+				dlarnv(arow, 2, rnd)
+				if jlen > 1 {
+					bi.Dscal(jlen-1, tscal, arow[1:], 1)
+				}
+				ab[i*ldab] = math.Copysign(1, ab[i*ldab])
+			}
+			ab[(n-1)*ldab] *= smlnum
+		} else {
+			for i := 0; i < n; i++ {
+				jlen := min(i+1, kd+1)
+				arow := ab[i*ldab+kd+1-jlen : i*ldab+kd+1]
+				dlarnv(arow, 2, rnd)
+				if jlen > 1 {
+					bi.Dscal(jlen-1, tscal, arow[:jlen-1], 1)
+				}
+				ab[i*ldab+kd] = math.Copysign(1, ab[i*ldab+kd])
+			}
+			ab[kd] *= smlnum
+		}
+
+	case 12:
+		// Make the first diagonal element in the solve small to cause
+		// immediate overflow when dividing by T[j,j].
+		// The offdiagonal elements are O(1) (cnorm[j] > 1).
+		if uplo == blas.Upper {
+			for i := 0; i < n; i++ {
+				jlen := min(n-i, kd+1)
+				arow := ab[i*ldab : i*ldab+jlen]
+				dlarnv(arow, 2, rnd)
+				ab[i*ldab] = math.Copysign(1, ab[i*ldab])
+			}
+			ab[(n-1)*ldab] *= smlnum
+		} else {
+			for i := 0; i < n; i++ {
+				jlen := min(i+1, kd+1)
+				arow := ab[i*ldab+kd+1-jlen : i*ldab+kd+1]
+				dlarnv(arow, 2, rnd)
+				ab[i*ldab+kd] = math.Copysign(1, ab[i*ldab+kd])
+			}
+			ab[kd] *= smlnum
+		}
+
+	case 13:
+		// T is diagonal with small numbers on the diagonal to make the growth
+		// factor underflow, but a small right hand side chosen so that the
+		// solution does not overflow.
+		if uplo == blas.Upper {
+			icount := 1
+			for i := n - 1; i >= 0; i-- {
+				if icount <= 2 {
+					ab[i*ldab] = smlnum
+				} else {
+					ab[i*ldab] = 1
+				}
+				for j := 1; j < min(n-i, kd+1); j++ {
+					ab[i*ldab+j] = 0
+				}
+				icount++
+				if icount > 4 {
+					icount = 1
+				}
+			}
+		} else {
+			icount := 1
+			for i := 0; i < n; i++ {
+				for j := max(0, kd-i); j < kd; j++ {
+					ab[i*ldab+j] = 0
+				}
+				if icount <= 2 {
+					ab[i*ldab+kd] = smlnum
+				} else {
+					ab[i*ldab+kd] = 1
+				}
+				icount++
+				if icount > 4 {
+					icount = 1
+				}
+			}
+		}
+		// Set the right hand side alternately zero and small.
+		if uplo == blas.Upper {
+			b[0] = 0
+			for i := n - 1; i > 1; i -= 2 {
+				b[i] = 0
+				b[i-1] = smlnum
+			}
+		} else {
+			b[n-1] = 0
+			for i := 0; i < n-1; i += 2 {
+				b[i] = 0
+				b[i+1] = smlnum
+			}
+		}
+
+	case 14:
+		// Make the diagonal elements small to cause gradual overflow when
+		// dividing by T[j,j]. To control the amount of scaling needed, the
+		// matrix is bidiagonal.
+		tscal := math.Pow(smlnum, 1/float64(kd+1))
+		if uplo == blas.Upper {
+			for i := 0; i < n; i++ {
+				ab[i*ldab] = tscal
+				if i < n-1 && kd > 0 {
+					ab[i*ldab+1] = -1
+				}
+				for j := 2; j < min(n-i, kd+1); j++ {
+					ab[i*ldab+j] = 0
+				}
+			}
+			b[n-1] = 1
+		} else {
+			for i := 0; i < n; i++ {
+				for j := max(0, kd-i); j < kd-1; j++ {
+					ab[i*ldab+j] = 0
+				}
+				if i > 0 && kd > 0 {
+					ab[i*ldab+kd-1] = -1
+				}
+				ab[i*ldab+kd] = tscal
+			}
+			b[0] = 1
+		}
+
+	case 15:
+		// One zero diagonal element.
+		iy := n / 2
+		if uplo == blas.Upper {
+			for i := 0; i < n; i++ {
+				jlen := min(n-i, kd+1)
+				dlarnv(ab[i*ldab:i*ldab+jlen], 2, rnd)
+				if i != iy {
+					ab[i*ldab] = math.Copysign(2, ab[i*ldab])
+				} else {
+					ab[i*ldab] = 0
+				}
+			}
+		} else {
+			for i := 0; i < n; i++ {
+				jlen := min(i+1, kd+1)
+				dlarnv(ab[i*ldab+kd+1-jlen:i*ldab+kd+1], 2, rnd)
+				if i != iy {
+					ab[i*ldab+kd] = math.Copysign(2, ab[i*ldab+kd])
+				} else {
+					ab[i*ldab+kd] = 0
+				}
+			}
+		}
+		bi.Dscal(n, 2, b, 1)
+
+		// case 16:
+		// Make the off-diagonal elements large to cause overflow when adding a
+		// column of T. In the non-transposed case, the matrix is constructed to
+		// cause overflow when adding a column in every other step.
+
+		// Initialize the matrix to zero.
+		// if uplo == blas.Upper {
+		// 	for i := 0; i < n; i++ {
+		// 		for j := 0; j < min(n-i, kd+1); j++ {
+		// 			ab[i*ldab+j] = 0
+		// 		}
+		// 	}
+		// } else {
+		// 	for i := 0; i < n; i++ {
+		// 		for j := max(0, kd-i); j < kd+1; j++ {
+		// 			ab[i*ldab+j] = 0
+		// 		}
+		// 	}
+		// }
+
+		// const tscal = (1 - ulp) / (unfl / ulp)
+		// texp := 1.0
+		// if kd > 0 {
+		// 	if uplo == blas.Upper {
+		// 		for j := n - 1; j >= 0; j -= kd {
+		// 		}
+		// 	} else {
+		// 		for j := 0; j < n; j += kd {
+		// 		}
+		// 	}
+		// } else {
+		// 	// Diagonal matrix.
+		// 	for i := 0; i < n; i++ {
+		// 		ab[i*ldab] = 1
+		// 		b[i] = float64(i + 1)
+		// 	}
+		// }
+
+	case 17:
+		// Generate a unit triangular matrix with elements between -1 and 1, and
+		// make the right hand side large so that it requires scaling.
+		if uplo == blas.Upper {
+			for i := 0; i < n; i++ {
+				ab[i*ldab] = float64(i + 2)
+				jlen := min(n-i-1, kd)
+				if jlen > 0 {
+					dlarnv(ab[i*ldab+1:i*ldab+1+jlen], 2, rnd)
+				}
+			}
+		} else {
+			for i := 0; i < n; i++ {
+				jlen := min(i, kd)
+				if jlen > 0 {
+					dlarnv(ab[i*ldab+kd-jlen:i*ldab+kd], 2, rnd)
+				}
+				ab[i*ldab+kd] = float64(i + 2)
+			}
+		}
+		// Set the right hand side so that the largest value is bignum.
+		bnorm := math.Abs(b[bi.Idamax(n, b, 1)])
+		bscal := bignum / math.Max(1, bnorm)
+		bi.Dscal(n, bscal, b, 1)
+
+	case 18:
+		// Generate a triangular matrix with elements between bignum/kd and
+		// bignum so that at least one of the column norms will exceed bignum.
+		tleft := bignum / math.Max(1, float64(kd))
+		// The reference LAPACK has
+		//  tscal := bignum * (float64(kd) / float64(kd+1))
+		// but this causes overflow when computing cnorm in Dlatbs. Our choice
+		// is more conservative but increases coverage in the same way as the
+		// LAPACK version.
+		tscal := bignum / math.Max(1, float64(kd))
+		if uplo == blas.Upper {
+			for i := 0; i < n; i++ {
+				for j := 0; j < min(n-i, kd+1); j++ {
+					r := uniformM11()
+					ab[i*ldab+j] = math.Copysign(tleft, r) + tscal*r
+				}
+			}
+		} else {
+			for i := 0; i < n; i++ {
+				for j := max(0, kd-i); j < kd+1; j++ {
+					r := uniformM11()
+					ab[i*ldab+j] = math.Copysign(tleft, r) + tscal*r
+				}
+			}
+		}
+		bi.Dscal(n, 2, b, 1)
+	}
+
+	// Flip the matrix if the transpose will be used.
+	if trans != blas.NoTrans {
+		if uplo == blas.Upper {
+			for j := 0; j < n/2; j++ {
+				jlen := min(n-2*j-1, kd+1)
+				bi.Dswap(jlen, ab[j*ldab:], 1, ab[(n-j-jlen)*ldab+jlen-1:], min(-ldab+1, -1))
+			}
+		} else {
+			for j := 0; j < n/2; j++ {
+				jlen := min(n-2*j-1, kd+1)
+				bi.Dswap(jlen, ab[j*ldab+kd:], max(ldab-1, 1), ab[(n-j-1)*ldab+kd+1-jlen:], -1)
+			}
+		}
+	}
+
+	return diag, b
+}


### PR DESCRIPTION
This is one of the uglier lapack routines, especially in combination with the band storage.
The coverage is almost complete, so hopefully this translation is also correct.

There are some differences from the Fortran version that I'll be happy to explain. Almost all are done to make the code clearer. I left one `goto` to not increase the indentation further.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
