### PR TITLE
mat: address two small TODOs

### DIFF
--- a/mat/cholesky.go
+++ b/mat/cholesky.go
@@ -494,11 +494,8 @@ func (c *Cholesky) ExtendVecSym(a *Cholesky, v Vector) (ok bool) {
 	//  3) c'*c + d'*d = k  =>  d = sqrt(k-c'*c)
 
 	// First, compute c = U'^-1 a
-	// TODO(btracey): Replace this with CopyVec when issue 167 is fixed.
 	w := NewVecDense(n, nil)
-	for i := 0; i < n; i++ {
-		w.SetVec(i, v.At(i, 0))
-	}
+	w.CopyVec(v)
 	k := v.At(n, 0)
 
 	var t VecDense

--- a/mat/cholesky.go
+++ b/mat/cholesky.go
@@ -528,7 +528,8 @@ func (c *Cholesky) ExtendVecSym(a *Cholesky, v Vector) (ok bool) {
 // Note that when alpha is negative, the updating problem may be ill-conditioned
 // and the results may be inaccurate, or the updated matrix A' may not be
 // positive definite and not have a Cholesky factorization. SymRankOne returns
-// whether the updated matrix A' is positive definite.
+// whether the updated matrix A' is positive definite. If the update fails
+// the receiver is left unchanged.
 //
 // SymRankOne updates a Cholesky factorization in O(n²) time. The Cholesky
 // factorization computation from scratch is O(n³).
@@ -661,13 +662,14 @@ func (c *Cholesky) SymRankOne(orig *Cholesky, alpha float64, x Vector) (ok bool)
 			sin[i] *= -1
 		}
 	}
-	umat := c.chol.mat
-	stride := umat.Stride
+	workMat := getWorkspaceTri(c.chol.mat.N, c.chol.triKind(), false)
+	defer putWorkspaceTri(workMat)
+	workMat.Copy(c.chol)
+	umat := workMat.mat
+	stride := workMat.mat.Stride
 	for i := n - 1; i >= 0; i-- {
 		work[i] = 0
 		// Apply Givens matrices to U.
-		// TODO(vladimir-ch): Use workspace to avoid modifying the
-		// receiver in case an invalid factorization is created.
 		blas64.Rot(
 			blas64.Vector{N: n - i, Data: work[i:n], Inc: 1},
 			blas64.Vector{N: n - i, Data: umat.Data[i*stride+i : i*stride+n], Inc: 1},
@@ -685,9 +687,8 @@ func (c *Cholesky) SymRankOne(orig *Cholesky, alpha float64, x Vector) (ok bool)
 		}
 	}
 	if ok {
+		c.chol.Copy(workMat)
 		c.updateCond(-1)
-	} else {
-		c.Reset()
 	}
 	return ok
 }

--- a/mat/svd.go
+++ b/mat/svd.go
@@ -228,7 +228,7 @@ func (svd *SVD) VTo(dst *Dense) {
 		panic(badFact)
 	}
 	kind := svd.kind
-	if kind&SVDThinU == 0 && kind&SVDFullV == 0 {
+	if kind&SVDThinV == 0 && kind&SVDFullV == 0 {
 		panic("svd: v not computed during factorization")
 	}
 	r := svd.vt.Rows

--- a/mat/svd_test.go
+++ b/mat/svd_test.go
@@ -90,6 +90,41 @@ func TestSVD(t *testing.T) {
 		if !EqualApprox(test.a, &ans, 1e-10) {
 			t.Errorf("A reconstruction mismatch.\nGot:\n%v\nWant:\n%v\n", Formatted(&ans), Formatted(test.a))
 		}
+
+		for _, kind := range []SVDKind{
+			SVDThinU, SVDFullU, SVDThinV, SVDFullV,
+		} {
+			var svd SVD
+			svd.Factorize(test.a, kind)
+			if kind&SVDThinU == 0 && kind&SVDFullU == 0 {
+				panicked, message := panics(func() {
+					var dst Dense
+					svd.UTo(&dst)
+				})
+				if !panicked {
+					t.Error("expected panic with no U matrix requested")
+					continue
+				}
+				want := "svd: u not computed during factorization"
+				if message != want {
+					t.Errorf("unexpected message: got:%q want:%q", message, want)
+				}
+			}
+			if kind&SVDThinV == 0 && kind&SVDFullV == 0 {
+				panicked, message := panics(func() {
+					var dst Dense
+					svd.VTo(&dst)
+				})
+				if !panicked {
+					t.Error("expected panic with no V matrix requested")
+					continue
+				}
+				want := "svd: v not computed during factorization"
+				if message != want {
+					t.Errorf("unexpected message: got:%q want:%q", message, want)
+				}
+			}
+		}
 	}
 
 	for _, test := range []struct {


### PR DESCRIPTION
use CopyVec per a TODO, references long-resolved issue #167
in Cholesky.SymRankOne don't modify receiver if singular