### PR TITLE
blas/{blas64,cblas128}: test wrapping of blas interfaces

### DIFF
--- a/blas/blas64/blas64_test.go
+++ b/blas/blas64/blas64_test.go
@@ -1,0 +1,289 @@
+// Copyright ©2019 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package blas64
+
+import (
+	"fmt"
+	"testing"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/testblas"
+)
+
+var impl = b64{}
+
+func TestDasum(t *testing.T)  { testblas.DasumTest(t, impl) }
+func TestDaxpy(t *testing.T)  { testblas.DaxpyTest(t, impl) }
+func TestDdot(t *testing.T)   { testblas.DdotTest(t, impl) }
+func TestDnrm2(t *testing.T)  { testblas.Dnrm2Test(t, impl) }
+func TestIdamax(t *testing.T) { testblas.IdamaxTest(t, impl) }
+func TestDswap(t *testing.T)  { testblas.DswapTest(t, impl) }
+func TestDcopy(t *testing.T)  { testblas.DcopyTest(t, impl) }
+func TestDrotg(t *testing.T)  { testblas.DrotgTest(t, impl) }
+func TestDrotmg(t *testing.T) { testblas.DrotmgTest(t, impl) }
+func TestDrot(t *testing.T)   { testblas.DrotTest(t, impl) }
+func TestDrotm(t *testing.T)  { testblas.DrotmTest(t, impl) }
+func TestDscal(t *testing.T)  { testblas.DscalTest(t, impl) }
+func TestDgemv(t *testing.T)  { testblas.DgemvTest(t, impl) }
+func TestDger(t *testing.T)   { testblas.DgerTest(t, impl) }
+func TestDtxmv(t *testing.T)  { testblas.DtxmvTest(t, impl) }
+func TestDgbmv(t *testing.T)  { testblas.DgbmvTest(t, impl) }
+func TestDtbsv(t *testing.T)  { testblas.DtbsvTest(t, impl) }
+func TestDsbmv(t *testing.T)  { testblas.DsbmvTest(t, impl) }
+func TestDtbmv(t *testing.T)  { testblas.DtbmvTest(t, impl) }
+func TestDtrsv(t *testing.T)  { testblas.DtrsvTest(t, impl) }
+func TestDtrmv(t *testing.T)  { testblas.DtrmvTest(t, impl) }
+func TestDsymv(t *testing.T)  { testblas.DsymvTest(t, impl) }
+func TestDsyr(t *testing.T)   { testblas.DsyrTest(t, impl) }
+func TestDsyr2(t *testing.T)  { testblas.Dsyr2Test(t, impl) }
+func TestDspr2(t *testing.T)  { testblas.Dspr2Test(t, impl) }
+func TestDspr(t *testing.T)   { testblas.DsprTest(t, impl) }
+func TestDspmv(t *testing.T)  { testblas.DspmvTest(t, impl) }
+func TestDtpsv(t *testing.T)  { testblas.DtpsvTest(t, impl) }
+func TestDtpmv(t *testing.T)  { testblas.DtpmvTest(t, impl) }
+func TestDgemm(t *testing.T)  { testblas.TestDgemm(t, impl) }
+func TestDsymm(t *testing.T)  { testblas.DsymmTest(t, impl) }
+func TestDtrsm(t *testing.T)  { testblas.DtrsmTest(t, impl) }
+func TestDsyrk(t *testing.T)  { testblas.DsyrkTest(t, impl) }
+func TestDsyr2k(t *testing.T) { testblas.Dsyr2kTest(t, impl) }
+func TestDtrmm(t *testing.T)  { testblas.DtrmmTest(t, impl) }
+
+type b64 struct{}
+
+var _ blas.Float64 = b64{}
+
+func (b64) Ddot(n int, x []float64, incX int, y []float64, incY int) float64 {
+	return Dot(Vector{N: n, Inc: incX, Data: x}, Vector{N: n, Inc: incY, Data: y})
+}
+func (b64) Dnrm2(n int, x []float64, incX int) float64 {
+	if incX < 0 {
+		return 0
+	}
+	return Nrm2(Vector{N: n, Inc: incX, Data: x})
+}
+func (b64) Dasum(n int, x []float64, incX int) float64 {
+	if incX < 0 {
+		return 0
+	}
+	return Asum(Vector{N: n, Inc: incX, Data: x})
+}
+func (b64) Idamax(n int, x []float64, incX int) int {
+	if incX < 0 {
+		return -1
+	}
+	return Iamax(Vector{N: n, Inc: incX, Data: x})
+}
+func (b64) Dswap(n int, x []float64, incX int, y []float64, incY int) {
+	Swap(Vector{N: n, Inc: incX, Data: x}, Vector{N: n, Inc: incY, Data: y})
+}
+func (b64) Dcopy(n int, x []float64, incX int, y []float64, incY int) {
+	Copy(Vector{N: n, Inc: incX, Data: x}, Vector{N: n, Inc: incY, Data: y})
+}
+func (b64) Daxpy(n int, alpha float64, x []float64, incX int, y []float64, incY int) {
+	Axpy(alpha, Vector{N: n, Inc: incX, Data: x}, Vector{N: n, Inc: incY, Data: y})
+}
+func (b64) Drotg(a, b float64) (c, s, r, z float64) {
+	return Rotg(a, b)
+}
+func (b64) Drotmg(d1, d2, b1, b2 float64) (p blas.DrotmParams, rd1, rd2, rb1 float64) {
+	return Rotmg(d1, d2, b1, b2)
+}
+func (b64) Drot(n int, x []float64, incX int, y []float64, incY int, c float64, s float64) {
+	Rot(Vector{N: n, Inc: incX, Data: x}, Vector{N: n, Inc: incY, Data: y}, c, s)
+}
+func (b64) Drotm(n int, x []float64, incX int, y []float64, incY int, p blas.DrotmParams) {
+	Rotm(Vector{N: n, Inc: incX, Data: x}, Vector{N: n, Inc: incY, Data: y}, p)
+}
+func (b64) Dscal(n int, alpha float64, x []float64, incX int) {
+	if incX < 0 {
+		return
+	}
+	Scal(alpha, Vector{N: n, Inc: incX, Data: x})
+}
+func (b64) Dgemv(tA blas.Transpose, m, n int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int) {
+	lenX := m
+	lenY := n
+	if tA == blas.NoTrans {
+		lenX = n
+		lenY = m
+	}
+	Gemv(tA, alpha,
+		General{Rows: m, Cols: n, Data: a, Stride: lda},
+		Vector{N: lenX, Inc: incX, Data: x},
+		beta,
+		Vector{N: lenY, Inc: incY, Data: y})
+}
+func (b64) Dgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int) {
+	lenX := m
+	lenY := n
+	if tA == blas.NoTrans {
+		lenX = n
+		lenY = m
+	}
+	Gbmv(tA, alpha,
+		Band{Rows: m, Cols: n, KL: kL, KU: kU, Data: a, Stride: lda},
+		Vector{N: lenX, Inc: incX, Data: x},
+		beta,
+		Vector{N: lenY, Inc: incY, Data: y})
+}
+func (b64) Dtrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []float64, lda int, x []float64, incX int) {
+	Trmv(tA,
+		Triangular{Uplo: ul, Diag: d, N: n, Data: a, Stride: lda},
+		Vector{N: n, Inc: incX, Data: x})
+}
+func (b64) Dtbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []float64, lda int, x []float64, incX int) {
+	Tbmv(tA,
+		TriangularBand{Uplo: ul, Diag: d, N: n, K: k, Data: a, Stride: lda},
+		Vector{N: n, Inc: incX, Data: x})
+}
+func (b64) Dtpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, ap []float64, x []float64, incX int) {
+	Tpmv(tA,
+		TriangularPacked{Uplo: ul, Diag: d, N: n, Data: ap},
+		Vector{N: n, Inc: incX, Data: x})
+}
+func (b64) Dtrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []float64, lda int, x []float64, incX int) {
+	Trsv(tA,
+		Triangular{Uplo: ul, Diag: d, N: n, Data: a, Stride: lda},
+		Vector{N: n, Inc: incX, Data: x})
+}
+func (b64) Dtbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []float64, lda int, x []float64, incX int) {
+	Tbsv(tA,
+		TriangularBand{Uplo: ul, Diag: d, N: n, K: k, Data: a, Stride: lda},
+		Vector{N: n, Inc: incX, Data: x})
+}
+func (b64) Dtpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, ap []float64, x []float64, incX int) {
+	Tpsv(tA,
+		TriangularPacked{Uplo: ul, Diag: d, N: n, Data: ap},
+		Vector{N: n, Inc: incX, Data: x})
+}
+func (b64) Dsymv(ul blas.Uplo, n int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int) {
+	Symv(alpha,
+		Symmetric{Uplo: ul, N: n, Data: a, Stride: lda},
+		Vector{N: n, Inc: incX, Data: x},
+		beta,
+		Vector{N: n, Inc: incY, Data: y})
+}
+func (b64) Dsbmv(ul blas.Uplo, n, k int, alpha float64, a []float64, lda int, x []float64, incX int, beta float64, y []float64, incY int) {
+	Sbmv(alpha,
+		SymmetricBand{Uplo: ul, N: n, K: k, Data: a, Stride: lda},
+		Vector{N: n, Inc: incX, Data: x},
+		beta,
+		Vector{N: n, Inc: incY, Data: y})
+}
+func (b64) Dspmv(ul blas.Uplo, n int, alpha float64, ap []float64, x []float64, incX int, beta float64, y []float64, incY int) {
+	Spmv(alpha,
+		SymmetricPacked{Uplo: ul, N: n, Data: ap},
+		Vector{N: n, Inc: incX, Data: x},
+		beta,
+		Vector{N: n, Inc: incY, Data: y})
+}
+func (b64) Dger(m, n int, alpha float64, x []float64, incX int, y []float64, incY int, a []float64, lda int) {
+	Ger(alpha,
+		Vector{N: m, Inc: incX, Data: x},
+		Vector{N: n, Inc: incY, Data: y},
+		General{Rows: m, Cols: n, Data: a, Stride: lda})
+}
+func (b64) Dsyr(ul blas.Uplo, n int, alpha float64, x []float64, incX int, a []float64, lda int) {
+	Syr(alpha,
+		Vector{N: n, Inc: incX, Data: x},
+		Symmetric{Uplo: ul, N: n, Data: a, Stride: lda})
+}
+func (b64) Dspr(ul blas.Uplo, n int, alpha float64, x []float64, incX int, ap []float64) {
+	Spr(alpha,
+		Vector{N: n, Inc: incX, Data: x},
+		SymmetricPacked{Uplo: ul, N: n, Data: ap})
+}
+func (b64) Dsyr2(ul blas.Uplo, n int, alpha float64, x []float64, incX int, y []float64, incY int, a []float64, lda int) {
+	Syr2(alpha,
+		Vector{N: n, Inc: incX, Data: x},
+		Vector{N: n, Inc: incY, Data: y},
+		Symmetric{Uplo: ul, N: n, Data: a, Stride: lda})
+}
+func (b64) Dspr2(ul blas.Uplo, n int, alpha float64, x []float64, incX int, y []float64, incY int, a []float64) {
+	Spr2(alpha,
+		Vector{N: n, Inc: incX, Data: x},
+		Vector{N: n, Inc: incY, Data: y},
+		SymmetricPacked{Uplo: ul, N: n, Data: a})
+}
+func (b64) Dgemm(tA, tB blas.Transpose, m, n, k int, alpha float64, a []float64, lda int, b []float64, ldb int, beta float64, c []float64, ldc int) {
+	am, an := m, k
+	if tA != blas.NoTrans {
+		am, an = an, am
+	}
+	bm, bn := k, n
+	if tB != blas.NoTrans {
+		bm, bn = bn, bm
+	}
+	Gemm(tA, tB, alpha,
+		General{Rows: am, Cols: an, Data: a, Stride: lda},
+		General{Rows: bm, Cols: bn, Data: b, Stride: ldb},
+		beta,
+		General{Rows: m, Cols: n, Data: c, Stride: ldc})
+}
+func (b64) Dsymm(s blas.Side, ul blas.Uplo, m, n int, alpha float64, a []float64, lda int, b []float64, ldb int, beta float64, c []float64, ldc int) {
+	var an int
+	switch s {
+	case blas.Left:
+		an = m
+	case blas.Right:
+		an = n
+	default:
+		panic(fmt.Sprintf("blas64: bad test: invalid side: %q", s))
+	}
+	Symm(s, alpha,
+		Symmetric{Uplo: ul, N: an, Data: a, Stride: lda},
+		General{Rows: m, Cols: n, Data: b, Stride: ldb},
+		beta,
+		General{Rows: m, Cols: n, Data: c, Stride: ldc})
+}
+func (b64) Dsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha float64, a []float64, lda int, beta float64, c []float64, ldc int) {
+	am, an := n, k
+	if t != blas.NoTrans {
+		am, an = an, am
+	}
+	Syrk(t, alpha,
+		General{Rows: am, Cols: an, Data: a, Stride: lda},
+		beta,
+		Symmetric{Uplo: ul, N: n, Data: c, Stride: ldc})
+}
+func (b64) Dsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha float64, a []float64, lda int, b []float64, ldb int, beta float64, c []float64, ldc int) {
+	am, an := n, k
+	if t != blas.NoTrans {
+		am, an = an, am
+	}
+	Syr2k(t, alpha,
+		General{Rows: am, Cols: an, Data: a, Stride: lda},
+		General{Rows: am, Cols: an, Data: b, Stride: ldb},
+		beta,
+		Symmetric{Uplo: ul, N: n, Data: c, Stride: ldc})
+}
+func (b64) Dtrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas.Diag, m, n int, alpha float64, a []float64, lda int, b []float64, ldb int) {
+	var k int
+	switch s {
+	case blas.Left:
+		k = m
+	case blas.Right:
+		k = n
+	default:
+		panic(fmt.Sprintf("blas64: bad test: invalid side: %q", s))
+	}
+	Trmm(s, tA, alpha,
+		Triangular{Uplo: ul, Diag: d, N: k, Data: a, Stride: lda},
+		General{Rows: m, Cols: n, Data: b, Stride: ldb})
+}
+func (b64) Dtrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas.Diag, m, n int, alpha float64, a []float64, lda int, b []float64, ldb int) {
+	var k int
+	switch s {
+	case blas.Left:
+		k = m
+	case blas.Right:
+		k = n
+	default:
+		panic(fmt.Sprintf("blas64: bad test: invalid side: %q", s))
+	}
+	Trsm(s, tA, alpha,
+		Triangular{Uplo: ul, Diag: d, N: k, Data: a, Stride: lda},
+		General{Rows: m, Cols: n, Data: b, Stride: ldb})
+}

