### PR TITLE
testlapack: use residualOrthogonal helper in Dorg2lTest and DgesvdTest

### DIFF
--- a/lapack/testlapack/dorg2l.go
+++ b/lapack/testlapack/dorg2l.go
@@ -18,6 +18,8 @@ type Dorg2ler interface {
 }
 
 func Dorg2lTest(t *testing.T, impl Dorg2ler) {
+	const tol = 1e-14
+
 	rnd := rand.New(rand.NewSource(1))
 	for _, test := range []struct {
 		m, n, k, lda int
@@ -48,8 +50,10 @@ func Dorg2lTest(t *testing.T, impl Dorg2ler) {
 		impl.Dgeql2(m, n, a, lda, tau, work)
 
 		impl.Dorg2l(m, n, k, a, lda, tau[n-k:], work)
-		if !hasOrthonormalColumns(blas64.General{Rows: m, Cols: n, Data: a, Stride: lda}) {
-			t.Errorf("Case m=%v, n=%v, k=%v: columns of Q not orthonormal", m, n, k)
+
+		q := blas64.General{Rows: m, Cols: n, Data: a, Stride: lda}
+		if resid := residualOrthogonal(q, false); resid > tol {
+			t.Errorf("Case m=%v, n=%v, k=%v, lda=%v: columns of Q not orthonormal; resid=%v, want<=%v", m, n, k, lda, resid, tol)
 		}
 	}
 }

--- a/lapack/testlapack/general.go
+++ b/lapack/testlapack/general.go
@@ -893,69 +893,6 @@ func isOrthogonal(q blas64.General) bool {
 	return true
 }
 
-// hasOrthonormalColumns returns whether the columns of Q are orthonormal.
-func hasOrthonormalColumns(q blas64.General) bool {
-	m, n := q.Rows, q.Cols
-	if n > m {
-		// Wide matrix cannot have all columns orthogonal.
-		return false
-	}
-	ldq := q.Stride
-	const tol = 1e-13
-	for i := 0; i < n; i++ {
-		nrm := blas64.Nrm2(blas64.Vector{N: m, Data: q.Data[i:], Inc: ldq})
-		if math.IsNaN(nrm) {
-			return false
-		}
-		if math.Abs(nrm-1) > tol {
-			return false
-		}
-		for j := i + 1; j < n; j++ {
-			dot := blas64.Dot(blas64.Vector{N: m, Data: q.Data[i:], Inc: ldq},
-				blas64.Vector{N: m, Data: q.Data[j:], Inc: ldq})
-			if math.IsNaN(dot) {
-				return false
-			}
-			if math.Abs(dot) > tol {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-// hasOrthonormalRows returns whether the rows of Q are orthonormal.
-func hasOrthonormalRows(q blas64.General) bool {
-	m, n := q.Rows, q.Cols
-	if m > n {
-		// Tall matrix cannot have all rows orthogonal.
-		return false
-	}
-	ldq := q.Stride
-	const tol = 1e-13
-	for i1 := 0; i1 < m; i1++ {
-		nrm := blas64.Nrm2(blas64.Vector{N: n, Data: q.Data[i1*ldq:], Inc: 1})
-		if math.IsNaN(nrm) {
-			return false
-		}
-		if math.Abs(nrm-1) > tol {
-			return false
-		}
-		for i2 := i1 + 1; i2 < m; i2++ {
-			dot := blas64.Dot(
-				blas64.Vector{N: n, Data: q.Data[i1*ldq:], Inc: 1},
-				blas64.Vector{N: n, Data: q.Data[i2*ldq:], Inc: 1})
-			if math.IsNaN(dot) {
-				return false
-			}
-			if math.Abs(dot) > tol {
-				return false
-			}
-		}
-	}
-	return true
-}
-
 // copyMatrix copies an m×n matrix src of stride n into an m×n matrix dst of stride ld.
 func copyMatrix(m, n int, dst []float64, ld int, src []float64) {
 	for i := 0; i < m; i++ {


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
