### PR TITLE
spatial/{kdtree,vptree}: fix lint warnings

### DIFF
--- a/spatial/kdtree/kdtree_test.go
+++ b/spatial/kdtree/kdtree_test.go
@@ -660,9 +660,9 @@ func dotFile(t *Tree, label, dotString string) (err error) {
 	}
 	defer f.Close()
 	if dotString == "" {
-		fmt.Fprintf(f, dot(t, label))
+		fmt.Fprint(f, dot(t, label))
 	} else {
-		fmt.Fprintf(f, dotString)
+		fmt.Fprint(f, dotString)
 	}
 	return
 }

--- a/spatial/vptree/vptree_test.go
+++ b/spatial/vptree/vptree_test.go
@@ -549,9 +549,9 @@ func dotFile(t *Tree, label, dotString string) (err error) {
 	}
 	defer f.Close()
 	if dotString == "" {
-		fmt.Fprintf(f, dot(t, label))
+		fmt.Fprint(f, dot(t, label))
 	} else {
-		fmt.Fprintf(f, dotString)
+		fmt.Fprint(f, dotString)
 	}
 	return
 }


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
