### PR TITLE
mat,all: Rename IsZero to IsEmpty

### DIFF
--- a/diff/fd/hessian.go
+++ b/diff/fd/hessian.go
@@ -18,12 +18,12 @@ import (
 // options are specified by settings. If settings is nil, the Hessian will be
 // estimated using the Forward formula and a default step size.
 //
-// If the dst matrix is zero-sized it will be resized to the correct dimensions,
+// If the dst matrix is empty it will be resized to the correct dimensions,
 // otherwise the dimensions of dst must match the length of x or Hessian will panic.
 // Hessian will panic if the derivative order of the formula is not 1.
 func Hessian(dst *mat.SymDense, f func(x []float64) float64, x []float64, settings *Settings) {
 	n := len(x)
-	if dst.IsZero() {
+	if dst.IsEmpty() {
 		*dst = *(dst.GrowSym(n).(*mat.SymDense))
 	} else if dst.Symmetric() != n {
 		panic("hessian: dst size mismatch")

--- a/mat/band.go
+++ b/mat/band.go
@@ -197,13 +197,13 @@ func (b *BandDense) SetRawBand(mat blas64.Band) {
 	b.mat = mat
 }
 
-// IsZero returns whether the receiver is zero-sized. Zero-sized matrices can be the
-// receiver for size-restricted operations. Dense matrices can be zeroed using Reset.
-func (b *BandDense) IsZero() bool {
+// IsEmpty returns whether the receiver is empty. Empty matrices can be the
+// receiver for size-restricted operations. The receiver can be zeroed using Reset.
+func (b *BandDense) IsEmpty() bool {
 	return b.mat.Stride == 0
 }
 
-// Reset zeros the dimensions of the matrix so that it can be reused as the
+// Reset empties the matrix so that it can be reused as the
 // receiver of a dimensionally restricted operation.
 //
 // Reset should not be used when the matrix shares backing data.

--- a/mat/cdense.go
+++ b/mat/cdense.go
@@ -77,7 +77,7 @@ func (m *CDense) reuseAsNonZeroed(r, c int) {
 	if r == 0 || c == 0 {
 		panic(ErrZeroLength)
 	}
-	if m.IsZero() {
+	if m.IsEmpty() {
 		m.mat = cblas128.General{
 			Rows:   r,
 			Cols:   c,
@@ -102,7 +102,7 @@ func (m *CDense) reuseAsZeroed(r, c int) {
 	if r == 0 || c == 0 {
 		panic(ErrZeroLength)
 	}
-	if m.IsZero() {
+	if m.IsEmpty() {
 		m.mat = cblas128.General{
 			Rows:   r,
 			Cols:   c,
@@ -131,9 +131,9 @@ func (m *CDense) Reset() {
 	m.mat.Data = m.mat.Data[:0]
 }
 
-// IsZero returns whether the receiver is zero-sized. Zero-sized matrices can be the
-// receiver for size-restricted operations. CDense matrices can be zeroed using Reset.
-func (m *CDense) IsZero() bool {
+// IsEmpty returns whether the receiver is empty. Empty matrices can be the
+// receiver for size-restricted operations. The receiver can be zeroed using Reset.
+func (m *CDense) IsEmpty() bool {
 	// It must be the case that m.Dims() returns
 	// zeros in this case. See comment in Reset().
 	return m.mat.Stride == 0

--- a/mat/cholesky.go
+++ b/mat/cholesky.go
@@ -410,7 +410,7 @@ func (c *Cholesky) InverseTo(s *SymDense) error {
 //  Uᵀ * U = A
 // the updated factorization is
 //  U'ᵀ * U' = f A = A'
-// Scale panics if the constant is non-positive, or if the receiver is non-zero
+// Scale panics if the constant is non-positive, or if the receiver is non-empty
 // and is of a different size from the input.
 func (c *Cholesky) Scale(f float64, orig *Cholesky) {
 	if !orig.valid() {
@@ -669,5 +669,5 @@ func (c *Cholesky) SymRankOne(orig *Cholesky, alpha float64, x Vector) (ok bool)
 }
 
 func (c *Cholesky) valid() bool {
-	return c.chol != nil && !c.chol.IsZero()
+	return c.chol != nil && !c.chol.IsEmpty()
 }

--- a/mat/cholesky_test.go
+++ b/mat/cholesky_test.go
@@ -289,10 +289,10 @@ func TestCloneCholesky(t *testing.T) {
 		chol2.Clone(&chol)
 
 		if chol.cond != chol2.cond {
-			t.Errorf("condition number mismatch from zero")
+			t.Errorf("condition number mismatch from empty")
 		}
 		if !Equal(chol.chol, chol2.chol) {
-			t.Errorf("chol mismatch from zero")
+			t.Errorf("chol mismatch from empty")
 		}
 
 		// Corrupt chol2 and try again
@@ -300,10 +300,10 @@ func TestCloneCholesky(t *testing.T) {
 		chol2.chol = NewTriDense(2, Upper, nil)
 		chol2.Clone(&chol)
 		if chol.cond != chol2.cond {
-			t.Errorf("condition number mismatch from non-zero")
+			t.Errorf("condition number mismatch from non-empty")
 		}
 		if !Equal(chol.chol, chol2.chol) {
-			t.Errorf("chol mismatch from non-zero")
+			t.Errorf("chol mismatch from non-empty")
 		}
 	}
 }

--- a/mat/dense.go
+++ b/mat/dense.go
@@ -69,13 +69,13 @@ func NewDense(r, c int, data []float64) *Dense {
 	}
 }
 
-// ReuseAs changes the receiver if it IsZero() to be of size r×c.
+// ReuseAs changes the receiver if it IsEmpty() to be of size r×c.
 //
 // ReuseAs re-uses the backing data slice if it has sufficient capacity,
 // otherwise a new slice is allocated. The data is then zeroed.
 //
-// ReuseAs panics if the receiver is not zero-sized, and panics if
-// the input sizes are less than one. To zero the receiver for re-use,
+// ReuseAs panics if the receiver is not empty, and panics if
+// the input sizes are less than one. To empty the receiver for re-use,
 // Reset should be used.
 func (m *Dense) ReuseAs(r, c int) {
 	if r <= 0 || c <= 0 {
@@ -84,8 +84,8 @@ func (m *Dense) ReuseAs(r, c int) {
 		}
 		panic(ErrNegativeDimension)
 	}
-	if !m.IsZero() {
-		panic(ErrReuseNonZero)
+	if !m.IsEmpty() {
+		panic(ErrReuseNonEmpty)
 	}
 	m.reuseAsZeroed(r, c)
 }
@@ -102,7 +102,7 @@ func (m *Dense) reuseAsNonZeroed(r, c int) {
 	if r == 0 || c == 0 {
 		panic(ErrZeroLength)
 	}
-	if m.IsZero() {
+	if m.IsEmpty() {
 		m.mat = blas64.General{
 			Rows:   r,
 			Cols:   c,
@@ -130,7 +130,7 @@ func (m *Dense) reuseAsZeroed(r, c int) {
 	if r == 0 || c == 0 {
 		panic(ErrZeroLength)
 	}
-	if m.IsZero() {
+	if m.IsEmpty() {
 		m.mat = blas64.General{
 			Rows:   r,
 			Cols:   c,
@@ -171,7 +171,7 @@ func (m *Dense) isolatedWorkspace(a Matrix) (w *Dense, restore func()) {
 	}
 }
 
-// Reset zeros the dimensions of the matrix so that it can be reused as the
+// Reset empties the matrix so that it can be reused as the
 // receiver of a dimensionally restricted operation.
 //
 // Reset should not be used when the matrix shares backing data.
@@ -183,9 +183,10 @@ func (m *Dense) Reset() {
 	m.mat.Data = m.mat.Data[:0]
 }
 
-// IsZero returns whether the receiver is zero-sized. Zero-sized matrices can be the
-// receiver for size-restricted operations. Dense matrices can be zeroed using Reset.
-func (m *Dense) IsZero() bool {
+// IsEmpty returns whether the receiver is empty. Empty matrices can be the
+// receiver for size-restricted operations. The receiver can be emptied using
+// Reset.
+func (m *Dense) IsEmpty() bool {
 	// It must be the case that m.Dims() returns
 	// zeros in this case. See comment in Reset().
 	return m.mat.Stride == 0

--- a/mat/dense_arithmetic.go
+++ b/mat/dense_arithmetic.go
@@ -755,7 +755,7 @@ func (m *Dense) Apply(fn func(i, j int, v float64) float64, a Matrix) {
 
 // RankOne performs a rank-one update to the matrix a with the vectors x and
 // y, where x and y are treated as column vectors. The result is stored in the
-// receiver. If a is zero, see Outer.
+// receiver. The Outer method can be used instead of RankOne if a is not needed.
 //  m = a + alpha * x * yᵀ
 func (m *Dense) RankOne(a Matrix, alpha float64, x, y Vector) {
 	ar, ac := a.Dims()
@@ -816,27 +816,7 @@ func (m *Dense) RankOne(a Matrix, alpha float64, x, y Vector) {
 func (m *Dense) Outer(alpha float64, x, y Vector) {
 	r, c := x.Len(), y.Len()
 
-	// Copied from reuseAs with use replaced by useZeroed
-	// and a final zero of the matrix elements if we pass
-	// the shape checks.
-	// TODO(kortschak): Factor out into reuseZeroedAs if
-	// we find another case that needs it.
-	if m.mat.Rows > m.capRows || m.mat.Cols > m.capCols {
-		// Panic as a string, not a mat.Error.
-		panic("mat: caps not correctly set")
-	}
-	if m.IsZero() {
-		m.mat = blas64.General{
-			Rows:   r,
-			Cols:   c,
-			Stride: c,
-			Data:   useZeroed(m.mat.Data, r*c),
-		}
-		m.capRows = r
-		m.capCols = c
-	} else if r != m.mat.Rows || c != m.mat.Cols {
-		panic(ErrShape)
-	}
+	m.reuseAsZeroed(r, c)
 
 	var xmat, ymat blas64.Vector
 	fast := true

--- a/mat/dense_example_test.go
+++ b/mat/dense_example_test.go
@@ -23,7 +23,7 @@ func ExampleDense_Add() {
 
 	// Add a and b, placing the result into c.
 	// Notice that the size is automatically adjusted
-	// when the receiver has zero size.
+	// when the receiver is empty (has zero size).
 	var c mat.Dense
 	c.Add(a, b)
 

--- a/mat/diagonal.go
+++ b/mat/diagonal.go
@@ -158,7 +158,7 @@ func (d *DiagDense) TriBand() (n, k int, kind TriKind) {
 	return d.mat.N, 0, Upper
 }
 
-// Reset zeros the dimensions of the matrix so that it can be reused as the
+// Reset empties the matrix so that it can be reused as the
 // receiver of a dimensionally restricted operation.
 //
 // Reset should not be used when the matrix shares backing data.
@@ -184,7 +184,7 @@ func (d *DiagDense) DiagView() Diagonal {
 }
 
 // DiagFrom copies the diagonal of m into the receiver. The receiver must
-// be min(r, c) long or zero. Otherwise DiagFrom will panic.
+// be min(r, c) long or empty, otherwise DiagFrom will panic.
 func (d *DiagDense) DiagFrom(m Matrix) {
 	n := min(m.Dims())
 	d.reuseAsNonZeroed(n)
@@ -292,7 +292,7 @@ func (d *DiagDense) reuseAsNonZeroed(r int) {
 	if r == 0 {
 		panic(ErrZeroLength)
 	}
-	if d.IsZero() {
+	if d.IsEmpty() {
 		d.mat = blas64.Vector{
 			Inc:  1,
 			Data: use(d.mat.Data, r),
@@ -305,9 +305,10 @@ func (d *DiagDense) reuseAsNonZeroed(r int) {
 	}
 }
 
-// IsZero returns whether the receiver is zero-sized. Zero-sized vectors can be the
-// receiver for size-restricted operations. DiagDenses can be zeroed using Reset.
-func (d *DiagDense) IsZero() bool {
+// IsEmpty returns whether the receiver is empty. Empty matrices can be the
+// receiver for size-restricted operations. The receiver can be emptied using
+// Reset.
+func (d *DiagDense) IsEmpty() bool {
 	// It must be the case that d.Dims() returns
 	// zeros in this case. See comment in Reset().
 	return d.mat.Inc == 0

--- a/mat/doc.go
+++ b/mat/doc.go
@@ -16,13 +16,16 @@
 //  - Methods and functions for using matrix data (Add, Trace, SymRankOne)
 //  - Types for constructing and using matrix factorizations (QR, LU)
 //  - The complementary types for complex matrices, CMatrix, CSymDense, etc.
+// In the documentation below, we use "matrix" as a short-hand for all of
+// the FooDense types implemented in this package. We use "Matrix" to
+// refer to the Matrix interface.
 //
 // A matrix may be constructed through the corresponding New function. If no
 // backing array is provided the matrix will be initialized to all zeros.
 //  // Allocate a zeroed real matrix of size 3×5
 //  zero := mat.NewDense(3, 5, nil)
 // If a backing data slice is provided, the matrix will have those elements.
-// Matrices are all stored in row-major format.
+// All matrices are all stored in row-major format.
 //  // Generate a 6×6 matrix of random values.
 //  data := make([]float64, 36)
 //  for i := range data {
@@ -34,26 +37,29 @@
 //  tr := mat.Trace(a)
 // and are implemented as methods when the operation modifies the receiver.
 //  zero.Copy(a)
+// Note that the input arguments to most functions and methods are interfaces
+// rather than concrete types `func Trace(Matrix)` rather than
+// `func Trace(*Dense)` allowing flexible use of internal and external
+// Matrix types.
 //
-// Receivers must be the correct size for the matrix operations, otherwise the
-// operation will panic. As a special case for convenience, a zero-value matrix
-// will be modified to have the correct size, allocating data if necessary.
-//  var c mat.Dense // construct a new zero-sized matrix
-//  c.Mul(a, a)     // c is automatically adjusted to be 6×6
+// When a matrix is the destination or receiver for a function or method,
+// the operation will panic if the matrix is not the correct size.
+// An exception is if that destination is empty (see below).
 //
-// Zero-value of a matrix
+// Empty matrix
 //
-// A zero-value matrix is either the Go language definition of a zero-value or
-// is a zero-sized matrix with zero-length stride. Matrix implementations may have
-// a Reset method to revert the receiver into a zero-valued matrix and an IsZero
-// method that returns whether the matrix is zero-valued.
-// So the following will all result in a zero-value matrix.
-//  - var a mat.Dense
-//  - a := NewDense(0, 0, make([]float64, 0, 100))
-//  - a.Reset()
+// An empty matrix is one that has zero size. Empty matrices are used to allow
+// the destination of a matrix operation to assume the correct size automatically.
+// This operation will re-use the backing data, if available, or will allocate
+// new data if necessary. The IsEmpty method returns whether the given matrix
+// is empty. The zero-value of a matrix is empty, and is useful for easily
+// getting the result of matrix operations.
+//  var c mat.Dense // construct a new zero-value matrix
+//  c.Mul(a, a)     // c is automatically adjusted to be the right size
+// The Reset method can be used to revert a matrix to an empty matrix.
 // Reset should not be used when multiple different matrices share the same backing
 // data slice. This can cause unexpected data modifications after being resized.
-// A zero-value matrix can not be sliced even if it does have an adequately sized
+// An empty matrix can not be sliced even if it does have an adequately sized
 // backing data slice, but can be expanded using its Grow method if it exists.
 //
 // The Matrix Interfaces
@@ -62,12 +68,12 @@
 // matrices, The Matrix interface is defined by three functions: Dims, which
 // returns the dimensions of the Matrix, At, which returns the element in the
 // specified location, and T for returning a Transpose (discussed later). All of
-// the concrete types can perform these behaviors and so implement the interface.
+// the matrix types can perform these behaviors and so implement the interface.
 // Methods and functions are designed to use this interface, so in particular the method
 //  func (m *Dense) Mul(a, b Matrix)
 // constructs a *Dense from the result of a multiplication with any Matrix types,
-// not just *Dense. Where more restrictive requirements must be met, there are also the
-// Symmetric and Triangular interfaces. For example, in
+// not just *Dense. Where more restrictive requirements must be met, there are also
+// additional interfaces like Symmetric and Triangular. For example, in
 //  func (s *SymDense) AddSym(a, b Symmetric)
 // the Symmetric interface guarantees a symmetric result.
 //
@@ -128,7 +134,8 @@
 // Invariants
 //
 // Matrix input arguments to functions are never directly modified. If an operation
-// changes Matrix data, the mutated matrix will be the receiver of a function.
+// changes Matrix data, the mutated matrix will be the receiver of a method, or
+// will be the first argument to a method or function.
 //
 // For convenience, a matrix may be used as both a receiver and as an input, e.g.
 //  a.Pow(a, 6)

--- a/mat/errors.go
+++ b/mat/errors.go
@@ -116,7 +116,7 @@ func (err Error) Error() string { return err.string }
 var (
 	ErrNegativeDimension   = Error{"mat: negative dimension"}
 	ErrIndexOutOfRange     = Error{"mat: index out of range"}
-	ErrReuseNonZero        = Error{"mat: reuse of non-zero matrix"}
+	ErrReuseNonEmpty       = Error{"mat: reuse of non-empty matrix"}
 	ErrRowAccess           = Error{"mat: row index out of range"}
 	ErrColAccess           = Error{"mat: column index out of range"}
 	ErrVectorAccess        = Error{"mat: vector index out of range"}

--- a/mat/hogsvd.go
+++ b/mat/hogsvd.go
@@ -128,7 +128,7 @@ func (gsvd *HOGSVD) Factorize(m ...Matrix) (ok bool) {
 	biT := getWorkspace(c, r, false)
 	defer putWorkspace(biT)
 	for i, d := range m {
-		// All calls to reset will leave a zeroed
+		// All calls to reset will leave an emptied
 		// matrix with capacity to store the result
 		// without additional allocation.
 		biT.Reset()

--- a/mat/io.go
+++ b/mat/io.go
@@ -127,7 +127,7 @@ func (m Dense) MarshalBinaryTo(w io.Writer) (int, error) {
 }
 
 // UnmarshalBinary decodes the binary form into the receiver.
-// It panics if the receiver is a non-zero Dense matrix.
+// It panics if the receiver is a non-empty Dense matrix.
 //
 // See MarshalBinary for the on-disk layout.
 //
@@ -139,8 +139,8 @@ func (m Dense) MarshalBinaryTo(w io.Writer) (int, error) {
 // UnmarshalBinary does not limit the size of the unmarshaled matrix, and so
 // it should not be used on untrusted data.
 func (m *Dense) UnmarshalBinary(data []byte) error {
-	if !m.IsZero() {
-		panic("mat: unmarshal into non-zero matrix")
+	if !m.IsEmpty() {
+		panic("mat: unmarshal into non-empty matrix")
 	}
 
 	if len(data) < headerSize {
@@ -186,7 +186,7 @@ func (m *Dense) UnmarshalBinary(data []byte) error {
 
 // UnmarshalBinaryFrom decodes the binary form into the receiver and returns
 // the number of bytes read and an error if any.
-// It panics if the receiver is a non-zero Dense matrix.
+// It panics if the receiver is a non-empty Dense matrix.
 //
 // See MarshalBinary for the on-disk layout.
 //
@@ -198,8 +198,8 @@ func (m *Dense) UnmarshalBinary(data []byte) error {
 // UnmarshalBinary does not limit the size of the unmarshaled matrix, and so
 // it should not be used on untrusted data.
 func (m *Dense) UnmarshalBinaryFrom(r io.Reader) (int, error) {
-	if !m.IsZero() {
-		panic("mat: unmarshal into non-zero matrix")
+	if !m.IsEmpty() {
+		panic("mat: unmarshal into non-empty matrix")
 	}
 
 	var header storage
@@ -313,7 +313,7 @@ func (v VecDense) MarshalBinaryTo(w io.Writer) (int, error) {
 }
 
 // UnmarshalBinary decodes the binary form into the receiver.
-// It panics if the receiver is a non-zero VecDense.
+// It panics if the receiver is a non-empty VecDense.
 //
 // See MarshalBinary for the on-disk layout.
 //
@@ -325,8 +325,8 @@ func (v VecDense) MarshalBinaryTo(w io.Writer) (int, error) {
 // UnmarshalBinary does not limit the size of the unmarshaled vector, and so
 // it should not be used on untrusted data.
 func (v *VecDense) UnmarshalBinary(data []byte) error {
-	if !v.IsZero() {
-		panic("mat: unmarshal into non-zero vector")
+	if !v.IsEmpty() {
+		panic("mat: unmarshal into non-empty vector")
 	}
 
 	if len(data) < headerSize {
@@ -373,13 +373,13 @@ func (v *VecDense) UnmarshalBinary(data []byte) error {
 
 // UnmarshalBinaryFrom decodes the binary form into the receiver, from the
 // io.Reader and returns the number of bytes read and an error if any.
-// It panics if the receiver is a non-zero VecDense.
+// It panics if the receiver is a non-empty VecDense.
 //
 // See MarshalBinary for the on-disk layout.
 // See UnmarshalBinary for the list of sanity checks performed on the input.
 func (v *VecDense) UnmarshalBinaryFrom(r io.Reader) (int, error) {
-	if !v.IsZero() {
-		panic("mat: unmarshal into non-zero vector")
+	if !v.IsEmpty() {
+		panic("mat: unmarshal into non-empty vector")
 	}
 
 	var header storage

--- a/mat/list_test.go
+++ b/mat/list_test.go
@@ -785,7 +785,7 @@ func underlyingData(a Matrix) []float64 {
 
 // testMatrices is a list of matrix types to test.
 // This test relies on the fact that the implementations of Triangle do not
-// corrupt the value of Uplo when they are zero-valued. This test will fail
+// corrupt the value of Uplo when they are empty. This test will fail
 // if that changes (and some mechanism will need to be used to force the
 // correct TriKind to be read).
 var testMatrices = []Matrix{

--- a/mat/lq.go
+++ b/mat/lq.go
@@ -71,7 +71,7 @@ func (lq *LQ) factorize(a Matrix, norm lapack.MatrixNorm) {
 
 // isValid returns whether the receiver contains a factorization.
 func (lq *LQ) isValid() bool {
-	return lq.lq != nil && !lq.lq.IsZero()
+	return lq.lq != nil && !lq.lq.IsEmpty()
 }
 
 // Cond returns the condition number for the factorized matrix.

--- a/mat/lu.go
+++ b/mat/lu.go
@@ -88,7 +88,7 @@ func (lu *LU) factorize(a Matrix, norm lapack.MatrixNorm) {
 
 // isValid returns whether the receiver contains a factorization.
 func (lu *LU) isValid() bool {
-	return lu.lu != nil && !lu.lu.IsZero()
+	return lu.lu != nil && !lu.lu.IsEmpty()
 }
 
 // Cond returns the condition number for the factorized matrix.

--- a/mat/matrix.go
+++ b/mat/matrix.go
@@ -35,7 +35,8 @@ type Matrix interface {
 // Dense types, especially helpful when adding new features.
 type allMatrix interface {
 	Reseter
-	IsZero() bool
+	IsEmpty() bool
+	Zero()
 }
 
 // denseMatrix represents the extra set of methods that all Dense Matrix types

--- a/mat/mul_test.go
+++ b/mat/mul_test.go
@@ -127,7 +127,7 @@ func TestMulTypes(t *testing.T) {
 		// Do normal multiply with empty dense
 		d := &Dense{}
 
-		testMul(t, a, b, d, acomp, bcomp, ccomp, false, "zero receiver")
+		testMul(t, a, b, d, acomp, bcomp, ccomp, false, "empty receiver")
 
 		// Normal multiply with existing receiver
 		c := NewDense(ar, bc, cvec)
@@ -138,11 +138,11 @@ func TestMulTypes(t *testing.T) {
 		am := (*basicMatrix)(a)
 		bm := (*basicMatrix)(b)
 		d.Reset()
-		testMul(t, am, b, d, acomp, bcomp, ccomp, true, "a is basic, receiver is zero")
+		testMul(t, am, b, d, acomp, bcomp, ccomp, true, "a is basic, receiver is empty")
 		d.Reset()
-		testMul(t, a, bm, d, acomp, bcomp, ccomp, true, "b is basic, receiver is zero")
+		testMul(t, a, bm, d, acomp, bcomp, ccomp, true, "b is basic, receiver is empty")
 		d.Reset()
-		testMul(t, am, bm, d, acomp, bcomp, ccomp, true, "both basic, receiver is zero")
+		testMul(t, am, bm, d, acomp, bcomp, ccomp, true, "both basic, receiver is empty")
 		randomSlice(cvec)
 		testMul(t, am, b, d, acomp, bcomp, ccomp, true, "a is basic, receiver is full")
 		randomSlice(cvec)

--- a/mat/product.go
+++ b/mat/product.go
@@ -71,7 +71,7 @@ func newMultiplier(m *Dense, factors []Matrix) *multiplier {
 	// allocate data for m.
 	r, c := m.Dims()
 	fr, fc := factors[0].Dims() // newMultiplier is only called with len(factors) > 2.
-	if !m.IsZero() {
+	if !m.IsEmpty() {
 		if fr != r {
 			panic(ErrShape)
 		}

--- a/mat/qr.go
+++ b/mat/qr.go
@@ -71,7 +71,7 @@ func (qr *QR) factorize(a Matrix, norm lapack.MatrixNorm) {
 
 // isValid returns whether the receiver contains a factorization.
 func (qr *QR) isValid() bool {
-	return qr.qr != nil && !qr.qr.IsZero()
+	return qr.qr != nil && !qr.qr.IsEmpty()
 }
 
 // Cond returns the condition number for the factorized matrix.

--- a/mat/symband.go
+++ b/mat/symband.go
@@ -159,13 +159,14 @@ func (s *SymBandDense) SetRawSymBand(mat blas64.SymmetricBand) {
 	s.mat = mat
 }
 
-// IsZero returns whether the receiver is zero-sized. Zero-sized matrices can be the
-// receiver for size-restricted operations. Dense matrices can be zeroed using Reset.
-func (s *SymBandDense) IsZero() bool {
+// IsEmpty returns whether the receiver is empty. Empty matrices can be the
+// receiver for size-restricted operations. The receiver can be emptied using
+// Reset.
+func (s *SymBandDense) IsEmpty() bool {
 	return s.mat.Stride == 0
 }
 
-// Reset zeros the dimensions of the matrix so that it can be reused as the
+// Reset empties the matrix so that it can be reused as the
 // receiver of a dimensionally restricted operation.
 //
 // Reset should not be used when the matrix shares backing data.

--- a/mat/symmetric.go
+++ b/mat/symmetric.go
@@ -126,7 +126,7 @@ func (s *SymDense) SetRawSymmetric(mat blas64.Symmetric) {
 	s.mat = mat
 }
 
-// Reset zeros the dimensions of the matrix so that it can be reused as the
+// Reset empties the matrix so that it can be reused as the
 // receiver of a dimensionally restricted operation.
 //
 // Reset should not be used when the matrix shares backing data.
@@ -137,13 +137,13 @@ func (s *SymDense) Reset() {
 	s.mat.Data = s.mat.Data[:0]
 }
 
-// ReuseAsSym changes the receiver if it IsZero() to be of size n×n.
+// ReuseAsSym changes the receiver if it IsEmpty() to be of size n×n.
 //
 // ReuseAsSym re-uses the backing data slice if it has sufficient capacity,
 // otherwise a new slice is allocated. The data is then zeroed.
 //
-// ReuseAsSym panics if the receiver is not zero-sized, and panics if
-// the input size is less than one. To zero the receiver for re-use,
+// ReuseAsSym panics if the receiver is not empty, and panics if
+// the input size is less than one. To empty the receiver for re-use,
 // Reset should be used.
 func (s *SymDense) ReuseAsSym(n int) {
 	if n <= 0 {
@@ -152,8 +152,8 @@ func (s *SymDense) ReuseAsSym(n int) {
 		}
 		panic(ErrNegativeDimension)
 	}
-	if !s.IsZero() {
-		panic(ErrReuseNonZero)
+	if !s.IsEmpty() {
+		panic(ErrReuseNonEmpty)
 	}
 	s.reuseAsZeroed(n)
 }
@@ -165,9 +165,10 @@ func (s *SymDense) Zero() {
 	}
 }
 
-// IsZero returns whether the receiver is zero-sized. Zero-sized matrices can be the
-// receiver for size-restricted operations. SymDense matrices can be zeroed using Reset.
-func (s *SymDense) IsZero() bool {
+// IsEmpty returns whether the receiver is empty. Empty matrices can be the
+// receiver for size-restricted operations. The receiver can be emptied using
+// Reset.
+func (s *SymDense) IsEmpty() bool {
 	// It must be the case that m.Dims() returns
 	// zeros in this case. See comment in Reset().
 	return s.mat.N == 0
@@ -183,7 +184,7 @@ func (s *SymDense) reuseAsNonZeroed(n int) {
 	if s.mat.N > s.cap {
 		panic(badSymCap)
 	}
-	if s.IsZero() {
+	if s.IsEmpty() {
 		s.mat = blas64.Symmetric{
 			N:      n,
 			Stride: n,
@@ -212,7 +213,7 @@ func (s *SymDense) reuseAsZeroed(n int) {
 	if s.mat.N > s.cap {
 		panic(badSymCap)
 	}
-	if s.IsZero() {
+	if s.IsEmpty() {
 		s.mat = blas64.Symmetric{
 			N:      n,
 			Stride: n,
@@ -390,7 +391,7 @@ func (s *SymDense) SymRankK(a Symmetric, alpha float64, x Matrix) {
 func (s *SymDense) SymOuterK(alpha float64, x Matrix) {
 	n, _ := x.Dims()
 	switch {
-	case s.IsZero():
+	case s.IsEmpty():
 		s.mat = blas64.Symmetric{
 			N:      n,
 			Stride: n,

--- a/mat/triangular.go
+++ b/mat/triangular.go
@@ -154,7 +154,7 @@ func (t *TriDense) Dims() (r, c int) {
 }
 
 // Triangle returns the dimension of t and its orientation. The returned
-// orientation is only valid when n is not zero.
+// orientation is only valid when n is not empty.
 func (t *TriDense) Triangle() (n int, kind TriKind) {
 	return t.mat.N, t.triKind()
 }
@@ -232,7 +232,7 @@ func (t *TriDense) SetRawTriangular(mat blas64.Triangular) {
 	t.mat = mat
 }
 
-// Reset zeros the dimensions of the matrix so that it can be reused as the
+// Reset empties the matrix so that it can be reused as the
 // receiver of a dimensionally restricted operation.
 //
 // Reset should not be used when the matrix shares backing data.
@@ -259,9 +259,10 @@ func (t *TriDense) Zero() {
 	}
 }
 
-// IsZero returns whether the receiver is zero-sized. Zero-sized matrices can be the
-// receiver for size-restricted operations. TriDense matrices can be zeroed using Reset.
-func (t *TriDense) IsZero() bool {
+// IsEmpty returns whether the receiver is empty. Empty matrices can be the
+// receiver for size-restricted operations. The receiver can be emptied using
+// Reset.
+func (t *TriDense) IsEmpty() bool {
 	// It must be the case that t.Dims() returns
 	// zeros in this case. See comment in Reset().
 	return t.mat.Stride == 0
@@ -277,13 +278,13 @@ func untransposeTri(a Triangular) (Triangular, bool) {
 	return a, false
 }
 
-// ReuseAsTri changes the receiver if it IsZero() to be of size n×n.
+// ReuseAsTri changes the receiver if it IsEmpty() to be of size n×n.
 //
 // ReuseAsTri re-uses the backing data slice if it has sufficient capacity,
 // otherwise a new slice is allocated. The data is then zeroed.
 //
-// ReuseAsTri panics if the receiver is not zero-sized, and panics if
-// the input size is less than one. To zero the receiver for re-use,
+// ReuseAsTri panics if the receiver is not empty, and panics if
+// the input size is less than one. To empty the receiver for re-use,
 // Reset should be used.
 func (t *TriDense) ReuseAsTri(n int, kind TriKind) {
 	if n <= 0 {
@@ -292,8 +293,8 @@ func (t *TriDense) ReuseAsTri(n int, kind TriKind) {
 		}
 		panic(ErrNegativeDimension)
 	}
-	if !t.IsZero() {
-		panic(ErrReuseNonZero)
+	if !t.IsEmpty() {
+		panic(ErrReuseNonEmpty)
 	}
 	t.reuseAsZeroed(n, kind)
 }
@@ -313,7 +314,7 @@ func (t *TriDense) reuseAsNonZeroed(n int, kind TriKind) {
 	if t.mat.N > t.cap {
 		panic(badTriCap)
 	}
-	if t.IsZero() {
+	if t.IsEmpty() {
 		t.mat = blas64.Triangular{
 			N:      n,
 			Stride: n,
@@ -347,7 +348,7 @@ func (t *TriDense) reuseAsZeroed(n int, kind TriKind) {
 	if t.mat.N > t.cap {
 		panic(badTriCap)
 	}
-	if t.IsZero() {
+	if t.IsEmpty() {
 		t.mat = blas64.Triangular{
 			N:      n,
 			Stride: n,

--- a/mat/triband.go
+++ b/mat/triband.go
@@ -239,17 +239,19 @@ func (t *TriBandDense) T() Matrix {
 	return Transpose{t}
 }
 
-// IsZero returns whether the receiver is zero-sized. Zero-sized matrices can be the
-// receiver for size-restricted operations. TriBandDense matrices can be zeroed using Reset.
-func (t *TriBandDense) IsZero() bool {
+// IsEmpty returns whether the receiver is empty. Empty matrices can be the
+// receiver for size-restricted operations. The receiver can be emptied using
+// Reset.
+func (t *TriBandDense) IsEmpty() bool {
 	// It must be the case that t.Dims() returns
 	// zeros in this case. See comment in Reset().
 	return t.mat.Stride == 0
 }
 
-// Reset zeros the dimensions of the matrix so that it can be reused as the
+// Reset empties the matrix so that it can be reused as the
 // receiver of a dimensionally restricted operation.
 //
+// Reset should not be used when the matrix shares backing data.
 // See the Reseter interface for more information.
 func (t *TriBandDense) Reset() {
 	t.mat.N = 0
@@ -308,7 +310,7 @@ func (t *TriBandDense) TBand() Banded {
 // TriBand returns the number of rows/columns in the matrix, the
 // size of the bandwidth, and the orientation.
 func (t *TriBandDense) TriBand() (n, k int, kind TriKind) {
-	return t.mat.N, t.mat.K, TriKind(!t.IsZero()) && t.triKind()
+	return t.mat.N, t.mat.K, TriKind(!t.IsEmpty()) && t.triKind()
 }
 
 // TTriBand performs an implicit transpose by returning the receiver inside a TransposeTriBand.

--- a/stat/distmv/dirichlet.go
+++ b/stat/distmv/dirichlet.go
@@ -60,11 +60,11 @@ func NewDirichlet(alpha []float64, src rand.Source) *Dirichlet {
 // storing the result in dst. Upon return, the value at element {i, j} of the
 // covariance matrix is equal to the covariance of the i^th and j^th variables.
 //  covariance(i, j) = E[(x_i - E[x_i])(x_j - E[x_j])]
-// If the dst matrix is zero-sized it will be resized to the correct dimensions,
+// If the dst matrix is empty it will be resized to the correct dimensions,
 // otherwise dst must match the dimension of the receiver or CovarianceMatrix
 // will panic.
 func (d *Dirichlet) CovarianceMatrix(dst *mat.SymDense) {
-	if dst.IsZero() {
+	if dst.IsEmpty() {
 		*dst = *(dst.GrowSym(d.dim).(*mat.SymDense))
 	} else if dst.Symmetric() != d.dim {
 		panic("dirichelet: input matrix size mismatch")

--- a/stat/distmv/normal.go
+++ b/stat/distmv/normal.go
@@ -154,11 +154,11 @@ func (n *Normal) ConditionNormal(observed []int, values []float64, src rand.Sour
 // Upon return, the value at element {i, j} of the covariance matrix is equal
 // to the covariance of the i^th and j^th variables.
 //  covariance(i, j) = E[(x_i - E[x_i])(x_j - E[x_j])]
-// If the dst matrix is zero-sized it will be resized to the correct dimensions,
+// If the dst matrix is empty it will be resized to the correct dimensions,
 // otherwise dst must match the dimension of the receiver or CovarianceMatrix
 // will panic.
 func (n *Normal) CovarianceMatrix(dst *mat.SymDense) {
-	if dst.IsZero() {
+	if dst.IsEmpty() {
 		*dst = *(dst.GrowSym(n.dim).(*mat.SymDense))
 	} else if dst.Symmetric() != n.dim {
 		panic("normal: input matrix size mismatch")

--- a/stat/distmv/studentst.go
+++ b/stat/distmv/studentst.go
@@ -225,11 +225,11 @@ func findUnob(observed []int, dim int) (unobserved []int) {
 // storing the result in dst. Upon return, the value at element {i, j} of the
 // covariance matrix is equal to the covariance of the i^th and j^th variables.
 //  covariance(i, j) = E[(x_i - E[x_i])(x_j - E[x_j])]
-// If the dst matrix is zero-sized it will be resized to the correct dimensions,
+// If the dst matrix is empty it will be resized to the correct dimensions,
 // otherwise dst must match the dimension of the receiver or CovarianceMatrix
 // will panic.
 func (st *StudentsT) CovarianceMatrix(dst *mat.SymDense) {
-	if dst.IsZero() {
+	if dst.IsEmpty() {
 		*dst = *(dst.GrowSym(st.dim).(*mat.SymDense))
 	} else if dst.Symmetric() != st.dim {
 		panic("studentst: input matrix size mismatch")

--- a/stat/mds/mds.go
+++ b/stat/mds/mds.go
@@ -18,7 +18,7 @@ import (
 // When the scaling is successful, mds will be resized to k columns wide.
 // Eigenvalues will be copied into eigdst and returned as eig if it is provided.
 //
-// If dst is nil, a new mat.Dense is allocated. If dst is not a zero matrix,
+// If dst is nil, a new mat.Dense is allocated. If dst is not empty,
 // the dimensions of dst and dis must match otherwise TorgersonScaling will panic.
 // The dis matrix must be square or TorgersonScaling will panic.
 func TorgersonScaling(dst *mat.Dense, eigdst []float64, dis mat.Symmetric) (k int, mds *mat.Dense, eig []float64) {
@@ -27,7 +27,7 @@ func TorgersonScaling(dst *mat.Dense, eigdst []float64, dis mat.Symmetric) (k in
 	n := dis.Symmetric()
 	if dst == nil {
 		dst = mat.NewDense(n, n, nil)
-	} else if r, c := dst.Dims(); !dst.IsZero() && (r != n || c != n) {
+	} else if r, c := dst.Dims(); !dst.IsEmpty() && (r != n || c != n) {
 		panic(mat.ErrShape)
 	}
 

--- a/stat/pca_cca.go
+++ b/stat/pca_cca.go
@@ -48,7 +48,7 @@ func (c *PC) PrincipalComponents(a mat.Matrix, weights []float64) (ok bool) {
 
 // VectorsTo returns the component direction vectors of a principal components
 // analysis. The vectors are returned in the columns of a d×min(n, d) matrix.
-// If dst is not nil it must either be zero-sized or be a d×min(n, d) matrix.
+// If dst is not nil it must either be empty or be a d×min(n, d) matrix.
 // dst will  be used as the destination for the direction vector data. If dst
 // is nil, a new mat.Dense is allocated for the destination.
 func (c *PC) VectorsTo(dst *mat.Dense) *mat.Dense {
@@ -57,7 +57,7 @@ func (c *PC) VectorsTo(dst *mat.Dense) *mat.Dense {
 	}
 
 	if dst != nil {
-		if d, n := dst.Dims(); !dst.IsZero() && (d != c.d || n != min(c.n, c.d)) {
+		if d, n := dst.Dims(); !dst.IsEmpty() && (d != c.d || n != min(c.n, c.d)) {
 			panic(mat.ErrShape)
 		}
 	}
@@ -217,7 +217,7 @@ func (c *CC) CorrsTo(dst []float64) []float64 {
 // LeftTo returns the left eigenvectors of the canonical correlation matrix if
 // spheredSpace is true. If spheredSpace is false it returns these eigenvectors
 // back-transformed to the original data space.
-// If dst is not nil it must either be zero-sized or be an xd×yd matrix where xd
+// If dst is not nil it must either be empty or be an xd×yd matrix where xd
 // and yd are the number of variables in the input x and y matrices. dst will
 // be used as the destination for the vector data. If dst is nil, a new
 // mat.Dense is allocated for the destination.
@@ -227,7 +227,7 @@ func (c *CC) LeftTo(dst *mat.Dense, spheredSpace bool) *mat.Dense {
 	}
 
 	if dst != nil {
-		if d, n := dst.Dims(); !dst.IsZero() && (n != c.yd || d != c.xd) {
+		if d, n := dst.Dims(); !dst.IsEmpty() && (n != c.yd || d != c.xd) {
 			panic(mat.ErrShape)
 		}
 	}

--- a/stat/statmat.go
+++ b/stat/statmat.go
@@ -18,7 +18,7 @@ import (
 // If weights is not nil the weighted covariance of x is calculated. weights
 // must have length equal to the number of rows in input data matrix and
 // must not contain negative elements.
-// The dst matrix must either be zero-sized or have the same number of
+// The dst matrix must either be empty or have the same number of
 // columns as the input data matrix.
 func CovarianceMatrix(dst *mat.SymDense, x mat.Matrix, weights []float64) {
 	// This is the matrix version of the two-pass algorithm. It doesn't use the
@@ -27,7 +27,7 @@ func CovarianceMatrix(dst *mat.SymDense, x mat.Matrix, weights []float64) {
 
 	r, c := x.Dims()
 
-	if dst.IsZero() {
+	if dst.IsEmpty() {
 		*dst = *(dst.GrowSym(c).(*mat.SymDense))
 	} else if n := dst.Symmetric(); n != c {
 		panic(mat.ErrShape)
@@ -76,7 +76,7 @@ func CovarianceMatrix(dst *mat.SymDense, x mat.Matrix, weights []float64) {
 // If weights is not nil the weighted correlation of x is calculated. weights
 // must have length equal to the number of rows in input data matrix and
 // must not contain negative elements.
-// The dst matrix must either be zero-sized or have the same number of
+// The dst matrix must either be empty or have the same number of
 // columns as the input data matrix.
 func CorrelationMatrix(dst *mat.SymDense, x mat.Matrix, weights []float64) {
 	// This will panic if the sizes don't match, or if weights is the wrong size.


### PR DESCRIPTION
This avoids the confusion between Zero() and IsZero() which sounds like they should be related
to one another but are not. This makes IsEmpty the counterpart to Reset. Add check for Zero in allMatrix

Fixes #1083.
Updates #1081.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
