### PR TITLE
travis: replace golangci.com service with travis-local golangci-lint

### DIFF
--- a/.travis/run.d/linux/02-check-lint.sh
+++ b/.travis/run.d/linux/02-check-lint.sh
@@ -1,0 +1,1 @@
+../../script.d/check-lint.sh

--- a/.travis/script.d/check-lint.sh
+++ b/.travis/script.d/check-lint.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+if [ "${TRAVIS_CPU_ARCH}" != "amd64" ];  then
+	# TODO(kortschak): Remove this when git fetch --shallow-exclude is supported by git on arm64.
+	# See https://travis-ci.community/t/git-fetch-shallow-exclude-does-not-work-on-arm64-architecture/7583
+	echo "Skip lint check on arm64"
+	exit 0
+fi
+
+if [ -n "${TAGS}" ];  then
+	echo "Skip redundant lint check"
+	exit 0
+fi
+
+BRANCH=${TRAVIS_BRANCH}
+if [ "${BRANCH}" == "master" ] && [ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ]; then
+	BRANCH=${TRAVIS_PULL_REQUEST_BRANCH}
+fi
+
+if [ "${BRANCH}" == "master" ]; then
+	# Don't run linter on master; it's too late by then.
+	exit 0
+fi
+
+if [ "${TRAVIS_COMMIT}" == "${TRAVIS_TAG}" ]; then
+	# Don't run linter on tag pushes.
+	exit 0
+fi
+
+set -xe
+
+# Get all the commits on the branch, and the base commit.
+git fetch --shallow-exclude=master origin ${BRANCH}
+git log --oneline
+if [ -z "${TRAVIS_PULL_REQUEST_BRANCH}" ]; then
+	# Get the previous commit as well if we are not in a pull request build.
+	# Otherwise we already have the base commit.
+	COMMITS=$(git log --oneline | wc -l)
+	git fetch --depth=$((COMMITS+1)) origin ${BRANCH}
+fi
+
+# Travis does not correctly report the branch commit range in ${TRAVIS_COMMIT_RANGE}
+# if there has been an amended commit, so just get it from the git log.
+SINCE=$(git log --oneline --reverse | head -n1 | cut -f1 -d' ')
+
+# Lint changes since we were on master.
+golangci-lint run --new-from-rev=${SINCE}

--- a/.travis/script.d/deps.sh
+++ b/.travis/script.d/deps.sh
@@ -9,6 +9,8 @@ pushd $WORK
 
 # Required for format check.
 go get golang.org/x/tools/cmd/goimports
+# Required for linting check: apparently golangci-lint should not be installed using go get (https://github.com/golangci/golangci-lint#go).
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.8
 # Required for imports check.
 go get gonum.org/v1/tools/cmd/check-imports
 # Required for copyright header check.


### PR DESCRIPTION
Please take a look.

The golangci.com linting service is [going away next month](https://medium.com/golangci/golangci-com-is-closing-d1fc1bd30e0e), so this replaces that with work done on travis. It is a little harsher since it will actually fail a build that fails a lint check, but we can adjust that if needed, and lint checks can be tuned or turned off with [`//nolint` directives](https://github.com/golangci/golangci-lint#nolint).

[Currently linting cannot be done on arm64](https://travis-ci.community/t/git-fetch-shallow-exclude-does-not-work-on-arm64-architecture/7583), so asm lint won't be checked on that arch for now.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
