### PR TITLE
stat/distuv: use math.Expm1 when calculating Exponential.CDF to improve accuracy for small x

### DIFF
--- a/stat/distuv/exponential.go
+++ b/stat/distuv/exponential.go
@@ -24,7 +24,7 @@ func (e Exponential) CDF(x float64) float64 {
 	if x < 0 {
 		return 0
 	}
-	return 1 - math.Exp(-e.Rate*x)
+	return -math.Expm1(-e.Rate * x)
 }
 
 // ConjugateUpdate updates the parameters of the distribution from the sufficient

--- a/stat/distuv/exponential_test.go
+++ b/stat/distuv/exponential_test.go
@@ -151,3 +151,13 @@ func TestExponentialFitPanic(t *testing.T) {
 	}()
 	e.Fit(make([]float64, 10), nil)
 }
+
+func TestExponentialCDFSmallArgument(t *testing.T) {
+	t.Parallel()
+	e := Exponential{Rate: 1}
+	x := 1e-17
+	p := e.CDF(x)
+	if math.Abs(p-x) > 1e-20 {
+		t.Errorf("Wrong CDF value for small argument. Got: %v, want: %g", p, x)
+	}
+}


### PR DESCRIPTION
Please take a look.

This changes the way the CDF is calculated for exponential distribution from

```
1 - math.Exp(-e.Rate * x)
```

to

```
- math.Expm1(-e.Rate * x)
```

giving higher accuracy for very small x.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
