### PR TITLE
optimize: relax gradient tolerance for Newton test

### DIFF
--- a/optimize/unconstrained_test.go
+++ b/optimize/unconstrained_test.go
@@ -938,7 +938,8 @@ var newtonTests = []unconstrainedTest{
 			Grad: functions.BrownBadlyScaled{}.Grad,
 			Hess: functions.BrownBadlyScaled{}.Hess,
 		},
-		x: []float64{1, 1},
+		x:       []float64{1, 1},
+		gradTol: 1e-9,
 	},
 	{
 		name: "PowellBadlyScaled",


### PR DESCRIPTION
Please take a look.

Relaxing the gradient tolerance on the equivalent test case for BFGS and LBFGS does not resolve those failures (as noted in #1243).

Updates #1218.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
