### PR TITLE
stat/distmat: change methods to accept empty instead of nil matrices

### DIFF
--- a/stat/distmat/wishart.go
+++ b/stat/distmat/wishart.go
@@ -69,7 +69,7 @@ func NewWishart(v mat.Symmetric, nu float64, src rand.Source) (*Wishart, bool) {
 	return w, true
 }
 
-// MeanSymTo calculates the mean matrix of the distribution in and stored it in dst.
+// MeanSymTo calculates the mean matrix of the distribution in and stores it in dst.
 // If dst is empty, it is resized to be an d×d symmetric matrix where d is the order
 // of the receiver. When dst is non-empty, MeanSymTo panics if dst is not d×d.
 func (w *Wishart) MeanSymTo(dst *mat.SymDense) {
@@ -150,8 +150,10 @@ func (w *Wishart) RandSymTo(dst *mat.SymDense) {
 	c.ToSym(dst)
 }
 
-// RandChol generates the Cholesky decomposition of a random matrix from the distribution.
+// RandCholTo generates the Cholesky decomposition of a random matrix from the distribution.
 func (w *Wishart) RandCholTo(dst *mat.Cholesky) {
+	// TODO(kortschak): Make RandCholTo care about the size of dst.
+
 	// TODO(btracey): Modify the code if the underlying data from c is exposed
 	// to avoid the dim^2 allocation here.
 
@@ -162,7 +164,7 @@ func (w *Wishart) RandCholTo(dst *mat.Cholesky) {
 	// off-diagonals are generated from standard normal variables.
 	// The above gives the cholesky decomposition of X, where L_x = L A.
 	//
-	// mat64 works with the upper triagular decomposition, so we would like to do
+	// mat works with the upper triagular decomposition, so we would like to do
 	// the same. We can instead say that
 	//  U_x = L_xᵀ = (L * A)ᵀ = Aᵀ * Lᵀ = Aᵀ * U
 	// Instead, generate Aᵀ, by using the procedure above, except as an upper

--- a/stat/distmat/wishart.go
+++ b/stat/distmat/wishart.go
@@ -152,9 +152,7 @@ func (w *Wishart) RandSymTo(dst *mat.SymDense) {
 
 // RandCholTo generates the Cholesky decomposition of a random matrix from the distribution.
 func (w *Wishart) RandCholTo(dst *mat.Cholesky) {
-	// TODO(kortschak): Make RandCholTo care about the size of dst.
-
-	// TODO(btracey): Modify the code if the underlying data from c is exposed
+	// TODO(btracey): Modify the code if the underlying data from dst is exposed
 	// to avoid the dim^2 allocation here.
 
 	// Use the Bartlett Decomposition, which says that

--- a/stat/distmat/wishart_test.go
+++ b/stat/distmat/wishart_test.go
@@ -70,12 +70,13 @@ func TestWishart(t *testing.T) {
 			}
 		}
 
-		ch := w.RandChol(nil)
-		w.RandChol(ch)
+		var ch mat.Cholesky
+		w.RandCholTo(&ch)
+		w.RandCholTo(&ch)
 
-		s := w.RandSym(nil)
-		w.RandSym(s)
-
+		var s mat.SymDense
+		w.RandSymTo(&s)
+		w.RandSymTo(&s)
 	}
 }
 
@@ -118,13 +119,14 @@ func TestWishartRand(t *testing.T) {
 		mean := mat.NewSymDense(dim, nil)
 		x := mat.NewSymDense(dim, nil)
 		for i := 0; i < test.samples; i++ {
-			w.RandSym(x)
+			w.RandSymTo(x)
 			x.ScaleSym(1/float64(test.samples), x)
 			mean.AddSym(mean, x)
 		}
-		trueMean := w.MeanSym(nil)
-		if !mat.EqualApprox(trueMean, mean, test.tol) {
-			t.Errorf("Case %d: Mismatch between estimated and true mean. Got\n%0.4v\nWant\n%0.4v\n", c, mat.Formatted(mean), mat.Formatted(trueMean))
+		var trueMean mat.SymDense
+		w.MeanSymTo(&trueMean)
+		if !mat.EqualApprox(&trueMean, mean, test.tol) {
+			t.Errorf("Case %d: Mismatch between estimated and true mean. Got\n%0.4v\nWant\n%0.4v\n", c, mat.Formatted(mean), mat.Formatted(&trueMean))
 		}
 	}
 }


### PR DESCRIPTION
Please take a look.

At the moment, `RandCholTo` doesn't care about sizes. Do we want it to?

Updates #1081.
<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
