### PR TITLE
Replacing the panic for a sort

### DIFF
--- a/stat/stat.go
+++ b/stat/stat.go
@@ -1043,7 +1043,7 @@ func Quantile(p float64, c CumulantKind, x, weights []float64) float64 {
 		return math.NaN() // This is needed because the algorithm breaks otherwise.
 	}
 	if !sort.Float64sAreSorted(x) {
-		panic("x data are not sorted")
+		sort.Float64s(x)
 	}
 
 	var sumWeights float64


### PR DESCRIPTION
At line 1046 I replaced the panic for a sort.Float64s. This very small change avoid the developer from the need to import the "sort" library in his algorithm and make the function simpler.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
