### PR TITLE
graph/path: add nodes to shortest path tree lazily

### DIFF
--- a/graph/path/a_star.go
+++ b/graph/path/a_star.go
@@ -9,6 +9,7 @@ import (
 
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/set"
+	"gonum.org/v1/gonum/graph/traverse"
 )
 
 // AStar finds the A*-shortest path from s to t in g using the heuristic h. The path and
@@ -23,9 +24,11 @@ import (
 // If h is nil, AStar will use the g.HeuristicCost method if g implements HeuristicCoster,
 // falling back to NullHeuristic otherwise. If the graph does not implement Weighted,
 // UniformCost is used. AStar will panic if g has an A*-reachable negative edge weight.
-func AStar(s, t graph.Node, g graph.Graph, h Heuristic) (path Shortest, expanded int) {
-	if g.Node(s.ID()) == nil || g.Node(t.ID()) == nil {
-		return Shortest{from: s}, 0
+func AStar(s, t graph.Node, g traverse.Graph, h Heuristic) (path Shortest, expanded int) {
+	if g, ok := g.(graph.Graph); ok {
+		if g.Node(s.ID()) == nil || g.Node(t.ID()) == nil {
+			return Shortest{from: s}, 0
+		}
 	}
 	var weight Weighting
 	if wg, ok := g.(Weighted); ok {
@@ -41,7 +44,7 @@ func AStar(s, t graph.Node, g graph.Graph, h Heuristic) (path Shortest, expanded
 		}
 	}
 
-	path = newShortestFrom(s, graph.NodesOf(g.Nodes()))
+	path = newShortestFrom(s, []graph.Node{s, t})
 	tid := t.ID()
 
 	visited := make(set.Int64s)
@@ -64,14 +67,17 @@ func AStar(s, t graph.Node, g graph.Graph, h Heuristic) (path Shortest, expanded
 			if visited.Has(vid) {
 				continue
 			}
-			j := path.indexOf[vid]
+			j, ok := path.indexOf[vid]
+			if !ok {
+				j = path.add(v)
+			}
 
 			w, ok := weight(u.node.ID(), vid)
 			if !ok {
-				panic("A*: unexpected invalid weight")
+				panic("path: A* unexpected invalid weight")
 			}
 			if w < 0 {
-				panic("A*: negative edge weight")
+				panic("path: A* negative edge weight")
 			}
 			g := u.gscore + w
 			if n, ok := open.node(vid); !ok {


### PR DESCRIPTION
This is an alternative to #1113 that gives the full benefits of the change to lazy addition to the shortest path tree during `AStar` execution, while also retaining the implied semantics of `graph.Graph` (that the graph does not change under the callee's feet).

This reduces total volume of allocations, particularly in the case where there is a heuristic provided at the cost of allocating more often in general. In the same situation, the time taken is dramatically improved. It also reduces the requirement of the input graph's method set (to match now what `Dijkstra` needs).

Please take a look.

Closes #1113.

/cc @phyrwork

<details>
<table class='benchstat oldnew'>
<tr class='configs'><th><th>old<th>new


<tbody>
<tr><th><th colspan='2' class='metric'>time/op<th>delta
<tr class='better'><td>AStarUndirected/GNP_Undirected_10_tenth-8<td>3.86µs ± 3%<td>3.44µs ± 1%<td class='delta'>−10.81%<td class='note'>(p=0.000 n=9&#43;8)
<tr class='worse'><td>AStarUndirected/GNP_Undirected_100_tenth-8<td>215µs ± 0%<td>217µs ± 0%<td class='delta'>&#43;1.14%<td class='note'>(p=0.000 n=9&#43;7)
<tr class='unchanged'><td>AStarUndirected/GNP_Undirected_1000_tenth-8<td>10.9ms ± 8%<td>10.8ms ± 4%<td class='nodelta'>~<td class='note'>(p=0.696 n=10&#43;8)
<tr class='better'><td>AStarUndirected/GNP_Undirected_10_half-8<td>9.60µs ± 0%<td>9.57µs ± 1%<td class='delta'>−0.35%<td class='note'>(p=0.041 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/GNP_Undirected_100_half-8<td>669µs ± 1%<td>676µs ± 1%<td class='delta'>&#43;1.01%<td class='note'>(p=0.001 n=10&#43;10)
<tr class='unchanged'><td>AStarUndirected/GNP_Undirected_1000_half-8<td>28.6ms ± 8%<td>28.4ms ± 6%<td class='nodelta'>~<td class='note'>(p=0.529 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/NSW_Undirected_10_2_2_2-8<td>52.5µs ± 1%<td>60.6µs ± 1%<td class='delta'>&#43;15.37%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='better'><td>AStarUndirected/NSW_Undirected_10_2_2_2_heuristic-8<td>15.9µs ± 0%<td>11.2µs ± 0%<td class='delta'>−29.79%<td class='note'>(p=0.000 n=9&#43;8)
<tr class='better'><td>AStarUndirected/NSW_Undirected_10_2_5_2-8<td>77.9µs ± 1%<td>76.7µs ± 1%<td class='delta'>−1.61%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='better'><td>AStarUndirected/NSW_Undirected_10_2_5_2_heuristic-8<td>16.3µs ± 1%<td>11.7µs ± 2%<td class='delta'>−28.30%<td class='note'>(p=0.000 n=9&#43;9)
<tr class='better'><td>AStarUndirected/NSW_Undirected_100_5_10_2-8<td>1.78ms ± 3%<td>1.34ms ± 3%<td class='delta'>−24.91%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='better'><td>AStarUndirected/NSW_Undirected_100_5_10_2_heuristic-8<td>718µs ± 3%<td>53µs ± 1%<td class='delta'>−92.65%<td class='note'>(p=0.000 n=8&#43;10)
<tr class='better'><td>AStarUndirected/NSW_Undirected_100_5_20_2-8<td>4.37ms ± 5%<td>3.99ms ± 5%<td class='delta'>−8.59%<td class='note'>(p=0.000 n=9&#43;9)
<tr class='better'><td>AStarUndirected/NSW_Undirected_100_5_20_2_heuristic-8<td>759µs ± 1%<td>121µs ±33%<td class='delta'>−84.08%<td class='note'>(p=0.000 n=10&#43;10)
<tr><td>&nbsp;
</tbody>

<tbody>
<tr><th><th colspan='2' class='metric'>alloc/op<th>delta
<tr class='better'><td>AStarUndirected/GNP_Undirected_10_tenth-8<td>1.65kB ± 0%<td>1.60kB ± 0%<td class='delta'>−3.15%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/GNP_Undirected_100_tenth-8<td>51.6kB ± 0%<td>58.7kB ± 0%<td class='delta'>&#43;13.72%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/GNP_Undirected_1000_tenth-8<td>1.82MB ± 8%<td>1.89MB ± 5%<td class='delta'>&#43;4.22%<td class='note'>(p=0.043 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/GNP_Undirected_10_half-8<td>3.14kB ± 0%<td>3.89kB ± 0%<td class='delta'>&#43;23.91%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/GNP_Undirected_100_half-8<td>127kB ± 1%<td>136kB ± 1%<td class='delta'>&#43;6.82%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='unchanged'><td>AStarUndirected/GNP_Undirected_1000_half-8<td>4.17MB ± 8%<td>4.25MB ± 6%<td class='nodelta'>~<td class='note'>(p=0.393 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/NSW_Undirected_10_2_2_2-8<td>20.7kB ± 0%<td>26.3kB ± 0%<td class='delta'>&#43;27.10%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='better'><td>AStarUndirected/NSW_Undirected_10_2_2_2_heuristic-8<td>10.8kB ± 0%<td>7.3kB ± 0%<td class='delta'>−32.14%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/NSW_Undirected_10_2_5_2-8<td>28.2kB ± 0%<td>33.6kB ± 0%<td class='delta'>&#43;18.97%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='better'><td>AStarUndirected/NSW_Undirected_10_2_5_2_heuristic-8<td>10.9kB ± 0%<td>7.4kB ± 0%<td class='delta'>−31.84%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='better'><td>AStarUndirected/NSW_Undirected_100_5_10_2-8<td>1.11MB ± 2%<td>0.81MB ± 3%<td class='delta'>−26.77%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='better'><td>AStarUndirected/NSW_Undirected_100_5_10_2_heuristic-8<td>668kB ± 0%<td>32kB ± 0%<td class='delta'>−95.21%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/NSW_Undirected_100_5_20_2-8<td>2.00MB ± 4%<td>2.12MB ± 3%<td class='delta'>&#43;6.05%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='better'><td>AStarUndirected/NSW_Undirected_100_5_20_2_heuristic-8<td>687kB ± 0%<td>64kB ± 0%<td class='delta'>−90.64%<td class='note'>(p=0.000 n=9&#43;10)
<tr><td>&nbsp;
</tbody>

<tbody>
<tr><th><th colspan='2' class='metric'>allocs/op<th>delta
<tr class='worse'><td>AStarUndirected/GNP_Undirected_10_tenth-8<td>33.0 ± 0%<td>38.0 ± 0%<td class='delta'>&#43;15.15%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/GNP_Undirected_100_tenth-8<td>621 ± 0%<td>646 ± 0%<td class='delta'>&#43;4.08%<td class='note'>(p=0.000 n=10&#43;8)
<tr class='unchanged'><td>AStarUndirected/GNP_Undirected_1000_tenth-8<td>20.8k ± 7%<td>20.7k ± 5%<td class='nodelta'>~<td class='note'>(p=0.684 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/GNP_Undirected_10_half-8<td>57.0 ± 0%<td>66.0 ± 0%<td class='delta'>&#43;15.79%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/GNP_Undirected_100_half-8<td>1.47k ± 1%<td>1.51k ± 1%<td class='delta'>&#43;2.81%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='unchanged'><td>AStarUndirected/GNP_Undirected_1000_half-8<td>55.9k ± 8%<td>56.0k ± 6%<td class='nodelta'>~<td class='note'>(p=0.971 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/NSW_Undirected_10_2_2_2-8<td>149 ± 0%<td>188 ± 1%<td class='delta'>&#43;25.91%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/NSW_Undirected_10_2_2_2_heuristic-8<td>47.0 ± 0%<td>56.0 ± 0%<td class='delta'>&#43;19.15%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/NSW_Undirected_10_2_5_2-8<td>212 ± 0%<td>230 ± 0%<td class='delta'>&#43;8.53%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/NSW_Undirected_10_2_5_2_heuristic-8<td>48.0 ± 0%<td>58.0 ± 0%<td class='delta'>&#43;20.83%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/NSW_Undirected_100_5_10_2-8<td>2.80k ± 4%<td>3.06k ± 2%<td class='delta'>&#43;9.55%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/NSW_Undirected_100_5_10_2_heuristic-8<td>141 ± 0%<td>163 ± 0%<td class='delta'>&#43;15.60%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='unchanged'><td>AStarUndirected/NSW_Undirected_100_5_20_2-8<td>7.99k ± 6%<td>7.75k ± 3%<td class='nodelta'>~<td class='note'>(p=0.075 n=10&#43;10)
<tr class='worse'><td>AStarUndirected/NSW_Undirected_100_5_20_2_heuristic-8<td>242 ± 0%<td>275 ± 0%<td class='delta'>&#43;13.64%<td class='note'>(p=0.000 n=8&#43;10)
<tr><td>&nbsp;
</tbody>

</table>
</details>

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
