### PR TITLE
ci: make golangci-linting a github action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,20 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v1
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.27
+          only-new-issues: true


### PR DESCRIPTION
When golangci.com went away we lost annotation within the PR, depending on golangci-lint to find errors in the travis build log. This is an experiment to use GitHub actions to do essentially the same thing.

Currently, it makes annotations on the code changes rather than sending comments to the PR conversation (which I would prefer), but that is a feature request on the action. If we don't like this was can revert it, but I'd like to try it out for a bit; it is running the action on this PR, though nothing should be found since there are no Go changes here.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
