### PR TITLE
lapack/testlapack: don't test unsupported matrix sizes in DlantrTest

### DIFF
--- a/lapack/testlapack/dlantr.go
+++ b/lapack/testlapack/dlantr.go
@@ -26,6 +26,12 @@ func DlantrTest(t *testing.T, impl Dlantrer) {
 	for _, m := range []int{0, 1, 2, 3, 4, 5, 10} {
 		for _, n := range []int{0, 1, 2, 3, 4, 5, 10} {
 			for _, uplo := range []blas.Uplo{blas.Lower, blas.Upper} {
+				if uplo == blas.Upper && m > n {
+					continue
+				}
+				if uplo == blas.Lower && n > m {
+					continue
+				}
 				for _, diag := range []blas.Diag{blas.NonUnit, blas.Unit} {
 					for _, lda := range []int{max(1, n), n + 3} {
 						dlantrTest(t, impl, rnd, uplo, diag, m, n, lda)


### PR DESCRIPTION
The current Dlantr failures in our netlib repository are caused by out-of-bounds write in the Fortran reference LAPACK when computing the inf-norm of wide lower-triangular matrices with "tight" `work`. I will submit a PR to the reference and OpenBLAS to lift this restriction (which is documented but unnecessary in my opinion and to top it off DLANTR doesn't check the input parameters) but it cannot be relied upon anyway.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
