### PR TITLE
internal/asm/f64: zero out ZERO even for zero-length input to L2NormInc

### DIFF
--- a/internal/asm/f64/l2norminc_amd64.s
+++ b/internal/asm/f64/l2norminc_amd64.s
@@ -36,10 +36,10 @@ TEXT ·L2NormInc(SB), NOSPLIT, $0
 	MOVQ n+24(FP), LEN    // LEN = len(x)
 	MOVQ incX+32(FP), INC
 	MOVQ x_base+0(FP), X_
+	XORPS ZERO, ZERO
 	CMPQ LEN, $0          // if LEN == 0 { return 0 }
 	JZ   retZero
 
-	XORPS ZERO, ZERO
 	XORPS INFMASK, INFMASK
 	XORPS NANMASK, NANMASK
 	MOVSD $1.0, SUMSQ           // ssq = 1


### PR DESCRIPTION
This is the minimal change required to fix the issue. I can replicate the bug on my work workstation, so presumably it only presenting on macOS at travis is down to CPU execution ordering differences.

The changes that are in asm/f64_l2norm_zeroing which are presumably performance oriented (from my reading around PXOR/XORPS differences) can go in in another PR.

Please take a look.

Fixes #1181.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
