### PR TITLE
spatial/{r2,r3}: add costheta, normalize

### DIFF
--- a/spatial/r2/vector.go
+++ b/spatial/r2/vector.go
@@ -54,8 +54,8 @@ func Norm2(p Vec) float64 {
 	return p.X*p.X + p.Y*p.Y
 }
 
-// Normalize returns the unit vector colinear to p.
-func Normalize(p Vec) Vec {
+// Unit returns the unit vector colinear to p.
+func Unit(p Vec) Vec {
 	if p.X == 0 && p.Y == 0 {
 		return Vec{}
 	}

--- a/spatial/r2/vector.go
+++ b/spatial/r2/vector.go
@@ -54,6 +54,16 @@ func Norm2(p Vec) float64 {
 	return p.X*p.X + p.Y*p.Y
 }
 
+// CosTheta returns the cosine of the opening angle between p and q.
+func CosTheta(p, q Vec) float64 {
+	var (
+		np2 = Norm2(p)
+		nq2 = Norm2(q)
+		dot = p.Dot(q)
+	)
+	return dot / math.Sqrt(np2*nq2)
+}
+
 // Box is a 2D bounding box.
 type Box struct {
 	Min, Max Vec

--- a/spatial/r2/vector.go
+++ b/spatial/r2/vector.go
@@ -62,14 +62,9 @@ func Unit(p Vec) Vec {
 	return p.Scale(1 / Norm(p))
 }
 
-// CosTheta returns the cosine of the opening angle between p and q.
-func CosTheta(p, q Vec) float64 {
-	var (
-		np2 = Norm2(p)
-		nq2 = Norm2(q)
-		dot = p.Dot(q)
-	)
-	return dot / math.Sqrt(np2*nq2)
+// Cos returns the cosine of the opening angle between p and q.
+func Cos(p, q Vec) float64 {
+	return p.Dot(q) / (Norm(p) * Norm(q))
 }
 
 // Box is a 2D bounding box.

--- a/spatial/r2/vector.go
+++ b/spatial/r2/vector.go
@@ -54,6 +54,14 @@ func Norm2(p Vec) float64 {
 	return p.X*p.X + p.Y*p.Y
 }
 
+// Normalize returns the unit vector colinear to p.
+func Normalize(p Vec) Vec {
+	if p.X == 0 && p.Y == 0 {
+		return Vec{}
+	}
+	return p.Scale(1 / Norm(p))
+}
+
 // CosTheta returns the cosine of the opening angle between p and q.
 func CosTheta(p, q Vec) float64 {
 	var (

--- a/spatial/r2/vector.go
+++ b/spatial/r2/vector.go
@@ -55,9 +55,10 @@ func Norm2(p Vec) float64 {
 }
 
 // Unit returns the unit vector colinear to p.
+// Unit returns {NaN,NaN} for the zero vector.
 func Unit(p Vec) Vec {
 	if p.X == 0 && p.Y == 0 {
-		return Vec{}
+		return Vec{X: math.NaN(), Y: math.NaN()}
 	}
 	return p.Scale(1 / Norm(p))
 }

--- a/spatial/r2/vector_test.go
+++ b/spatial/r2/vector_test.go
@@ -188,7 +188,7 @@ func TestUnit(t *testing.T) {
 	for _, test := range []struct {
 		v, want Vec
 	}{
-		{Vec{}, Vec{}},
+		{Vec{}, Vec{math.NaN(), math.NaN()}},
 		{Vec{1, 0}, Vec{1, 0}},
 		{Vec{0, 1}, Vec{0, 1}},
 		{Vec{-1, 0}, Vec{-1, 0}},
@@ -207,7 +207,7 @@ func TestUnit(t *testing.T) {
 					test.v, got, test.want,
 				)
 			}
-			if got == (Vec{}) {
+			if vecIsNaN(got) {
 				return
 			}
 			if n, want := Norm(got), 1.0; n != want {
@@ -240,8 +240,20 @@ func TestCos(t *testing.T) {
 	}
 }
 
+func vecIsNaN(v Vec) bool {
+	return math.IsNaN(v.X) && math.IsNaN(v.Y)
+}
+
+func vecIsNaNAny(v Vec) bool {
+	return math.IsNaN(v.X) || math.IsNaN(v.Y)
+}
+
 func vecApproxEqual(a, b Vec) bool {
 	const tol = 1e-14
+	if vecIsNaNAny(a) || vecIsNaNAny(b) {
+		return vecIsNaN(a) && vecIsNaN(b)
+	}
+
 	return floats.EqualWithinAbs(a.X, b.X, tol) &&
 		floats.EqualWithinAbs(a.Y, b.Y, tol)
 }

--- a/spatial/r2/vector_test.go
+++ b/spatial/r2/vector_test.go
@@ -181,3 +181,25 @@ func TestNorm2(t *testing.T) {
 		})
 	}
 }
+
+func TestCosTheta(t *testing.T) {
+	for _, test := range []struct {
+		v1, v2 Vec
+		want   float64
+	}{
+		{Vec{1, 1}, Vec{1, 1}, 1},
+		{Vec{1, 1}, Vec{-1, -1}, -1},
+		{Vec{1, 0}, Vec{1, 0}, 1},
+		{Vec{1, 0}, Vec{0, 1}, 0},
+		{Vec{1, 0}, Vec{-1, 0}, -1},
+	} {
+		t.Run("", func(t *testing.T) {
+			got := CosTheta(test.v1, test.v2)
+			if got != test.want {
+				t.Fatalf("cos(theta)(%v, %v)= %v, want %v",
+					test.v1, test.v2, got, test.want,
+				)
+			}
+		})
+	}
+}

--- a/spatial/r2/vector_test.go
+++ b/spatial/r2/vector_test.go
@@ -217,7 +217,7 @@ func TestUnit(t *testing.T) {
 	}
 }
 
-func TestCosTheta(t *testing.T) {
+func TestCos(t *testing.T) {
 	for _, test := range []struct {
 		v1, v2 Vec
 		want   float64
@@ -229,9 +229,10 @@ func TestCosTheta(t *testing.T) {
 		{Vec{1, 0}, Vec{-1, 0}, -1},
 	} {
 		t.Run("", func(t *testing.T) {
-			got := CosTheta(test.v1, test.v2)
-			if got != test.want {
-				t.Fatalf("cos(theta)(%v, %v)= %v, want %v",
+			tol := 1e-14
+			got := Cos(test.v1, test.v2)
+			if !floats.EqualWithinAbs(got, test.want, tol) {
+				t.Fatalf("cos(%v, %v)= %v, want %v",
 					test.v1, test.v2, got, test.want,
 				)
 			}

--- a/spatial/r2/vector_test.go
+++ b/spatial/r2/vector_test.go
@@ -7,6 +7,8 @@ package r2
 import (
 	"math"
 	"testing"
+
+	"gonum.org/v1/gonum/floats"
 )
 
 func TestAdd(t *testing.T) {
@@ -182,6 +184,39 @@ func TestNorm2(t *testing.T) {
 	}
 }
 
+func TestNormalize(t *testing.T) {
+	for _, test := range []struct {
+		v, want Vec
+	}{
+		{Vec{}, Vec{}},
+		{Vec{1, 0}, Vec{1, 0}},
+		{Vec{0, 1}, Vec{0, 1}},
+		{Vec{-1, 0}, Vec{-1, 0}},
+		{Vec{3, 4}, Vec{0.6, 0.8}},
+		{Vec{3, -4}, Vec{0.6, -0.8}},
+		{Vec{1, 1}, Vec{1. / math.Sqrt(2), 1. / math.Sqrt(2)}},
+		{Vec{1, 1e-16}, Vec{1, 1e-16}},
+		{Vec{1, 1e16}, Vec{1e-16, 1}},
+		{Vec{1e4, math.MaxFloat32 - 1}, Vec{0, 1}},
+	} {
+		t.Run("", func(t *testing.T) {
+			got := Normalize(test.v)
+			if !vecApproxEqual(got, test.want) {
+				t.Fatalf(
+					"Normalize(%v) = %v, want %v",
+					test.v, got, test.want,
+				)
+			}
+			if got == (Vec{}) {
+				return
+			}
+			if n, want := Norm(got), 1.0; n != want {
+				t.Fatalf("|%v| = %v, want 1", got, n)
+			}
+		})
+	}
+}
+
 func TestCosTheta(t *testing.T) {
 	for _, test := range []struct {
 		v1, v2 Vec
@@ -202,4 +237,10 @@ func TestCosTheta(t *testing.T) {
 			}
 		})
 	}
+}
+
+func vecApproxEqual(a, b Vec) bool {
+	const tol = 1e-14
+	return floats.EqualWithinAbs(a.X, b.X, tol) &&
+		floats.EqualWithinAbs(a.Y, b.Y, tol)
 }

--- a/spatial/r2/vector_test.go
+++ b/spatial/r2/vector_test.go
@@ -184,7 +184,7 @@ func TestNorm2(t *testing.T) {
 	}
 }
 
-func TestNormalize(t *testing.T) {
+func TestUnit(t *testing.T) {
 	for _, test := range []struct {
 		v, want Vec
 	}{
@@ -200,10 +200,10 @@ func TestNormalize(t *testing.T) {
 		{Vec{1e4, math.MaxFloat32 - 1}, Vec{0, 1}},
 	} {
 		t.Run("", func(t *testing.T) {
-			got := Normalize(test.v)
+			got := Unit(test.v)
 			if !vecApproxEqual(got, test.want) {
 				t.Fatalf(
-					"Normalize(%v) = %v, want %v",
+					"Unit(%v) = %v, want %v",
 					test.v, got, test.want,
 				)
 			}

--- a/spatial/r3/vector.go
+++ b/spatial/r3/vector.go
@@ -61,8 +61,8 @@ func Norm2(p Vec) float64 {
 	return p.X*p.X + p.Y*p.Y + p.Z*p.Z
 }
 
-// Normalize returns the unit vector colinear to p.
-func Normalize(p Vec) Vec {
+// Unit returns the unit vector colinear to p.
+func Unit(p Vec) Vec {
 	if p.X == 0 && p.Y == 0 && p.Z == 0 {
 		return Vec{}
 	}

--- a/spatial/r3/vector.go
+++ b/spatial/r3/vector.go
@@ -61,6 +61,14 @@ func Norm2(p Vec) float64 {
 	return p.X*p.X + p.Y*p.Y + p.Z*p.Z
 }
 
+// Normalize returns the unit vector colinear to p.
+func Normalize(p Vec) Vec {
+	if p.X == 0 && p.Y == 0 && p.Z == 0 {
+		return Vec{}
+	}
+	return p.Scale(1 / Norm(p))
+}
+
 // CosTheta returns the cosine of the opening angle between p and q.
 func CosTheta(p, q Vec) float64 {
 	var (

--- a/spatial/r3/vector.go
+++ b/spatial/r3/vector.go
@@ -61,6 +61,16 @@ func Norm2(p Vec) float64 {
 	return p.X*p.X + p.Y*p.Y + p.Z*p.Z
 }
 
+// CosTheta returns the cosine of the opening angle between p and q.
+func CosTheta(p, q Vec) float64 {
+	var (
+		np2 = Norm2(p)
+		nq2 = Norm2(q)
+		dot = p.Dot(q)
+	)
+	return dot / math.Sqrt(np2*nq2)
+}
+
 // Box is a 3D bounding box.
 type Box struct {
 	Min, Max Vec

--- a/spatial/r3/vector.go
+++ b/spatial/r3/vector.go
@@ -69,14 +69,9 @@ func Unit(p Vec) Vec {
 	return p.Scale(1 / Norm(p))
 }
 
-// CosTheta returns the cosine of the opening angle between p and q.
-func CosTheta(p, q Vec) float64 {
-	var (
-		np2 = Norm2(p)
-		nq2 = Norm2(q)
-		dot = p.Dot(q)
-	)
-	return dot / math.Sqrt(np2*nq2)
+// Cos returns the cosine of the opening angle between p and q.
+func Cos(p, q Vec) float64 {
+	return p.Dot(q) / (Norm(p) * Norm(q))
 }
 
 // Box is a 3D bounding box.

--- a/spatial/r3/vector.go
+++ b/spatial/r3/vector.go
@@ -62,9 +62,10 @@ func Norm2(p Vec) float64 {
 }
 
 // Unit returns the unit vector colinear to p.
+// Unit returns {NaN,NaN,NaN} for the zero vector.
 func Unit(p Vec) Vec {
 	if p.X == 0 && p.Y == 0 && p.Z == 0 {
-		return Vec{}
+		return Vec{X: math.NaN(), Y: math.NaN(), Z: math.NaN()}
 	}
 	return p.Scale(1 / Norm(p))
 }

--- a/spatial/r3/vector_test.go
+++ b/spatial/r3/vector_test.go
@@ -176,3 +176,27 @@ func TestNorm2(t *testing.T) {
 		})
 	}
 }
+
+func TestCosTheta(t *testing.T) {
+	for _, test := range []struct {
+		v1, v2 Vec
+		want   float64
+	}{
+		{Vec{1, 1, 1}, Vec{1, 1, 1}, 1},
+		{Vec{1, 1, 1}, Vec{-1, -1, -1}, -1},
+		{Vec{1, 1, 1}, Vec{1, -1, 1}, 1.0 / 3},
+		{Vec{1, 0, 0}, Vec{1, 0, 0}, 1},
+		{Vec{1, 0, 0}, Vec{0, 1, 0}, 0},
+		{Vec{1, 0, 0}, Vec{0, 1, 1}, 0},
+		{Vec{1, 0, 0}, Vec{-1, 0, 0}, -1},
+	} {
+		t.Run("", func(t *testing.T) {
+			got := CosTheta(test.v1, test.v2)
+			if got != test.want {
+				t.Fatalf("cos(theta)(%v, %v)= %v, want %v",
+					test.v1, test.v2, got, test.want,
+				)
+			}
+		})
+	}
+}

--- a/spatial/r3/vector_test.go
+++ b/spatial/r3/vector_test.go
@@ -4,7 +4,10 @@
 
 package r3
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestAdd(t *testing.T) {
 	for _, test := range []struct {
@@ -172,6 +175,31 @@ func TestNorm2(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			if got, want := Norm2(test.v), test.want; got != want {
 				t.Fatalf("|%v|^2 = %v, want %v", test.v, got, want)
+			}
+		})
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	for _, test := range []struct {
+		v, want Vec
+	}{
+		{Vec{1, 0, 0}, Vec{1, 0, 0}},
+		{Vec{0, 1, 0}, Vec{0, 1, 0}},
+		{Vec{0, 0, 1}, Vec{0, 0, 1}},
+		{Vec{1, 1, 1}, Vec{1. / math.Sqrt(3), 1. / math.Sqrt(3), 1. / math.Sqrt(3)}},
+		{Vec{1, 1e-16, 1e-32}, Vec{1, 1e-16, 1e-32}},
+	} {
+		t.Run("", func(t *testing.T) {
+			got := Normalize(test.v)
+			if got != test.want {
+				t.Fatalf(
+					"Normalize(%v) = %v, want %v",
+					test.v, got, test.want,
+				)
+			}
+			if n, want := Norm(got), 1.0; n != want {
+				t.Fatalf("|%v| = %v, want 1", got, n)
 			}
 		})
 	}

--- a/spatial/r3/vector_test.go
+++ b/spatial/r3/vector_test.go
@@ -7,6 +7,8 @@ package r3
 import (
 	"math"
 	"testing"
+
+	"gonum.org/v1/gonum/floats"
 )
 
 func TestAdd(t *testing.T) {
@@ -209,7 +211,7 @@ func TestUnit(t *testing.T) {
 	}
 }
 
-func TestCosTheta(t *testing.T) {
+func TestCos(t *testing.T) {
 	for _, test := range []struct {
 		v1, v2 Vec
 		want   float64
@@ -223,9 +225,10 @@ func TestCosTheta(t *testing.T) {
 		{Vec{1, 0, 0}, Vec{-1, 0, 0}, -1},
 	} {
 		t.Run("", func(t *testing.T) {
-			got := CosTheta(test.v1, test.v2)
-			if got != test.want {
-				t.Fatalf("cos(theta)(%v, %v)= %v, want %v",
+			tol := 1e-14
+			got := Cos(test.v1, test.v2)
+			if !floats.EqualWithinAbs(got, test.want, tol) {
+				t.Fatalf("cos(%v, %v)= %v, want %v",
 					test.v1, test.v2, got, test.want,
 				)
 			}

--- a/spatial/r3/vector_test.go
+++ b/spatial/r3/vector_test.go
@@ -184,6 +184,7 @@ func TestUnit(t *testing.T) {
 	for _, test := range []struct {
 		v, want Vec
 	}{
+		{Vec{}, Vec{}},
 		{Vec{1, 0, 0}, Vec{1, 0, 0}},
 		{Vec{0, 1, 0}, Vec{0, 1, 0}},
 		{Vec{0, 0, 1}, Vec{0, 0, 1}},
@@ -197,6 +198,9 @@ func TestUnit(t *testing.T) {
 					"Normalize(%v) = %v, want %v",
 					test.v, got, test.want,
 				)
+			}
+			if test.v == (Vec{}) {
+				return
 			}
 			if n, want := Norm(got), 1.0; n != want {
 				t.Fatalf("|%v| = %v, want 1", got, n)

--- a/spatial/r3/vector_test.go
+++ b/spatial/r3/vector_test.go
@@ -180,7 +180,7 @@ func TestNorm2(t *testing.T) {
 	}
 }
 
-func TestNormalize(t *testing.T) {
+func TestUnit(t *testing.T) {
 	for _, test := range []struct {
 		v, want Vec
 	}{
@@ -191,7 +191,7 @@ func TestNormalize(t *testing.T) {
 		{Vec{1, 1e-16, 1e-32}, Vec{1, 1e-16, 1e-32}},
 	} {
 		t.Run("", func(t *testing.T) {
-			got := Normalize(test.v)
+			got := Unit(test.v)
 			if got != test.want {
 				t.Fatalf(
 					"Normalize(%v) = %v, want %v",

--- a/spatial/r3/vector_test.go
+++ b/spatial/r3/vector_test.go
@@ -186,7 +186,7 @@ func TestUnit(t *testing.T) {
 	for _, test := range []struct {
 		v, want Vec
 	}{
-		{Vec{}, Vec{}},
+		{Vec{}, Vec{math.NaN(), math.NaN(), math.NaN()}},
 		{Vec{1, 0, 0}, Vec{1, 0, 0}},
 		{Vec{0, 1, 0}, Vec{0, 1, 0}},
 		{Vec{0, 0, 1}, Vec{0, 0, 1}},
@@ -195,7 +195,7 @@ func TestUnit(t *testing.T) {
 	} {
 		t.Run("", func(t *testing.T) {
 			got := Unit(test.v)
-			if got != test.want {
+			if !vecEqual(got, test.want) {
 				t.Fatalf(
 					"Normalize(%v) = %v, want %v",
 					test.v, got, test.want,
@@ -234,4 +234,19 @@ func TestCos(t *testing.T) {
 			}
 		})
 	}
+}
+
+func vecIsNaN(v Vec) bool {
+	return math.IsNaN(v.X) && math.IsNaN(v.Y) && math.IsNaN(v.Z)
+}
+
+func vecIsNaNAny(v Vec) bool {
+	return math.IsNaN(v.X) || math.IsNaN(v.Y) || math.IsNaN(v.Z)
+}
+
+func vecEqual(a, b Vec) bool {
+	if vecIsNaNAny(a) || vecIsNaNAny(b) {
+		return vecIsNaN(a) && vecIsNaN(b)
+	}
+	return a == b
 }


### PR DESCRIPTION
Please take a look.

This CL adds the ability to compute the cosine of the opening angle between 2 vectors (in `r2` and `r3`) and to normalize a vector (ditto).

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
