### PR TITLE
travis: make sure checks exit non-zero if they fail

### DIFF
--- a/.travis/run-parts
+++ b/.travis/run-parts
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ $# -ne 1 ]; then
     echo "run-parts <directory>"
     exit 1


### PR DESCRIPTION
At the moment, it's printing file names for missing headers, but not failing.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
