### PR TITLE
testlapack: rework test for Dlaexc and clean up test for Dtrexc

### DIFF
--- a/lapack/testlapack/dtrexc.go
+++ b/lapack/testlapack/dtrexc.go
@@ -41,12 +41,11 @@ func DtrexcTest(t *testing.T, impl Dtrexcer) {
 func dtrexcTest(t *testing.T, impl Dtrexcer, rnd *rand.Rand, n, ifst, ilst, extra int) {
 	const tol = 1e-13
 
-	tmatCopy, _, _ := randomSchurCanonical(n, n+extra, false, rnd)
-	tmat1 := cloneGeneral(tmatCopy)
-	tmat2 := cloneGeneral(tmatCopy)
+	tmat, wr, wi := randomSchurCanonical(n, n+extra, false, rnd)
+	tmatCopy := cloneGeneral(tmat)
 
-	fstSize, fstFirst := schurBlockSize(tmat1, ifst)
-	lstSize, lstFirst := schurBlockSize(tmat1, ilst)
+	fstSize, fstFirst := schurBlockSize(tmat, ifst)
+	lstSize, lstFirst := schurBlockSize(tmat, ilst)
 
 	name := fmt.Sprintf("Case n=%v,ifst=%v,nbfst=%v,ilst=%v,nblst=%v,extra=%v",
 		n, ifst, fstSize, ilst, lstSize, extra)
@@ -54,38 +53,45 @@ func dtrexcTest(t *testing.T, impl Dtrexcer, rnd *rand.Rand, n, ifst, ilst, extr
 	// 1. Test without accumulating Q.
 
 	compq := lapack.UpdateSchurNone
-	work := nanSlice(n)
-	ifstGot1, ilstGot1, ok1 := impl.Dtrexc(compq, n, tmat1.Data, tmat1.Stride, nil, 1, ifst, ilst, work)
 
-	if !generalOutsideAllNaN(tmat1) {
-		t.Errorf("%v: out-of-range write to T1", name)
+	work := nanSlice(n)
+
+	ifstGot, ilstGot, ok := impl.Dtrexc(compq, n, tmat.Data, tmat.Stride, nil, 1, ifst, ilst, work)
+
+	if !generalOutsideAllNaN(tmat) {
+		t.Errorf("%v: out-of-range write to T", name)
 	}
 
 	// 2. Test with accumulating Q.
 
+	compq = lapack.UpdateSchur
+
+	tmat2 := cloneGeneral(tmatCopy)
 	q := eye(n, n+extra)
 	qCopy := cloneGeneral(q)
-
-	compq = lapack.UpdateSchur
 	work = nanSlice(n)
+
 	ifstGot2, ilstGot2, ok2 := impl.Dtrexc(compq, n, tmat2.Data, tmat2.Stride, q.Data, q.Stride, ifst, ilst, work)
 
+	if !generalOutsideAllNaN(tmat2) {
+		t.Errorf("%v: out-of-range write to T2", name)
+	}
 	if !generalOutsideAllNaN(q) {
 		t.Errorf("%v: out-of-range write to Q", name)
 	}
 
 	// Check that outputs from cases 1. and 2. are exactly equal, then check one of them.
-	if ifstGot1 != ifstGot2 {
-		t.Errorf("%v: ifstGot1 != ifstGot2", name)
+	if ifstGot != ifstGot2 {
+		t.Errorf("%v: ifstGot != ifstGot2", name)
 	}
-	if ilstGot1 != ilstGot2 {
-		t.Errorf("%v: ilstGot1 != ilstGot2", name)
+	if ilstGot != ilstGot2 {
+		t.Errorf("%v: ilstGot != ilstGot2", name)
 	}
-	if ok1 != ok2 {
-		t.Errorf("%v: ok1 != ok2", name)
+	if ok != ok2 {
+		t.Errorf("%v: ok != ok2", name)
 	}
-	if !equalGeneral(tmat1, tmat2) {
-		t.Errorf("%v: T1 != T2", name)
+	if !equalGeneral(tmat, tmat2) {
+		t.Errorf("%v: T != T2", name)
 	}
 
 	// Check that the index of the first block was correctly updated (if
@@ -94,8 +100,8 @@ func dtrexcTest(t *testing.T, impl Dtrexcer, rnd *rand.Rand, n, ifst, ilst, extr
 	if !fstFirst {
 		ifstWant = ifst - 1
 	}
-	if ifstWant != ifstGot1 {
-		t.Errorf("%v: unexpected ifst=%v, want %v", name, ifstGot1, ifstWant)
+	if ifstWant != ifstGot {
+		t.Errorf("%v: unexpected ifst=%v, want %v", name, ifstGot, ifstWant)
 	}
 
 	// Check that the index of the last block is as expected when ok=true.
@@ -105,7 +111,7 @@ func dtrexcTest(t *testing.T, impl Dtrexcer, rnd *rand.Rand, n, ifst, ilst, extr
 	if !lstFirst {
 		ilstWant--
 	}
-	if ok1 {
+	if ok {
 		if ifstWant < ilstWant {
 			// If the blocks are swapped backwards, these
 			// adjustments are not necessary, the first row of the
@@ -117,15 +123,15 @@ func dtrexcTest(t *testing.T, impl Dtrexcer, rnd *rand.Rand, n, ifst, ilst, extr
 				ilstWant++
 			}
 		}
-		if ilstWant != ilstGot1 {
-			t.Errorf("%v: unexpected ilst=%v, want %v", name, ilstGot1, ilstWant)
+		if ilstWant != ilstGot {
+			t.Errorf("%v: unexpected ilst=%v, want %v", name, ilstGot, ilstWant)
 		}
 	}
 
-	if n <= 1 || ifstGot1 == ilstGot1 {
+	if n <= 1 || ifstGot == ilstGot {
 		// Too small matrix or no swapping.
 		// Check that T was not modified.
-		if !equalGeneral(tmat1, tmatCopy) {
+		if !equalGeneral(tmat, tmatCopy) {
 			t.Errorf("%v: unexpected modification of T when no swapping", name)
 		}
 		// Check that Q was not modified.
@@ -136,14 +142,14 @@ func dtrexcTest(t *testing.T, impl Dtrexcer, rnd *rand.Rand, n, ifst, ilst, extr
 		return
 	}
 
-	if !isSchurCanonicalGeneral(tmat1) {
+	if !isSchurCanonicalGeneral(tmat) {
 		t.Errorf("%v: T is not in Schur canonical form", name)
 	}
 
 	// Check that T was not modified except above the second subdiagonal in
 	// rows and columns [modMin,modMax].
-	modMin := min(ifstGot1, ilstGot1)
-	modMax := max(ifstGot1, ilstGot1) + fstSize
+	modMin := min(ifstGot, ilstGot)
+	modMax := max(ifstGot, ilstGot) + fstSize
 	for i := 0; i < n; i++ {
 		for j := 0; j < n; j++ {
 			if modMin <= i && i < modMax && j+1 >= i {
@@ -152,7 +158,7 @@ func dtrexcTest(t *testing.T, impl Dtrexcer, rnd *rand.Rand, n, ifst, ilst, extr
 			if modMin <= j && j < modMax && j+1 >= i {
 				continue
 			}
-			diff := tmat1.Data[i*tmat1.Stride+j] - tmatCopy.Data[i*tmatCopy.Stride+j]
+			diff := tmat.Data[i*tmat.Stride+j] - tmatCopy.Data[i*tmatCopy.Stride+j]
 			if diff != 0 {
 				t.Errorf("%v: unexpected modification at T[%v,%v]", name, i, j)
 			}
@@ -162,36 +168,39 @@ func dtrexcTest(t *testing.T, impl Dtrexcer, rnd *rand.Rand, n, ifst, ilst, extr
 	// Check that the block at ifstGot was delivered to ilstGot correctly.
 	if fstSize == 1 {
 		// 1×1 blocks are swapped exactly.
-		got := tmat1.Data[ilstGot1*tmat1.Stride+ilstGot1]
-		want := tmatCopy.Data[ifstGot1*tmatCopy.Stride+ifstGot1]
+		got := tmat.Data[ilstGot*tmat.Stride+ilstGot]
+		want := wr[ifstGot]
 		if want != got {
-			t.Errorf("%v: unexpected 1×1 block at T[%v,%v]. Want %v, got %v",
-				name, want, got, ilstGot1, ilstGot1)
+			t.Errorf("%v: unexpected 1×1 block at T[%v,%v]; got %v, want %v",
+				name, ilstGot, ilstGot, got, want)
 		}
 	} else {
 		// Check that the swapped 2×2 block has the same eigenvalues.
-		a, b, c, d := extract2x2Block(tmat1.Data[ilstGot1*tmat1.Stride+ilstGot1:], tmat1.Stride)
+		a, b, c, d := extract2x2Block(tmat.Data[ilstGot*tmat.Stride+ilstGot:], tmat.Stride)
 		ev1Got, ev2Got := schurBlockEigenvalues(a, b, c, d)
+
 		// The block was originally located at T[ifstGot,ifstGot].
-		a, b, c, d = extract2x2Block(tmatCopy.Data[ifstGot1*tmatCopy.Stride+ifstGot1:], tmatCopy.Stride)
-		ev1Want, ev2Want := schurBlockEigenvalues(a, b, c, d)
+		ev1Want := complex(wr[ifstGot], wi[ifstGot])
+		ev2Want := complex(wr[ifstGot+1], wi[ifstGot+1])
+
 		diff := cmplx.Abs(ev1Got - ev1Want)
 		if diff > tol {
-			t.Errorf("%v: unexpected first eigenvalue of 2×2 block [%v %v; %v %v] at T[%v,%v]; diff=%v, want<=%v",
-				name, a, b, c, d, ilstGot1, ilstGot1, diff, tol)
+			t.Errorf("%v: unexpected first eigenvalue of 2×2 block at T[%v,%v]; diff=%v, want<=%v",
+				name, ilstGot, ilstGot, diff, tol)
 		}
 		diff = cmplx.Abs(ev2Got - ev2Want)
 		if diff > tol {
-			t.Errorf("%v: unexpected second eigenvalue of 2×2 block [%v %v; %v %v] at T[%v,%v]. Want %v, got %v",
-				name, a, b, c, d, ilstGot1, ilstGot1, diff, tol)
+			t.Errorf("%v: unexpected second eigenvalue of 2×2 block at T[%v,%v]; diff=%v, want<=%v",
+				name, ilstGot, ilstGot, diff, tol)
 		}
 	}
 
 	// Check that Q is orthogonal.
 	resid := residualOrthogonal(q, false)
-	if resid > float64(n)*tol {
-		t.Errorf("%v: Q is not orthogonal; resid=%v, want<=%v", name, resid, float64(n)*tol)
+	if resid > tol {
+		t.Errorf("%v: Q is not orthogonal; resid=%v, want<=%v", name, resid, tol)
 	}
+
 	// Check that Q is unchanged outside of columns [modMin,modMax].
 	for i := 0; i < n; i++ {
 		for j := 0; j < n; j++ {
@@ -203,15 +212,16 @@ func dtrexcTest(t *testing.T, impl Dtrexcer, rnd *rand.Rand, n, ifst, ilst, extr
 			}
 		}
 	}
+
 	// Check that Qᵀ * TOrig * Q == T
 	qt := zeros(n, n, n)
 	blas64.Gemm(blas.Trans, blas.NoTrans, 1, q, tmatCopy, 0, qt)
-	qtq := cloneGeneral(tmat1)
+	qtq := cloneGeneral(tmat)
 	blas64.Gemm(blas.NoTrans, blas.NoTrans, -1, qt, q, 1, qtq)
 	resid = dlange(lapack.MaxColumnSum, n, n, qtq.Data, qtq.Stride)
-	if resid > float64(n)*tol {
+	if resid > tol {
 		t.Errorf("%v: mismatch between Qᵀ*(initial T)*Q and (final T); resid=%v, want<=%v",
-			name, resid, float64(n)*tol)
+			name, resid, tol)
 	}
 }
 


### PR DESCRIPTION
The tests now use "bad" matrices.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
