### PR TITLE
graph/path: Adjusted bellman ford algorithm to use queue.

### DIFF
--- a/graph/path/bellman_ford_moore.go
+++ b/graph/path/bellman_ford_moore.go
@@ -35,14 +35,11 @@ func BellmanFordFrom(u graph.Node, g graph.Graph) (path Shortest, ok bool) {
 	queue := newBellmanFordQueue(path.indexOf)
 	queue.enqueue(u)
 
-	n := len(nodes)
-	// The maximum of edges in a graph is |V| * (|V| -1) which is also the worst case complexity.
+	// The maximum of edges in a graph is |V| * (|V|-1) which is also the worst case complexity.
 	// If the queue-loop has more iterations than the amount of maximum edges
 	// it indicates that we have a negative cycle.
-	maxEdges := n * (n - 1)
-	negativeCycle := false
-
-	loops := 0
+	maxEdges := len(nodes) * (len(nodes) - 1)
+	var loops int
 
 	// TODO(kortschak): Consider adding further optimisations
 	// from http://arxiv.org/abs/1111.5414.
@@ -70,23 +67,17 @@ func BellmanFordFrom(u graph.Node, g graph.Graph) (path Shortest, ok bool) {
 		}
 
 		if loops > maxEdges {
-			negativeCycle = true
-			break
+			path.hasNegativeCycle = true
+			return path, false
 		}
 		loops++
-	}
-
-	if negativeCycle {
-		path.hasNegativeCycle = true
-		return path, false
 	}
 
 	return path, true
 }
 
