### PR TITLE
floats: Rename Same to AllSame. Add Same for scalars.

### DIFF
--- a/blas/testblas/common_test.go
+++ b/blas/testblas/common_test.go
@@ -155,7 +155,7 @@ func TestFlattenBanded(t *testing.T) {
 	} {
 		condensed := flattenBanded(test.dense, test.ku, test.kl)
 		correct := flatten(test.condensed)
-		if !floats.Same(condensed, correct) {
+		if !floats.AllSame(condensed, correct) {
 			t.Errorf("Case %v mismatch. Want %v, got %v.", i, correct, condensed)
 		}
 	}

--- a/floats/floats.go
+++ b/floats/floats.go
@@ -82,6 +82,21 @@ func (a argsort) Swap(i, j int) {
 	a.inds[i], a.inds[j] = a.inds[j], a.inds[i]
 }
 
+// AllSame returns true if the input slices have the same length and all elements
+// have the same value with NaN treated as the same.
+func AllSame(s, t []float64) bool {
+	if len(s) != len(t) {
+		return false
+	}
+	for i, v := range s {
+		w := t[i]
+		if !Same(v, w) {
+			return false
+		}
+	}
+	return true
+}
+
 // Argsort sorts the elements of dst while tracking their original order.
 // At the conclusion of Argsort, dst will contain the original elements of dst
 // but sorted in increasing order, and inds will contain the original position
@@ -779,19 +794,9 @@ func isHalfway(x float64) bool {
 	return frac == 0.5 || (math.Nextafter(frac, math.Inf(-1)) < 0.5 && math.Nextafter(frac, math.Inf(1)) > 0.5)
 }
 
-// Same returns true if the input slices have the same length and all elements
-// have the same value with NaN treated as the same.
-func Same(s, t []float64) bool {
-	if len(s) != len(t) {
-		return false
-	}
-	for i, v := range s {
-		w := t[i]
-		if v != w && !(math.IsNaN(v) && math.IsNaN(w)) {
-			return false
-		}
-	}
-	return true
+// Same returns true if the inputs have the same value with NaN treated as the same.
+func Same(a, b float64) bool {
+	return a == b || (math.IsNaN(a) && math.IsNaN(b))
 }
 
 // Scale multiplies every element in dst by the scalar c.

--- a/mat/list_test.go
+++ b/mat/list_test.go
@@ -110,7 +110,7 @@ func sameAnswerFloatApproxTol(tol float64) func(a, b interface{}) bool {
 
 func sameAnswerF64SliceOfSlice(a, b interface{}) bool {
 	for i, v := range a.([][]float64) {
-		if same := floats.Same(v, b.([][]float64)[i]); !same {
+		if same := floats.AllSame(v, b.([][]float64)[i]); !same {
 			return false
 		}
 	}

--- a/stat/distmv/studentst_test.go
+++ b/stat/distmv/studentst_test.go
@@ -74,7 +74,7 @@ func TestStudentTProbs(t *testing.T) {
 			xcpy := make([]float64, len(x))
 			copy(xcpy, x)
 			p := s.Prob(x)
-			if !floats.Same(x, xcpy) {
+			if !floats.AllSame(x, xcpy) {
 				t.Errorf("X modified during call to prob, %v, %v", x, xcpy)
 			}
 			if !floats.EqualWithinAbsOrRel(p, test.probs[i], 1e-10, 1e-10) {

--- a/stat/roc_test.go
+++ b/stat/roc_test.go
@@ -213,13 +213,13 @@ func TestROC(t *testing.T) {
 	}
 	for i, test := range cases {
 		gotTPR, gotFPR, gotThresh := ROC(test.cutoffs, test.y, test.c, test.w)
-		if !floats.Same(gotTPR, test.wantTPR) && !floats.EqualApprox(gotTPR, test.wantTPR, tol) {
+		if !floats.AllSame(gotTPR, test.wantTPR) && !floats.EqualApprox(gotTPR, test.wantTPR, tol) {
 			t.Errorf("%d: unexpected TPR got:%v want:%v", i, gotTPR, test.wantTPR)
 		}
-		if !floats.Same(gotFPR, test.wantFPR) && !floats.EqualApprox(gotFPR, test.wantFPR, tol) {
+		if !floats.AllSame(gotFPR, test.wantFPR) && !floats.EqualApprox(gotFPR, test.wantFPR, tol) {
 			t.Errorf("%d: unexpected FPR got:%v want:%v", i, gotFPR, test.wantFPR)
 		}
-		if !floats.Same(gotThresh, test.wantThresh) {
+		if !floats.AllSame(gotThresh, test.wantThresh) {
 			t.Errorf("%d: unexpected thresholds got:%#v want:%v", i, gotThresh, test.wantThresh)
 		}
 	}

--- a/stat/stat_test.go
+++ b/stat/stat_test.go
@@ -1479,10 +1479,10 @@ func TestQuantile(t *testing.T) {
 		for j, p := range test.p {
 			for k, kind := range cumulantKinds {
 				v := Quantile(p, kind, test.x, test.w)
-				if !floats.Same(copyX, test.x) {
+				if !floats.AllSame(copyX, test.x) {
 					t.Errorf("x changed for case %d kind %d percentile %v", i, k, p)
 				}
-				if !floats.Same(copyW, test.w) {
+				if !floats.AllSame(copyW, test.w) {
 					t.Errorf("x changed for case %d kind %d percentile %v", i, k, p)
 				}
 				if v != test.ans[k][j] && !(math.IsNaN(v) && math.IsNaN(test.ans[k][j])) {
@@ -1619,10 +1619,10 @@ func TestSortWeighted(t *testing.T) {
 		},
 	} {
 		SortWeighted(test.x, test.w)
-		if !floats.Same(test.x, test.ansx) {
+		if !floats.AllSame(test.x, test.ansx) {
 			t.Errorf("SortWeighted mismatch case %d. Expected x %v, Found x %v", i, test.ansx, test.x)
 		}
-		if !(test.w == nil) && !floats.Same(test.w, test.answ) {
+		if !(test.w == nil) && !floats.AllSame(test.w, test.answ) {
 			t.Errorf("SortWeighted mismatch case %d. Expected w %v, Found w %v", i, test.answ, test.w)
 		}
 	}
@@ -1666,13 +1666,13 @@ func TestSortWeightedLabeled(t *testing.T) {
 		},
 	} {
 		SortWeightedLabeled(test.x, test.l, test.w)
-		if !floats.Same(test.x, test.ansx) {
+		if !floats.AllSame(test.x, test.ansx) {
 			t.Errorf("SortWeightedLabelled mismatch case %d. Expected x %v, Found x %v", i, test.ansx, test.x)
 		}
 		if (test.l != nil) && !reflect.DeepEqual(test.l, test.ansl) {
 			t.Errorf("SortWeightedLabelled mismatch case %d. Expected l %v, Found l %v", i, test.ansl, test.l)
 		}
-		if (test.w != nil) && !floats.Same(test.w, test.answ) {
+		if (test.w != nil) && !floats.AllSame(test.w, test.answ) {
 			t.Errorf("SortWeightedLabelled mismatch case %d. Expected w %v, Found w %v", i, test.answ, test.w)
 		}
 	}


### PR DESCRIPTION
Fixes #1405. Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
