### PR TITLE
testlapack: allocate work only for MaxColumnSum in DlantrTest

### DIFF
--- a/lapack/testlapack/dlantr.go
+++ b/lapack/testlapack/dlantr.go
@@ -102,10 +102,13 @@ func dlantrTest(t *testing.T, impl Dlantrer, rnd *rand.Rand, uplo blas.Uplo, dia
 	aCopy := make([]float64, len(a))
 	copy(aCopy, a)
 
-	work := make([]float64, n)
 	for _, norm := range []lapack.MatrixNorm{lapack.MaxAbs, lapack.MaxColumnSum, lapack.MaxRowSum, lapack.Frobenius} {
 		name := fmt.Sprintf("norm=%v,uplo=%v,diag=%v,m=%v,n=%v,lda=%v", string(norm), string(uplo), string(diag), m, n, lda)
 
+		var work []float64
+		if norm == lapack.MaxColumnSum {
+			work = make([]float64, n)
+		}
 		normGot := impl.Dlantr(norm, uplo, diag, m, n, a, lda, work)
 
 		if !floats.Equal(a, aCopy) {


### PR DESCRIPTION
Not strictly necessary but would have hinted probably much earlier at the root cause of the issue fixed in https://github.com/gonum/netlib/pull/67

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
