### PR TITLE
stat/distuv: add ScoreInput implementations for Uniform and Triangle

### DIFF
--- a/stat/distuv/general_test.go
+++ b/stat/distuv/general_test.go
@@ -204,8 +204,27 @@ func testDerivParam(t *testing.T, d derivParamTester) {
 	if !panics(func() { d.Score(make([]float64, d.NumParameters()+1), 0) }) {
 		t.Errorf("Expected panic for wrong derivative slice length")
 	}
+	if !panics(func() { d.parameters(make([]Parameter, d.NumParameters()+1)) }) {
+		t.Errorf("Expected panic for wrong parameter slice length")
+	}
 
 	initParams := d.parameters(nil)
+	tooLongParams := make([]Parameter, len(initParams)+1)
+	copy(tooLongParams, initParams)
+	if !panics(func() { d.setParameters(tooLongParams) }) {
+		t.Errorf("Expected panic for wrong parameter slice length")
+	}
+	badNameParams := make([]Parameter, len(initParams))
+	copy(badNameParams, initParams)
+	const badName = "__badName__"
+	for i := 0; i < len(initParams); i++ {
+		badNameParams[i].Name = badName
+		if !panics(func() { d.setParameters(badNameParams) }) {
+			t.Errorf("Expected panic for wrong %d-th parameter name", i)
+		}
+		badNameParams[i].Name = initParams[i].Name
+	}
+
 	init := make([]float64, d.NumParameters())
 	for i, v := range initParams {
 		init[i] = v.Value

--- a/stat/distuv/laplace.go
+++ b/stat/distuv/laplace.go
@@ -210,11 +210,11 @@ func (l Laplace) Score(deriv []float64, x float64) []float64 {
 // derivative of the log-likelihood
 //  (d/dx) log(p(x)) .
 // Special cases:
-//  ScoreInput(l.Mu) = 0
+//  ScoreInput(l.Mu) = NaN
 func (l Laplace) ScoreInput(x float64) float64 {
 	diff := x - l.Mu
 	if diff == 0 {
-		return 0
+		return math.NaN()
 	}
 	if diff > 0 {
 		return -1 / l.Scale

--- a/stat/distuv/triangle.go
+++ b/stat/distuv/triangle.go
@@ -194,6 +194,22 @@ func (t Triangle) Score(deriv []float64, x float64) []float64 {
 	return deriv
 }
 
+// ScoreInput returns the score function with respect to the input of the
+// distribution at the input location specified by x. The score function is the
+// derivative of the log-likelihood
+//  (d/dx) log(p(x)) .
+// Special cases:
+//  ScoreInput(t.c) = NaN
+func (t Triangle) ScoreInput(x float64) float64 {
+	if (x <= t.a) || (x >= t.b) || (x == t.c) {
+		return math.NaN()
+	}
+	if x < t.c {
+		return 1 / (x - t.a)
+	}
+	return 1 / (x - t.b)
+}
+
 // Skewness returns the skewness of the distribution.
 func (t Triangle) Skewness() float64 {
 	n := math.Sqrt2 * (t.a + t.b - 2*t.c) * (2*t.a - t.b - t.c) * (t.a - 2*t.b + t.c)

--- a/stat/distuv/triangle.go
+++ b/stat/distuv/triangle.go
@@ -198,8 +198,9 @@ func (t Triangle) Score(deriv []float64, x float64) []float64 {
 // distribution at the input location specified by x. The score function is the
 // derivative of the log-likelihood
 //  (d/dx) log(p(x)) .
-// Special cases:
-//  ScoreInput(t.c) = NaN
+// Special cases (c is the mode of the distribution):
+//  ScoreInput(c) = NaN
+//  ScoreInput(x) = NaN for x not in (a, b)
 func (t Triangle) ScoreInput(x float64) float64 {
 	if (x <= t.a) || (x >= t.b) || (x == t.c) {
 		return math.NaN()

--- a/stat/distuv/triangle_test.go
+++ b/stat/distuv/triangle_test.go
@@ -169,24 +169,11 @@ func logProbDerivative(t Triangle, x float64, i int, h float64) float64 {
 func TestTriangleScoreInput(t *testing.T) {
 	t.Parallel()
 	f := Triangle{a: -0.5, b: 0.7, c: 0.1}
-	scoreInput := f.ScoreInput(f.a)
-	if !math.IsNaN(scoreInput) {
-		t.Errorf("Expected NaN input score for x == A, got %v", scoreInput)
-	}
-	scoreInput = f.ScoreInput(f.b)
-	if !math.IsNaN(scoreInput) {
-		t.Errorf("Expected NaN input score for x == B, got %v", scoreInput)
-	}
-	scoreInput = f.ScoreInput(f.c)
-	if !math.IsNaN(scoreInput) {
-		t.Errorf("Expected NaN input score for x == C, got %v", scoreInput)
-	}
-	scoreInput = f.ScoreInput(f.a - 0.0001)
-	if !math.IsNaN(scoreInput) {
-		t.Errorf("Expected NaN input score for x < A, got %v", scoreInput)
-	}
-	scoreInput = f.ScoreInput(f.b + 0.0001)
-	if !math.IsNaN(scoreInput) {
-		t.Errorf("Expected NaN input score for x > B, got %v", scoreInput)
+	xs := []float64{f.a, f.b, f.c, f.a - 0.0001, f.b + 0.0001}
+	for _, x := range xs {
+		scoreInput := f.ScoreInput(x)
+		if !math.IsNaN(scoreInput) {
+			t.Errorf("Expected NaN input score for x == %g, got %v", x, scoreInput)
+		}
 	}
 }

--- a/stat/distuv/triangle_test.go
+++ b/stat/distuv/triangle_test.go
@@ -165,3 +165,28 @@ func logProbDerivative(t Triangle, x float64, i int, h float64) float64 {
 	t.setParameters(origParams)
 	return (lpUp - lpDown) / (2 * h)
 }
+
+func TestTriangleScoreInput(t *testing.T) {
+	t.Parallel()
+	f := Triangle{a: -0.5, b: 0.7, c: 0.1}
+	scoreInput := f.ScoreInput(f.a)
+	if !math.IsNaN(scoreInput) {
+		t.Errorf("Expected NaN input score for x == A, got %v", scoreInput)
+	}
+	scoreInput = f.ScoreInput(f.b)
+	if !math.IsNaN(scoreInput) {
+		t.Errorf("Expected NaN input score for x == B, got %v", scoreInput)
+	}
+	scoreInput = f.ScoreInput(f.c)
+	if !math.IsNaN(scoreInput) {
+		t.Errorf("Expected NaN input score for x == C, got %v", scoreInput)
+	}
+	scoreInput = f.ScoreInput(f.a - 0.0001)
+	if !math.IsNaN(scoreInput) {
+		t.Errorf("Expected NaN input score for x < A, got %v", scoreInput)
+	}
+	scoreInput = f.ScoreInput(f.b + 0.0001)
+	if !math.IsNaN(scoreInput) {
+		t.Errorf("Expected NaN input score for x > B, got %v", scoreInput)
+	}
+}

--- a/stat/distuv/uniform.go
+++ b/stat/distuv/uniform.go
@@ -154,6 +154,17 @@ func (u Uniform) Score(deriv []float64, x float64) []float64 {
 	return deriv
 }
 
+// ScoreInput returns the score function with respect to the input of the
+// distribution at the input location specified by x. The score function is the
+// derivative of the log-likelihood
+//  (d/dx) log(p(x)) .
+func (u Uniform) ScoreInput(x float64) float64 {
+	if (x <= u.Min) || (x >= u.Max) {
+		return math.NaN()
+	}
+	return 0
+}
+
 // Skewness returns the skewness of the distribution.
 func (Uniform) Skewness() float64 {
 	return 0

--- a/stat/distuv/uniform_test.go
+++ b/stat/distuv/uniform_test.go
@@ -5,6 +5,7 @@
 package distuv
 
 import (
+	"math"
 	"sort"
 	"testing"
 
@@ -77,4 +78,20 @@ func testUniform(t *testing.T, u Uniform, i int) {
 	checkProbContinuous(t, i, x, u.Min, u.Max, u, 1e-10)
 	checkQuantileCDFSurvival(t, i, x, u, 1e-2)
 	testDerivParam(t, &u)
+}
+
+func TestUniformScoreInput(t *testing.T) {
+	t.Parallel()
+	u := Uniform{0, 1, nil}
+	scoreInput := u.ScoreInput(0.5)
+	if scoreInput != 0 {
+		t.Errorf("Mismatch in input score for U(0, 1) at x == 0.5: got %v, want 0", scoreInput)
+	}
+	xs := []float64{-0.0001, 0, 1, 1.0001}
+	for _, x := range xs {
+		scoreInput = u.ScoreInput(x)
+		if !math.IsNaN(scoreInput) {
+			t.Errorf("Expected NaN score input for U(0, 1) at x == %g, got %v", x, scoreInput)
+		}
+	}
 }


### PR DESCRIPTION
Also fixes a bug in Laplace ScoreInput, and tests existing ScoreInput implementations.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
