### PR TITLE
stat/card: use more conventional type encoding

### DIFF
--- a/stat/card/card.go
+++ b/stat/card/card.go
@@ -6,7 +6,10 @@
 
 package card
 
-import "math"
+import (
+	"math"
+	"reflect"
+)
 
 const (
 	w32 = 32
@@ -42,4 +45,17 @@ func min(a, b uint8) uint8 {
 		return a
 	}
 	return b
+}
+
+func typeNameOf(v interface{}) string {
+	t := reflect.TypeOf(v)
+	var prefix string
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+		prefix = "*"
+	}
+	if t.PkgPath() == "" {
+		return prefix + t.Name()
+	}
+	return prefix + t.PkgPath() + "." + t.Name()
 }


### PR DESCRIPTION
This matches the approach used in gob.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
