### PR TITLE
graph/path: Patch AStar to support lazy node generation

### DIFF
--- a/graph/path/a_star.go
+++ b/graph/path/a_star.go
@@ -64,7 +64,10 @@ func AStar(s, t graph.Node, g graph.Graph, h Heuristic) (path Shortest, expanded
 			if visited.Has(vid) {
 				continue
 			}
-			j := path.indexOf[vid]
+			j, ok := path.indexOf[vid]
+			if !ok {
+				j = path.add(v)
+			}
 
 			w, ok := weight(u.node.ID(), vid)
 			if !ok {


### PR DESCRIPTION
AStar searches from each node in a Graph as given by Nodes()
at the start of the search. However, this doesn't work for Graph
implementations where the full set of Nodes() is not known
beforehand e.g. in a case where the graph can be procedurally
generated and the scope of the search space is not known. 

I'm not sure why we're starting the search from all nodes anyways,
given that we specify a starting node and the algorithm has
discovery of reachable nodes baked into it by DFS anyways...

If a new node is encountered mid search because it was lazily
generated, then Shortest.indexOf does not contain this node yet. The
current implementation assumes that all nodes are indeed known
beforehand and as such returns an incorrect index into the results
tree.

Instead check for a map miss and add the new node using
Shortest.add(). This fixes the bad indexing and allows the search
to work correctly when discovering nodes starting from the
specified start node.

Please take a look.
