### PR TITLE
interp: add Akima splines and generic piecewise cubic interpolators

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -281,12 +281,7 @@ func (as *AkimaSpline) Fit(xs, ys []float64) error {
 	for i := 0; i < n; i++ {
 		wLeft := math.Abs(slopes[i+2] - slopes[i+3])
 		wRight := math.Abs(slopes[i+1] - slopes[i])
-		w := wLeft + wRight
-		if w > 0 {
-			dydxs[i] = (wLeft*slopes[i+1] + wRight*slopes[i+2]) / w
-		} else {
-			dydxs[i] = (slopes[i+1] + slopes[i+2]) / 2
-		}
+		dydxs[i] = weightedAverage(slopes[i+1], slopes[i+2], wLeft, wRight)
 	}
 	as.cubic.FitWithDerivatives(xs, ys, dydxs)
 	return nil
@@ -297,4 +292,14 @@ func (as *AkimaSpline) Fit(xs, ys []float64) error {
 // without checking.
 func findSegment(xs []float64, x float64) int {
 	return sort.Search(len(xs), func(i int) bool { return xs[i] > x }) - 1
+}
+
+// weightedAverage returns (v1 * w1 + v2 * w2) / (w1 + w2) for w1, w2 >= 0 (not checked).
+// If w1 == w2 == 0, it returns a simple average of v1 and v2.
+func weightedAverage(v1, v2, w1, w2 float64) float64 {
+	w := w1 + w2
+	if w > 0 {
+		return (v1*w1 + v2*w2) / w
+	}
+	return 0.5*v1 + 0.5*v2
 }

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -268,26 +268,26 @@ func (as *AkimaSplines) Fit(xs, ys []float64) error {
 		dydxs[1] = slope
 		return as.FitWithDerivatives(xs, ys, dydxs)
 	}
-	
+
 	m := n - 1
-	slopes := make([]float64, m + 4)
+	slopes := make([]float64, m+4)
 	for i := 0; i < m; i++ {
 		dx := xs[i+1] - xs[i]
 		if dx <= 0 {
 			return errors.New(xsNotStrictlyIncreasing)
 		}
-		slopes[i + 2] = (ys[i+1] - ys[i]) / dx
+		slopes[i+2] = (ys[i+1] - ys[i]) / dx
 	}
-	slopes[1] = 2 * slopes[2] - slopes[3]
-	slopes[0] = 3 * slopes[2] - 2 * slopes[3]
-	slopes[m + 2] = 2 * slopes[n] - slopes[m]
-	slopes[m + 3] = 3 * slopes[n] - 2 * slopes[m]
+	slopes[1] = 2*slopes[2] - slopes[3]
+	slopes[0] = 3*slopes[2] - 2*slopes[3]
+	slopes[m+2] = 2*slopes[n] - slopes[m]
+	slopes[m+3] = 3*slopes[n] - 2*slopes[m]
 	for i := 0; i < n; i++ {
 		wLeft := math.Abs(slopes[i+2] - slopes[i+3])
 		wRight := math.Abs(slopes[i+1] - slopes[i])
 		w := wLeft + wRight
 		if w > 0 {
-			dydxs[i] = (wLeft * slopes[i+1] + wRight * slopes[i+2]) / w
+			dydxs[i] = (wLeft*slopes[i+1] + wRight*slopes[i+2]) / w
 		} else {
 			dydxs[i] = (slopes[i+1] + slopes[i+2]) / 2
 		}

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -27,7 +27,7 @@ type Predictor interface {
 // Fitter fits a predictor to data.
 type Fitter interface {
 	// Fit fits a predictor to (X, Y) value pairs provided as two slices.
-	// It panicks if len(xs) < 2, elements of xs are not strictly increasing
+	// It panics if len(xs) < 2, elements of xs are not strictly increasing
 	// or len(xs) != len(ys). It returns an error if there is an unpredictable
 	// failure to fit.
 	Fit(xs, ys []float64) error
@@ -68,7 +68,7 @@ type PiecewiseLinear struct {
 }
 
 // Fit fits a predictor to (X, Y) value pairs provided as two slices.
-// It panicks if len(xs) < 2, elements of xs are not strictly increasing
+// It panics if len(xs) < 2, elements of xs are not strictly increasing
 // or len(xs) != len(ys). It returns an error if there is an unpredictable
 // failure to fit.
 func (pl *PiecewiseLinear) Fit(xs, ys []float64) error {
@@ -123,7 +123,7 @@ type PiecewiseConstant struct {
 }
 
 // Fit fits a predictor to (X, Y) value pairs provided as two slices.
-// It panicks if len(xs) < 2, elements of xs are not strictly increasing
+// It panics if len(xs) < 2, elements of xs are not strictly increasing
 // or len(xs) != len(ys). It returns an error if there is an unpredictable
 // failure to fit.
 func (pc *PiecewiseConstant) Fit(xs, ys []float64) error {
@@ -202,7 +202,7 @@ func (pc PiecewiseCubic) Predict(x float64) float64 {
 
 // fitWithDerivatives fits a piecewise cubic predictor to (X, Y, dY/dX) value
 // triples provided as three slices.
-// It panicks if len(xs) < 2, elements of xs are not strictly increasing,
+// It panics if len(xs) < 2, elements of xs are not strictly increasing,
 // len(xs) != len(ys) or len(xs) != len(dydxs).
 func (pc *PiecewiseCubic) fitWithDerivatives(xs, ys, dydxs []float64) {
 	n := len(xs)
@@ -241,11 +241,16 @@ func (pc *PiecewiseCubic) fitWithDerivatives(xs, ys, dydxs []float64) {
 // value pairs without providing derivatives.
 // See https://www.iue.tuwien.ac.at/phd/rottinger/node60.html for more details.
 type AkimaSpline struct {
-	PiecewiseCubic
+	cubic PiecewiseCubic
+}
+
+// Predict returns the interpolation value at x.
+func (as *AkimaSpline) Predict(x float64) float64 {
+	return as.cubic.Predict(x)
 }
 
 // Fit fits a predictor to (X, Y) value pairs provided as two slices.
-// It panicks if len(xs) < 2, elements of xs are not strictly increasing
+// It panics if len(xs) < 2, elements of xs are not strictly increasing
 // or len(xs) != len(ys). It returns an error if there is an unpredictable
 // failure to fit.
 // If len(xs) == 2, we set both derivatives dY/dX to the slope
@@ -261,7 +266,7 @@ func (as *AkimaSpline) Fit(xs, ys []float64) error {
 		slope := (ys[1] - ys[0]) / (xs[1] - xs[0])
 		dydxs[0] = slope
 		dydxs[1] = slope
-		as.fitWithDerivatives(xs, ys, dydxs)
+		as.cubic.fitWithDerivatives(xs, ys, dydxs)
 		return nil
 	}
 
@@ -288,7 +293,7 @@ func (as *AkimaSpline) Fit(xs, ys []float64) error {
 			dydxs[i] = (slopes[i+1] + slopes[i+2]) / 2
 		}
 	}
-	as.fitWithDerivatives(xs, ys, dydxs)
+	as.cubic.fitWithDerivatives(xs, ys, dydxs)
 	return nil
 }
 

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -100,17 +100,14 @@ func (pl PiecewiseLinear) Predict(x float64) float64 {
 	if i < 0 {
 		return pl.ys[0]
 	}
-	// i < len(pl.xs)
 	xI := pl.xs[i]
 	if x == xI {
 		return pl.ys[i]
 	}
 	n := len(pl.xs)
 	if i == n-1 {
-		// x > pl.xs[i]
 		return pl.ys[n-1]
 	}
-	// i < len(pl.xs) - 1
 	return pl.ys[i] + pl.slopes[i]*(x-xI)
 }
 
@@ -153,20 +150,17 @@ func (pc PiecewiseConstant) Predict(x float64) float64 {
 	if i < 0 {
 		return pc.ys[0]
 	}
-	// i < len(pc.xs)
 	if x == pc.xs[i] {
 		return pc.ys[i]
 	}
 	n := len(pc.xs)
 	if i == n-1 {
-		// x > pc.xs[i]
 		return pc.ys[n-1]
 	}
 	return pc.ys[i+1]
 }
 
-// PiecewiseCubic is a left-continuous, piecewise cubic
-// 1-dimensional interpolator.
+// PiecewiseCubic is a left-continuous, piecewise cubic 1-dimensional interpolator.
 type PiecewiseCubic struct {
 	// Interpolated X values.
 	xs []float64
@@ -189,7 +183,6 @@ func (pc PiecewiseCubic) Predict(x float64) float64 {
 		return pc.coeffs.At(0, 0)
 	}
 	m := len(pc.xs) - 1
-	// i < len(pc.xs)
 	if x == pc.xs[i] {
 		if i < m {
 			return pc.coeffs.At(i, 0)
@@ -197,7 +190,6 @@ func (pc PiecewiseCubic) Predict(x float64) float64 {
 		return pc.lastY
 	}
 	if i == m {
-		// x > pc.xs[i]
 		return pc.lastY
 	}
 	dx := x - pc.xs[i]
@@ -242,9 +234,8 @@ func (pc *PiecewiseCubic) FitWithDerivatives(xs, ys, dydxs []float64) error {
 	return nil
 }
 
-// AkimaSplines is a left-continuous, piecewise cubic
-// 1-dimensional interpolator which can be fitted to
-// (X, Y) value pairs without providing derivatives.
+// AkimaSplines is a left-continuous, piecewise cubic 1-dimensional interpolator
+// which can be fitted to (X, Y) value pairs without providing derivatives.
 // See https://www.iue.tuwien.ac.at/phd/rottinger/node60.html for more details.
 type AkimaSplines struct {
 	PiecewiseCubic

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -409,17 +409,6 @@ func TestAkimaSpline(t *testing.T) {
 		if err != nil {
 			t.Errorf("Error when fitting AkimaSpline in test case %d: %v", i, err)
 		}
-		x0 := test.xs[0]
-		x1 := test.xs[len(test.xs)-1]
-		dx := (x1 - x0) / nPts
-		for j := -1; j <= nPts+1; j++ {
-			x := x0 + float64(j)*dx
-			got := as.Predict(x)
-			want := test.f(math.Min(x1, math.Max(x0, x)))
-			if math.Abs(got-want) > test.tol {
-				t.Errorf("Mismatch in interpolated value at x == %g for test case %d: got %v, want %g", x, i, got, want)
-			}
-		}
 		n := len(test.xs)
 		for j := 0; j < n; j++ {
 			x := test.xs[j]

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -370,11 +370,7 @@ func TestPiecewiseCubicFitWithDerivativesErrors(t *testing.T) {
 
 func TestAkimaSpline(t *testing.T) {
 	t.Parallel()
-	const (
-		nPts = 40
-		h    = 1e-8
-		tol  = 1e-14
-	)
+	const tol = 1e-14
 	for i, test := range []struct {
 		xs []float64
 		f  func(float64) float64
@@ -480,6 +476,7 @@ func TestAkimaWeightedAverage(t *testing.T) {
 	t.Parallel()
 	for i, test := range []struct {
 		v1, v2, w1, w2, want float64
+		// "want" values calculated by hand.
 	}{
 		{
 			v1:   -1,
@@ -535,6 +532,7 @@ func TestAkimaSlopes(t *testing.T) {
 	t.Parallel()
 	for i, test := range []struct {
 		xs, ys, want []float64
+		// "want" values calculated by hand.
 	}{
 		{
 			xs:   []float64{-2, 0, 1},
@@ -608,6 +606,7 @@ func TestAkimaWeights(t *testing.T) {
 	t.Parallel()
 	const tol = 1e-14
 	slopes := []float64{-2, -1, -0.1, 0.2, 1.2, 2.5}
+	// "want" values calculated by hand.
 	want := [][]float64{
 		{0.3, 1},
 		{1, 0.9},

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -210,7 +210,7 @@ func TestPiecewiseCubic(t *testing.T) {
 			df: func(x float64) float64 { return 2 * x },
 		},
 		{
-			xs: []float64{-1.001, 0.2, 2},
+			xs: []float64{-1.2, -1.001, 0, 0.2, 2.01, 2.1},
 			f:  func(x float64) float64 { return 4*math.Pow(x, 3) - 2*x*x + 10*x - 7 },
 			df: func(x float64) float64 { return 12*x*x - 4*x + 10 },
 		},

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -615,10 +615,10 @@ func TestAkimaWeights(t *testing.T) {
 	}
 	for i := 0; i < len(want); i++ {
 		gotLeft, gotRight := akimaWeights(slopes, i)
-		if math.Abs(gotLeft-want[i][0]) > 1e-14 {
+		if math.Abs(gotLeft-want[i][0]) > tol {
 			t.Errorf("Mismatch in left weight for node %d: got %v, want %g", i, gotLeft, want[i][0])
 		}
-		if math.Abs(gotRight-want[i][1]) > 1e-14 {
+		if math.Abs(gotRight-want[i][1]) > tol {
 			t.Errorf("Mismatch in left weight for node %d: got %v, want %g", i, gotRight, want[i][1])
 		}
 	}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -389,3 +389,33 @@ func TestAkimaSplinesNoWiggles(t *testing.T) {
 		}
 	}
 }
+
+func TestAkimaSplinesFitErrors(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		xs, ys          []float64
+		expectedMessage string
+	}{
+		{
+			xs:              []float64{0, 1, 2},
+			ys:              []float64{10, 20},
+			expectedMessage: differentLengths,
+		},
+		{
+			xs:              []float64{0},
+			ys:              []float64{0},
+			expectedMessage: tooFewPoints,
+		},
+		{
+			xs:              []float64{0, 1, 1},
+			ys:              []float64{10, 20, 10},
+			expectedMessage: xsNotStrictlyIncreasing,
+		},
+	} {
+		var as AkimaSplines
+		err := as.Fit(test.xs, test.ys)
+		if err == nil || err.Error() != test.expectedMessage {
+			t.Errorf("expected error for xs: %v and ys: %v with message: %s", test.xs, test.ys, test.expectedMessage)
+		}
+	}
+}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -460,6 +460,61 @@ func TestAkimaSplineFitErrors(t *testing.T) {
 	}
 }
 
+func TestWeightedAverage(t *testing.T) {
+	t.Parallel()
+	for i, test := range []struct {
+		v1, v2, w1, w2, want float64
+	}{
+		{
+			v1:   -1,
+			v2:   1,
+			w1:   0,
+			w2:   0,
+			want: 0,
+		},
+		{
+			v1:   -1,
+			v2:   1,
+			w1:   1e6,
+			w2:   1e6,
+			want: 0,
+		},
+		{
+			v1:   -1,
+			v2:   1,
+			w1:   1e-10,
+			w2:   0,
+			want: -1,
+		},
+		{
+			v1:   -1,
+			v2:   1,
+			w1:   0,
+			w2:   1e-10,
+			want: 1,
+		},
+		{
+			v1:   0,
+			v2:   1000,
+			w1:   1e-13,
+			w2:   3e-13,
+			want: 750,
+		},
+		{
+			v1:   0,
+			v2:   1000,
+			w1:   3e-13,
+			w2:   1e-13,
+			want: 250,
+		},
+	} {
+		got := weightedAverage(test.v1, test.v2, test.w1, test.w2)
+		if !floats.EqualWithinAbsOrRel(got, test.want, 1e-14, 1e-14) {
+			t.Errorf("Mismatch in test case %d: got %v, want %g", i, got, test.want)
+		}
+	}
+}
+
 func applyFunc(xs []float64, f func(x float64) float64) []float64 {
 	ys := make([]float64, len(xs))
 	for i, x := range xs {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -5,7 +5,6 @@
 package interp
 
 import (
-	"fmt"
 	"math"
 	"testing"
 
@@ -71,21 +70,18 @@ func BenchmarkFindSegment(b *testing.B) {
 // testPiecewiseInterpolatorCreation tests common functionality in creating piecewise  interpolators.
 func testPiecewiseInterpolatorCreation(t *testing.T, fp FittablePredictor) {
 	type errorParams struct {
-		xs              []float64
-		ys              []float64
-		expectedMessage string
+		xs []float64
+		ys []float64
 	}
 	errorParamSets := []errorParams{
-		{[]float64{0, 1, 2}, []float64{-0.5, 1.5}, "input slices have different lengths"},
-		{[]float64{0.3}, []float64{0}, "too few points for interpolation"},
-		{[]float64{0.3, 0.3}, []float64{0, 0}, "xs values not strictly increasing"},
-		{[]float64{0.3, -0.3}, []float64{0, 0}, "xs values not strictly increasing"},
+		{[]float64{0, 1, 2}, []float64{-0.5, 1.5}},
+		{[]float64{0.3}, []float64{0}},
+		{[]float64{0.3, 0.3}, []float64{0, 0}},
+		{[]float64{0.3, -0.3}, []float64{0, 0}},
 	}
 	for _, params := range errorParamSets {
-		err := fp.Fit(params.xs, params.ys)
-		expectedMessage := fmt.Sprintf("interp: %s", params.expectedMessage)
-		if err == nil || err.Error() != expectedMessage {
-			t.Errorf("expected error for xs: %v and ys: %v with message: %s", params.xs, params.ys, expectedMessage)
+		if !panics(func() { fp.Fit(params.xs, params.ys) }) {
+			t.Errorf("expected panic for xs: %v and ys: %v", params.xs, params.ys)
 		}
 	}
 }
@@ -393,7 +389,7 @@ func TestPiecewiseCubicFitWithDerivativesErrors(t *testing.T) {
 	} {
 		var pc PiecewiseCubic
 		if !panics(func() { pc.fitWithDerivatives(test.xs, test.ys, test.dydxs) }) {
-			t.Errorf("expected panick for xs: %v, ys: %v and dydxs: %v", test.xs, test.ys, test.dydxs)
+			t.Errorf("expected panic for xs: %v, ys: %v and dydxs: %v", test.xs, test.ys, test.dydxs)
 		}
 	}
 }
@@ -509,7 +505,7 @@ func TestAkimaSplineFitErrors(t *testing.T) {
 	} {
 		var as AkimaSpline
 		if !panics(func() { as.Fit(test.xs, test.ys) }) {
-			t.Errorf("expected panick for xs: %v and ys: %v", test.xs, test.ys)
+			t.Errorf("expected panic for xs: %v and ys: %v", test.xs, test.ys)
 		}
 	}
 }

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -80,7 +80,7 @@ func testPiecewiseInterpolatorCreation(t *testing.T, fp FittablePredictor) {
 		{[]float64{0.3, -0.3}, []float64{0, 0}},
 	}
 	for _, params := range errorParamSets {
-		if !panics(func() { fp.Fit(params.xs, params.ys) }) {
+		if !panics(func() { _ = fp.Fit(params.xs, params.ys) }) {
 			t.Errorf("expected panic for xs: %v and ys: %v", params.xs, params.ys)
 		}
 	}
@@ -195,7 +195,7 @@ func TestPiecewiseCubic(t *testing.T) {
 	t.Parallel()
 	const (
 		h        = 1e-8
-		valueTol = 1e-14
+		valueTol = 1e-13
 		derivTol = 1e-6
 	)
 	for i, test := range []struct {
@@ -504,7 +504,7 @@ func TestAkimaSplineFitErrors(t *testing.T) {
 		},
 	} {
 		var as AkimaSpline
-		if !panics(func() { as.Fit(test.xs, test.ys) }) {
+		if !panics(func() { _ = as.Fit(test.xs, test.ys) }) {
 			t.Errorf("expected panic for xs: %v and ys: %v", test.xs, test.ys)
 		}
 	}


### PR DESCRIPTION
For now all code is in interp.go, but the file starts getting rather large. Should I split it?

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
