### PR TITLE
math32: add arm64 assembly implementation for Sqrt

### DIFF
--- a/internal/math32/sqrt_arm64.go
+++ b/internal/math32/sqrt_arm64.go
@@ -1,14 +1,14 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // Copyright ©2015 The Gonum Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64,!arm64 noasm appengine safe
+// +build !noasm,!appengine,!safe
 
 package math32
-
-import (
-	"math"
-)
 
 // Sqrt returns the square root of x.
 //
@@ -17,8 +17,4 @@ import (
 //	Sqrt(±0) = ±0
 //	Sqrt(x < 0) = NaN
 //	Sqrt(NaN) = NaN
-func Sqrt(x float32) float32 {
-	// FIXME(kortschak): Direct translation of the math package
-	// asm code for 386 fails to build.
-	return float32(math.Sqrt(float64(x)))
-}
+func Sqrt(x float32) float32

--- a/internal/math32/sqrt_arm64.s
+++ b/internal/math32/sqrt_arm64.s
@@ -1,0 +1,18 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Copyright ©2020 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !noasm,!appengine,!safe
+
+#include "textflag.h"
+
+// func Sqrt(x float32) float32
+TEXT ·Sqrt(SB),NOSPLIT,$0
+	FMOVS	x+0(FP), F0
+	FSQRTS	F0, F0
+	FMOVS	F0, ret+8(FP)
+	RET


### PR DESCRIPTION
Please take a look.

Closes #1215.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
