### PR TITLE
graph/{multi,simple}: don't return pointer values from NewEdge/NewLine

### DIFF
--- a/graph/multi/directed.go
+++ b/graph/multi/directed.go
@@ -147,7 +147,7 @@ func (g *DirectedGraph) Lines(uid, vid int64) graph.Lines {
 // The returned Line will have a graph-unique ID.
 // The Line's ID does not become valid in g until the Line is added to g.
 func (g *DirectedGraph) NewLine(from, to graph.Node) graph.Line {
-	return &Line{F: from, T: to, UID: g.lineIDs.NewID()}
+	return Line{F: from, T: to, UID: g.lineIDs.NewID()}
 }
 
 // NewNode returns a new unique Node to be added to g. The Node's ID does

--- a/graph/multi/undirected.go
+++ b/graph/multi/undirected.go
@@ -153,7 +153,7 @@ func (g *UndirectedGraph) LinesBetween(xid, yid int64) graph.Lines {
 // The returned Line will have a graph-unique ID.
 // The Line's ID does not become valid in g until the Line is added to g.
 func (g *UndirectedGraph) NewLine(from, to graph.Node) graph.Line {
-	return &Line{F: from, T: to, UID: g.lineIDs.NewID()}
+	return Line{F: from, T: to, UID: g.lineIDs.NewID()}
 }
 
 // NewNode returns a new unique Node to be added to g. The Node's ID does

--- a/graph/multi/weighted_directed.go
+++ b/graph/multi/weighted_directed.go
@@ -167,7 +167,7 @@ func (g *WeightedDirectedGraph) NewNode() graph.Node {
 // The returned WeightedLine will have a graph-unique ID.
 // The Line's ID does not become valid in g until the Line is added to g.
 func (g *WeightedDirectedGraph) NewWeightedLine(from, to graph.Node, weight float64) graph.WeightedLine {
-	return &WeightedLine{F: from, T: to, W: weight, UID: g.lineIDs.NewID()}
+	return WeightedLine{F: from, T: to, W: weight, UID: g.lineIDs.NewID()}
 }
 
 // Node returns the node with the given ID if it exists in the graph,

--- a/graph/multi/weighted_undirected.go
+++ b/graph/multi/weighted_undirected.go
@@ -175,7 +175,7 @@ func (g *WeightedUndirectedGraph) NewNode() graph.Node {
 // The returned WeightedLine will have a graph-unique ID.
 // The Line's ID does not become valid in g until the Line is added to g.
 func (g *WeightedUndirectedGraph) NewWeightedLine(from, to graph.Node, weight float64) graph.WeightedLine {
-	return &WeightedLine{F: from, T: to, W: weight, UID: g.lineIDs.NewID()}
+	return WeightedLine{F: from, T: to, W: weight, UID: g.lineIDs.NewID()}
 }
 
 // Node returns the node with the given ID if it exists in the graph,

--- a/graph/simple/directed.go
+++ b/graph/simple/directed.go
@@ -114,7 +114,7 @@ func (g *DirectedGraph) HasEdgeFromTo(uid, vid int64) bool {
 
 // NewEdge returns a new Edge from the source to the destination node.
 func (g *DirectedGraph) NewEdge(from, to graph.Node) graph.Edge {
-	return &Edge{F: from, T: to}
+	return Edge{F: from, T: to}
 }
 
 // NewNode returns a new unique Node to be added to g. The Node's ID does

--- a/graph/simple/undirected.go
+++ b/graph/simple/undirected.go
@@ -119,7 +119,7 @@ func (g *UndirectedGraph) HasEdgeBetween(xid, yid int64) bool {
 
 // NewEdge returns a new Edge from the source to the destination node.
 func (g *UndirectedGraph) NewEdge(from, to graph.Node) graph.Edge {
-	return &Edge{F: from, T: to}
+	return Edge{F: from, T: to}
 }
 
 // NewNode returns a new unique Node to be added to g. The Node's ID does

--- a/graph/simple/weighted_directed.go
+++ b/graph/simple/weighted_directed.go
@@ -130,7 +130,7 @@ func (g *WeightedDirectedGraph) NewNode() graph.Node {
 
 // NewWeightedEdge returns a new weighted edge from the source to the destination node.
 func (g *WeightedDirectedGraph) NewWeightedEdge(from, to graph.Node, weight float64) graph.WeightedEdge {
-	return &WeightedEdge{F: from, T: to, W: weight}
+	return WeightedEdge{F: from, T: to, W: weight}
 }
 
 // Node returns the node with the given ID if it exists in the graph,

--- a/graph/simple/weighted_undirected.go
+++ b/graph/simple/weighted_undirected.go
@@ -132,7 +132,7 @@ func (g *WeightedUndirectedGraph) NewNode() graph.Node {
 
 // NewWeightedEdge returns a new weighted edge from the source to the destination node.
 func (g *WeightedUndirectedGraph) NewWeightedEdge(from, to graph.Node, weight float64) graph.WeightedEdge {
-	return &WeightedEdge{F: from, T: to, W: weight}
+	return WeightedEdge{F: from, T: to, W: weight}
 }
 
 // Node returns the node with the given ID if it exists in the graph,


### PR DESCRIPTION
Please take a look.

Fixes #1183.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
