### PR TITLE
mat: fix typos

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -62,6 +62,7 @@ Kirill Motkov <motkov.kirill@gmail.com>
 Konstantin Shaposhnikov <k.shaposhnikov@gmail.com>
 Leonid Kneller <recondite.matter@gmail.com>
 Lyron Winderbaum <lyron.winderbaum@student.adelaide.edu.au>
+Marco Leogrande <dark.knight.ita@gmail.com>
 Martin Diz <github@martindiz.com.ar>
 Matthieu Di Mercurio <matthieu.dimercurio@gmail.com>
 Max Halford <maxhalford25@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -69,6 +69,7 @@ Kirill Motkov <motkov.kirill@gmail.com>
 Konstantin Shaposhnikov <k.shaposhnikov@gmail.com>
 Leonid Kneller <recondite.matter@gmail.com>
 Lyron Winderbaum <lyron.winderbaum@student.adelaide.edu.au>
+Marco Leogrande <dark.knight.ita@gmail.com>
 Martin Diz <github@martindiz.com.ar>
 Matthieu Di Mercurio <matthieu.dimercurio@gmail.com>
 Max Halford <maxhalford25@gmail.com>

--- a/mat/errors.go
+++ b/mat/errors.go
@@ -20,7 +20,7 @@ import (
 // number of A is sufficiently large. If A is exactly singular to working precision,
 // Condition == ∞, and the solve algorithm may have completed early. If Condition
 // is large and finite the solve algorithm will be performed, but the computed
-// solution may be innacurate. Due to the nature of finite precision arithmetic,
+// solution may be inaccurate. Due to the nature of finite precision arithmetic,
 // the value of Condition is only an approximate test of singularity.
 type Condition float64
 

--- a/mat/matrix.go
+++ b/mat/matrix.go
@@ -371,7 +371,7 @@ func Row(dst []float64, i int, a Matrix) []float64 {
 // Cond will panic with matrix.ErrShape if the matrix has zero size.
 //
 // BUG(btracey): The computation of the 1-norm and ∞-norm for non-square matrices
-// is innacurate, although is typically the right order of magnitude. See
+// is inaccurate, although is typically the right order of magnitude. See
 // https://github.com/xianyi/OpenBLAS/issues/636. While the value returned will
 // change with the resolution of this bug, the result from Cond will match the
 // condition number used internally.


### PR DESCRIPTION
This is a minor change, that fixes typos for the word 'inaccurate' in a couple of documentation-visible locations in the 'mat' package.