### PR TITLE
travis: remove windows autocrlf workaround and use .travis.yml configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,6 @@ matrix:
   - go: master
 
 before_install:
- # Make sure we have the origin master to compare HEADs and
- # save the sha for comparison in test-coverage.sh.
- - export ORIGIN_MASTER=$(git ls-remote origin master | cut -f1)
-
  - ${TRAVIS_BUILD_DIR}/.travis/run-parts ${TRAVIS_BUILD_DIR}/.travis/deps.d/${TRAVIS_OS_NAME}
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ cache:
 
 git:
  depth: 1
+ autocrlf: input
 
 matrix:
  fast_finish: true
@@ -60,27 +61,7 @@ matrix:
 before_install:
  # Make sure we have the origin master to compare HEADs and
  # save the sha for comparison in test-coverage.sh.
- # It is necessary to do this here since the rigmarole for
- # Windows loses the link to the real origin master.
- - git fetch --depth=1 origin master
  - export ORIGIN_MASTER=$(git ls-remote origin master | cut -f1)
-
- # This garbage is necessary because on windows, Travis 
- # helpfully sets core.autocrlf to true.
- #
- # The block here repeats the clone after having unset
- # core.autcrlf. There is no simple way to do this
- # conditionally on OS because windows will not allow
- # a file to be removed or moved while the file is open,
- # and we use constructed paths to scripts to get
- # conditional execution.
- #
- # Happy windowsing!
- - pushd ../../..
- - mv gonum.org/v1/gonum .
- - git config --global core.autocrlf false
- - git clone gonum gonum.org/v1/gonum
- - popd
 
  - ${TRAVIS_BUILD_DIR}/.travis/run-parts ${TRAVIS_BUILD_DIR}/.travis/deps.d/${TRAVIS_OS_NAME}
 

--- a/.travis/script.d/test-coverage.sh
+++ b/.travis/script.d/test-coverage.sh
@@ -5,6 +5,7 @@ if [[ "${TRAVIS_SECURE_ENV_VARS}" != true ]]; then
 	exit 0
 fi
 
+ORIGIN_MASTER="$(git ls-remote origin master | cut -f1)"
 CURRENT="$(git rev-parse HEAD)"
 if [[ ${ORIGIN_MASTER} != ${CURRENT} ]]; then
 	echo "skipping coverage - not merged into master"


### PR DESCRIPTION
Please take a look.

This was just added to travis. There is no documentation for it yet.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
