### PR TITLE
blas: fix up length handling

### DIFF
--- a/blas/blas32/blas32.go
+++ b/blas/blas32/blas32.go
@@ -99,23 +99,38 @@ type SymmetricPacked struct {
 
 // Level 1
 
-const negInc = "blas32: negative vector increment"
+const (
+	negInc    = "blas32: negative vector increment"
+	badLength = "blas32: vector length mismatch"
+)
 
 // Dot computes the dot product of the two vectors:
 //  \sum_i x[i]*y[i].
+// Dot will panic if the lengths of x and y do not match.
 func Dot(x, y Vector) float32 {
+	if x.N != y.N {
+		panic(badLength)
+	}
 	return blas32.Sdot(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // DDot computes the dot product of the two vectors:
 //  \sum_i x[i]*y[i].
+// DDot will panic if the lengths of x and y do not match.
 func DDot(x, y Vector) float64 {
+	if x.N != y.N {
+		panic(badLength)
+	}
 	return blas32.Dsdot(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // SDDot computes the dot product of the two vectors adding a constant:
 //  alpha + \sum_i x[i]*y[i].
+// SDDot will panic if the lengths of x and y do not match.
 func SDDot(alpha float32, x, y Vector) float32 {
+	if x.N != y.N {
+		panic(badLength)
+	}
 	return blas32.Sdsdot(x.N, alpha, x.Data, x.Inc, y.Data, y.Inc)
 }
 
@@ -155,19 +170,31 @@ func Iamax(x Vector) int {
 
 // Swap exchanges the elements of the two vectors:
 //  x[i], y[i] = y[i], x[i] for all i.
+// Swap will panic if the lengths of x and y do not match.
 func Swap(x, y Vector) {
+	if x.N != y.N {
+		panic(badLength)
+	}
 	blas32.Sswap(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Copy copies the elements of x into the elements of y:
 //  y[i] = x[i] for all i.
+// Copy will panic if the lengths of x and y do not match.
 func Copy(x, y Vector) {
+	if x.N != y.N {
+		panic(badLength)
+	}
 	blas32.Scopy(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Axpy adds x scaled by alpha to y:
 //  y[i] += alpha*x[i] for all i.
+// Axpy will panic if the lengths of x and y do not match.
 func Axpy(alpha float32, x, y Vector) {
+	if x.N != y.N {
+		panic(badLength)
+	}
 	blas32.Saxpy(x.N, alpha, x.Data, x.Inc, y.Data, y.Inc)
 }
 

--- a/blas/blas32/blas32.go
+++ b/blas/blas32/blas32.go
@@ -28,6 +28,7 @@ func Implementation() blas.Float32 {
 
 // Vector represents a vector with an associated element increment.
 type Vector struct {
+	N    int
 	Inc  int
 	Data []float32
 }
@@ -102,42 +103,42 @@ const negInc = "blas32: negative vector increment"
 
 // Dot computes the dot product of the two vectors:
 //  \sum_i x[i]*y[i].
-func Dot(n int, x, y Vector) float32 {
-	return blas32.Sdot(n, x.Data, x.Inc, y.Data, y.Inc)
+func Dot(x, y Vector) float32 {
+	return blas32.Sdot(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // DDot computes the dot product of the two vectors:
 //  \sum_i x[i]*y[i].
-func DDot(n int, x, y Vector) float64 {
-	return blas32.Dsdot(n, x.Data, x.Inc, y.Data, y.Inc)
+func DDot(x, y Vector) float64 {
+	return blas32.Dsdot(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // SDDot computes the dot product of the two vectors adding a constant:
 //  alpha + \sum_i x[i]*y[i].
-func SDDot(n int, alpha float32, x, y Vector) float32 {
-	return blas32.Sdsdot(n, alpha, x.Data, x.Inc, y.Data, y.Inc)
+func SDDot(alpha float32, x, y Vector) float32 {
+	return blas32.Sdsdot(x.N, alpha, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Nrm2 computes the Euclidean norm of the vector x:
 //  sqrt(\sum_i x[i]*x[i]).
 //
 // Nrm2 will panic if the vector increment is negative.
-func Nrm2(n int, x Vector) float32 {
+func Nrm2(x Vector) float32 {
 	if x.Inc < 0 {
 		panic(negInc)
 	}
-	return blas32.Snrm2(n, x.Data, x.Inc)
+	return blas32.Snrm2(x.N, x.Data, x.Inc)
 }
 
 // Asum computes the sum of the absolute values of the elements of x:
 //  \sum_i |x[i]|.
 //
 // Asum will panic if the vector increment is negative.
-func Asum(n int, x Vector) float32 {
+func Asum(x Vector) float32 {
 	if x.Inc < 0 {
 		panic(negInc)
 	}
-	return blas32.Sasum(n, x.Data, x.Inc)
+	return blas32.Sasum(x.N, x.Data, x.Inc)
 }
 
 // Iamax returns the index of an element of x with the largest absolute value.
@@ -145,29 +146,29 @@ func Asum(n int, x Vector) float32 {
 // Iamax returns -1 if n == 0.
 //
 // Iamax will panic if the vector increment is negative.
-func Iamax(n int, x Vector) int {
+func Iamax(x Vector) int {
 	if x.Inc < 0 {
 		panic(negInc)
 	}
-	return blas32.Isamax(n, x.Data, x.Inc)
+	return blas32.Isamax(x.N, x.Data, x.Inc)
 }
 
 // Swap exchanges the elements of the two vectors:
 //  x[i], y[i] = y[i], x[i] for all i.
-func Swap(n int, x, y Vector) {
-	blas32.Sswap(n, x.Data, x.Inc, y.Data, y.Inc)
+func Swap(x, y Vector) {
+	blas32.Sswap(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Copy copies the elements of x into the elements of y:
 //  y[i] = x[i] for all i.
-func Copy(n int, x, y Vector) {
-	blas32.Scopy(n, x.Data, x.Inc, y.Data, y.Inc)
+func Copy(x, y Vector) {
+	blas32.Scopy(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Axpy adds x scaled by alpha to y:
 //  y[i] += alpha*x[i] for all i.
-func Axpy(n int, alpha float32, x, y Vector) {
-	blas32.Saxpy(n, alpha, x.Data, x.Inc, y.Data, y.Inc)
+func Axpy(alpha float32, x, y Vector) {
+	blas32.Saxpy(x.N, alpha, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Rotg computes the parameters of a Givens plane rotation so that
@@ -211,11 +212,11 @@ func Rotm(n int, x, y Vector, p blas.SrotmParams) {
 //  x[i] *= alpha for all i.
 //
 // Scal will panic if the vector increment is negative.
-func Scal(n int, alpha float32, x Vector) {
+func Scal(alpha float32, x Vector) {
 	if x.Inc < 0 {
 		panic(negInc)
 	}
-	blas32.Sscal(n, alpha, x.Data, x.Inc)
+	blas32.Sscal(x.N, alpha, x.Data, x.Inc)
 }
 
 // Level 2

--- a/blas/blas64/blas64.go
+++ b/blas/blas64/blas64.go
@@ -106,6 +106,7 @@ const (
 
 // Dot computes the dot product of the two vectors:
 //  \sum_i x[i]*y[i].
+// Dot will panic if the lengths of x and y do not match.
 func Dot(x, y Vector) float64 {
 	if x.N != y.N {
 		panic(badLength)
@@ -149,6 +150,7 @@ func Iamax(x Vector) int {
 
 // Swap exchanges the elements of the two vectors:
 //  x[i], y[i] = y[i], x[i] for all i.
+// Swap will panic if the lengths of x and y do not match.
 func Swap(x, y Vector) {
 	if x.N != y.N {
 		panic(badLength)
@@ -158,7 +160,7 @@ func Swap(x, y Vector) {
 
 // Copy copies the elements of x into the elements of y:
 //  y[i] = x[i] for all i.
-// Copy requires that the lengths of x and y match and will panic otherwise.
+// Copy will panic if the lengths of x and y do not match.
 func Copy(x, y Vector) {
 	if x.N != y.N {
 		panic(badLength)
@@ -168,6 +170,7 @@ func Copy(x, y Vector) {
 
 // Axpy adds x scaled by alpha to y:
 //  y[i] += alpha*x[i] for all i.
+// Axpy will panic if the lengths of x and y do not match.
 func Axpy(alpha float64, x, y Vector) {
 	if x.N != y.N {
 		panic(badLength)

--- a/blas/cblas128/cblas128.go
+++ b/blas/cblas128/cblas128.go
@@ -108,19 +108,30 @@ type HermitianPacked SymmetricPacked
 
 // Level 1
 
-const negInc = "cblas128: negative vector increment"
+const (
+	negInc    = "cblas128: negative vector increment"
+	badLength = "cblas128: vector length mismatch"
+)
 
 // Dotu computes the dot product of the two vectors without
 // complex conjugation:
 //  xᵀ * y.
+// Dotu will panic if the lengths of x and y do not match.
 func Dotu(x, y Vector) complex128 {
+	if x.N != y.N {
+		panic(badLength)
+	}
 	return cblas128.Zdotu(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Dotc computes the dot product of the two vectors with
 // complex conjugation:
 //  xᴴ * y.
+// Dotc will panic if the lengths of x and y do not match.
 func Dotc(x, y Vector) complex128 {
+	if x.N != y.N {
+		panic(badLength)
+	}
 	return cblas128.Zdotc(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
@@ -163,20 +174,32 @@ func Iamax(x Vector) int {
 
 // Swap exchanges the elements of two vectors:
 //  x[i], y[i] = y[i], x[i] for all i.
+// Swap will panic if the lengths of x and y do not match.
 func Swap(x, y Vector) {
+	if x.N != y.N {
+		panic(badLength)
+	}
 	cblas128.Zswap(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Copy copies the elements of x into the elements of y:
 //  y[i] = x[i] for all i.
+// Copy will panic if the lengths of x and y do not match.
 func Copy(x, y Vector) {
+	if x.N != y.N {
+		panic(badLength)
+	}
 	cblas128.Zcopy(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Axpy computes
 //  y = alpha * x + y,
 // where x and y are vectors, and alpha is a scalar.
+// Axpy will panic if the lengths of x and y do not match.
 func Axpy(alpha complex128, x, y Vector) {
+	if x.N != y.N {
+		panic(badLength)
+	}
 	cblas128.Zaxpy(x.N, alpha, x.Data, x.Inc, y.Data, y.Inc)
 }
 

--- a/blas/cblas64/cblas64.go
+++ b/blas/cblas64/cblas64.go
@@ -108,19 +108,30 @@ type HermitianPacked SymmetricPacked
 
 // Level 1
 
-const negInc = "cblas64: negative vector increment"
+const (
+	negInc    = "cblas64: negative vector increment"
+	badLength = "cblas64: vector length mismatch"
+)
 
 // Dotu computes the dot product of the two vectors without
 // complex conjugation:
 //  xᵀ * y
+// Dotu will panic if the lengths of x and y do not match.
 func Dotu(x, y Vector) complex64 {
+	if x.N != y.N {
+		panic(badLength)
+	}
 	return cblas64.Cdotu(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Dotc computes the dot product of the two vectors with
 // complex conjugation:
 //  xᴴ * y.
+// Dotc will panic if the lengths of x and y do not match.
 func Dotc(x, y Vector) complex64 {
+	if x.N != y.N {
+		panic(badLength)
+	}
 	return cblas64.Cdotc(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
@@ -163,20 +174,32 @@ func Iamax(x Vector) int {
 
 // Swap exchanges the elements of two vectors:
 //  x[i], y[i] = y[i], x[i] for all i.
+// Swap will panic if the lengths of x and y do not match.
 func Swap(x, y Vector) {
+	if x.N != y.N {
+		panic(badLength)
+	}
 	cblas64.Cswap(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Copy copies the elements of x into the elements of y:
 //  y[i] = x[i] for all i.
+// Copy will panic if the lengths of x and y do not match.
 func Copy(x, y Vector) {
+	if x.N != y.N {
+		panic(badLength)
+	}
 	cblas64.Ccopy(x.N, x.Data, x.Inc, y.Data, y.Inc)
 }
 
 // Axpy computes
 //  y = alpha * x + y,
 // where x and y are vectors, and alpha is a scalar.
+// Axpy will panic if the lengths of x and y do not match.
 func Axpy(alpha complex64, x, y Vector) {
+	if x.N != y.N {
+		panic(badLength)
+	}
 	cblas64.Caxpy(x.N, alpha, x.Data, x.Inc, y.Data, y.Inc)
 }
 


### PR DESCRIPTION
Please take a look.

So it turns out we partially did this already in blas64, and I left out blas32 with the vector length fields. Things are now harmonised.

Closes #1158.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