-// bellmanFordQueue is a queue for the Queue-based Bellman ford algorithm.
+// bellmanFordQueue is a queue for the Queue-based Bellman-Ford algorithm.
 type bellmanFordQueue struct {
-
 	// queue holds the nodes which need to be relaxed.
 	queue linear.NodeQueue
 
@@ -114,10 +105,10 @@ func (q *bellmanFordQueue) dequeue() graph.Node {
 	return n
 }
 
-// len returns the amount of nodes in the bellmanFordQueue.
+// len returns the number of nodes in the bellmanFordQueue.
 func (q *bellmanFordQueue) len() int { return q.queue.Len() }
 
-// has returns true if a node with the given id is already on the queue.
+// has returns whether a node with the given id is in the queue.
 func (q bellmanFordQueue) has(id int64) bool { return q.onQueue[q.indexOf[id]] }
 
 // newBellmanFordQueue creates a new bellmanFordQueue.

--- a/graph/path/bellman_ford_moore.go
+++ b/graph/path/bellman_ford_moore.go
@@ -4,7 +4,10 @@
 
 package path
 
-import "gonum.org/v1/gonum/graph"
+import (
+	"errors"
+	"gonum.org/v1/gonum/graph"
+)
 
 // BellmanFordFrom returns a shortest-path tree for a shortest path from u to all nodes in
 // the graph g, or false indicating that a negative cycle exists in the graph. If the graph
@@ -27,10 +30,63 @@ func BellmanFordFrom(u graph.Node, g graph.Graph) (path Shortest, ok bool) {
 	path = newShortestFrom(u, nodes)
 	path.dist[path.indexOf[u.ID()]] = 0
 
-	// TODO(kortschak): Consider adding further optimisations
-	// from http://arxiv.org/abs/1111.5414.
-	for i := 1; i < len(nodes); i++ {
-		changed := false
+	// queue to keep track which nodes need to be relaxed
+	// only nodes whose vertex distance changed in the previous iterations need to be relaxed again
+	queue := newBellmanFordQueue()
+	queue.enqueue(u)
+
+	// bool array to keep track whether a node is on the queue or not
+	onQueue := make([]bool, len(nodes))
+	onQueue[path.indexOf[u.ID()]] = true
+
+	n := len(nodes)
+	// the maximum of edges in a graph is |V| * (|V| -1)
+	// which is also the worst case complexity
+	// íf the queue-loop has more iterations than the amount of maximum edges
+	// it indicates that we have a negative cycle
+	maxEdges := n * (n - 1)
+	negativeCycle := false
+
+	loops := 0
+	for queue.len() != 0 {
+		u, err := queue.dequeue()
+		if err != nil {
+			panic(err)
+		}
+		uid := u.ID()
+		onQueue[path.indexOf[uid]] = false
+
+		for _, v := range graph.NodesOf(g.From(uid)) {
+			vid := v.ID()
+			k := path.indexOf[vid]
+			w, ok := weight(uid, vid)
+			if !ok {
+				panic("bellman-ford: unexpected invalid weight")
+			}
+
+			j := path.indexOf[uid]
+			joint := path.dist[j] + w
+			if joint < path.dist[k] {
+				path.set(k, joint, j)
+				index := path.indexOf[vid]
+
+				// check if node is already in the queue
+				// we do not want any duplicates in the queue
+				if !onQueue[index] {
+					onQueue[index] = true
+					queue.enqueue(v)
+				}
+			}
+		}
+
+		loops++
+		if loops > maxEdges {
+			negativeCycle = true
+			break
+		}
+	}
+
+	if negativeCycle {
 		for j, u := range nodes {
 			uid := u.ID()
 			for _, v := range graph.NodesOf(g.From(uid)) {
@@ -40,33 +96,46 @@ func BellmanFordFrom(u graph.Node, g graph.Graph) (path Shortest, ok bool) {
 				if !ok {
 					panic("bellman-ford: unexpected invalid weight")
 				}
-				joint := path.dist[j] + w
-				if joint < path.dist[k] {
-					path.set(k, joint, j)
-					changed = true
+				if path.dist[j]+w < path.dist[k] {
+					path.hasNegativeCycle = true
+					return path, false
 				}
-			}
-		}
-		if !changed {
-			break
-		}
-	}
-
-	for j, u := range nodes {
-		uid := u.ID()
-		for _, v := range graph.NodesOf(g.From(uid)) {
-			vid := v.ID()
-			k := path.indexOf[vid]
-			w, ok := weight(uid, vid)
-			if !ok {
-				panic("bellman-ford: unexpected invalid weight")
-			}
-			if path.dist[j]+w < path.dist[k] {
-				path.hasNegativeCycle = true
-				return path, false
 			}
 		}
 	}
 
 	return path, true
+}
+
+// bellmanFordQueue is a queue for the Queue-based Bellman ford algorithm
+type bellmanFordQueue struct {
+	nodes []graph.Node
+}
+
+// enqueue adds a node to the bellmanFordQueue
+func (b *bellmanFordQueue) enqueue(n graph.Node) {
+	b.nodes = append(b.nodes, n)
+}
+
+// dequeue returns the first value of the bellmanFordQueue
+func (b *bellmanFordQueue) dequeue() (graph.Node, error) {
+	if len(b.nodes) == 0 {
+		return nil, errors.New("queue is empty!")
+	}
+
+	u := b.nodes[0]
+	b.nodes = b.nodes[1:]
+	return u, nil
+}
+
+// len returns the amount of nodes in the bellmanFordQueue
+func (b *bellmanFordQueue) len() int {
+	return len(b.nodes)
+}
+
+// newBellmanFordQueue creates a new bellmanFordQueue
+func newBellmanFordQueue() bellmanFordQueue {
+	return bellmanFordQueue{
+		nodes: make([]graph.Node, 0),
+	}
 }

--- a/graph/path/bellman_ford_moore.go
+++ b/graph/path/bellman_ford_moore.go
@@ -84,20 +84,20 @@ func BellmanFordFrom(u graph.Node, g graph.Graph) (path Shortest, ok bool) {
 	return path, true
 }
 
-// bellmanFordQueue is a queue for the Queue-based Bellman ford algorithm
+// bellmanFordQueue is a queue for the Queue-based Bellman ford algorithm.
 type bellmanFordQueue struct {
 
-	// queue holds the nodes which need to be relaxed
+	// queue holds the nodes which need to be relaxed.
 	queue linear.NodeQueue
 
-	// onQueue keeps track whether a node is on the queue or not
+	// onQueue keeps track whether a node is on the queue or not.
 	onQueue []bool
 
-	// indexOf contains a mapping holding the id of a node with its index in the onQueue array
+	// indexOf contains a mapping holding the id of a node with its index in the onQueue array.
 	indexOf map[int64]int
 }
 
-// enqueue adds a node to the bellmanFordQueue
+// enqueue adds a node to the bellmanFordQueue.
 func (q *bellmanFordQueue) enqueue(n graph.Node) {
 	i := q.indexOf[n.ID()]
 	if q.onQueue[i] {
@@ -107,20 +107,20 @@ func (q *bellmanFordQueue) enqueue(n graph.Node) {
 	q.queue.Enqueue(n)
 }
 
-// dequeue returns the first value of the bellmanFordQueue
+// dequeue returns the first value of the bellmanFordQueue.
 func (q *bellmanFordQueue) dequeue() graph.Node {
 	n := q.queue.Dequeue()
 	q.onQueue[q.indexOf[n.ID()]] = false
 	return n
 }
 
-// len returns the amount of nodes in the bellmanFordQueue
+// len returns the amount of nodes in the bellmanFordQueue.
 func (q *bellmanFordQueue) len() int { return q.queue.Len() }
 
-// has returns true if a node with the given id is already on the queue
+// has returns true if a node with the given id is already on the queue.
 func (q bellmanFordQueue) has(id int64) bool { return q.onQueue[q.indexOf[id]] }
 
-// newBellmanFordQueue creates a new bellmanFordQueue
+// newBellmanFordQueue creates a new bellmanFordQueue.
 func newBellmanFordQueue(indexOf map[int64]int) bellmanFordQueue {
 	return bellmanFordQueue{
 		onQueue: make([]bool, len(indexOf)),

--- a/graph/path/bench_test.go
+++ b/graph/path/bench_test.go
@@ -139,3 +139,35 @@ func BenchmarkAStarUndirectedmallWorld_100_5_20_2_Heur(b *testing.B) {
 	}
 	benchmarkAStarHeuristic(b, nswUndirected_100_5_20_2, h)
 }
+
+var (
+	gnpDirected_500_tenth   = gnpDirected(500, 0.1)
+	gnpDirected_1000_tenth  = gnpDirected(1000, 0.1)
+	gnpDirected_2000_tenth 	= gnpDirected(2000, 0.1)
+	gnpDirected_500_half    = gnpDirected(500, 0.5)
+	gnpDirected_1000_half   = gnpDirected(1000, 0.5)
+	gnpDirected_2000_half  	= gnpDirected(2000, 0.5)
+	gnpDirected_500_full    = gnpDirected(500, 1)
+	gnpDirected_1000_full   = gnpDirected(1000, 1)
+	gnpDirected_2000_full  	= gnpDirected(2000, 1)
+)
+
+func gnpDirected(n int, p float64) graph.Directed {
+	g := simple.NewDirectedGraph()
+	gen.Gnp(g, n, p, nil)
+	return g
+}
+
+func benchmarkBellmanFord(b *testing.B, n int, p float64, g graph.Directed) {
+	BellmanFordFrom(g.Node(0), g)
+}
+
+func BenchmarkBellmanFordFrom_500_tenth(b *testing.B) { benchmarkBellmanFord(b, 500, 0.5, gnpDirected_500_tenth) }
+func BenchmarkBellmanFordFrom_1000_tenth(b *testing.B) {benchmarkBellmanFord(b, 1000, 0.5, gnpDirected_1000_tenth) }
+func BenchmarkBellmanFordFrom_2000_tenth(b *testing.B) { benchmarkBellmanFord(b, 2000, 0.5, gnpDirected_2000_tenth) }
+func BenchmarkBellmanFordFrom_500_half(b *testing.B) { benchmarkBellmanFord(b, 500, 0.5, gnpDirected_500_half) }
+func BenchmarkBellmanFordFrom_1000_half(b *testing.B) {benchmarkBellmanFord(b, 1000, 0.5, gnpDirected_1000_half) }
+func BenchmarkBellmanFordFrom_2000_half(b *testing.B) { benchmarkBellmanFord(b, 2000, 0.5, gnpDirected_2000_half) }
+func BenchmarkBellmanFordFrom_500_full(b *testing.B) { benchmarkBellmanFord(b, 500, 1, gnpDirected_500_full) }
+func BenchmarkBellmanFordFrom_1000_full(b *testing.B) {benchmarkBellmanFord(b, 1000, 1, gnpDirected_1000_full) }
+func BenchmarkBellmanFordFrom_2000_full(b *testing.B) { benchmarkBellmanFord(b, 2000, 1, gnpDirected_2000_full) }

--- a/graph/path/bench_test.go
+++ b/graph/path/bench_test.go
@@ -141,15 +141,15 @@ func BenchmarkAStarUndirectedmallWorld_100_5_20_2_Heur(b *testing.B) {
 }
 
 var (
-	gnpDirected_500_tenth   = gnpDirected(500, 0.1)
-	gnpDirected_1000_tenth  = gnpDirected(1000, 0.1)
-	gnpDirected_2000_tenth 	= gnpDirected(2000, 0.1)
-	gnpDirected_500_half    = gnpDirected(500, 0.5)
-	gnpDirected_1000_half   = gnpDirected(1000, 0.5)
-	gnpDirected_2000_half  	= gnpDirected(2000, 0.5)
-	gnpDirected_500_full    = gnpDirected(500, 1)
-	gnpDirected_1000_full   = gnpDirected(1000, 1)
-	gnpDirected_2000_full  	= gnpDirected(2000, 1)
+	gnpDirected_500_tenth  = gnpDirected(500, 0.1)
+	gnpDirected_1000_tenth = gnpDirected(1000, 0.1)
+	gnpDirected_2000_tenth = gnpDirected(2000, 0.1)
+	gnpDirected_500_half   = gnpDirected(500, 0.5)
+	gnpDirected_1000_half  = gnpDirected(1000, 0.5)
+	gnpDirected_2000_half  = gnpDirected(2000, 0.5)
+	gnpDirected_500_full   = gnpDirected(500, 1)
+	gnpDirected_1000_full  = gnpDirected(1000, 1)
+	gnpDirected_2000_full  = gnpDirected(2000, 1)
 )
 
 func gnpDirected(n int, p float64) graph.Directed {
@@ -158,16 +158,27 @@ func gnpDirected(n int, p float64) graph.Directed {
 	return g
 }
 
-func benchmarkBellmanFord(b *testing.B, n int, p float64, g graph.Directed) {
-	BellmanFordFrom(g.Node(0), g)
-}
+func BenchmarkBellmanFordFrom(b *testing.B) {
+	benchmarks := []struct {
+		name  string
+		graph graph.Directed
+	}{
+		{"500 tenth", gnpDirected_500_tenth},
+		{"1000 tenth", gnpDirected_1000_tenth},
+		{"2000 tenth", gnpDirected_2000_tenth},
+		{"500 half", gnpDirected_500_half},
+		{"1000 half", gnpDirected_1000_half},
+		{"2000 half", gnpDirected_2000_half},
+		{"500 full", gnpDirected_500_full},
+		{"1000 full", gnpDirected_1000_full},
+		{"2000 full", gnpDirected_2000_full},
+	}
 
-func BenchmarkBellmanFordFrom_500_tenth(b *testing.B) { benchmarkBellmanFord(b, 500, 0.5, gnpDirected_500_tenth) }
-func BenchmarkBellmanFordFrom_1000_tenth(b *testing.B) {benchmarkBellmanFord(b, 1000, 0.5, gnpDirected_1000_tenth) }
-func BenchmarkBellmanFordFrom_2000_tenth(b *testing.B) { benchmarkBellmanFord(b, 2000, 0.5, gnpDirected_2000_tenth) }
-func BenchmarkBellmanFordFrom_500_half(b *testing.B) { benchmarkBellmanFord(b, 500, 0.5, gnpDirected_500_half) }
-func BenchmarkBellmanFordFrom_1000_half(b *testing.B) {benchmarkBellmanFord(b, 1000, 0.5, gnpDirected_1000_half) }
-func BenchmarkBellmanFordFrom_2000_half(b *testing.B) { benchmarkBellmanFord(b, 2000, 0.5, gnpDirected_2000_half) }
-func BenchmarkBellmanFordFrom_500_full(b *testing.B) { benchmarkBellmanFord(b, 500, 1, gnpDirected_500_full) }
-func BenchmarkBellmanFordFrom_1000_full(b *testing.B) {benchmarkBellmanFord(b, 1000, 1, gnpDirected_1000_full) }
-func BenchmarkBellmanFordFrom_2000_full(b *testing.B) { benchmarkBellmanFord(b, 2000, 1, gnpDirected_2000_full) }
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				BellmanFordFrom(bm.graph.Node(0), bm.graph)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hey there,

I started working on the _todo_ left in the [bellman_ford_moore-file](https://github.com/gonum/gonum/blob/master/graph/path/bellman_ford_moore.go): "Consider adding further optimisations"

This semester I finished an algorithm course at my university. We learned based on [Sedgewick & Wayne](https://books.google.de/books?id=MTpsAQAAQBAJ&pg=PA672&lpg=PA672&dq=Sedgewick+%26+Wayne+queue+bellman+ford&source=bl&ots=QfpHzOG8nZ&sig=ACfU3U32xLZKnJsvoSeKNpQzY_6oTm-GJg&hl=en&sa=X&ved=2ahUKEwjYodKmha3kAhVCKVAKHflyCqwQ6AEwC3oECAkQAQ#v=onepage&q=Sedgewick%20%26%20Wayne%20queue%20bellman%20ford&f=false) suggestion a queue approach is to be preferred since we only have to relax those nodes whose vertex distance changed in the previous iteration.

While the worst case complexity is still **O(|V| . |E|)** it is typically **O(|V| + |E|)**.

I have implemented such queue and I would appreciate any feedback! :)

Best regards,
Dario