### PR TITLE
mat: work around change in cmd/compile unsigned integer behaviour

### DIFF
--- a/mat/offset.go
+++ b/mat/offset.go
@@ -16,7 +16,7 @@ func offset(a, b []float64) int {
 	// This expression must be atomic with respect to GC moves.
 	// At this stage this is true, because the GC does not
 	// move. See https://golang.org/issue/12445.
-	return int(uintptr(unsafe.Pointer(&b[0]))-uintptr(unsafe.Pointer(&a[0]))) / int(unsafe.Sizeof(float64(0)))
+	return (int(uintptr(unsafe.Pointer(&b[0]))) - int(uintptr(unsafe.Pointer(&a[0])))) / int(unsafe.Sizeof(float64(0)))
 }
 
 // offsetComplex returns the number of complex128 values b[0] is after a[0].
@@ -27,5 +27,5 @@ func offsetComplex(a, b []complex128) int {
 	// This expression must be atomic with respect to GC moves.
 	// At this stage this is true, because the GC does not
 	// move. See https://golang.org/issue/12445.
-	return int(uintptr(unsafe.Pointer(&b[0]))-uintptr(unsafe.Pointer(&a[0]))) / int(unsafe.Sizeof(complex128(0)))
+	return (int(uintptr(unsafe.Pointer(&b[0]))) - int(uintptr(unsafe.Pointer(&a[0])))) / int(unsafe.Sizeof(complex128(0)))
 }


### PR DESCRIPTION
Please take a look.

Issue only presents itself after go1.14.

DO NOT MERGE

The underlying issue is being reverted in the compiler.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
