### PR TITLE
mat: add MulVecTo method to BandDense and SymBandDense

### DIFF
--- a/mat/band.go
+++ b/mat/band.go
@@ -5,6 +5,7 @@
 package mat
 
 import (
+	"gonum.org/v1/gonum/blas"
 	"gonum.org/v1/gonum/blas/blas64"
 )
 
@@ -296,4 +297,39 @@ func (b *BandDense) Trace() float64 {
 		tr += rb.Data[rb.KL+i*rb.Stride]
 	}
 	return tr
+}
+
+// MulVecTo computes B⋅x or Bᵀ⋅x storing the result into dst.
+func (b *BandDense) MulVecTo(dst *VecDense, trans bool, x Vector) {
+	m, n := b.Dims()
+	if trans {
+		m, n = n, m
+	}
+	if x.Len() != n {
+		panic(ErrShape)
+	}
+	dst.reuseAsNonZeroed(m)
+
+	t := blas.NoTrans
+	if trans {
+		t = blas.Trans
+	}
+
+	xMat, _ := untransposeExtract(x)
+	if xVec, ok := xMat.(*VecDense); ok {
+		if dst != xVec {
+			dst.checkOverlap(xVec.mat)
+			blas64.Gbmv(t, 1, b.mat, xVec.mat, 0, dst.mat)
+		} else {
+			xCopy := getWorkspaceVec(n, false)
+			xCopy.CloneVec(xVec)
+			blas64.Gbmv(t, 1, b.mat, xCopy.mat, 0, dst.mat)
+			putWorkspaceVec(xCopy)
+		}
+	} else {
+		xCopy := getWorkspaceVec(n, false)
+		xCopy.CloneVec(x)
+		blas64.Gbmv(t, 1, b.mat, xCopy.mat, 0, dst.mat)
+		putWorkspaceVec(xCopy)
+	}
 }

--- a/mat/symband.go
+++ b/mat/symband.go
@@ -251,3 +251,30 @@ func (s *SymBandDense) Trace() float64 {
 	}
 	return tr
 }
+
+// MulVecTo computes S⋅x storing the result into dst.
+func (s *SymBandDense) MulVecTo(dst *VecDense, _ bool, x Vector) {
+	n := s.mat.N
+	if x.Len() != n {
+		panic(ErrShape)
+	}
+	dst.reuseAsNonZeroed(n)
+
+	xMat, _ := untransposeExtract(x)
+	if xVec, ok := xMat.(*VecDense); ok {
+		if dst != xVec {
+			dst.checkOverlap(xVec.mat)
+			blas64.Sbmv(1, s.mat, xVec.mat, 0, dst.mat)
+		} else {
+			xCopy := getWorkspaceVec(n, false)
+			xCopy.CloneVec(xVec)
+			blas64.Sbmv(1, s.mat, xCopy.mat, 0, dst.mat)
+			putWorkspaceVec(xCopy)
+		}
+	} else {
+		xCopy := getWorkspaceVec(n, false)
+		xCopy.CloneVec(x)
+		blas64.Sbmv(1, s.mat, xCopy.mat, 0, dst.mat)
+		putWorkspaceVec(xCopy)
+	}
+}


### PR DESCRIPTION
This is adding the `MulVecTo` method to two matrix types which I think that it makes most sense to support natively in `linsolve`. However, seeing the function signature in the context of `mat` it doesn't seem to fit because of the slices, so I'm wondering whether it should take `*mat.VecDense` instead. This would of course require revisiting `linsolve` and changing the implementation to be more mat-like.

Just a draft at the moment.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
