### PR TITLE
mat: clean up docs

### DIFF
--- a/mat/cholesky.go
+++ b/mat/cholesky.go
@@ -293,13 +293,12 @@ func (c *Cholesky) RawU() Triangular {
 	return c.chol
 }
 
-// UTo extracts the n×n upper triangular matrix U from a Cholesky
-// decomposition into dst and returns the result. If dst is empty
-// it is resized to be a upper-triangular n×n matrix. When dst is
-// non-empty, UTo panics if dst is not n×n or not Upper.
-// UTo will also panic if the receiver does not contain a
-// successful factorization
-//  A = L * Lᵀ.
+// UTo stores into dst the n×n upper triangular matrix U from a Cholesky
+// decomposition
+//  A = Uᵀ * U.
+// If dst is empty, it is resized to be an n×n upper triangular matrix. When dst
+// is non-empty, UTo panics if dst is not n×n or not Upper. UTo will also panic
+// if the receiver does not contain a successful factorization.
 func (c *Cholesky) UTo(dst *TriDense) {
 	if !c.valid() {
 		panic(badCholesky)
@@ -319,13 +318,12 @@ func (c *Cholesky) UTo(dst *TriDense) {
 	dst.Copy(c.chol)
 }
 
-// LTo extracts the n×n lower triangular matrix L from a Cholesky
-// decomposition into dst and returns the result. If dst is empty
-// it is resized to be a lower-triangular n×n matrix. When dst is
-// non-empty, LTo panics if dst is not n×n or not Lower.
-// LTo will also panic if the receiver does not contain a
-// successful factorization
+// LTo stores into dst the n×n lower triangular matrix L from a Cholesky
+// decomposition
 //  A = L * Lᵀ.
+// If dst is empty, it is resized to be an n×n lower triangular matrix. When dst
+// is non-empty, LTo panics if dst is not n×n or not Lower. LTo will also panic
+// if the receiver does not contain a successful factorization.
 func (c *Cholesky) LTo(dst *TriDense) {
 	if !c.valid() {
 		panic(badCholesky)
@@ -349,7 +347,7 @@ func (c *Cholesky) LTo(dst *TriDense) {
 // Cholesky decomposition, storing the result into dst. If dst is
 // empty it is resized to be n×n. If dst is non-empty, ToSym panics
 // if dst is not of size n×n. ToSym will also panic if the receiver
-// does not contain a successful factorization
+// does not contain a successful factorization.
 func (c *Cholesky) ToSym(dst *SymDense) {
 	if !c.valid() {
 		panic(badCholesky)

--- a/mat/eigen.go
+++ b/mat/eigen.go
@@ -91,8 +91,8 @@ func (e *EigenSym) Values(dst []float64) []float64 {
 	return dst
 }
 
-// VectorsTo returns the eigenvectors of the decomposition, stored in-place
-// into dst.
+// VectorsTo stores the eigenvectors of the decomposition into the columns of
+// dst.
 //
 // If dst is empty, VectorsTo will resize dst to be n×n. When dst is
 // non-empty, VectorsTo will panic if dst is not n×n. VectorsTo will also
@@ -307,9 +307,9 @@ func (e *Eigen) complexEigenTo(dst *CDense, d *Dense) {
 	}
 }
 
-// VectorsTo returns the right eigenvectors of the decomposition, stored in-place
-// into dst. The computed eigenvectors are normalized to have Euclidean norm equal to 1
-// and largest component real.
+// VectorsTo stores the right eigenvectors of the decomposition into the columns
+// of dst. The computed eigenvectors are normalized to have Euclidean norm equal
+// to 1 and largest component real.
 //
 // If dst is empty, VectorsTo will resize dst to be n×n. When dst is
 // non-empty, VectorsTo will panic if dst is not n×n. VectorsTo will also
@@ -333,9 +333,9 @@ func (e *Eigen) VectorsTo(dst *CDense) {
 	dst.Copy(e.rVectors)
 }
 
-// LeftVectorsTo returns the left eigenvectors of the decomposition, stored in-place
-// into dst. The computed eigenvectors are normalized to have Euclidean norm equal to 1
-// and largest component real.
+// LeftVectorsTo stores the left eigenvectors of the decomposition into the
+// columns of dst. The computed eigenvectors are normalized to have Euclidean
+// norm equal to 1 and largest component real.
 //
 // If dst is empty, LeftVectorsTo will resize dst to be n×n. When dst is
 // non-empty, LeftVectorsTo will panic if dst is not n×n. LeftVectorsTo will also

--- a/mat/gsvd.go
+++ b/mat/gsvd.go
@@ -236,11 +236,12 @@ func (gsvd *GSVD) ValuesB(s []float64) []float64 {
 	return s
 }
 
-// ZeroRTo extracts the matrix [ 0 R ] from the singular value decomposition, storing
-// the result in-place into dst. [ 0 R ] is size (k+l)×c.
-// If dst is nil, a new matrix is allocated. The resulting ZeroR matrix is returned.
+// ZeroRTo extracts the matrix [ 0 R ] from the singular value decomposition,
+// storing the result into dst. [ 0 R ] is of size (k+l)×c.
 //
-// ZeroRTo will panic if the receiver does not contain a successful factorization.
+// If dst is empty, ZeroRTo will resize dst to be (k+l)×c. When dst is
+// non-empty, ZeroRTo will panic if dst is not (k+l)×c. ZeroRTo will also panic
+// if the receiver does not contain a successful factorization.
 func (gsvd *GSVD) ZeroRTo(dst *Dense) {
 	if !gsvd.succFact() {
 		panic(badFact)
@@ -278,7 +279,7 @@ func (gsvd *GSVD) ZeroRTo(dst *Dense) {
 }
 
 // SigmaATo extracts the matrix Σ₁ from the singular value decomposition, storing
-// the result in-place into dst. Σ₁ is size r×(k+l).
+// the result into dst. Σ₁ is size r×(k+l).
 //
 // If dst is empty, SigmaATo will resize dst to be r×(k+l). When dst is
 // non-empty, SigmATo will panic if dst is not r×(k+l). SigmaATo will also
@@ -308,7 +309,7 @@ func (gsvd *GSVD) SigmaATo(dst *Dense) {
 }
 
 // SigmaBTo extracts the matrix Σ₂ from the singular value decomposition, storing
-// the result in-place into dst. Σ₂ is size p×(k+l).
+// the result into dst. Σ₂ is size p×(k+l).
 //
 // If dst is empty, SigmaBTo will resize dst to be p×(k+l). When dst is
 // non-empty, SigmBTo will panic if dst is not p×(k+l). SigmaBTo will also
@@ -339,7 +340,7 @@ func (gsvd *GSVD) SigmaBTo(dst *Dense) {
 }
 
 // UTo extracts the matrix U from the singular value decomposition, storing
-// the result in-place into dst. U is size r×r.
+// the result into dst. U is size r×r.
 //
 // If dst is empty, UTo will resize dst to be r×r. When dst is
 // non-empty, UTo will panic if dst is not r×r. UTo will also
@@ -371,7 +372,7 @@ func (gsvd *GSVD) UTo(dst *Dense) {
 }
 
 // VTo extracts the matrix V from the singular value decomposition, storing
-// the result in-place into dst. V is size p×p.
+// the result into dst. V is size p×p.
 //
 // If dst is empty, VTo will resize dst to be p×p. When dst is
 // non-empty, VTo will panic if dst is not p×p. VTo will also
@@ -403,7 +404,7 @@ func (gsvd *GSVD) VTo(dst *Dense) {
 }
 
 // QTo extracts the matrix Q from the singular value decomposition, storing
-// the result in-place into dst. Q is size c×c.
+// the result into dst. Q is size c×c.
 //
 // If dst is empty, QTo will resize dst to be c×c. When dst is
 // non-empty, QTo will panic if dst is not c×c. QTo will also

--- a/mat/hogsvd.go
+++ b/mat/hogsvd.go
@@ -106,8 +106,8 @@ func (gsvd *HOGSVD) Factorize(m ...Matrix) (ok bool) {
 		gsvd.err = errors.New("hogsvd: eigen decomposition failed")
 		return false
 	}
-	vc := &CDense{}
-	eig.VectorsTo(vc)
+	var vc CDense
+	eig.VectorsTo(&vc)
 	// vc is guaranteed to have real eigenvalues.
 	rc, cc := vc.Dims()
 	v := NewDense(rc, cc, nil)

--- a/mat/lu.go
+++ b/mat/lu.go
@@ -58,7 +58,7 @@ func (lu *LU) updateCond(anorm float64, norm lapack.MatrixNorm) {
 // The LU factorization is computed with pivoting, and so really the decomposition
 // is a PLU decomposition where P is a permutation matrix. The individual matrix
 // factors can be extracted from the factorization using the Permutation method
-// on Dense, and the LU LTo and UTo methods.
+// on Dense, and the LU.LTo and LU.UTo methods.
 func (lu *LU) Factorize(a Matrix) {
 	lu.factorize(a, CondNorm)
 }
@@ -251,8 +251,8 @@ func (lu *LU) RankOne(orig *LU, alpha float64, x, y Vector) {
 
 // LTo extracts the lower triangular matrix from an LU factorization.
 //
-// If dst is empty, LTo will resize dst to be a lower-triangular c×c matrix.
-// When dst is non-empty, LTo will panic if dst is not c×c not Lower.
+// If dst is empty, LTo will resize dst to be a lower-triangular n×n matrix.
+// When dst is non-empty, LTo will panic if dst is not n×n or not Lower.
 // LTo will also panic if the receiver does not contain a successful
 // factorization.
 func (lu *LU) LTo(dst *TriDense) *TriDense {

--- a/mat/svd.go
+++ b/mat/svd.go
@@ -40,7 +40,7 @@ const (
 
 	// SVDThin is a convenience value for computing both thin vectors.
 	SVDThin SVDKind = SVDThinU | SVDThinV
-	// SVDThin is a convenience value for computing both full vectors.
+	// SVDFull is a convenience value for computing both full vectors.
 	SVDFull SVDKind = SVDFullU | SVDFullV
 )
 


### PR DESCRIPTION
Should the documentation of other *To functions like `Cholesky.InverseTo`, `Cholesky.SolveTo` or `LU.SolveTo` be also adapted to describe the behavior w.r.t. `dst` parameter?

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
