### PR TITLE
lapack/gonum: fix matrix slice length checks in banded functions

### DIFF
--- a/lapack/gonum/dlatbs.go
+++ b/lapack/gonum/dlatbs.go
@@ -54,7 +54,7 @@ func (Implementation) Dlatbs(uplo blas.Uplo, trans blas.Transpose, diag blas.Dia
 	}
 
 	switch {
-	case len(ab) < (n-1)*ldab+kd:
+	case len(ab) < (n-1)*ldab+kd+1:
 		panic(shortAB)
 	case len(x) < n:
 		panic(shortX)

--- a/lapack/gonum/dpbtf2.go
+++ b/lapack/gonum/dpbtf2.go
@@ -64,7 +64,7 @@ func (Implementation) Dpbtf2(uplo blas.Uplo, n, kd int, ab []float64, ldab int) 
 		return true
 	}
 
-	if len(ab) < (n-1)*ldab+kd {
+	if len(ab) < (n-1)*ldab+kd+1 {
 		panic(shortAB)
 	}
 

--- a/lapack/gonum/dpbtrf.go
+++ b/lapack/gonum/dpbtrf.go
@@ -55,7 +55,7 @@ func (impl Implementation) Dpbtrf(uplo blas.Uplo, n, kd int, ab []float64, ldab 
 		return true
 	}
 
-	if len(ab) < (n-1)*ldab+kd {
+	if len(ab) < (n-1)*ldab+kd+1 {
 		panic(shortAB)
 	}
 

--- a/lapack/gonum/dpbtrs.go
+++ b/lapack/gonum/dpbtrs.go
@@ -39,7 +39,7 @@ func (Implementation) Dpbtrs(uplo blas.Uplo, n, kd, nrhs int, ab []float64, ldab
 		return
 	}
 
-	if len(ab) < (n-1)*ldab+kd {
+	if len(ab) < (n-1)*ldab+kd+1 {
 		panic(shortAB)
 	}
 	if len(b) < (n-1)*ldb+nrhs {

--- a/lapack/testlapack/dlatbs.go
+++ b/lapack/testlapack/dlatbs.go
@@ -42,7 +42,10 @@ func dlatbsTest(t *testing.T, impl Dlatbser, rnd *rand.Rand, kind int, uplo blas
 	const eps = 1e-15
 
 	// Allocate a triangular band matrix.
-	ab := make([]float64, n*ldab)
+	var ab []float64
+	if n > 0 {
+		ab = make([]float64, (n-1)*ldab+kd+1)
+	}
 	for i := range ab {
 		ab[i] = rnd.NormFloat64()
 	}

--- a/lapack/testlapack/general.go
+++ b/lapack/testlapack/general.go
@@ -1034,7 +1034,10 @@ func equalApproxSymmetric(a, b blas64.Symmetric, tol float64) bool {
 // with kd diagonals.
 func randSymBand(uplo blas.Uplo, n, kd, ldab int, rnd *rand.Rand) []float64 {
 	// Allocate a triangular band matrix U or L and fill it with random numbers.
-	ab := make([]float64, n*ldab)
+	var ab []float64
+	if n > 0 {
+		ab = make([]float64, (n-1)*ldab+kd+1)
+	}
 	for i := range ab {
 		ab[i] = rnd.NormFloat64()
 	}


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
