### PR TITLE
graph/path: add option to retain all paths from single-source path finding routines

### DIFF
--- a/graph/path/bellman_ford_moore_test.go
+++ b/graph/path/bellman_ford_moore_test.go
@@ -7,9 +7,11 @@ package path
 import (
 	"math"
 	"reflect"
+	"sort"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/path/internal/testgraphs"
 )
 
@@ -64,6 +66,100 @@ func TestBellmanFordFrom(t *testing.T) {
 		if pt.From().ID() == test.NoPathFor.From().ID() && (np != nil || !math.IsInf(weight, 1)) {
 			t.Errorf("%q: unexpected path:\ngot: path=%v weight=%f\nwant:path=<nil> weight=+Inf",
 				test.Name, np, weight)
+		}
+	}
+}
+
+func TestBellmanFordAllFrom(t *testing.T) {
+	t.Parallel()
+	for _, test := range testgraphs.ShortestPathTests {
+		g := test.Graph()
+		for _, e := range test.Edges {
+			g.SetWeightedEdge(e)
+		}
+
+		pt, ok := BellmanFordAllFrom(test.Query.From(), g.(graph.Graph))
+		if test.HasNegativeCycle {
+			if ok {
+				t.Errorf("%q: expected negative cycle", test.Name)
+			}
+		} else if !ok {
+			t.Fatalf("%q: unexpected negative cycle", test.Name)
+		}
+
+		if pt.From().ID() != test.Query.From().ID() {
+			t.Fatalf("%q: unexpected from node ID: got:%d want:%d", test.Name, pt.From().ID(), test.Query.From().ID())
+		}
+
+		// Test single path results.
+		p, weight, unique := pt.To(test.Query.To().ID())
+		if weight != test.Weight {
+			t.Errorf("%q: unexpected weight from To: got:%f want:%f",
+				test.Name, weight, test.Weight)
+		}
+		if weight := pt.WeightTo(test.Query.To().ID()); !math.IsInf(test.Weight, -1) && weight != test.Weight {
+			t.Errorf("%q: unexpected weight from Weight: got:%f want:%f",
+				test.Name, weight, test.Weight)
+		}
+
+		var gotPath []int64
+		for _, n := range p {
+			gotPath = append(gotPath, n.ID())
+		}
+		ok = len(gotPath) == 0 && len(test.WantPaths) == 0
+		for _, sp := range test.WantPaths {
+			if reflect.DeepEqual(gotPath, sp) {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			t.Errorf("%q: unexpected shortest path:\ngot: %v\nwant from:%v",
+				test.Name, p, test.WantPaths)
+		}
+		if unique != test.HasUniquePath {
+			t.Errorf("%q: unexpected uniqueness from To: got:%t want:%t (%d paths)",
+				test.Name, unique, test.HasUniquePath, len(test.WantPaths))
+		}
+
+		// Test multiple path results.
+		paths, weight := pt.AllTo(test.Query.To().ID())
+		if weight != test.Weight {
+			t.Errorf("%q: unexpected weight from AllTo: got:%f want:%f",
+				test.Name, weight, test.Weight)
+		}
+		if weight := pt.WeightTo(test.Query.To().ID()); !math.IsInf(test.Weight, -1) && weight != test.Weight {
+			t.Errorf("%q: unexpected weight from Weight: got:%f want:%f",
+				test.Name, weight, test.Weight)
+		}
+
+		var gotPaths [][]int64
+		if len(paths) != 0 {
+			gotPaths = make([][]int64, len(paths))
+		}
+		for i, p := range paths {
+			for _, v := range p {
+				gotPaths[i] = append(gotPaths[i], v.ID())
+			}
+		}
+		if test.HasNegativeCycleInPath {
+			if gotPaths != nil {
+				t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant: []",
+					test.Name, gotPaths)
+			}
+		} else {
+			sort.Sort(ordered.BySliceValues(gotPaths))
+			if !reflect.DeepEqual(gotPaths, test.WantPaths) {
+				t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
+					test.Name, gotPaths, test.WantPaths)
+			}
+		}
+
+		// Test absent paths.
+		np, weight, unique := pt.To(test.NoPathFor.To().ID())
+		if pt.From().ID() == test.NoPathFor.From().ID() && !(np == nil && math.IsInf(weight, 1) && !unique) {
+			t.Errorf("%q: unexpected path:\ngot: path=%v weight=%f unique=%t\nwant:path=<nil> weight=+Inf unique=false",
+				test.Name, np, weight, unique)
 		}
 	}
 }

--- a/graph/path/dijkstra.go
+++ b/graph/path/dijkstra.go
@@ -84,6 +84,79 @@ func DijkstraFrom(u graph.Node, g traverse.Graph) Shortest {
 	return path
 }
 
