### PR TITLE
amos: add bug note to failing Fortran/Go comparison tests

### DIFF
--- a/mathext/internal/amos/amos_fortran_test.go
+++ b/mathext/internal/amos/amos_fortran_test.go
@@ -16,6 +16,10 @@ import (
 	"gonum.org/v1/gonum/mathext/internal/amos/amoslib"
 )
 
+// BUG(kortschak): Some tests here comparing the direct Go translation
+// of the Fortran code fail. Do not delete these tests or this file until
+// https://github.com/gonum/gonum/issues/1322 has been satisfactorily
+// resolved.
 var runFailing = flag.Bool("failing", false, "run known failing cases")
 
 func TestAiryFortran(t *testing.T) {


### PR DESCRIPTION
Please take a look.

Updates #1322.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