--- a/blas/cblas128/cblas128.go
+++ b/blas/cblas128/cblas128.go
@@ -28,6 +28,7 @@ func Implementation() blas.Complex128 {
 
 // Vector represents a vector with an associated element increment.
 type Vector struct {
+	N    int
 	Inc  int
 	Data []complex128
 }
@@ -112,26 +113,26 @@ const negInc = "cblas128: negative vector increment"
 // Dotu computes the dot product of the two vectors without
 // complex conjugation:
 //  xᵀ * y.
-func Dotu(n int, x, y Vector) complex128 {
-	return cblas128.Zdotu(n, x.Data, x.Inc, y.Data, y.Inc)
+func Dotu(x, y Vector) complex128 {
+	return cblas128.Zdotu(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Dotc computes the dot product of the two vectors with
 // complex conjugation:
 //  xᴴ * y.
-func Dotc(n int, x, y Vector) complex128 {
-	return cblas128.Zdotc(n, x.Data, x.Inc, y.Data, y.Inc)
+func Dotc(x, y Vector) complex128 {
+	return cblas128.Zdotc(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Nrm2 computes the Euclidean norm of the vector x:
 //  sqrt(\sum_i x[i] * x[i]).
 //
 // Nrm2 will panic if the vector increment is negative.
-func Nrm2(n int, x Vector) float64 {
+func Nrm2(x Vector) float64 {
 	if x.Inc < 0 {
 		panic(negInc)
 	}
-	return cblas128.Dznrm2(n, x.Data, x.Inc)
+	return cblas128.Dznrm2(x.N, x.Data, x.Inc)
 }
 
 // Asum computes the sum of magnitudes of the real and imaginary parts of
@@ -139,11 +140,11 @@ func Nrm2(n int, x Vector) float64 {
 //  \sum_i (|Re x[i]| + |Im x[i]|).
 //
 // Asum will panic if the vector increment is negative.
-func Asum(n int, x Vector) float64 {
+func Asum(x Vector) float64 {
 	if x.Inc < 0 {
 		panic(negInc)
 	}
-	return cblas128.Dzasum(n, x.Data, x.Inc)
+	return cblas128.Dzasum(x.N, x.Data, x.Inc)
 }
 
 // Iamax returns the index of an element of x with the largest sum of
@@ -153,30 +154,30 @@ func Asum(n int, x Vector) float64 {
 // Iamax returns -1 if n == 0.
 //
 // Iamax will panic if the vector increment is negative.
-func Iamax(n int, x Vector) int {
+func Iamax(x Vector) int {
 	if x.Inc < 0 {
 		panic(negInc)
 	}
-	return cblas128.Izamax(n, x.Data, x.Inc)
+	return cblas128.Izamax(x.N, x.Data, x.Inc)
 }
 
 // Swap exchanges the elements of two vectors:
 //  x[i], y[i] = y[i], x[i] for all i.
-func Swap(n int, x, y Vector) {
-	cblas128.Zswap(n, x.Data, x.Inc, y.Data, y.Inc)
+func Swap(x, y Vector) {
+	cblas128.Zswap(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Copy copies the elements of x into the elements of y:
 //  y[i] = x[i] for all i.
-func Copy(n int, x, y Vector) {
-	cblas128.Zcopy(n, x.Data, x.Inc, y.Data, y.Inc)
+func Copy(x, y Vector) {
+	cblas128.Zcopy(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Axpy computes
 //  y = alpha * x + y,
 // where x and y are vectors, and alpha is a scalar.
-func Axpy(n int, alpha complex128, x, y Vector) {
-	cblas128.Zaxpy(n, alpha, x.Data, x.Inc, y.Data, y.Inc)
+func Axpy(alpha complex128, x, y Vector) {
+	cblas128.Zaxpy(x.N, alpha, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Scal computes
@@ -184,11 +185,11 @@ func Axpy(n int, alpha complex128, x, y Vector) {
 // where x is a vector, and alpha is a scalar.
 //
 // Scal will panic if the vector increment is negative.
-func Scal(n int, alpha complex128, x Vector) {
+func Scal(alpha complex128, x Vector) {
 	if x.Inc < 0 {
 		panic(negInc)
 	}
-	cblas128.Zscal(n, alpha, x.Data, x.Inc)
+	cblas128.Zscal(x.N, alpha, x.Data, x.Inc)
 }
 
 // Dscal computes
@@ -196,11 +197,11 @@ func Scal(n int, alpha complex128, x Vector) {
 // where x is a vector, and alpha is a real scalar.
 //
 // Dscal will panic if the vector increment is negative.
-func Dscal(n int, alpha float64, x Vector) {
+func Dscal(alpha float64, x Vector) {
 	if x.Inc < 0 {
 		panic(negInc)
 	}
-	cblas128.Zdscal(n, alpha, x.Data, x.Inc)
+	cblas128.Zdscal(x.N, alpha, x.Data, x.Inc)
 }
 
 // Level 2

--- a/blas/cblas128/cblas128_test.go
+++ b/blas/cblas128/cblas128_test.go
@@ -1,0 +1,322 @@
+// Copyright ©2019 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cblas128
+
+import (
+	"fmt"
+	"testing"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/blas64"
+	"gonum.org/v1/gonum/blas/testblas"
+)
+
+var impl = c128{}
+
+func TestDzasum(t *testing.T) { testblas.DzasumTest(t, impl) }
+func TestDznrm2(t *testing.T) { testblas.Dznrm2Test(t, impl) }
+func TestIzamax(t *testing.T) { testblas.IzamaxTest(t, impl) }
+func TestZaxpy(t *testing.T)  { testblas.ZaxpyTest(t, impl) }
+func TestZcopy(t *testing.T)  { testblas.ZcopyTest(t, impl) }
+func TestZdotc(t *testing.T)  { testblas.ZdotcTest(t, impl) }
+func TestZdotu(t *testing.T)  { testblas.ZdotuTest(t, impl) }
+func TestZdscal(t *testing.T) { testblas.ZdscalTest(t, impl) }
+func TestZscal(t *testing.T)  { testblas.ZscalTest(t, impl) }
+func TestZswap(t *testing.T)  { testblas.ZswapTest(t, impl) }
+func TestZgbmv(t *testing.T)  { testblas.ZgbmvTest(t, impl) }
+func TestZgemv(t *testing.T)  { testblas.ZgemvTest(t, impl) }
+func TestZgerc(t *testing.T)  { testblas.ZgercTest(t, impl) }
+func TestZgeru(t *testing.T)  { testblas.ZgeruTest(t, impl) }
+func TestZhbmv(t *testing.T)  { testblas.ZhbmvTest(t, impl) }
+func TestZhemv(t *testing.T)  { testblas.ZhemvTest(t, impl) }
+func TestZher(t *testing.T)   { testblas.ZherTest(t, impl) }
+func TestZher2(t *testing.T)  { testblas.Zher2Test(t, impl) }
+func TestZhpmv(t *testing.T)  { testblas.ZhpmvTest(t, impl) }
+func TestZhpr(t *testing.T)   { testblas.ZhprTest(t, impl) }
+func TestZhpr2(t *testing.T)  { testblas.Zhpr2Test(t, impl) }
+func TestZtbmv(t *testing.T)  { testblas.ZtbmvTest(t, impl) }
+func TestZtbsv(t *testing.T)  { testblas.ZtbsvTest(t, impl) }
+func TestZtpmv(t *testing.T)  { testblas.ZtpmvTest(t, impl) }
+func TestZtpsv(t *testing.T)  { testblas.ZtpsvTest(t, impl) }
+func TestZtrmv(t *testing.T)  { testblas.ZtrmvTest(t, impl) }
+func TestZtrsv(t *testing.T)  { testblas.ZtrsvTest(t, impl) }
+func TestZgemm(t *testing.T)  { testblas.ZgemmTest(t, impl) }
+func TestZhemm(t *testing.T)  { testblas.ZhemmTest(t, impl) }
+func TestZherk(t *testing.T)  { testblas.ZherkTest(t, impl) }
+func TestZher2k(t *testing.T) { testblas.Zher2kTest(t, impl) }
+func TestZsymm(t *testing.T)  { testblas.ZsymmTest(t, impl) }
+func TestZsyrk(t *testing.T)  { testblas.ZsyrkTest(t, impl) }
+func TestZsyr2k(t *testing.T) { testblas.Zsyr2kTest(t, impl) }
+func TestZtrmm(t *testing.T)  { testblas.ZtrmmTest(t, impl) }
+func TestZtrsm(t *testing.T)  { testblas.ZtrsmTest(t, impl) }
+
+type c128 struct{}
+
+var _ blas.Complex128 = c128{}
+
+func (c128) Zdotu(n int, x []complex128, incX int, y []complex128, incY int) complex128 {
+	return Dotu(n, Vector{Inc: incX, Data: x}, Vector{Inc: incY, Data: y})
+}
+func (c128) Zdotc(n int, x []complex128, incX int, y []complex128, incY int) complex128 {
+	return Dotc(n, Vector{Inc: incX, Data: x}, Vector{Inc: incY, Data: y})
+}
+func (c128) Dznrm2(n int, x []complex128, incX int) float64 {
+	if incX < 0 {
+		return 0
+	}
+	return Nrm2(n, Vector{Inc: incX, Data: x})
+}
+func (c128) Dnrm2(n int, x []float64, incX int) float64 {
+	return blas64.Nrm2(blas64.Vector{N: n, Inc: incX, Data: x})
+}
+func (c128) Dzasum(n int, x []complex128, incX int) float64 {
+	if incX < 0 {
+		return 0
+	}
+	return Asum(n, Vector{Inc: incX, Data: x})
+}
+func (c128) Izamax(n int, x []complex128, incX int) int {
+	if incX < 0 {
+		return -1
+	}
+	return Iamax(n, Vector{Inc: incX, Data: x})
+}
+func (c128) Zswap(n int, x []complex128, incX int, y []complex128, incY int) {
+	Swap(n, Vector{Inc: incX, Data: x}, Vector{Inc: incY, Data: y})
+}
+func (c128) Zcopy(n int, x []complex128, incX int, y []complex128, incY int) {
+	Copy(n, Vector{Inc: incX, Data: x}, Vector{Inc: incY, Data: y})
+}
+func (c128) Zaxpy(n int, alpha complex128, x []complex128, incX int, y []complex128, incY int) {
+	Axpy(n, alpha, Vector{Inc: incX, Data: x}, Vector{Inc: incY, Data: y})
+}
+func (c128) Zscal(n int, alpha complex128, x []complex128, incX int) {
+	if incX < 0 {
+		return
+	}
+	Scal(n, alpha, Vector{Inc: incX, Data: x})
+}
+func (c128) Zdscal(n int, alpha float64, x []complex128, incX int) {
+	if incX < 0 {
+		return
+	}
+	Dscal(n, alpha, Vector{Inc: incX, Data: x})
+}
+func (c128) Zgemv(tA blas.Transpose, m, n int, alpha complex128, a []complex128, lda int, x []complex128, incX int, beta complex128, y []complex128, incY int) {
+	Gemv(tA, alpha,
+		General{Rows: m, Cols: n, Data: a, Stride: lda},
+		Vector{Inc: incX, Data: x},
+		beta,
+		Vector{Inc: incY, Data: y})
+}
+func (c128) Zgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex128, a []complex128, lda int, x []complex128, incX int, beta complex128, y []complex128, incY int) {
+	Gbmv(tA, alpha,
+		Band{Rows: m, Cols: n, KL: kL, KU: kU, Data: a, Stride: lda},
+		Vector{Inc: incX, Data: x},
+		beta,
+		Vector{Inc: incY, Data: y})
+}
+func (c128) Ztrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []complex128, lda int, x []complex128, incX int) {
+	Trmv(tA,
+		Triangular{Uplo: ul, Diag: d, N: n, Data: a, Stride: lda},
+		Vector{Inc: incX, Data: x})
+}
+func (c128) Ztbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []complex128, lda int, x []complex128, incX int) {
+	Tbmv(tA,
+		TriangularBand{Uplo: ul, Diag: d, N: n, K: k, Data: a, Stride: lda},
+		Vector{Inc: incX, Data: x})
+}
+func (c128) Ztpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, ap []complex128, x []complex128, incX int) {
+	Tpmv(tA,
+		TriangularPacked{Uplo: ul, Diag: d, N: n, Data: ap},
+		Vector{Inc: incX, Data: x})
+}
+func (c128) Ztrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []complex128, lda int, x []complex128, incX int) {
+	Trsv(tA,
+		Triangular{Uplo: ul, Diag: d, N: n, Data: a, Stride: lda},
+		Vector{Inc: incX, Data: x})
+}
+func (c128) Ztbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []complex128, lda int, x []complex128, incX int) {
+	Tbsv(tA,
+		TriangularBand{Uplo: ul, Diag: d, N: n, K: k, Data: a, Stride: lda},
+		Vector{Inc: incX, Data: x})
+}
+func (c128) Ztpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, ap []complex128, x []complex128, incX int) {
+	Tpsv(tA,
+		TriangularPacked{Uplo: ul, Diag: d, N: n, Data: ap},
+		Vector{Inc: incX, Data: x})
+}
+func (c128) Zhemv(ul blas.Uplo, n int, alpha complex128, a []complex128, lda int, x []complex128, incX int, beta complex128, y []complex128, incY int) {
+	Hemv(alpha,
+		Hermitian{Uplo: ul, N: n, Data: a, Stride: lda},
+		Vector{Inc: incX, Data: x},
+		beta,
+		Vector{Inc: incY, Data: y})
+}
+func (c128) Zhbmv(ul blas.Uplo, n, k int, alpha complex128, a []complex128, lda int, x []complex128, incX int, beta complex128, y []complex128, incY int) {
+	Hbmv(alpha,
+		HermitianBand{Uplo: ul, N: n, K: k, Data: a, Stride: lda},
+		Vector{Inc: incX, Data: x},
+		beta,
+		Vector{Inc: incY, Data: y})
+}
+func (c128) Zhpmv(ul blas.Uplo, n int, alpha complex128, ap []complex128, x []complex128, incX int, beta complex128, y []complex128, incY int) {
+	Hpmv(alpha,
+		HermitianPacked{Uplo: ul, N: n, Data: ap},
+		Vector{Inc: incX, Data: x},
+		beta,
+		Vector{Inc: incY, Data: y})
+}
+func (c128) Zgeru(m, n int, alpha complex128, x []complex128, incX int, y []complex128, incY int, a []complex128, lda int) {
+	Geru(alpha,
+		Vector{Inc: incX, Data: x},
+		Vector{Inc: incY, Data: y},
+		General{Rows: m, Cols: n, Data: a, Stride: lda})
+}
+func (c128) Zgerc(m, n int, alpha complex128, x []complex128, incX int, y []complex128, incY int, a []complex128, lda int) {
+	Gerc(alpha,
+		Vector{Inc: incX, Data: x},
+		Vector{Inc: incY, Data: y},
+		General{Rows: m, Cols: n, Data: a, Stride: lda})
+}
+func (c128) Zher(ul blas.Uplo, n int, alpha float64, x []complex128, incX int, a []complex128, lda int) {
+	Her(alpha,
+		Vector{Inc: incX, Data: x},
+		Hermitian{Uplo: ul, N: n, Data: a, Stride: lda})
+}
+func (c128) Zhpr(ul blas.Uplo, n int, alpha float64, x []complex128, incX int, ap []complex128) {
+	Hpr(alpha,
+		Vector{Inc: incX, Data: x},
+		HermitianPacked{Uplo: ul, N: n, Data: ap})
+}
+func (c128) Zher2(ul blas.Uplo, n int, alpha complex128, x []complex128, incX int, y []complex128, incY int, a []complex128, lda int) {
+	Her2(alpha,
+		Vector{Inc: incX, Data: x},
+		Vector{Inc: incY, Data: y},
+		Hermitian{Uplo: ul, N: n, Data: a, Stride: lda})
+}
+func (c128) Zhpr2(ul blas.Uplo, n int, alpha complex128, x []complex128, incX int, y []complex128, incY int, a []complex128) {
+	Hpr2(alpha,
+		Vector{Inc: incX, Data: x},
+		Vector{Inc: incY, Data: y},
+		HermitianPacked{Uplo: ul, N: n, Data: a})
+}
+func (c128) Zgemm(tA, tB blas.Transpose, m, n, k int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta complex128, c []complex128, ldc int) {
+	am, an := m, k
+	if tA != blas.NoTrans {
+		am, an = an, am
+	}
+	bm, bn := k, n
+	if tB != blas.NoTrans {
+		bm, bn = bn, bm
+	}
+	Gemm(tA, tB, alpha,
+		General{Rows: am, Cols: an, Data: a, Stride: lda},
+		General{Rows: bm, Cols: bn, Data: b, Stride: ldb},
+		beta,
+		General{Rows: m, Cols: n, Data: c, Stride: ldc})
+}
+func (c128) Zsymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta complex128, c []complex128, ldc int) {
+	var an int
+	switch s {
+	case blas.Left:
+		an = m
+	case blas.Right:
+		an = n
+	default:
+		panic(fmt.Sprintf("blas64: bad test: invalid side: %q", s))
+	}
+	Symm(s, alpha,
+		Symmetric{Uplo: ul, N: an, Data: a, Stride: lda},
+		General{Rows: m, Cols: n, Data: b, Stride: ldb},
+		beta,
+		General{Rows: m, Cols: n, Data: c, Stride: ldc})
+}
+func (c128) Zsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha complex128, a []complex128, lda int, beta complex128, c []complex128, ldc int) {
+	am, an := n, k
+	if t != blas.NoTrans {
+		am, an = an, am
+	}
+	Syrk(t, alpha,
+		General{Rows: am, Cols: an, Data: a, Stride: lda},
+		beta,
+		Symmetric{Uplo: ul, N: n, Data: c, Stride: ldc})
+}
+func (c128) Zsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta complex128, c []complex128, ldc int) {
+	am, an := n, k
+	if t != blas.NoTrans {
+		am, an = an, am
+	}
+	Syr2k(t, alpha,
+		General{Rows: am, Cols: an, Data: a, Stride: lda},
+		General{Rows: am, Cols: an, Data: b, Stride: ldb},
+		beta,
+		Symmetric{Uplo: ul, N: n, Data: c, Stride: ldc})
+}
+func (c128) Zhemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta complex128, c []complex128, ldc int) {
+	var an int
+	switch s {
+	case blas.Left:
+		an = m
+	case blas.Right:
+		an = n
+	default:
+		panic(fmt.Sprintf("blas64: bad test: invalid side: %q", s))
+	}
+	Hemm(s, alpha,
+		Hermitian{Uplo: ul, N: an, Data: a, Stride: lda},
+		General{Rows: m, Cols: n, Data: b, Stride: ldb},
+		beta,
+		General{Rows: m, Cols: n, Data: c, Stride: ldc})
+}
+func (c128) Zherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha float64, a []complex128, lda int, beta float64, c []complex128, ldc int) {
+	am, an := n, k
+	if t != blas.NoTrans {
+		am, an = an, am
+	}
+	Herk(t, alpha,
+		General{Rows: am, Cols: an, Data: a, Stride: lda},
+		beta,
+		Hermitian{Uplo: ul, N: n, Data: c, Stride: ldc})
+}
+func (c128) Zher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta float64, c []complex128, ldc int) {
+	am, an := n, k
+	if t != blas.NoTrans {
+		am, an = an, am
+	}
+	Her2k(t, alpha,
+		General{Rows: am, Cols: an, Data: a, Stride: lda},
+		General{Rows: am, Cols: an, Data: b, Stride: ldb},
+		beta,
+		Hermitian{Uplo: ul, N: n, Data: c, Stride: ldc})
+}
+func (c128) Ztrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas.Diag, m, n int, alpha complex128, a []complex128, lda int, b []complex128, ldb int) {
+	var k int
+	switch s {
+	case blas.Left:
+		k = m
+	case blas.Right:
+		k = n
+	default:
+		panic(fmt.Sprintf("blas64: bad test: invalid side: %q", s))
+	}
+	Trmm(s, tA, alpha,
+		Triangular{Uplo: ul, Diag: d, N: k, Data: a, Stride: lda},
+		General{Rows: m, Cols: n, Data: b, Stride: ldb})
+}
+func (c128) Ztrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas.Diag, m, n int, alpha complex128, a []complex128, lda int, b []complex128, ldb int) {
+	var k int
+	switch s {
+	case blas.Left:
+		k = m
+	case blas.Right:
+		k = n
+	default:
+		panic(fmt.Sprintf("blas64: bad test: invalid side: %q", s))
+	}
+	Trsm(s, tA, alpha,
+		Triangular{Uplo: ul, Diag: d, N: k, Data: a, Stride: lda},
+		General{Rows: m, Cols: n, Data: b, Stride: ldb})
+}

--- a/blas/cblas128/cblas128_test.go
+++ b/blas/cblas128/cblas128_test.go
@@ -57,16 +57,16 @@ type c128 struct{}
 var _ blas.Complex128 = c128{}
 
 func (c128) Zdotu(n int, x []complex128, incX int, y []complex128, incY int) complex128 {
-	return Dotu(n, Vector{Inc: incX, Data: x}, Vector{Inc: incY, Data: y})
+	return Dotu(Vector{N: n, Inc: incX, Data: x}, Vector{N: n, Inc: incY, Data: y})
 }
 func (c128) Zdotc(n int, x []complex128, incX int, y []complex128, incY int) complex128 {
-	return Dotc(n, Vector{Inc: incX, Data: x}, Vector{Inc: incY, Data: y})
+	return Dotc(Vector{N: n, Inc: incX, Data: x}, Vector{N: n, Inc: incY, Data: y})
 }
 func (c128) Dznrm2(n int, x []complex128, incX int) float64 {
 	if incX < 0 {
 		return 0
 	}
-	return Nrm2(n, Vector{Inc: incX, Data: x})
+	return Nrm2(Vector{N: n, Inc: incX, Data: x})
 }
 func (c128) Dnrm2(n int, x []float64, incX int) float64 {
 	return blas64.Nrm2(blas64.Vector{N: n, Inc: incX, Data: x})
@@ -75,132 +75,144 @@ func (c128) Dzasum(n int, x []complex128, incX int) float64 {
 	if incX < 0 {
 		return 0
 	}
-	return Asum(n, Vector{Inc: incX, Data: x})
+	return Asum(Vector{N: n, Inc: incX, Data: x})
 }
 func (c128) Izamax(n int, x []complex128, incX int) int {
 	if incX < 0 {
 		return -1
 	}
-	return Iamax(n, Vector{Inc: incX, Data: x})
+	return Iamax(Vector{N: n, Inc: incX, Data: x})
 }
 func (c128) Zswap(n int, x []complex128, incX int, y []complex128, incY int) {
-	Swap(n, Vector{Inc: incX, Data: x}, Vector{Inc: incY, Data: y})
+	Swap(Vector{N: n, Inc: incX, Data: x}, Vector{N: n, Inc: incY, Data: y})
 }
 func (c128) Zcopy(n int, x []complex128, incX int, y []complex128, incY int) {
-	Copy(n, Vector{Inc: incX, Data: x}, Vector{Inc: incY, Data: y})
+	Copy(Vector{N: n, Inc: incX, Data: x}, Vector{N: n, Inc: incY, Data: y})
 }
 func (c128) Zaxpy(n int, alpha complex128, x []complex128, incX int, y []complex128, incY int) {
-	Axpy(n, alpha, Vector{Inc: incX, Data: x}, Vector{Inc: incY, Data: y})
+	Axpy(alpha, Vector{N: n, Inc: incX, Data: x}, Vector{N: n, Inc: incY, Data: y})
 }
 func (c128) Zscal(n int, alpha complex128, x []complex128, incX int) {
 	if incX < 0 {
 		return
 	}
-	Scal(n, alpha, Vector{Inc: incX, Data: x})
+	Scal(alpha, Vector{N: n, Inc: incX, Data: x})
 }
 func (c128) Zdscal(n int, alpha float64, x []complex128, incX int) {
 	if incX < 0 {
 		return
 	}
-	Dscal(n, alpha, Vector{Inc: incX, Data: x})
+	Dscal(alpha, Vector{N: n, Inc: incX, Data: x})
 }
 func (c128) Zgemv(tA blas.Transpose, m, n int, alpha complex128, a []complex128, lda int, x []complex128, incX int, beta complex128, y []complex128, incY int) {
+	lenX := m
+	lenY := n
+	if tA == blas.NoTrans {
+		lenX = n
+		lenY = m
+	}
 	Gemv(tA, alpha,
 		General{Rows: m, Cols: n, Data: a, Stride: lda},
-		Vector{Inc: incX, Data: x},
+		Vector{N: lenX, Inc: incX, Data: x},
 		beta,
-		Vector{Inc: incY, Data: y})
+		Vector{N: lenY, Inc: incY, Data: y})
 }
 func (c128) Zgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex128, a []complex128, lda int, x []complex128, incX int, beta complex128, y []complex128, incY int) {
+	lenX := m
+	lenY := n
+	if tA == blas.NoTrans {
+		lenX = n
+		lenY = m
+	}
 	Gbmv(tA, alpha,
 		Band{Rows: m, Cols: n, KL: kL, KU: kU, Data: a, Stride: lda},
-		Vector{Inc: incX, Data: x},
+		Vector{N: lenX, Inc: incX, Data: x},
 		beta,
-		Vector{Inc: incY, Data: y})
+		Vector{N: lenY, Inc: incY, Data: y})
 }
 func (c128) Ztrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []complex128, lda int, x []complex128, incX int) {
 	Trmv(tA,
 		Triangular{Uplo: ul, Diag: d, N: n, Data: a, Stride: lda},
-		Vector{Inc: incX, Data: x})
+		Vector{N: n, Inc: incX, Data: x})
 }
 func (c128) Ztbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []complex128, lda int, x []complex128, incX int) {
 	Tbmv(tA,
 		TriangularBand{Uplo: ul, Diag: d, N: n, K: k, Data: a, Stride: lda},
-		Vector{Inc: incX, Data: x})
+		Vector{N: n, Inc: incX, Data: x})
 }
 func (c128) Ztpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, ap []complex128, x []complex128, incX int) {
 	Tpmv(tA,
 		TriangularPacked{Uplo: ul, Diag: d, N: n, Data: ap},
-		Vector{Inc: incX, Data: x})
+		Vector{N: n, Inc: incX, Data: x})
 }
 func (c128) Ztrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []complex128, lda int, x []complex128, incX int) {
 	Trsv(tA,
 		Triangular{Uplo: ul, Diag: d, N: n, Data: a, Stride: lda},
-		Vector{Inc: incX, Data: x})
+		Vector{N: n, Inc: incX, Data: x})
 }
 func (c128) Ztbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []complex128, lda int, x []complex128, incX int) {
 	Tbsv(tA,
 		TriangularBand{Uplo: ul, Diag: d, N: n, K: k, Data: a, Stride: lda},
-		Vector{Inc: incX, Data: x})
+		Vector{N: n, Inc: incX, Data: x})
 }
 func (c128) Ztpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, ap []complex128, x []complex128, incX int) {
 	Tpsv(tA,
 		TriangularPacked{Uplo: ul, Diag: d, N: n, Data: ap},
-		Vector{Inc: incX, Data: x})
+		Vector{N: n, Inc: incX, Data: x})
 }
 func (c128) Zhemv(ul blas.Uplo, n int, alpha complex128, a []complex128, lda int, x []complex128, incX int, beta complex128, y []complex128, incY int) {
 	Hemv(alpha,
 		Hermitian{Uplo: ul, N: n, Data: a, Stride: lda},
-		Vector{Inc: incX, Data: x},
+		Vector{N: n, Inc: incX, Data: x},
 		beta,
-		Vector{Inc: incY, Data: y})
+		Vector{N: n, Inc: incY, Data: y})
 }
 func (c128) Zhbmv(ul blas.Uplo, n, k int, alpha complex128, a []complex128, lda int, x []complex128, incX int, beta complex128, y []complex128, incY int) {
 	Hbmv(alpha,
 		HermitianBand{Uplo: ul, N: n, K: k, Data: a, Stride: lda},
-		Vector{Inc: incX, Data: x},
+		Vector{N: n, Inc: incX, Data: x},
 		beta,
-		Vector{Inc: incY, Data: y})
+		Vector{N: n, Inc: incY, Data: y})
 }
 func (c128) Zhpmv(ul blas.Uplo, n int, alpha complex128, ap []complex128, x []complex128, incX int, beta complex128, y []complex128, incY int) {
 	Hpmv(alpha,
 		HermitianPacked{Uplo: ul, N: n, Data: ap},
-		Vector{Inc: incX, Data: x},
+		Vector{N: n, Inc: incX, Data: x},
 		beta,
-		Vector{Inc: incY, Data: y})
+		Vector{N: n, Inc: incY, Data: y})
 }
 func (c128) Zgeru(m, n int, alpha complex128, x []complex128, incX int, y []complex128, incY int, a []complex128, lda int) {
 	Geru(alpha,
-		Vector{Inc: incX, Data: x},
-		Vector{Inc: incY, Data: y},
+		Vector{N: n, Inc: incX, Data: x},
+		Vector{N: n, Inc: incY, Data: y},
 		General{Rows: m, Cols: n, Data: a, Stride: lda})
 }
 func (c128) Zgerc(m, n int, alpha complex128, x []complex128, incX int, y []complex128, incY int, a []complex128, lda int) {
 	Gerc(alpha,
-		Vector{Inc: incX, Data: x},
-		Vector{Inc: incY, Data: y},
+		Vector{N: n, Inc: incX, Data: x},
+		Vector{N: n, Inc: incY, Data: y},
 		General{Rows: m, Cols: n, Data: a, Stride: lda})
 }
 func (c128) Zher(ul blas.Uplo, n int, alpha float64, x []complex128, incX int, a []complex128, lda int) {
 	Her(alpha,
-		Vector{Inc: incX, Data: x},
+		Vector{N: n, Inc: incX, Data: x},
 		Hermitian{Uplo: ul, N: n, Data: a, Stride: lda})
 }
 func (c128) Zhpr(ul blas.Uplo, n int, alpha float64, x []complex128, incX int, ap []complex128) {
 	Hpr(alpha,
-		Vector{Inc: incX, Data: x},
+		Vector{N: n, Inc: incX, Data: x},
 		HermitianPacked{Uplo: ul, N: n, Data: ap})
 }
 func (c128) Zher2(ul blas.Uplo, n int, alpha complex128, x []complex128, incX int, y []complex128, incY int, a []complex128, lda int) {
 	Her2(alpha,
-		Vector{Inc: incX, Data: x},
-		Vector{Inc: incY, Data: y},
+		Vector{N: n, Inc: incX, Data: x},
+		Vector{N: n, Inc: incY, Data: y},
 		Hermitian{Uplo: ul, N: n, Data: a, Stride: lda})
 }
 func (c128) Zhpr2(ul blas.Uplo, n int, alpha complex128, x []complex128, incX int, y []complex128, incY int, a []complex128) {
 	Hpr2(alpha,
-		Vector{Inc: incX, Data: x},
-		Vector{Inc: incY, Data: y},
+		Vector{N: n, Inc: incX, Data: x},
+		Vector{N: n, Inc: incY, Data: y},
 		HermitianPacked{Uplo: ul, N: n, Data: a})
 }
 func (c128) Zgemm(tA, tB blas.Transpose, m, n, k int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta complex128, c []complex128, ldc int) {

--- a/blas/cblas64/cblas64.go
+++ b/blas/cblas64/cblas64.go
@@ -28,6 +28,7 @@ func Implementation() blas.Complex64 {
 
 // Vector represents a vector with an associated element increment.
 type Vector struct {
+	N    int
 	Inc  int
 	Data []complex64
 }
@@ -112,26 +113,26 @@ const negInc = "cblas64: negative vector increment"
 // Dotu computes the dot product of the two vectors without
 // complex conjugation:
 //  xᵀ * y
-func Dotu(n int, x, y Vector) complex64 {
-	return cblas64.Cdotu(n, x.Data, x.Inc, y.Data, y.Inc)
+func Dotu(x, y Vector) complex64 {
+	return cblas64.Cdotu(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Dotc computes the dot product of the two vectors with
 // complex conjugation:
 //  xᴴ * y.
-func Dotc(n int, x, y Vector) complex64 {
-	return cblas64.Cdotc(n, x.Data, x.Inc, y.Data, y.Inc)
+func Dotc(x, y Vector) complex64 {
+	return cblas64.Cdotc(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Nrm2 computes the Euclidean norm of the vector x:
 //  sqrt(\sum_i x[i] * x[i]).
 //
 // Nrm2 will panic if the vector increment is negative.
-func Nrm2(n int, x Vector) float32 {
+func Nrm2(x Vector) float32 {
 	if x.Inc < 0 {
 		panic(negInc)
 	}
-	return cblas64.Scnrm2(n, x.Data, x.Inc)
+	return cblas64.Scnrm2(x.N, x.Data, x.Inc)
 }
 
 // Asum computes the sum of magnitudes of the real and imaginary parts of
@@ -139,11 +140,11 @@ func Nrm2(n int, x Vector) float32 {
 //  \sum_i (|Re x[i]| + |Im x[i]|).
 //
 // Asum will panic if the vector increment is negative.
-func Asum(n int, x Vector) float32 {
+func Asum(x Vector) float32 {
 	if x.Inc < 0 {
 		panic(negInc)
 	}
-	return cblas64.Scasum(n, x.Data, x.Inc)
+	return cblas64.Scasum(x.N, x.Data, x.Inc)
 }
 
 // Iamax returns the index of an element of x with the largest sum of
@@ -153,30 +154,30 @@ func Asum(n int, x Vector) float32 {
 // Iamax returns -1 if n == 0.
 //
 // Iamax will panic if the vector increment is negative.
-func Iamax(n int, x Vector) int {
+func Iamax(x Vector) int {
 	if x.Inc < 0 {
 		panic(negInc)
 	}
-	return cblas64.Icamax(n, x.Data, x.Inc)
+	return cblas64.Icamax(x.N, x.Data, x.Inc)
 }
 
 // Swap exchanges the elements of two vectors:
 //  x[i], y[i] = y[i], x[i] for all i.
-func Swap(n int, x, y Vector) {
-	cblas64.Cswap(n, x.Data, x.Inc, y.Data, y.Inc)
+func Swap(x, y Vector) {
+	cblas64.Cswap(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Copy copies the elements of x into the elements of y:
 //  y[i] = x[i] for all i.
-func Copy(n int, x, y Vector) {
-	cblas64.Ccopy(n, x.Data, x.Inc, y.Data, y.Inc)
+func Copy(x, y Vector) {
+	cblas64.Ccopy(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Axpy computes
 //  y = alpha * x + y,
 // where x and y are vectors, and alpha is a scalar.
-func Axpy(n int, alpha complex64, x, y Vector) {
-	cblas64.Caxpy(n, alpha, x.Data, x.Inc, y.Data, y.Inc)
+func Axpy(alpha complex64, x, y Vector) {
+	cblas64.Caxpy(x.N, alpha, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Scal computes
@@ -184,11 +185,11 @@ func Axpy(n int, alpha complex64, x, y Vector) {
 // where x is a vector, and alpha is a scalar.
 //
 // Scal will panic if the vector increment is negative.
-func Scal(n int, alpha complex64, x Vector) {
+func Scal(alpha complex64, x Vector) {
 	if x.Inc < 0 {
 		panic(negInc)
 	}
-	cblas64.Cscal(n, alpha, x.Data, x.Inc)
+	cblas64.Cscal(x.N, alpha, x.Data, x.Inc)
 }
 
 // Dscal computes
@@ -196,11 +197,11 @@ func Scal(n int, alpha complex64, x Vector) {
 // where x is a vector, and alpha is a real scalar.
 //
 // Dscal will panic if the vector increment is negative.
-func Dscal(n int, alpha float32, x Vector) {
+func Dscal(alpha float32, x Vector) {
 	if x.Inc < 0 {
 		panic(negInc)
 	}
-	cblas64.Csscal(n, alpha, x.Data, x.Inc)
+	cblas64.Csscal(x.N, alpha, x.Data, x.Inc)
 }
 
 // Level 2


### PR DESCRIPTION
Please take a look.

Running through this, I identified a discordance in the APIs of blas64 and cblas128 in how level 1 operations (or other operations with vectors) are performed. These should be made concordant (#1156).

Fixes #1156.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
