### PR TITLE
lapack: add Dpb* functions to Float64 interface

### DIFF
--- a/lapack/lapack.go
+++ b/lapack/lapack.go
@@ -27,6 +27,9 @@ type Float64 interface {
 	Dlapmt(forward bool, m, n int, x []float64, ldx int, k []int)
 	Dormqr(side blas.Side, trans blas.Transpose, m, n, k int, a []float64, lda int, tau, c []float64, ldc int, work []float64, lwork int)
 	Dormlq(side blas.Side, trans blas.Transpose, m, n, k int, a []float64, lda int, tau, c []float64, ldc int, work []float64, lwork int)
+	Dpbcon(uplo blas.Uplo, n, kd int, ab []float64, ldab int, anorm float64, work []float64, iwork []int) float64
+	Dpbtrf(uplo blas.Uplo, n, kd int, ab []float64, ldab int) (ok bool)
+	Dpbtrs(uplo blas.Uplo, n, kd, nrhs int, ab []float64, ldab int, b []float64, ldb int)
 	Dpocon(uplo blas.Uplo, n int, a []float64, lda int, anorm float64, work []float64, iwork []int) float64
 	Dpotrf(ul blas.Uplo, n int, a []float64, lda int) (ok bool)
 	Dpotri(ul blas.Uplo, n int, a []float64, lda int) (ok bool)

--- a/lapack/testlapack/dpbcon.go
+++ b/lapack/testlapack/dpbcon.go
@@ -19,8 +19,6 @@ type Dpbconer interface {
 	Dpbcon(uplo blas.Uplo, n, kd int, ab []float64, ldab int, anorm float64, work []float64, iwork []int) float64
 
 	Dpbtrser
-	Dlanger
-	Dlansber
 }
 
 // DpbconTest tests Dpbcon by generating a random symmetric band matrix A and
@@ -57,7 +55,7 @@ func dpbconTest(t *testing.T, impl Dpbconer, uplo blas.Uplo, n, kd, ldab int, rn
 
 	// Compute the norm of A.
 	work := make([]float64, 3*n)
-	aNorm := impl.Dlansb(lapack.MaxColumnSum, uplo, n, kd, ab, ldab, work)
+	aNorm := dlansb(lapack.MaxColumnSum, uplo, n, kd, ab, ldab, work)
 
 	// Compute an estimate of rCond.
 	iwork := make([]int, n)
@@ -77,7 +75,7 @@ func dpbconTest(t *testing.T, impl Dpbconer, uplo blas.Uplo, n, kd, ldab int, rn
 		aInv[i*lda+i] = 1
 	}
 	impl.Dpbtrs(uplo, n, kd, n, abFac, ldab, aInv, lda)
-	aInvNorm := impl.Dlange(lapack.MaxColumnSum, n, n, aInv, lda, work)
+	aInvNorm := dlange(lapack.MaxColumnSum, n, n, aInv, lda)
 	rCondWant := 1.0
 	if aNorm > 0 && aInvNorm > 0 {
 		rCondWant = 1 / aNorm / aInvNorm


### PR DESCRIPTION
Also remove the dependence of DpbconTest on Dlansber (and Dlanger) interfaces because the netlib package doesn't provide Dlansb.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