+// DijkstraAllFrom returns a shortest-path tree for shortest paths from u to all nodes in
+// the graph g. If the graph does not implement Weighted, UniformCost is used.
+// DijkstraAllFrom will panic if g has a u-reachable negative edge weight.
+//
+// If g is a graph.Graph, all nodes of the graph will be stored in the shortest-path
+// tree, otherwise only nodes reachable from u will be stored.
+//
+// The time complexity of DijkstrAllFrom is O(|E|.log|V|).
+func DijkstraAllFrom(u graph.Node, g traverse.Graph) ShortestAlts {
+	var path ShortestAlts
+	if h, ok := g.(graph.Graph); ok {
+		if h.Node(u.ID()) == nil {
+			return ShortestAlts{from: u}
+		}
+		path = newShortestAltsFrom(u, graph.NodesOf(h.Nodes()))
+	} else {
+		if g.From(u.ID()) == nil {
+			return ShortestAlts{from: u}
+		}
+		path = newShortestAltsFrom(u, []graph.Node{u})
+	}
+
+	var weight Weighting
+	if wg, ok := g.(Weighted); ok {
+		weight = wg.Weight
+	} else {
+		weight = UniformCost(g)
+	}
+
+	// Dijkstra's algorithm here is implemented essentially as
+	// described in Function B.2 in figure 6 of UTCS Technical
+	// Report TR-07-54.
+	//
+	// This implementation deviates from the report as follows:
+	// - the value of path.dist for the start vertex u is initialized to 0;
+	// - outdated elements from the priority queue (i.e. with respect to the dist value)
+	//   are skipped.
+	//
+	// http://www.cs.utexas.edu/ftp/techreports/tr07-54.pdf
+	Q := priorityQueue{{node: u, dist: 0}}
+	for Q.Len() != 0 {
+		mid := heap.Pop(&Q).(distanceNode)
+		k := path.indexOf[mid.node.ID()]
+		if mid.dist > path.dist[k] {
+			continue
+		}
+		mnid := mid.node.ID()
+		for _, v := range graph.NodesOf(g.From(mnid)) {
+			vid := v.ID()
+			j, ok := path.indexOf[vid]
+			if !ok {
+				j = path.add(v)
+			}
+			w, ok := weight(mnid, vid)
+			if !ok {
+				panic("dijkstra: unexpected invalid weight")
+			}
+			if w < 0 {
+				panic("dijkstra: negative edge weight")
+			}
+			joint := path.dist[k] + w
+			if joint < path.dist[j] {
+				heap.Push(&Q, distanceNode{node: v, dist: joint})
+				path.set(j, joint, k)
+			} else if joint == path.dist[j] {
+				path.addPath(j, k)
+			}
+		}
+	}
+
+	return path
+}
+
 // DijkstraAllPaths returns a shortest-path tree for shortest paths in the graph g.
 // If the graph does not implement graph.Weighter, UniformCost is used.
 // DijkstraAllPaths will panic if g has a negative edge weight.

--- a/graph/path/internal/testgraphs/shortest.go
+++ b/graph/path/internal/testgraphs/shortest.go
@@ -15,11 +15,12 @@ import (
 // DijkstraAllPaths, DijkstraFrom, FloydWarshall and Johnson, and the static degenerate case for the
 // dynamic shortest path routine in path/dynamic: DStarLite.
 var ShortestPathTests = []struct {
-	Name              string
-	Graph             func() graph.WeightedEdgeAdder
-	Edges             []simple.WeightedEdge
-	HasNegativeWeight bool
-	HasNegativeCycle  bool
+	Name                   string
+	Graph                  func() graph.WeightedEdgeAdder
+	Edges                  []simple.WeightedEdge
+	HasNegativeWeight      bool
+	HasNegativeCycle       bool
+	HasNegativeCycleInPath bool
 
 	Query         simple.Edge
 	Weight        float64
@@ -594,8 +595,9 @@ var ShortestPathTests = []struct {
 		HasNegativeWeight: true,
 		HasNegativeCycle:  true,
 
-		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(1)},
-		Weight: math.Inf(-1),
+		Query:                  simple.Edge{F: simple.Node(0), T: simple.Node(1)},
+		HasNegativeCycleInPath: true,
+		Weight:                 math.Inf(-1),
 		WantPaths: [][]int64{
 			{0, 1}, // One loop around negative cycle and no lead-in path.
 		},
@@ -615,8 +617,9 @@ var ShortestPathTests = []struct {
 		HasNegativeWeight: true,
 		HasNegativeCycle:  true,
 
-		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(3)},
-		Weight: math.Inf(-1),
+		Query:                  simple.Edge{F: simple.Node(0), T: simple.Node(3)},
+		HasNegativeCycleInPath: true,
+		Weight:                 math.Inf(-1),
 		WantPaths: [][]int64{
 			{1, 2, 1, 3}, // One loop around negative cycle and no lead-in path.
 		},
@@ -636,8 +639,9 @@ var ShortestPathTests = []struct {
 		HasNegativeWeight: true,
 		HasNegativeCycle:  true,
 
-		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(4)},
-		Weight: 10,
+		Query:                  simple.Edge{F: simple.Node(0), T: simple.Node(4)},
+		HasNegativeCycleInPath: false,
+		Weight:                 10,
 		WantPaths: [][]int64{
 			{0, 4},
 		},
@@ -658,8 +662,9 @@ var ShortestPathTests = []struct {
 		HasNegativeWeight: true,
 		HasNegativeCycle:  true,
 
-		Query:  simple.Edge{F: simple.Node(0), T: simple.Node(3)},
-		Weight: math.Inf(-1),
+		Query:                  simple.Edge{F: simple.Node(0), T: simple.Node(3)},
+		HasNegativeCycleInPath: true,
+		Weight:                 math.Inf(-1),
 		WantPaths: [][]int64{
 			{1, 2, 1, 3}, // One loop around negative cycle and no lead-in path.
 		},


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
