### PR TITLE
blas/gonum: make drotmg test pass

### DIFF
--- a/blas/gonum/level1float32.go
+++ b/blas/gonum/level1float32.go
@@ -336,7 +336,7 @@ func (Implementation) Srotmg(d1, d2, x1, y1 float32) (p blas.SrotmParams, rd1, r
 			h22 = 1
 			h21 = -y1 / x1
 			h12 = p2 / p1
-			u := 1 - h12*h21
+			u := 1 - float32(h12*h21)
 			if u <= 0 {
 				p.Flag = blas.Rescaling // Error state.
 				return p, 0, 0, 0
@@ -356,7 +356,7 @@ func (Implementation) Srotmg(d1, d2, x1, y1 float32) (p blas.SrotmParams, rd1, r
 			h12 = 1
 			h11 = p1 / p2
 			h22 = x1 / y1
-			u := 1 + h11*h22
+			u := 1 + float32(h11*h22)
 			d1, d2 = d2/u, d1/u
 			x1 = y1 * u
 		}
@@ -489,7 +489,7 @@ func (Implementation) Srotm(n int, x []float32, incX int, y []float32, incY int,
 			x = x[:n]
 			for i, vx := range x {
 				vy := y[i]
-				x[i], y[i] = vx*h11+vy*h12, vx*h21+vy*h22
+				x[i], y[i] = float32(vx*h11)+float32(vy*h12), float32(vx*h21)+float32(vy*h22)
 			}
 			return
 		}
@@ -503,7 +503,7 @@ func (Implementation) Srotm(n int, x []float32, incX int, y []float32, incY int,
 		for i := 0; i < n; i++ {
 			vx := x[ix]
 			vy := y[iy]
-			x[ix], y[iy] = vx*h11+vy*h12, vx*h21+vy*h22
+			x[ix], y[iy] = float32(vx*h11)+float32(vy*h12), float32(vx*h21)+float32(vy*h22)
 			ix += incX
 			iy += incY
 		}
@@ -514,7 +514,7 @@ func (Implementation) Srotm(n int, x []float32, incX int, y []float32, incY int,
 			x = x[:n]
 			for i, vx := range x {
 				vy := y[i]
-				x[i], y[i] = vx+vy*h12, vx*h21+vy
+				x[i], y[i] = vx+float32(vy*h12), float32(vx*h21)+vy
 			}
 			return
 		}
@@ -528,7 +528,7 @@ func (Implementation) Srotm(n int, x []float32, incX int, y []float32, incY int,
 		for i := 0; i < n; i++ {
 			vx := x[ix]
 			vy := y[iy]
-			x[ix], y[iy] = vx+vy*h12, vx*h21+vy
+			x[ix], y[iy] = vx+float32(vy*h12), float32(vx*h21)+vy
 			ix += incX
 			iy += incY
 		}
@@ -539,7 +539,7 @@ func (Implementation) Srotm(n int, x []float32, incX int, y []float32, incY int,
 			x = x[:n]
 			for i, vx := range x {
 				vy := y[i]
-				x[i], y[i] = vx*h11+vy, -vx+vy*h22
+				x[i], y[i] = float32(vx*h11)+vy, -vx+float32(vy*h22)
 			}
 			return
 		}
@@ -553,7 +553,7 @@ func (Implementation) Srotm(n int, x []float32, incX int, y []float32, incY int,
 		for i := 0; i < n; i++ {
 			vx := x[ix]
 			vy := y[iy]
-			x[ix], y[iy] = vx*h11+vy, -vx+vy*h22
+			x[ix], y[iy] = float32(vx*h11)+vy, -vx+float32(vy*h22)
 			ix += incX
 			iy += incY
 		}

--- a/blas/gonum/level1float64.go
+++ b/blas/gonum/level1float64.go
@@ -318,7 +318,7 @@ func (Implementation) Drotmg(d1, d2, x1, y1 float64) (p blas.DrotmParams, rd1, r
 			h22 = 1
 			h21 = -y1 / x1
 			h12 = p2 / p1
-			u := 1 - h12*h21
+			u := 1 - float64(h12*h21)
 			if u <= 0 {
 				p.Flag = blas.Rescaling // Error state.
 				return p, 0, 0, 0
@@ -338,7 +338,7 @@ func (Implementation) Drotmg(d1, d2, x1, y1 float64) (p blas.DrotmParams, rd1, r
 			h12 = 1
 			h11 = p1 / p2
 			h22 = x1 / y1
-			u := 1 + h11*h22
+			u := 1 + float64(h11*h22)
 			d1, d2 = d2/u, d1/u
 			x1 = y1 * u
 		}
@@ -467,7 +467,7 @@ func (Implementation) Drotm(n int, x []float64, incX int, y []float64, incY int,
 			x = x[:n]
 			for i, vx := range x {
 				vy := y[i]
-				x[i], y[i] = vx*h11+vy*h12, vx*h21+vy*h22
+				x[i], y[i] = float64(vx*h11)+float64(vy*h12), float64(vx*h21)+float64(vy*h22)
 			}
 			return
 		}
@@ -481,7 +481,7 @@ func (Implementation) Drotm(n int, x []float64, incX int, y []float64, incY int,
 		for i := 0; i < n; i++ {
 			vx := x[ix]
 			vy := y[iy]
-			x[ix], y[iy] = vx*h11+vy*h12, vx*h21+vy*h22
+			x[ix], y[iy] = float64(vx*h11)+float64(vy*h12), float64(vx*h21)+float64(vy*h22)
 			ix += incX
 			iy += incY
 		}
@@ -492,7 +492,7 @@ func (Implementation) Drotm(n int, x []float64, incX int, y []float64, incY int,
 			x = x[:n]
 			for i, vx := range x {
 				vy := y[i]
-				x[i], y[i] = vx+vy*h12, vx*h21+vy
+				x[i], y[i] = vx+float64(vy*h12), float64(vx*h21)+vy
 			}
 			return
 		}
@@ -506,7 +506,7 @@ func (Implementation) Drotm(n int, x []float64, incX int, y []float64, incY int,
 		for i := 0; i < n; i++ {
 			vx := x[ix]
 			vy := y[iy]
-			x[ix], y[iy] = vx+vy*h12, vx*h21+vy
+			x[ix], y[iy] = vx+float64(vy*h12), float64(vx*h21)+vy
 			ix += incX
 			iy += incY
 		}
@@ -517,7 +517,7 @@ func (Implementation) Drotm(n int, x []float64, incX int, y []float64, incY int,
 			x = x[:n]
 			for i, vx := range x {
 				vy := y[i]
-				x[i], y[i] = vx*h11+vy, -vx+vy*h22
+				x[i], y[i] = float64(vx*h11)+vy, -vx+float64(vy*h22)
 			}
 			return
 		}
@@ -531,7 +531,7 @@ func (Implementation) Drotm(n int, x []float64, incX int, y []float64, incY int,
 		for i := 0; i < n; i++ {
 			vx := x[ix]
 			vy := y[iy]
-			x[ix], y[iy] = vx*h11+vy, -vx+vy*h22
+			x[ix], y[iy] = float64(vx*h11)+vy, -vx+float64(vy*h22)
 			ix += incX
 			iy += incY
 		}


### PR DESCRIPTION
This change prevents the compiler from emitting FMA instructions during Drotmg and Drotm which would otherwise cause the arm64 build to fail.

Please take a look.

Updates #1218.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
