### PR TITLE
stat/distuv: Test Quantile with out of range arguments inside the common test function

### DIFF
--- a/stat/distuv/beta_test.go
+++ b/stat/distuv/beta_test.go
@@ -94,13 +94,6 @@ func testBeta(t *testing.T, b Beta, i int) {
 	if b.Survival(1.01) != 0 {
 		t.Errorf("Survival above 1 is not 0")
 	}
-
-	if !panics(func() { b.Quantile(-0.01) }) {
-		t.Errorf("Quantile did not panic for negative argument")
-	}
-	if !panics(func() { b.Quantile(1.01) }) {
-		t.Errorf("Quantile did not panic for argument above 1")
-	}
 }
 
 func TestBetaBadParams(t *testing.T) {

--- a/stat/distuv/chisquared_test.go
+++ b/stat/distuv/chisquared_test.go
@@ -90,12 +90,6 @@ func testChiSquared(t *testing.T, c ChiSquared, i int) {
 	if c.NumParameters() != 1 {
 		t.Errorf("NumParameters is not 1. Got %v", c.NumParameters())
 	}
-	if !panics(func() { c.Quantile(-0.0001) }) {
-		t.Errorf("Expected panic with negative argument to Quantile")
-	}
-	if !panics(func() { c.Quantile(1.0001) }) {
-		t.Errorf("Expected panic with argument to Quantile above 1")
-	}
 	survival := c.Survival(-0.00001)
 	if survival != 1 {
 		t.Errorf("Survival is not 1 for negative argument. Got %v", survival)

--- a/stat/distuv/distribution_test.go
+++ b/stat/distuv/distribution_test.go
@@ -149,6 +149,12 @@ func checkQuantileCDFSurvival(t *testing.T, i int, xs []float64, c cumulanter, t
 			t.Errorf("Survival/CDF mismatch case %v: want: %v, got: %v", i, 1-cdf, c.Survival(x))
 		}
 	}
+	if !panics(func() { c.Quantile(-0.0001) }) {
+		t.Errorf("Expected panic with negative argument to Quantile")
+	}
+	if !panics(func() { c.Quantile(1.0001) }) {
+		t.Errorf("Expected panic with Quantile argument above 1")
+	}
 }
 
 func checkProbContinuous(t *testing.T, i int, x []float64, p probLogprober, tol float64) {


### PR DESCRIPTION
This change tests all distributions which are tested using `checkQuantileCDFSurvival` for Quantile rejecting arguments which are out of range.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
