### PR TITLE
stat/distuv: Provide full test coverage for Gamma distribution and small fixes

### DIFF
--- a/stat/distuv/distribution_test.go
+++ b/stat/distuv/distribution_test.go
@@ -161,9 +161,10 @@ func checkProbContinuous(t *testing.T, i int, x []float64, p probLogprober, tol 
 	checkProbContinuousWithBounds(t, i, x, math.Inf(-1), math.Inf(1), p, tol)
 }
 
-func checkProbContinuousWithBounds(t *testing.T, i int, x []float64, lb float64, ub float64, p probLogprober, tol float64) {
-	// Check that the PDF is consistent (integrates to 1). Takes lower and upper bounds for X.
-	q := quad.Fixed(p.Prob, lb, ub, 1000000, nil, 0)
+// checkProbContinuousWithBounds checks that the PDF is consistent
+// with LogPDF and integrates to 1 from the lower to upper bound.
+func checkProbContinuousWithBounds(t *testing.T, i int, x []float64, lower float64, upper float64, p probLogprober, tol float64) {
+	q := quad.Fixed(p.Prob, lower, upper, 1000000, nil, 0)
 	if math.Abs(q-1) > tol {
 		t.Errorf("Probability distribution doesn't integrate to 1. Case %v: Got %v", i, q)
 	}

--- a/stat/distuv/distribution_test.go
+++ b/stat/distuv/distribution_test.go
@@ -158,8 +158,12 @@ func checkQuantileCDFSurvival(t *testing.T, i int, xs []float64, c cumulanter, t
 }
 
 func checkProbContinuous(t *testing.T, i int, x []float64, p probLogprober, tol float64) {
-	// Check that the PDF is consistent (integrates to 1).
-	q := quad.Fixed(p.Prob, math.Inf(-1), math.Inf(1), 1000000, nil, 0)
+	checkProbContinuousWithBounds(t, i, x, math.Inf(-1), math.Inf(1), p, tol)
+}
+
+func checkProbContinuousWithBounds(t *testing.T, i int, x []float64, lb float64, ub float64, p probLogprober, tol float64) {
+	// Check that the PDF is consistent (integrates to 1). Takes lower and upper bounds for X.
+	q := quad.Fixed(p.Prob, lb, ub, 1000000, nil, 0)
 	if math.Abs(q-1) > tol {
 		t.Errorf("Probability distribution doesn't integrate to 1. Case %v: Got %v", i, q)
 	}
@@ -261,7 +265,7 @@ func testRandLogProbContinuous(t *testing.T, i int, min float64, x []float64, f 
 			return math.Exp(f.LogProb(x))
 		}
 		// Integrate the PDF to find the CDF
-		estCDF := quad.Fixed(prob, min, pt, 1000, nil, 0)
+		estCDF := quad.Fixed(prob, min, pt, 10000, nil, 0)
 		if !floats.EqualWithinAbsOrRel(cdf, estCDF, tol, tol) {
 			t.Errorf("Mismatch between integral of PDF and empirical CDF. Case %v. Want %v, got %v", i, cdf, estCDF)
 		}

--- a/stat/distuv/gamma.go
+++ b/stat/distuv/gamma.go
@@ -94,7 +94,8 @@ func (g Gamma) Quantile(p float64) float64 {
 // Rand panics if either alpha or beta is <= 0.
 func (g Gamma) Rand() float64 {
 	const (
-		// 0.2 threshold is from https://www4.stat.ncsu.edu/~rmartin/Codes/rgamss.R
+		// The 0.2 threshold is from https://www4.stat.ncsu.edu/~rmartin/Codes/rgamss.R
+		// described in detail in https://arxiv.org/abs/1302.1884.
 		smallAlphaThresh = 0.2
 	)
 	if g.Beta <= 0 {
@@ -128,8 +129,7 @@ func (g Gamma) Rand() float64 {
 
 		// Algorithm adjusted to work in log space as much as possible.
 		lambda := 1/a - 1
-		w := 1 / lambda / math.E
-		lr := -math.Log1p(w)
+		lr := -math.Log1p(1 / lambda / math.E)
 		for {
 			e := exprnd()
 			var z float64

--- a/stat/distuv/gamma.go
+++ b/stat/distuv/gamma.go
@@ -93,6 +93,10 @@ func (g Gamma) Quantile(p float64) float64 {
 //
 // Rand panics if either alpha or beta is <= 0.
 func (g Gamma) Rand() float64 {
+	const (
+		// 0.2 threshold is from https://www4.stat.ncsu.edu/~rmartin/Codes/rgamss.R
+		smallAlphaThresh = 0.2
+	)
 	if g.Beta <= 0 {
 		panic("gamma: beta <= 0")
 	}
@@ -115,7 +119,7 @@ func (g Gamma) Rand() float64 {
 	case a == 1:
 		// Generate from exponential
 		return exprnd() / b
-	case a < 0.3:
+	case a < smallAlphaThresh:
 		// Generate using
 		//  Liu, Chuanhai, Martin, Ryan and Syring, Nick. "Simulating from a
 		//  gamma distribution with small shape parameter"
@@ -146,7 +150,7 @@ func (g Gamma) Rand() float64 {
 				return eza / b
 			}
 		}
-	case a >= 0.3 && a < 1:
+	case a >= smallAlphaThresh && a < 1:
 		// Generate using:
 		//  Kundu, Debasis, and Rameshwar D. Gupta. "A convenient way of generating
 		//  gamma random variables using generalized exponential distribution."

--- a/stat/distuv/gamma_test.go
+++ b/stat/distuv/gamma_test.go
@@ -33,6 +33,7 @@ func TestGamma(t *testing.T) {
 	for i, g := range []Gamma{
 		{Alpha: 0.1, Beta: 0.8, Src: src},
 
+		{Alpha: 0.3, Beta: 0.8, Src: src},
 		{Alpha: 0.5, Beta: 0.8, Src: src},
 		{Alpha: 0.9, Beta: 6, Src: src},
 		{Alpha: 0.9, Beta: 500, Src: src},
@@ -62,7 +63,7 @@ func testGamma(t *testing.T, f Gamma, i int) {
 
 	var quadTol float64
 
-	if f.Alpha < 1 {
+	if f.Alpha < 0.3 {
 		// Gamma PDF has a singularity at 0 for alpha < 1.
 		quadTol = 0.2
 	} else {
@@ -72,10 +73,10 @@ func testGamma(t *testing.T, f Gamma, i int) {
 	checkMean(t, i, x, f, tol)
 	checkVarAndStd(t, i, x, f, 2e-2)
 	checkExKurtosis(t, i, x, f, 2e-1)
-	if f.Alpha < 1 {
+	if f.Alpha < 0.3 {
 		quadTol = 0.1
 	} else {
-		quadTol = 1e-4
+		quadTol = 1e-3
 	}
 	checkProbContinuousWithBounds(t, i, x, 0, math.Inf(1), f, quadTol)
 	checkQuantileCDFSurvival(t, i, x, f, 5e-2)

--- a/stat/distuv/gamma_test.go
+++ b/stat/distuv/gamma_test.go
@@ -32,14 +32,11 @@ func TestGamma(t *testing.T) {
 	src := rand.New(rand.NewSource(1))
 	for i, g := range []Gamma{
 		{Alpha: 0.1, Beta: 0.8, Src: src},
-
 		{Alpha: 0.3, Beta: 0.8, Src: src},
 		{Alpha: 0.5, Beta: 0.8, Src: src},
 		{Alpha: 0.9, Beta: 6, Src: src},
 		{Alpha: 0.9, Beta: 500, Src: src},
-
 		{Alpha: 1, Beta: 1, Src: src},
-
 		{Alpha: 1.6, Beta: 0.4, Src: src},
 		{Alpha: 2.6, Beta: 1.5, Src: src},
 		{Alpha: 5.6, Beta: 0.5, Src: src},

--- a/stat/distuv/gamma_test.go
+++ b/stat/distuv/gamma_test.go
@@ -31,6 +31,7 @@ func TestGamma(t *testing.T) {
 	}
 	src := rand.New(rand.NewSource(1))
 	for i, g := range []Gamma{
+		{Alpha: 0.1, Beta: 0.8, Src: src},
 
 		{Alpha: 0.5, Beta: 0.8, Src: src},
 		{Alpha: 0.9, Beta: 6, Src: src},
@@ -59,11 +60,24 @@ func testGamma(t *testing.T, f Gamma, i int) {
 	generateSamples(x, f)
 	sort.Float64s(x)
 
-	testRandLogProbContinuous(t, i, 0, x, f, tol, bins)
+	var quadTol float64
+
+	if f.Alpha < 1 {
+		// Gamma PDF has a singularity at 0 for alpha < 1.
+		quadTol = 0.2
+	} else {
+		quadTol = tol
+	}
+	testRandLogProbContinuous(t, i, 0, x, f, quadTol, bins)
 	checkMean(t, i, x, f, tol)
 	checkVarAndStd(t, i, x, f, 2e-2)
 	checkExKurtosis(t, i, x, f, 2e-1)
-	checkProbContinuous(t, i, x, f, 1e-3)
+	if f.Alpha < 1 {
+		quadTol = 0.1
+	} else {
+		quadTol = 1e-4
+	}
+	checkProbContinuousWithBounds(t, i, x, 0, math.Inf(1), f, quadTol)
 	checkQuantileCDFSurvival(t, i, x, f, 5e-2)
 	if f.Alpha < 1 {
 		if !math.IsNaN(f.Mode()) {
@@ -71,5 +85,31 @@ func testGamma(t *testing.T, f Gamma, i int) {
 		}
 	} else {
 		checkMode(t, i, x, f, 2e-1, 1)
+	}
+	cdfNegX := f.CDF(-0.0001)
+	if cdfNegX != 0 {
+		t.Errorf("Expected zero CDF for negative argument, got %v", cdfNegX)
+	}
+	survNegX := f.Survival(-0.0001)
+	if survNegX != 1 {
+		t.Errorf("Expected survival function of 1 for negative argument, got %v", survNegX)
+	}
+	if f.NumParameters() != 2 {
+		t.Errorf("Mismatch in NumParameters: got %v, want 2", f.NumParameters())
+	}
+	lPdf := f.LogProb(-0.0001)
+	if !math.IsInf(lPdf, -1) {
+		t.Errorf("Expected log(CDF) to be -Infinity for negative argument, got %v", lPdf)
+	}
+}
+
+func TestGammaPanics(t *testing.T) {
+	g := Gamma{1, 0, nil}
+	if !panics(func() { g.Rand() }) {
+		t.Errorf("Expected Rand panic for Beta <= 0")
+	}
+	g = Gamma{0, 1, nil}
+	if !panics(func() { g.Rand() }) {
+		t.Errorf("Expected Rand panic for Alpha <= 0")
 	}
 }

--- a/stat/distuv/pareto_test.go
+++ b/stat/distuv/pareto_test.go
@@ -150,9 +150,11 @@ func TestPareto(t *testing.T) {
 }
 
 func testPareto(t *testing.T, p Pareto, i int) {
-	tol := 1e-2
-	const n = 1e6
-	const bins = 50
+	const (
+		tol  = 1e-2
+		n    = 1e6
+		bins = 50
+	)
 	x := make([]float64, n)
 	generateSamples(x, p)
 	sort.Float64s(x)


### PR DESCRIPTION
- Full test coverage
- Removed redundant calculations in the small alpha version of Rand()
- Lowered the threshold for small alpha to 0.2 in accordance with https://www4.stat.ncsu.edu/~rmartin/Codes/rgamss.R
- Added the option to pass integration bounds to PDF normalisation check
- Other small fixes

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
