### PR TITLE
mat: clarify that prefix is only added after the first line

### DIFF
--- a/mat/format.go
+++ b/mat/format.go
@@ -36,7 +36,7 @@ type formatter struct {
 type FormatOption func(*formatter)
 
 // Prefix sets the formatted prefix to the string p. Prefix is a string that is prepended to
-// each line of output.
+// each line of output after the first line.
 func Prefix(p string) FormatOption {
 	return func(f *formatter) { f.prefix = p }
 }


### PR DESCRIPTION
Please take a look.

Fixes #1404.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
