### PR TITLE
stat/distuv: provide complete test coverage for Poisson

### DIFF
--- a/stat/distuv/poisson.go
+++ b/stat/distuv/poisson.go
@@ -129,7 +129,10 @@ func (p Poisson) StdDev() float64 {
 
 // Survival returns the survival function (complementary CDF) at x.
 func (p Poisson) Survival(x float64) float64 {
-	return 1 - p.CDF(x)
+	if x < 0 {
+		return 1
+	}
+	return mathext.GammaIncReg(math.Floor(x+1), p.Lambda)
 }
 
 // Variance returns the variance of the probability distribution.

--- a/stat/distuv/poisson.go
+++ b/stat/distuv/poisson.go
@@ -129,10 +129,7 @@ func (p Poisson) StdDev() float64 {
 
 // Survival returns the survival function (complementary CDF) at x.
 func (p Poisson) Survival(x float64) float64 {
-	if x < 0 {
-		return 1
-	}
-	return mathext.GammaIncReg(math.Floor(x+1), p.Lambda)
+	return 1 - p.CDF(x)
 }
 
 // Variance returns the variance of the probability distribution.


### PR DESCRIPTION
Also uses mathext.GammaIncReg to implement Poisson Survival.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
