### PR TITLE
mat: use "mat" prefix for all errors and panics

### DIFF
--- a/mat/dense_arithmetic.go
+++ b/mat/dense_arithmetic.go
@@ -626,7 +626,7 @@ func (m *Dense) Exp(a Matrix) {
 // in the receiver. Pow will panic if n is negative or if a is not square.
 func (m *Dense) Pow(a Matrix, n int) {
 	if n < 0 {
-		panic("matrix: illegal power")
+		panic("mat: illegal power")
 	}
 	r, c := a.Dims()
 	if r != c {

--- a/mat/errors.go
+++ b/mat/errors.go
@@ -114,28 +114,28 @@ type Error struct{ string }
 func (err Error) Error() string { return err.string }
 
 var (
-	ErrNegativeDimension   = Error{"matrix: negative dimension"}
-	ErrIndexOutOfRange     = Error{"matrix: index out of range"}
+	ErrNegativeDimension   = Error{"mat: negative dimension"}
+	ErrIndexOutOfRange     = Error{"mat: index out of range"}
 	ErrReuseNonZero        = Error{"mat: reuse of non-zero matrix"}
-	ErrRowAccess           = Error{"matrix: row index out of range"}
-	ErrColAccess           = Error{"matrix: column index out of range"}
-	ErrVectorAccess        = Error{"matrix: vector index out of range"}
-	ErrZeroLength          = Error{"matrix: zero length in matrix dimension"}
-	ErrRowLength           = Error{"matrix: row length mismatch"}
-	ErrColLength           = Error{"matrix: col length mismatch"}
-	ErrSquare              = Error{"matrix: expect square matrix"}
-	ErrNormOrder           = Error{"matrix: invalid norm order for matrix"}
-	ErrSingular            = Error{"matrix: matrix is singular"}
-	ErrShape               = Error{"matrix: dimension mismatch"}
-	ErrIllegalStride       = Error{"matrix: illegal stride"}
-	ErrPivot               = Error{"matrix: malformed pivot list"}
-	ErrTriangle            = Error{"matrix: triangular storage mismatch"}
-	ErrTriangleSet         = Error{"matrix: triangular set out of bounds"}
-	ErrBandSet             = Error{"matrix: band set out of bounds"}
-	ErrDiagSet             = Error{"matrix: diagonal set out of bounds"}
-	ErrSliceLengthMismatch = Error{"matrix: input slice length mismatch"}
-	ErrNotPSD              = Error{"matrix: input not positive symmetric definite"}
-	ErrFailedEigen         = Error{"matrix: eigendecomposition not successful"}
+	ErrRowAccess           = Error{"mat: row index out of range"}
+	ErrColAccess           = Error{"mat: column index out of range"}
+	ErrVectorAccess        = Error{"mat: vector index out of range"}
+	ErrZeroLength          = Error{"mat: zero length in matrix dimension"}
+	ErrRowLength           = Error{"mat: row length mismatch"}
+	ErrColLength           = Error{"mat: col length mismatch"}
+	ErrSquare              = Error{"mat: expect square matrix"}
+	ErrNormOrder           = Error{"mat: invalid norm order for matrix"}
+	ErrSingular            = Error{"mat: matrix is singular"}
+	ErrShape               = Error{"mat: dimension mismatch"}
+	ErrIllegalStride       = Error{"mat: illegal stride"}
+	ErrPivot               = Error{"mat: malformed pivot list"}
+	ErrTriangle            = Error{"mat: triangular storage mismatch"}
+	ErrTriangleSet         = Error{"mat: triangular set out of bounds"}
+	ErrBandSet             = Error{"mat: band set out of bounds"}
+	ErrDiagSet             = Error{"mat: diagonal set out of bounds"}
+	ErrSliceLengthMismatch = Error{"mat: input slice length mismatch"}
+	ErrNotPSD              = Error{"mat: input not positive symmetric definite"}
+	ErrFailedEigen         = Error{"mat: eigendecomposition not successful"}
 )
 
 // ErrorStack represents matrix handling errors that have been recovered by Maybe wrappers.


### PR DESCRIPTION
Please take a look.

Fixes #1084.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
