### PR TITLE
graph: clean up lint

### DIFF
--- a/graph/encoding/digraph6/digraph6.go
+++ b/graph/encoding/digraph6/digraph6.go
@@ -113,7 +113,7 @@ func (g Graph) Edge(uid, vid int64) graph.Edge {
 	if !g.HasEdgeFromTo(uid, vid) {
 		return nil
 	}
-	return simple.Edge{simple.Node(uid), simple.Node(vid)}
+	return simple.Edge{F: simple.Node(uid), T: simple.Node(vid)}
 }
 
 // From returns all nodes that can be reached directly from the node with the

--- a/graph/encoding/dot/encode_test.go
+++ b/graph/encoding/dot/encode_test.go
@@ -114,7 +114,6 @@ func undirectedNamedIDGraphFrom(g []intset) graph.Graph {
 
 type attrNode struct {
 	id   int64
-	name string
 	attr []encoding.Attribute
 }
 
@@ -247,8 +246,6 @@ func undirectedEdgeAttrGraphFrom(g []intset, attr map[edge][]encoding.Attribute)
 
 type portedEdge struct {
 	from, to graph.Node
-
-	directed bool
 
 	fromPort    string
 	fromCompass string

--- a/graph/encoding/graph6/graph6.go
+++ b/graph/encoding/graph6/graph6.go
@@ -113,7 +113,7 @@ func (g Graph) Edge(uid, vid int64) graph.Edge {
 	if !g.HasEdgeBetween(uid, vid) {
 		return nil
 	}
-	return simple.Edge{simple.Node(uid), simple.Node(vid)}
+	return simple.Edge{F: simple.Node(uid), T: simple.Node(vid)}
 }
 
 // EdgeBetween returns the edge between nodes x and y with IDs xid and yid.

--- a/graph/layout/eades_test.go
+++ b/graph/layout/eades_test.go
@@ -27,7 +27,7 @@ var eadesR2Tests = []struct {
 		name: "line",
 		g: func() graph.Graph {
 			edges := []simple.Edge{
-				{simple.Node(0), simple.Node(1)},
+				{F: simple.Node(0), T: simple.Node(1)},
 			}
 			g := simple.NewUndirectedGraph()
 			for _, e := range edges {
@@ -42,10 +42,10 @@ var eadesR2Tests = []struct {
 		name: "square",
 		g: func() graph.Graph {
 			edges := []simple.Edge{
-				{simple.Node(0), simple.Node(1)},
-				{simple.Node(0), simple.Node(2)},
-				{simple.Node(1), simple.Node(3)},
-				{simple.Node(2), simple.Node(3)},
+				{F: simple.Node(0), T: simple.Node(1)},
+				{F: simple.Node(0), T: simple.Node(2)},
+				{F: simple.Node(1), T: simple.Node(3)},
+				{F: simple.Node(2), T: simple.Node(3)},
 			}
 			g := simple.NewUndirectedGraph()
 			for _, e := range edges {
@@ -60,12 +60,12 @@ var eadesR2Tests = []struct {
 		name: "tetrahedron",
 		g: func() graph.Graph {
 			edges := []simple.Edge{
-				{simple.Node(0), simple.Node(1)},
-				{simple.Node(0), simple.Node(2)},
-				{simple.Node(0), simple.Node(3)},
-				{simple.Node(1), simple.Node(2)},
-				{simple.Node(1), simple.Node(3)},
-				{simple.Node(2), simple.Node(3)},
+				{F: simple.Node(0), T: simple.Node(1)},
+				{F: simple.Node(0), T: simple.Node(2)},
+				{F: simple.Node(0), T: simple.Node(3)},
+				{F: simple.Node(1), T: simple.Node(2)},
+				{F: simple.Node(1), T: simple.Node(3)},
+				{F: simple.Node(2), T: simple.Node(3)},
 			}
 			g := simple.NewUndirectedGraph()
 			for _, e := range edges {
@@ -80,18 +80,18 @@ var eadesR2Tests = []struct {
 		name: "sheet",
 		g: func() graph.Graph {
 			edges := []simple.Edge{
-				{simple.Node(0), simple.Node(1)},
-				{simple.Node(0), simple.Node(3)},
-				{simple.Node(1), simple.Node(2)},
-				{simple.Node(1), simple.Node(4)},
-				{simple.Node(2), simple.Node(5)},
-				{simple.Node(3), simple.Node(4)},
-				{simple.Node(3), simple.Node(6)},
-				{simple.Node(4), simple.Node(5)},
-				{simple.Node(4), simple.Node(7)},
-				{simple.Node(5), simple.Node(8)},
-				{simple.Node(6), simple.Node(7)},
-				{simple.Node(7), simple.Node(8)},
+				{F: simple.Node(0), T: simple.Node(1)},
+				{F: simple.Node(0), T: simple.Node(3)},
+				{F: simple.Node(1), T: simple.Node(2)},
+				{F: simple.Node(1), T: simple.Node(4)},
+				{F: simple.Node(2), T: simple.Node(5)},
+				{F: simple.Node(3), T: simple.Node(4)},
+				{F: simple.Node(3), T: simple.Node(6)},
+				{F: simple.Node(4), T: simple.Node(5)},
+				{F: simple.Node(4), T: simple.Node(7)},
+				{F: simple.Node(5), T: simple.Node(8)},
+				{F: simple.Node(6), T: simple.Node(7)},
+				{F: simple.Node(7), T: simple.Node(8)},
 			}
 			g := simple.NewUndirectedGraph()
 			for _, e := range edges {
@@ -106,21 +106,21 @@ var eadesR2Tests = []struct {
 		name: "tube",
 		g: func() graph.Graph {
 			edges := []simple.Edge{
-				{simple.Node(0), simple.Node(1)},
-				{simple.Node(0), simple.Node(2)},
-				{simple.Node(0), simple.Node(3)},
-				{simple.Node(1), simple.Node(2)},
-				{simple.Node(1), simple.Node(4)},
-				{simple.Node(2), simple.Node(5)},
-				{simple.Node(3), simple.Node(4)},
-				{simple.Node(3), simple.Node(5)},
-				{simple.Node(3), simple.Node(6)},
-				{simple.Node(4), simple.Node(5)},
-				{simple.Node(4), simple.Node(7)},
-				{simple.Node(5), simple.Node(8)},
-				{simple.Node(6), simple.Node(7)},
-				{simple.Node(6), simple.Node(8)},
-				{simple.Node(7), simple.Node(8)},
+				{F: simple.Node(0), T: simple.Node(1)},
+				{F: simple.Node(0), T: simple.Node(2)},
+				{F: simple.Node(0), T: simple.Node(3)},
+				{F: simple.Node(1), T: simple.Node(2)},
+				{F: simple.Node(1), T: simple.Node(4)},
+				{F: simple.Node(2), T: simple.Node(5)},
+				{F: simple.Node(3), T: simple.Node(4)},
+				{F: simple.Node(3), T: simple.Node(5)},
+				{F: simple.Node(3), T: simple.Node(6)},
+				{F: simple.Node(4), T: simple.Node(5)},
+				{F: simple.Node(4), T: simple.Node(7)},
+				{F: simple.Node(5), T: simple.Node(8)},
+				{F: simple.Node(6), T: simple.Node(7)},
+				{F: simple.Node(6), T: simple.Node(8)},
+				{F: simple.Node(7), T: simple.Node(8)},
 			}
 			g := simple.NewUndirectedGraph()
 			for _, e := range edges {
@@ -137,21 +137,21 @@ var eadesR2Tests = []struct {
 		name: "tube-steep",
 		g: func() graph.Graph {
 			edges := []simple.Edge{
-				{simple.Node(0), simple.Node(1)},
-				{simple.Node(0), simple.Node(2)},
-				{simple.Node(0), simple.Node(3)},
-				{simple.Node(1), simple.Node(2)},
-				{simple.Node(1), simple.Node(4)},
-				{simple.Node(2), simple.Node(5)},
-				{simple.Node(3), simple.Node(4)},
-				{simple.Node(3), simple.Node(5)},
-				{simple.Node(3), simple.Node(6)},
-				{simple.Node(4), simple.Node(5)},
-				{simple.Node(4), simple.Node(7)},
-				{simple.Node(5), simple.Node(8)},
-				{simple.Node(6), simple.Node(7)},
-				{simple.Node(6), simple.Node(8)},
-				{simple.Node(7), simple.Node(8)},
+				{F: simple.Node(0), T: simple.Node(1)},
+				{F: simple.Node(0), T: simple.Node(2)},
+				{F: simple.Node(0), T: simple.Node(3)},
+				{F: simple.Node(1), T: simple.Node(2)},
+				{F: simple.Node(1), T: simple.Node(4)},
+				{F: simple.Node(2), T: simple.Node(5)},
+				{F: simple.Node(3), T: simple.Node(4)},
+				{F: simple.Node(3), T: simple.Node(5)},
+				{F: simple.Node(3), T: simple.Node(6)},
+				{F: simple.Node(4), T: simple.Node(5)},
+				{F: simple.Node(4), T: simple.Node(7)},
+				{F: simple.Node(5), T: simple.Node(8)},
+				{F: simple.Node(6), T: simple.Node(7)},
+				{F: simple.Node(6), T: simple.Node(8)},
+				{F: simple.Node(7), T: simple.Node(8)},
 			}
 			g := simple.NewUndirectedGraph()
 			for _, e := range edges {
@@ -167,21 +167,21 @@ var eadesR2Tests = []struct {
 		name: "wp_page", // https://en.wikipedia.org/wiki/PageRank#/media/File:PageRanks-Example.jpg
 		g: func() graph.Graph {
 			edges := []simple.Edge{
-				{simple.Node(0), simple.Node(3)},
-				{simple.Node(1), simple.Node(2)},
-				{simple.Node(1), simple.Node(3)},
-				{simple.Node(1), simple.Node(4)},
-				{simple.Node(1), simple.Node(5)},
-				{simple.Node(1), simple.Node(6)},
-				{simple.Node(1), simple.Node(7)},
-				{simple.Node(1), simple.Node(8)},
-				{simple.Node(3), simple.Node(4)},
-				{simple.Node(4), simple.Node(5)},
-				{simple.Node(4), simple.Node(6)},
-				{simple.Node(4), simple.Node(7)},
-				{simple.Node(4), simple.Node(8)},
-				{simple.Node(4), simple.Node(9)},
-				{simple.Node(4), simple.Node(10)},
+				{F: simple.Node(0), T: simple.Node(3)},
+				{F: simple.Node(1), T: simple.Node(2)},
+				{F: simple.Node(1), T: simple.Node(3)},
+				{F: simple.Node(1), T: simple.Node(4)},
+				{F: simple.Node(1), T: simple.Node(5)},
+				{F: simple.Node(1), T: simple.Node(6)},
+				{F: simple.Node(1), T: simple.Node(7)},
+				{F: simple.Node(1), T: simple.Node(8)},
+				{F: simple.Node(3), T: simple.Node(4)},
+				{F: simple.Node(4), T: simple.Node(5)},
+				{F: simple.Node(4), T: simple.Node(6)},
+				{F: simple.Node(4), T: simple.Node(7)},
+				{F: simple.Node(4), T: simple.Node(8)},
+				{F: simple.Node(4), T: simple.Node(9)},
+				{F: simple.Node(4), T: simple.Node(10)},
 			}
 			g := simple.NewUndirectedGraph()
 			for _, e := range edges {

--- a/graph/layout/isomap_test.go
+++ b/graph/layout/isomap_test.go
@@ -27,7 +27,7 @@ var isomapR2Tests = []struct {
 		name: "line_isomap",
 		g: func() graph.Graph {
 			edges := []simple.Edge{
-				{simple.Node(0), simple.Node(1)},
+				{F: simple.Node(0), T: simple.Node(1)},
 			}
 			g := simple.NewUndirectedGraph()
 			for _, e := range edges {
@@ -40,10 +40,10 @@ var isomapR2Tests = []struct {
 		name: "square_isomap",
 		g: func() graph.Graph {
 			edges := []simple.Edge{
-				{simple.Node(0), simple.Node(1)},
-				{simple.Node(0), simple.Node(2)},
-				{simple.Node(1), simple.Node(3)},
-				{simple.Node(2), simple.Node(3)},
+				{F: simple.Node(0), T: simple.Node(1)},
+				{F: simple.Node(0), T: simple.Node(2)},
+				{F: simple.Node(1), T: simple.Node(3)},
+				{F: simple.Node(2), T: simple.Node(3)},
 			}
 			g := simple.NewUndirectedGraph()
 			for _, e := range edges {
@@ -56,12 +56,12 @@ var isomapR2Tests = []struct {
 		name: "tetrahedron_isomap",
 		g: func() graph.Graph {
 			edges := []simple.Edge{
-				{simple.Node(0), simple.Node(1)},
-				{simple.Node(0), simple.Node(2)},
-				{simple.Node(0), simple.Node(3)},
-				{simple.Node(1), simple.Node(2)},
-				{simple.Node(1), simple.Node(3)},
-				{simple.Node(2), simple.Node(3)},
+				{F: simple.Node(0), T: simple.Node(1)},
+				{F: simple.Node(0), T: simple.Node(2)},
+				{F: simple.Node(0), T: simple.Node(3)},
+				{F: simple.Node(1), T: simple.Node(2)},
+				{F: simple.Node(1), T: simple.Node(3)},
+				{F: simple.Node(2), T: simple.Node(3)},
 			}
 			g := simple.NewUndirectedGraph()
 			for _, e := range edges {
@@ -74,18 +74,18 @@ var isomapR2Tests = []struct {
 		name: "sheet_isomap",
 		g: func() graph.Graph {
 			edges := []simple.Edge{
-				{simple.Node(0), simple.Node(1)},
-				{simple.Node(0), simple.Node(3)},
-				{simple.Node(1), simple.Node(2)},
-				{simple.Node(1), simple.Node(4)},
-				{simple.Node(2), simple.Node(5)},
-				{simple.Node(3), simple.Node(4)},
-				{simple.Node(3), simple.Node(6)},
-				{simple.Node(4), simple.Node(5)},
-				{simple.Node(4), simple.Node(7)},
-				{simple.Node(5), simple.Node(8)},
-				{simple.Node(6), simple.Node(7)},
-				{simple.Node(7), simple.Node(8)},
+				{F: simple.Node(0), T: simple.Node(1)},
+				{F: simple.Node(0), T: simple.Node(3)},
+				{F: simple.Node(1), T: simple.Node(2)},
+				{F: simple.Node(1), T: simple.Node(4)},
+				{F: simple.Node(2), T: simple.Node(5)},
+				{F: simple.Node(3), T: simple.Node(4)},
+				{F: simple.Node(3), T: simple.Node(6)},
+				{F: simple.Node(4), T: simple.Node(5)},
+				{F: simple.Node(4), T: simple.Node(7)},
+				{F: simple.Node(5), T: simple.Node(8)},
+				{F: simple.Node(6), T: simple.Node(7)},
+				{F: simple.Node(7), T: simple.Node(8)},
 			}
 			g := simple.NewUndirectedGraph()
 			for _, e := range edges {
@@ -98,21 +98,21 @@ var isomapR2Tests = []struct {
 		name: "tube_isomap",
 		g: func() graph.Graph {
 			edges := []simple.Edge{
-				{simple.Node(0), simple.Node(1)},
-				{simple.Node(0), simple.Node(2)},
-				{simple.Node(0), simple.Node(3)},
-				{simple.Node(1), simple.Node(2)},
-				{simple.Node(1), simple.Node(4)},
-				{simple.Node(2), simple.Node(5)},
-				{simple.Node(3), simple.Node(4)},
-				{simple.Node(3), simple.Node(5)},
-				{simple.Node(3), simple.Node(6)},
-				{simple.Node(4), simple.Node(5)},
-				{simple.Node(4), simple.Node(7)},
-				{simple.Node(5), simple.Node(8)},
-				{simple.Node(6), simple.Node(7)},
-				{simple.Node(6), simple.Node(8)},
-				{simple.Node(7), simple.Node(8)},
+				{F: simple.Node(0), T: simple.Node(1)},
+				{F: simple.Node(0), T: simple.Node(2)},
+				{F: simple.Node(0), T: simple.Node(3)},
+				{F: simple.Node(1), T: simple.Node(2)},
+				{F: simple.Node(1), T: simple.Node(4)},
+				{F: simple.Node(2), T: simple.Node(5)},
+				{F: simple.Node(3), T: simple.Node(4)},
+				{F: simple.Node(3), T: simple.Node(5)},
+				{F: simple.Node(3), T: simple.Node(6)},
+				{F: simple.Node(4), T: simple.Node(5)},
+				{F: simple.Node(4), T: simple.Node(7)},
+				{F: simple.Node(5), T: simple.Node(8)},
+				{F: simple.Node(6), T: simple.Node(7)},
+				{F: simple.Node(6), T: simple.Node(8)},
+				{F: simple.Node(7), T: simple.Node(8)},
 			}
 			g := simple.NewUndirectedGraph()
 			for _, e := range edges {
@@ -125,21 +125,21 @@ var isomapR2Tests = []struct {
 		name: "wp_page_isomap", // https://en.wikipedia.org/wiki/PageRank#/media/File:PageRanks-Example.jpg
 		g: func() graph.Graph {
 			edges := []simple.Edge{
-				{simple.Node(0), simple.Node(3)},
-				{simple.Node(1), simple.Node(2)},
-				{simple.Node(1), simple.Node(3)},
-				{simple.Node(1), simple.Node(4)},
-				{simple.Node(1), simple.Node(5)},
-				{simple.Node(1), simple.Node(6)},
-				{simple.Node(1), simple.Node(7)},
-				{simple.Node(1), simple.Node(8)},
-				{simple.Node(3), simple.Node(4)},
-				{simple.Node(4), simple.Node(5)},
-				{simple.Node(4), simple.Node(6)},
-				{simple.Node(4), simple.Node(7)},
-				{simple.Node(4), simple.Node(8)},
-				{simple.Node(4), simple.Node(9)},
-				{simple.Node(4), simple.Node(10)},
+				{F: simple.Node(0), T: simple.Node(3)},
+				{F: simple.Node(1), T: simple.Node(2)},
+				{F: simple.Node(1), T: simple.Node(3)},
+				{F: simple.Node(1), T: simple.Node(4)},
+				{F: simple.Node(1), T: simple.Node(5)},
+				{F: simple.Node(1), T: simple.Node(6)},
+				{F: simple.Node(1), T: simple.Node(7)},
+				{F: simple.Node(1), T: simple.Node(8)},
+				{F: simple.Node(3), T: simple.Node(4)},
+				{F: simple.Node(4), T: simple.Node(5)},
+				{F: simple.Node(4), T: simple.Node(6)},
+				{F: simple.Node(4), T: simple.Node(7)},
+				{F: simple.Node(4), T: simple.Node(8)},
+				{F: simple.Node(4), T: simple.Node(9)},
+				{F: simple.Node(4), T: simple.Node(10)},
 			}
 			g := simple.NewUndirectedGraph()
 			for _, e := range edges {

--- a/graph/path/bench_test.go
+++ b/graph/path/bench_test.go
@@ -5,6 +5,7 @@
 package path
 
 import (
+	"fmt"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -28,13 +29,19 @@ var (
 
 func gnpUndirected(n int, p float64) graph.Undirected {
 	g := simple.NewUndirectedGraph()
-	gen.Gnp(g, n, p, nil)
+	err := gen.Gnp(g, n, p, nil)
+	if err != nil {
+		panic(fmt.Sprintf("path: bad test: %v", err))
+	}
 	return g
 }
 
 func navigableSmallWorldUndirected(n, p, q int, r float64) graph.Undirected {
 	g := simple.NewUndirectedGraph()
-	gen.NavigableSmallWorld(g, []int{n, n}, p, q, r, nil)
+	err := gen.NavigableSmallWorld(g, []int{n, n}, p, q, r, nil)
+	if err != nil {
+		panic(fmt.Sprintf("path: bad test: %v", err))
+	}
 	return g
 }
 
@@ -118,7 +125,10 @@ var (
 
 func gnpDirected(n int, p float64) graph.Directed {
 	g := simple.NewDirectedGraph()
-	gen.Gnp(g, n, p, nil)
+	err := gen.Gnp(g, n, p, nil)
+	if err != nil {
+		panic(fmt.Sprintf("path: bad test: %v", err))
+	}
 	return g
 }
 

--- a/graph/simple/weighted_directed_test.go
+++ b/graph/simple/weighted_directed_test.go
@@ -160,7 +160,7 @@ func TestWeightedDirected(t *testing.T) {
 
 // Tests Issue #27
 func TestWeightedEdgeOvercounting(t *testing.T) {
-	g := generateDummyGraph()
+	g := generateDummyWeightedGraph()
 
 	if neigh := graph.NodesOf(g.From(int64(2))); len(neigh) != 2 {
 		t.Errorf("Node 2 has incorrect number of neighbors got neighbors %v (count %d), expected 2 neighbors {0,1}", neigh, len(neigh))

--- a/graph/topo/bench_test.go
+++ b/graph/topo/bench_test.go
@@ -5,6 +5,7 @@
 package topo
 
 import (
+	"fmt"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -23,7 +24,10 @@ var (
 
 func gnpDirected(n int, p float64) graph.Directed {
 	g := simple.NewDirectedGraph()
-	gen.Gnp(g, n, p, nil)
+	err := gen.Gnp(g, n, p, nil)
+	if err != nil {
+		panic(fmt.Sprintf("topo: bad test: %v", err))
+	}
 	return g
 }
 

--- a/graph/traverse/traverse_test.go
+++ b/graph/traverse/traverse_test.go
@@ -366,7 +366,10 @@ var (
 
 func gnpUndirected(n int, p float64) graph.Undirected {
 	g := simple.NewUndirectedGraph()
-	gen.Gnp(g, n, p, nil)
+	err := gen.Gnp(g, n, p, nil)
+	if err != nil {
+		panic(fmt.Sprintf("traverse: bad test: %v", err))
+	}
 	return g
 }
 


### PR DESCRIPTION
These were all identified by golangci-lint. The remaining two lint issues are false positives:
```
encoding/dot/decode.go:152:2: `graphAttr` is unused (structcheck)
	graphAttr, nodeAttr, edgeAttr encoding.AttributeSetter
	^
topo/2sat_example_test.go:177:1: tests: ExampleTarjanSCC_2sat refers to unknown field or method: TarjanSCC.2sat (govet)
func ExampleTarjanSCC_2sat() {
^
```
The first is golangci/golangci-lint#826 and the second is golang/go#23864.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
