### PR TITLE
graph/flow: avoid non-rune to string conversion

### DIFF
--- a/graph/flow/control_flow_test.go
+++ b/graph/flow/control_flow_test.go
@@ -126,7 +126,7 @@ var dominatorsTests = []struct {
 	},
 }
 
-type char int64
+type char rune
 
 func (n char) ID() int64      { return int64(n) }
 func (n char) String() string { return string(n) }


### PR DESCRIPTION
Please take a look.

This prepares for the coming default cmd/vet behaviour that disallows `string(T)` conversions where T is not `rune` (or `byte`?).

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
