### PR TITLE
travis: use github PR number for obtaining branch

### DIFF
--- a/.travis/script.d/check-lint.sh
+++ b/.travis/script.d/check-lint.sh
@@ -12,20 +12,12 @@ if [ -n "${TAGS}" ];  then
 	exit 0
 fi
 
-BRANCH=${TRAVIS_BRANCH}
-if [ "${BRANCH}" == "master" ] && [ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ]; then
-	BRANCH=${TRAVIS_PULL_REQUEST_BRANCH}
-fi
-
-if [ "${BRANCH}" == "master" ]; then
-	# Don't run linter on master; it's too late by then.
+if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
+	# Only run on pull requests.
 	exit 0
 fi
 
-if [ "${TRAVIS_COMMIT}" == "${TRAVIS_TAG}" ]; then
-	# Don't run linter on tag pushes.
-	exit 0
-fi
+BRANCH="+refs/pull/${TRAVIS_PULL_REQUEST}/head"
 
 set -xe
 


### PR DESCRIPTION
This fixes the issue seen [here](https://github.com/gonum/gonum/pull/1301#issuecomment-606239235). It only runs golangci-lint on pull requests, so not on a push, and allows people contributing changes from outside the gonum/gonum repo to have their code linted and not fail.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
