### PR TITLE
blas/gonum: use atomics to distribute work

### DIFF
--- a/blas/gonum/dgemm.go
+++ b/blas/gonum/dgemm.go
@@ -162,27 +162,24 @@ func dgemmParallel(aTrans, bTrans bool, m, n, k int, a []float64, lda int, b []f
 	if parBlocks < nWorkers {
 		nWorkers = parBlocks
 	}
-	// There is a tradeoff between the workers having to wait for work
-	// and a large buffer making operations slow.
-	buf := buffMul * nWorkers
-	if buf > parBlocks {
-		buf = parBlocks
-	}
 
-	sendChan := make(chan subMul, buf)
+	var work blockWorkQueue
+	work.Reset(m, n)
 
 	// Launch workers. A worker receives an {i, j} submatrix of c, and computes
-	// A_ik B_ki (or the transposed version) storing the result in c_ij. When the
-	// channel is finally closed, it signals to the waitgroup that it has finished
-	// computing.
+	// A_ik B_ki (or the transposed version) storing the result in c_ij.
 	var wg sync.WaitGroup
 	for i := 0; i < nWorkers; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for sub := range sendChan {
-				i := sub.i
-				j := sub.j
+
+			for {
+				i, j, ok := work.Next()
+				if !ok {
+					return
+				}
+
 				leni := blockSize
 				if i+leni > m {
 					leni = m - i
@@ -217,16 +214,6 @@ func dgemmParallel(aTrans, bTrans bool, m, n, k int, a []float64, lda int, b []f
 		}()
 	}
 
-	// Send out all of the {i, j} subblocks for computation.
-	for i := 0; i < m; i += blockSize {
-		for j := 0; j < n; j += blockSize {
-			sendChan <- subMul{
-				i: i,
-				j: j,
-			}
-		}
-	}
-	close(sendChan)
 	wg.Wait()
 }
 

--- a/blas/gonum/workqueue.go
+++ b/blas/gonum/workqueue.go
@@ -1,0 +1,43 @@
+// Copyright ©2020 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+import (
+	"sync/atomic"
+)
+
+// blockWorkQueue implements parallel iterator over two dimensions with blockSize.
+//
+// The implementation corresponds to this double loop:
+//
+//   for i := 0; i < m; i += blockSize {
+//      for j := 0; j < n; j += blockSize {
+//         next(i, j)
+//      }
+//   }
+type blockWorkQueue struct {
+	head int64
+
+	total int
+	mod   int
+}
+
+// Reset resets the work queue with the parameters.
+func (q *blockWorkQueue) Reset(m, n int) {
+	q.head = 0
+
+	qm := blocks(m, blockSize)
+	qn := blocks(n, blockSize)
+	q.total = qm * qn
+	q.mod = qn
+}
+
+// Next returns work items until everything has been exhausted.
+func (q *blockWorkQueue) Next() (i, j int, ok bool) {
+	w := int(atomic.AddInt64(&q.head, 1)) - 1
+	i = (w / q.mod) * blockSize
+	j = (w % q.mod) * blockSize
+	return i, j, w < q.total
+}

--- a/blas/gonum/workqueue_test.go
+++ b/blas/gonum/workqueue_test.go
@@ -1,0 +1,32 @@
+// Copyright ©2020 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+import "testing"
+
+func TestBlockWorkQueue(t *testing.T) {
+	// exhaustive test for 4 items
+	for m := 0; m < blockSize*2+1; m++ {
+		for n := 0; n < blockSize*2+1; n++ {
+			testBlockWorkQueue(t, m, n)
+		}
+	}
+}
+
+func testBlockWorkQueue(t *testing.T, m, n int) {
+	var q blockWorkQueue
+	q.Reset(m, n)
+	for i := 0; i < m; i += blockSize {
+		for j := 0; j < n; j += blockSize {
+			ei, ej, ok := q.Next()
+			if !ok {
+				t.Fatalf("[%d:%d:%d] expected <%d, %d>", m, n, blockSize, i, j)
+			}
+			if i != ei || j != ej {
+				t.Fatalf("[%d:%d:%d] expected <%d, %d> got <%d, %d>", m, n, blockSize, i, j, ei, ej)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Optimizes use of a channel for distributing work to workers.

```
$ benchstat before.txt after.txt

name                  old time/op  new time/op  delta
DgemmSmSmSm-32         822ns ± 1%   817ns ± 1%     ~     (p=0.190 n=5+5)
DgemmMedMedMed-32      136µs ± 1%   141µs ± 3%   +3.30%  (p=0.008 n=5+5)
DgemmMedLgMed-32       463µs ± 0%   394µs ± 0%  -14.83%  (p=0.008 n=5+5)
DgemmLgLgLg-32        25.0ms ± 0%  24.9ms ± 0%   -0.51%  (p=0.008 n=5+5)
DgemmLgSmLg-32         697µs ± 0%   673µs ± 1%   -3.49%  (p=0.008 n=5+5)
DgemmLgLgSm-32         811µs ± 0%   735µs ± 0%   -9.36%  (p=0.008 n=5+5)
DgemmHgHgSm-32        72.5ms ± 0%  68.3ms ± 0%   -5.79%  (p=0.008 n=5+5)
DgemmMedMedMedTNT-32   299µs ± 3%   410µs ±16%  +36.95%  (p=0.008 n=5+5)
DgemmMedMedMedNTT-32   145µs ± 3%   147µs ± 3%     ~     (p=0.421 n=5+5)
DgemmMedMedMedTT-32    522µs ±12%   770µs ±20%  +47.43%  (p=0.008 n=5+5)
```

`DgemmMedMedMedTNT` is quite noisy in the measurements because the go scheduler decisions can affect the benchmark results quite significantly here.

If a worker finishes early then it might grab a work item and starve another worker. In MedMedMed case I got a case where the work distribution looked like `[0 1 0 3]`. Channels do avoid this problem due to having some fairness guarantees, however this also means that there's more machinery involved.