### PR TITLE
translate netlib l2norm algorithm to asm and remove branches

### DIFF
--- a/floats/floats_test.go
+++ b/floats/floats_test.go
@@ -36,7 +36,6 @@ func areSlicesSame(t *testing.T, truth, comp []float64, str string) {
 				break
 			}
 		}
-
 	}
 	if !ok {
 		t.Errorf(str+". Expected %v, returned %v", truth, comp)
@@ -96,7 +95,6 @@ func TestAddTo(t *testing.T) {
 	if !Panics(func() { AddTo(make([]float64, 3), make([]float64, 3), make([]float64, 2)) }) {
 		t.Errorf("Did not panic with length mismatch")
 	}
-
 }
 
 func TestAddConst(t *testing.T) {
@@ -208,7 +206,6 @@ func TestCumProd(t *testing.T) {
 	truth = []float64{}
 	CumProd(emptyReceiver, emptyReceiver)
 	areSlicesEqual(t, truth, emptyReceiver, "Wrong cumprod returned with empty receiver")
-
 }
 
 func TestCumSum(t *testing.T) {
@@ -231,7 +228,6 @@ func TestCumSum(t *testing.T) {
 	truth = []float64{}
 	CumSum(emptyReceiver, emptyReceiver)
 	areSlicesEqual(t, truth, emptyReceiver, "Wrong cumsum returned with empty receiver")
-
 }
 
 func TestDistance(t *testing.T) {
@@ -270,7 +266,6 @@ func TestDistance(t *testing.T) {
 	if !Panics(func() { Distance([]float64{}, norms, 1) }) {
 		t.Errorf("Did not panic with unequal lengths")
 	}
-
 }
 
 func TestDiv(t *testing.T) {
@@ -398,7 +393,7 @@ func TestEqualFunc(t *testing.T) {
 }
 
 func TestEqualsRelative(t *testing.T) {
-	var equalityTests = []struct {
+	equalityTests := []struct {
 		a, b  float64
 		tol   float64
 		equal bool
@@ -518,7 +513,6 @@ func TestEqualsULP(t *testing.T) {
 	if EqualWithinULP(1, math.NaN(), 10) {
 		t.Errorf("NaN returned as equal")
 	}
-
 }
 
 func TestEqualLengths(t *testing.T) {
@@ -699,7 +693,6 @@ func TestLogSumExp(t *testing.T) {
 	if math.Abs(val-truth) > EqTolerance {
 		t.Errorf("Wrong logsumexp for values with negative infinity")
 	}
-
 }
 
 func TestMaxAndIdx(t *testing.T) {
@@ -1572,7 +1565,6 @@ func TestWithin(t *testing.T) {
 			t.Errorf("Case %v: Idx mismatch. Want: %v, got: %v", i, test.idx, idx)
 		}
 	}
-
 }
 
 func randomSlice(l int) []float64 {

--- a/internal/asm/f64/l2norm.go
+++ b/internal/asm/f64/l2norm.go
@@ -6,33 +6,6 @@ package f64
 
 import "math"
 
-// L2NormUnitary is the level 2 norm of x.
-func L2NormUnitary(x []float64) (sum float64) {
-	var scale float64
-	sumSquares := 1.0
-	for _, v := range x {
-		if v == 0 {
-			continue
-		}
-		absxi := math.Abs(v)
-		if math.IsNaN(absxi) {
-			return math.NaN()
-		}
-		if scale < absxi {
-			s := scale / absxi
-			sumSquares = 1 + sumSquares*s*s
-			scale = absxi
-		} else {
-			s := absxi / scale
-			sumSquares += s * s
-		}
-	}
-	if math.IsInf(scale, 1) {
-		return math.Inf(1)
-	}
-	return scale * math.Sqrt(sumSquares)
-}
-
 // L2NormInc is the level 2 norm of x.
 func L2NormInc(x []float64, n, incX uintptr) (sum float64) {
 	var scale float64

--- a/internal/asm/f64/l2norm_amd64.s
+++ b/internal/asm/f64/l2norm_amd64.s
@@ -1,0 +1,109 @@
+// Copyright ©2019 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !noasm,!appengine,!safe
+
+#include "textflag.h"
+
+#define SUMSQ X0
+#define ABSX X1
+#define SCALE X2
+#define ZERO X3
+#define TMP X4
+#define ABSMASK X5
+#define INF X7
+#define INFMASK X11
+#define NANMASK X12
+#define IDX AX
+#define LEN SI
+#define X_ DI
+
+#define ABSMASK_DATA l2nrodata<>+0(SB)
+#define INF_DATA l2nrodata<>+8(SB)
+#define NAN_DATA l2nrodata<>+16(SB)
+// AbsMask
+DATA l2nrodata<>+0(SB)/8, $0x7FFFFFFFFFFFFFFF
+// Inf
+DATA l2nrodata<>+8(SB)/8, $0x7FF0000000000000
+// NaN
+DATA l2nrodata<>+16(SB)/8, $0xFFF8000000000000
+GLOBL l2nrodata<>+0(SB), RODATA, $24
+
+// L2NormUnitary returns the L2-norm of x.
+// func L2NormUnitary(x []float64) (sum float64)
+TEXT ·L2NormUnitary(SB), NOSPLIT, $0
+	MOVQ x_len+8(FP), LEN
+	MOVQ x_base+0(FP), X_
+	PXOR ZERO, ZERO
+	CMPQ LEN, $0          // if len== 0 {return 0}
+	JZ   retZero
+
+	PXOR  INFMASK, INFMASK
+	PXOR  NANMASK, NANMASK
+	MOVSD $1.0, SUMSQ                // ssq = 1
+	XORPS SCALE, SCALE
+	MOVSD l2nrodata<>+0(SB), ABSMASK
+	MOVSD l2nrodata<>+8(SB), INF
+	XORQ  IDX, IDX                   // idx == 0
+
+initZero:  // for ;x[i]==0; i++ {}
+	// Skip all leading zeros, to avoid divide by zero NaN
+	MOVSD   (X_)(IDX*8), ABSX // absxi = x[i]
+	UCOMISD ABSX, ZERO
+	JP      retNaN            // if isNaN(x[i]) { return NaN }
+	JNE     loop              // if x[i] != 0 { goto loop }
+	INCQ    IDX
+	CMPQ    IDX, LEN
+	JE      retZero           // if ++i == len(x) { return 0 }
+	JMP     initZero
+
+loop:
+	MOVSD   (X_)(IDX*8), ABSX // absxi = x[i]
+	MOVUPS  ABSX, TMP
+	CMPSD   ABSX, TMP, $3
+	ORPD    TMP, NANMASK      // NANMASK = NANMASK | IsNaN(absxi)
+	MOVSD   INF, TMP
+	ANDPD   ABSMASK, ABSX     // absxi == Abs(absxi)
+	CMPSD   ABSX, TMP, $0
+	ORPD    TMP, INFMASK      // INFMASK =  INFMASK | IsInf(absxi)
+	UCOMISD SCALE, ABSX
+	JA      adjScale          // IF SCALE > ABSXI { goto adjScale }
+
+	DIVSD SCALE, ABSX // absxi = scale / absxi
+	MULSD ABSX, ABSX  // absxi *= absxi
+	ADDSD ABSX, SUMSQ // sumsq += absxi
+	INCQ  IDX         // ++i
+	CMPQ  IDX, LEN
+	JNE   loop        // if i < len(x) { continue }
+	JMP   retSum      // if i == len(x) { goto retSum }
+
+adjScale:  // Scale > Absxi
+	DIVSD  ABSX, SCALE  // tmp = absxi / scale
+	MULSD  SCALE, SUMSQ // sumsq *= tmp
+	MULSD  SCALE, SUMSQ // sumsq *= tmp
+	ADDSD  $1.0, SUMSQ  // sumsq += 1
+	MOVUPS ABSX, SCALE  // scale = absxi
+	INCQ   IDX          // ++i
+	CMPQ   IDX, LEN
+	JNE    loop         // if i < len(x) { continue }
+
+retSum:  // Calculate return value
+	SQRTSD  SUMSQ, SUMSQ    // sumsq = sqrt(sumsq)
+	MULSD   SCALE, SUMSQ    // sumsq += scale
+	MOVQ    SUMSQ, R10      // tmp = sumsq
+	UCOMISD ZERO, INFMASK
+	CMOVQPS INF_DATA, R10   // if INFMASK { tmp = INF }
+	UCOMISD ZERO, NANMASK
+	CMOVQPS NAN_DATA, R10   // if NANMASK { tmp = NaN }
+	MOVQ    R10, sum+24(FP) // return tmp
+	RET
+
+retZero:
+	MOVSD ZERO, sum+24(FP) // return 0
+	RET
+
+retNaN:
+	MOVSD NAN_DATA, TMP   // return NaN
+	MOVSD TMP, sum+24(FP)
+	RET

--- a/internal/asm/f64/l2norm_noasm.go
+++ b/internal/asm/f64/l2norm_noasm.go
@@ -1,0 +1,36 @@
+// Copyright ©2019 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !amd64 noasm appengine safe
+
+package f64
+
+import "math"
+
+// L2NormUnitary returns the L2-norm of x.
+func L2NormUnitary(x []float64) (sum float64) {
+	var scale float64
+	sumSquares := 1.0
+	for _, v := range x {
+		if v == 0 {
+			continue
+		}
+		absxi := math.Abs(v)
+		if math.IsNaN(absxi) {
+			return math.NaN()
+		}
+		if scale < absxi {
+			s := scale / absxi
+			sumSquares = 1 + sumSquares*s*s
+			scale = absxi
+		} else {
+			s := absxi / scale
+			sumSquares += s * s
+		}
+	}
+	if math.IsInf(scale, 1) {
+		return math.Inf(1)
+	}
+	return scale * math.Sqrt(sumSquares)
+}

--- a/internal/asm/f64/stubs_amd64.go
+++ b/internal/asm/f64/stubs_amd64.go
@@ -170,3 +170,29 @@ func ScalIncTo(dst []float64, incDst uintptr, alpha float64, x []float64, n, inc
 //      sum += x[i]
 //  }
 func Sum(x []float64) float64
+
+// L2NormUnitary returns the L2-norm of x.
+//   var scale float64
+//   sumSquares := 1.0
+//   for _, v := range x {
+//   	if v == 0 {
+//   		continue
+//   	}
+//   	absxi := math.Abs(v)
+//   	if math.IsNaN(absxi) {
+//   		return math.NaN()
+//   	}
+//   	if scale < absxi {
+//   		s := scale / absxi
+//   		sumSquares = 1 + sumSquares*s*s
+//   		scale = absxi
+//   	} else {
+//   		s := absxi / scale
+//   		sumSquares += s * s
+//   	}
+// 	  	if math.IsInf(scale, 1) {
+// 		  	return math.Inf(1)
+// 	  	}
+//   }
+//   return scale * math.Sqrt(sumSquares)
+func L2NormUnitary(x []float64) (sum float64)


### PR DESCRIPTION
Netlib algorithm reduces overflow while calculating the l2norm of a
vector.

Translated to asm while reducing branches in NaN and Inf checks.
Overflow protection is equivalent to the Netlib standard implementation.

Builds upon #1134 to further speed up L2Norm operations.

<details>
<summary>Speedup ~-33%</summary>

```
name                                 old time/op    new time/op    delta
L2NormNetlib/L2NormUnitary-1-8         5.08ns ± 2%    5.20ns ± 3%   +2.36%  (p=0.019 n=10+10)
L2NormNetlib/L2NormUnitary-3-8         9.00ns ± 2%    8.64ns ± 3%   -3.95%  (p=0.000 n=10+10)
L2NormNetlib/L2NormUnitary-10-8        27.6ns ± 4%    22.1ns ± 1%  -19.84%  (p=0.000 n=10+9)
L2NormNetlib/L2NormUnitary-30-8        89.5ns ± 6%    61.8ns ± 1%  -31.00%  (p=0.000 n=10+10)
L2NormNetlib/L2NormUnitary-100-8        314ns ± 1%     213ns ± 1%  -32.06%  (p=0.000 n=9+9)
L2NormNetlib/L2NormUnitary-300-8        977ns ± 3%     650ns ± 2%  -33.47%  (p=0.000 n=10+10)
L2NormNetlib/L2NormUnitary-1000-8      3.28µs ± 2%    2.17µs ± 2%  -33.83%  (p=0.000 n=10+10)
L2NormNetlib/L2NormUnitary-3000-8      9.89µs ± 1%    6.47µs ± 0%  -34.58%  (p=0.000 n=9+9)
L2NormNetlib/L2NormUnitary-10000-8     33.0µs ± 1%    21.6µs ± 0%  -34.62%  (p=0.000 n=8+8)
L2NormNetlib/L2NormUnitary-30000-8     97.9µs ± 1%    64.9µs ± 1%  -33.71%  (p=0.000 n=10+10)
L2NormNetlib/L2NormUnitary-100000-8     323µs ± 0%     216µs ± 0%  -33.27%  (p=0.000 n=9+8)
```
</details> 

Please take a look.

edit: 

Though this doesn't directly change any floats code, updates via #1134:
<details>
<summary>Floats</summary>

```
name           old time/op  new time/op  delta
Norm2Small-8   27.6ns ± 7%  21.1ns ± 8%  -23.66%  (p=0.000 n=10+10)
Norm2Medium-8  2.12µs ± 3%  1.24µs ± 2%  -41.39%  (p=0.000 n=10+9)
Norm2Large-8    205µs ± 2%   122µs ± 2%  -40.27%  (p=0.000 n=10+10)
Norm2Huge-8    21.1ms ± 2%  13.0ms ± 3%  -38.74%  (p=0.000 n=10+10)
```
</details>