### PR TITLE
lapack/gonum: add Dlantb

### DIFF
--- a/lapack/gonum/bench_test.go
+++ b/lapack/gonum/bench_test.go
@@ -10,4 +10,5 @@ import (
 	"gonum.org/v1/gonum/lapack/testlapack"
 )
 
-func BenchmarkDgeev(b *testing.B) { testlapack.DgeevBenchmark(b, impl) }
+func BenchmarkDgeev(b *testing.B)  { testlapack.DgeevBenchmark(b, impl) }
+func BenchmarkDlantb(b *testing.B) { testlapack.DlantbBenchmark(b, impl) }

--- a/lapack/gonum/dcombssq.go
+++ b/lapack/gonum/dcombssq.go
@@ -4,6 +4,8 @@
 
 package gonum
 
+import "math"
+
 // Dcombssq adds two scaled sum-of-squares quantities, V := V1 + V2,
 //  V_scale^2 * V_ssq := V1_scale^2 * V1_ssq + V2_scale^2 * V2_ssq
 // and returns the result V.
@@ -14,7 +16,10 @@ func (Implementation) Dcombssq(scale1, ssq1, scale2, ssq2 float64) (scale, ssq f
 		if scale1 != 0 {
 			return scale1, ssq1 + (scale2/scale1)*(scale2/scale1)*ssq2
 		}
-		// If the input is non-negative and we are here, then scale2 must inevitably be 0, too.
+		// Both scales are zero.
+		if math.IsNaN(ssq1) || math.IsNaN(ssq2) {
+			return 0, math.NaN()
+		}
 		return 0, 0
 	}
 	return scale2, ssq2 + (scale1/scale2)*(scale1/scale2)*ssq1

--- a/lapack/gonum/dlantb.go
+++ b/lapack/gonum/dlantb.go
@@ -1,0 +1,213 @@
+// Copyright ©2020 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+import (
+	"math"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/lapack"
+)
+
+// Dlantb returns the value of the given norm of an n×n triangular band matrix A
+// with k+1 diagonals.
+//
+// When norm is lapack.MaxColumnSum, the length of work must be at least n.
+func (impl Implementation) Dlantb(norm lapack.MatrixNorm, uplo blas.Uplo, diag blas.Diag, n, k int, a []float64, lda int, work []float64) float64 {
+	switch {
+	case norm != lapack.MaxAbs && norm != lapack.MaxRowSum && norm != lapack.MaxColumnSum && norm != lapack.Frobenius:
+		panic(badNorm)
+	case uplo != blas.Upper && uplo != blas.Lower:
+		panic(badUplo)
+	case n < 0:
+		panic(nLT0)
+	case k < 0:
+		panic(kdLT0)
+	case lda < k+1:
+		panic(badLdA)
+	}
+
+	// Quick return if possible.
+	if n == 0 {
+		return 0
+	}
+
+	switch {
+	case len(a) < (n-1)*lda+k+1:
+		panic(shortAB)
+	case len(work) < n && norm == lapack.MaxColumnSum:
+		panic(shortWork)
+	}
+
+	var value float64
+	switch norm {
+	case lapack.MaxAbs:
+		if uplo == blas.Upper {
+			var jfirst int
+			if diag == blas.Unit {
+				value = 1
+				jfirst = 1
+			}
+			for i := 0; i < n; i++ {
+				for _, aij := range a[i*lda+jfirst : i*lda+min(n-i, k+1)] {
+					if math.IsNaN(aij) {
+						return aij
+					}
+					aij = math.Abs(aij)
+					if aij > value {
+						value = aij
+					}
+				}
+			}
+		} else {
+			jlast := k + 1
+			if diag == blas.Unit {
+				value = 1
+				jlast = k
+			}
+			for i := 0; i < n; i++ {
+				for _, aij := range a[i*lda+max(0, k-i) : i*lda+jlast] {
+					if math.IsNaN(aij) {
+						return math.NaN()
+					}
+					aij = math.Abs(aij)
+					if aij > value {
+						value = aij
+					}
+				}
+			}
+		}
+	case lapack.MaxRowSum:
+		var sum float64
+		if uplo == blas.Upper {
+			var jfirst int
+			if diag == blas.Unit {
+				jfirst = 1
+			}
+			for i := 0; i < n; i++ {
+				sum = 0
+				if diag == blas.Unit {
+					sum = 1
+				}
+				for _, aij := range a[i*lda+jfirst : i*lda+min(n-i, k+1)] {
+					sum += math.Abs(aij)
+				}
+				if math.IsNaN(sum) {
+					return math.NaN()
+				}
+				if sum > value {
+					value = sum
+				}
+			}
+		} else {
+			jlast := k + 1
+			if diag == blas.Unit {
+				jlast = k
+			}
+			for i := 0; i < n; i++ {
+				sum = 0
+				if diag == blas.Unit {
+					sum = 1
+				}
+				for _, aij := range a[i*lda+max(0, k-i) : i*lda+jlast] {
+					sum += math.Abs(aij)
+				}
+				if math.IsNaN(sum) {
+					return math.NaN()
+				}
+				if sum > value {
+					value = sum
+				}
+			}
+		}
+	case lapack.MaxColumnSum:
+		work = work[:n]
+		if diag == blas.Unit {
+			for i := range work {
+				work[i] = 1
+			}
+		} else {
+			for i := range work {
+				work[i] = 0
+			}
+		}
+		if uplo == blas.Upper {
+			var jfirst int
+			if diag == blas.Unit {
+				jfirst = 1
+			}
+			for i := 0; i < n; i++ {
+				for j, aij := range a[i*lda+jfirst : i*lda+min(n-i, k+1)] {
+					work[i+jfirst+j] += math.Abs(aij)
+				}
+			}
+		} else {
+			jlast := k + 1
+			if diag == blas.Unit {
+				jlast = k
+			}
+			for i := 0; i < n; i++ {
+				off := max(0, k-i)
+				for j, aij := range a[i*lda+off : i*lda+jlast] {
+					work[i+j+off-k] += math.Abs(aij)
+				}
+			}
+		}
+		for _, wi := range work {
+			if math.IsNaN(wi) {
+				return math.NaN()
+			}
+			if wi > value {
+				value = wi
+			}
+		}
+	case lapack.Frobenius:
+		var scale, ssq float64
+		switch uplo {
+		case blas.Upper:
+			if diag == blas.Unit {
+				scale = 1
+				ssq = float64(n)
+				if k > 0 {
+					for i := 0; i < n-1; i++ {
+						ilen := min(n-i-1, k)
+						rowscale, rowssq := impl.Dlassq(ilen, a[i*lda+1:], 1, 0, 1)
+						scale, ssq = impl.Dcombssq(scale, ssq, rowscale, rowssq)
+					}
+				}
+			} else {
+				scale = 0
+				ssq = 1
+				for i := 0; i < n; i++ {
+					ilen := min(n-i, k+1)
+					rowscale, rowssq := impl.Dlassq(ilen, a[i*lda:], 1, 0, 1)
+					scale, ssq = impl.Dcombssq(scale, ssq, rowscale, rowssq)
+				}
+			}
+		case blas.Lower:
+			if diag == blas.Unit {
+				scale = 1
+				ssq = float64(n)
+				if k > 0 {
+					for i := 1; i < n; i++ {
+						ilen := min(i, k)
+						rowscale, rowssq := impl.Dlassq(ilen, a[i*lda+k-ilen:], 1, 0, 1)
+						scale, ssq = impl.Dcombssq(scale, ssq, rowscale, rowssq)
+					}
+				}
+			} else {
+				scale = 0
+				ssq = 1
+				for i := 0; i < n; i++ {
+					ilen := min(i, k) + 1
+					rowscale, rowssq := impl.Dlassq(ilen, a[i*lda+k+1-ilen:], 1, 0, 1)
+					scale, ssq = impl.Dcombssq(scale, ssq, rowscale, rowssq)
+				}
+			}
+		}
+		value = scale * math.Sqrt(ssq)
+	}
+	return value
+}

--- a/lapack/gonum/lapack_test.go
+++ b/lapack/gonum/lapack_test.go
@@ -268,6 +268,11 @@ func TestDlansy(t *testing.T) {
 	testlapack.DlansyTest(t, impl)
 }
 
+func TestDlantb(t *testing.T) {
+	t.Parallel()
+	testlapack.DlantbTest(t, impl)
+}
+
 func TestDlantr(t *testing.T) {
 	t.Parallel()
 	testlapack.DlantrTest(t, impl)

--- a/lapack/lapack.go
+++ b/lapack/lapack.go
@@ -21,6 +21,7 @@ type Float64 interface {
 	Dgetri(n int, a []float64, lda int, ipiv []int, work []float64, lwork int) (ok bool)
 	Dgetrs(trans blas.Transpose, n, nrhs int, a []float64, lda int, ipiv []int, b []float64, ldb int)
 	Dggsvd3(jobU, jobV, jobQ GSVDJob, m, n, p int, a []float64, lda int, b []float64, ldb int, alpha, beta, u []float64, ldu int, v []float64, ldv int, q []float64, ldq int, work []float64, lwork int, iwork []int) (k, l int, ok bool)
+	Dlantb(norm MatrixNorm, uplo blas.Uplo, diag blas.Diag, n, k int, a []float64, lda int, work []float64) float64
 	Dlantr(norm MatrixNorm, uplo blas.Uplo, diag blas.Diag, m, n int, a []float64, lda int, work []float64) float64
 	Dlange(norm MatrixNorm, m, n int, a []float64, lda int, work []float64) float64
 	Dlansb(norm MatrixNorm, uplo blas.Uplo, n, kd int, a []float64, lda int, work []float64) float64

--- a/lapack/lapack64/lapack64.go
+++ b/lapack/lapack64/lapack64.go
@@ -425,6 +425,13 @@ func Lansy(norm lapack.MatrixNorm, a blas64.Symmetric, work []float64) float64 {
 	return lapack64.Dlansy(norm, a.Uplo, a.N, a.Data, max(1, a.Stride), work)
 }
 
+// Lantb computes the specified norm of an n×n triangular band matrix A. If
+// norm == lapack.MaxColumnSum work must have length at least n and this function
+// will panic otherwise. There are no restrictions on work for the other matrix norms.
+func Lantb(norm lapack.MatrixNorm, a blas64.TriangularBand, work []float64) float64 {
+	return lapack64.Dlantb(norm, a.Uplo, a.Diag, a.N, a.K, a.Data, max(1, a.Stride), work)
+}
+
 // Lantr computes the specified norm of an m×n trapezoidal matrix A. If
 // norm == lapack.MaxColumnSum work must have length at least n and this function
 // will panic otherwise. There are no restrictions on work for the other matrix norms.

--- a/lapack/testlapack/dcombssq.go
+++ b/lapack/testlapack/dcombssq.go
@@ -19,13 +19,28 @@ func DcombssqTest(t *testing.T, impl Dcombssqer) {
 	const tol = 1e-15
 
 	rnd := rand.New(rand.NewSource(1))
-	for i := 0; i < 10; i++ {
-		// Generate random, non-negative input.
+	for i := 0; i < 100; i++ {
+		// Generate random, non-negative input, with an occasional NaN.
+		var hasNaN bool
 		scale1 := rnd.Float64()
-		ssq1 := rnd.Float64()
+		var ssq1 float64
+		if rnd.Float64() < 0.5 {
+			ssq1 = math.NaN()
+			hasNaN = true
+		} else {
+			ssq1 = rnd.Float64()
+		}
+
 		scale2 := rnd.Float64()
-		ssq2 := rnd.Float64()
-		switch i {
+		var ssq2 float64
+		if rnd.Float64() < 0.5 {
+			ssq2 = math.NaN()
+			hasNaN = true
+		} else {
+			ssq2 = rnd.Float64()
+		}
+
+		switch rnd.Intn(4) {
 		case 0:
 			scale1 = 0
 		case 1:
@@ -37,6 +52,13 @@ func DcombssqTest(t *testing.T, impl Dcombssqer) {
 		// Compute scale and ssq such that
 		//  scale^2 * ssq := scale1^2 * ssq1 + scale2^2 * ssq2
 		scale, ssq := impl.Dcombssq(scale1, ssq1, scale2, ssq2)
+
+		if hasNaN {
+			if !math.IsNaN(ssq) {
+				t.Errorf("Case %v: unexpected ssq; got %v, want NaN", i, ssq)
+			}
+			continue
+		}
 
 		// Compute the expected result in a non-sophisticated way and
 		// compare against the result we got.

--- a/lapack/testlapack/dlantb.go
+++ b/lapack/testlapack/dlantb.go
@@ -1,0 +1,136 @@
+// Copyright ©2020 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"golang.org/x/exp/rand"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/floats"
+	"gonum.org/v1/gonum/lapack"
+)
+
+type Dlantber interface {
+	Dlantb(norm lapack.MatrixNorm, uplo blas.Uplo, diag blas.Diag, n, k int, a []float64, lda int, work []float64) float64
+}
+
+func DlantbTest(t *testing.T, impl Dlantber) {
+	rnd := rand.New(rand.NewSource(1))
+	for _, norm := range []lapack.MatrixNorm{lapack.MaxAbs, lapack.MaxRowSum, lapack.MaxColumnSum, lapack.Frobenius} {
+		for _, uplo := range []blas.Uplo{blas.Lower, blas.Upper} {
+			for _, diag := range []blas.Diag{blas.NonUnit, blas.Unit} {
+				name := normToString(norm) + uploToString(uplo) + diagToString(diag)
+				t.Run(name, func(t *testing.T) {
+					for _, n := range []int{0, 1, 2, 3, 4, 5, 10} {
+						for _, k := range []int{0, 1, 2, 3, n, n + 2} {
+							for _, lda := range []int{k + 1, k + 3} {
+								for iter := 0; iter < 10; iter++ {
+									dlantbTest(t, impl, rnd, norm, uplo, diag, n, k, lda)
+								}
+							}
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func dlantbTest(t *testing.T, impl Dlantber, rnd *rand.Rand, norm lapack.MatrixNorm, uplo blas.Uplo, diag blas.Diag, n, k, lda int) {
+	const tol = 1e-14
+
+	name := fmt.Sprintf("n=%v,k=%v,lda=%v", n, k, lda)
+
+	// Deal with zero-sized matrices early.
+	if n == 0 {
+		got := impl.Dlantb(norm, uplo, diag, n, k, nil, lda, nil)
+		if got != 0 {
+			t.Errorf("%v: unexpected result for zero-sized matrix", name)
+		}
+		return
+	}
+
+	a := make([]float64, max(0, (n-1)*lda+k+1))
+	if rnd.Float64() < 0.5 {
+		// Sometimes fill A with elements between -0.5 and 0.5 so that for
+		// blas.Unit matrices the largest element is the 1 on the main diagonal.
+		for i := range a {
+			// Between -0.5 and 0.5.
+			a[i] = rnd.Float64() - 0.5
+		}
+	} else {
+		for i := range a {
+			// Between -2 and 2.
+			a[i] = 4*rnd.Float64() - 2
+		}
+	}
+	// Sometimes put a NaN into A.
+	if rnd.Float64() < 0.5 {
+		a[rnd.Intn(len(a))] = math.NaN()
+	}
+	// Make a copy of A for later comparison.
+	aCopy := make([]float64, len(a))
+	copy(aCopy, a)
+
+	var work []float64
+	if norm == lapack.MaxColumnSum {
+		work = make([]float64, n)
+	}
+	// Fill work with random garbage.
+	for i := range work {
+		work[i] = rnd.NormFloat64()
+	}
+
+	got := impl.Dlantb(norm, uplo, diag, n, k, a, lda, work)
+
+	if !floats.Same(a, aCopy) {
+		t.Fatalf("%v: unexpected modification of a", name)
+	}
+
+	// Generate a dense representation of A and compute the wanted result.
+	ldaGen := n
+	aGen := make([]float64, n*ldaGen)
+	if uplo == blas.Upper {
+		for i := 0; i < n; i++ {
+			for j := 0; j < min(n-i, k+1); j++ {
+				aGen[i*ldaGen+i+j] = a[i*lda+j]
+			}
+		}
+	} else {
+		for i := 0; i < n; i++ {
+			for j := max(0, k-i); j < k+1; j++ {
+				aGen[i*ldaGen+i-(k-j)] = a[i*lda+j]
+			}
+		}
+	}
+	if diag == blas.Unit {
+		for i := 0; i < n; i++ {
+			aGen[i*ldaGen+i] = 1
+		}
+	}
+	want := dlange(norm, n, n, aGen, ldaGen)
+
+	if math.IsNaN(want) {
+		if !math.IsNaN(got) {
+			t.Errorf("%v: unexpected result with NaN element; got %v, want %v\n%v\n%v", name, got, want, a, aGen)
+		}
+		return
+	}
+
+	if norm == lapack.MaxAbs {
+		if got != want {
+			t.Errorf("%v: unexpected result; got %v, want %v", name, got, want)
+		}
+		return
+	}
+	diff := math.Abs(got - want)
+	if diff > tol {
+		t.Errorf("%v: unexpected result; got %v, want %v, diff=%v", name, got, want, diff)
+	}
+}

--- a/lapack/testlapack/dlantb_bench.go
+++ b/lapack/testlapack/dlantb_bench.go
@@ -1,0 +1,54 @@
+// Copyright ©2020 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/exp/rand"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/lapack"
+)
+
+var result float64
+
+func DlantbBenchmark(b *testing.B, impl Dlantber) {
+	rnd := rand.New(rand.NewSource(1))
+	for _, bm := range []struct {
+		n, k int
+	}{
+		{n: 10000, k: 1},
+		{n: 10000, k: 2},
+		{n: 10000, k: 100},
+	} {
+		n := bm.n
+		k := bm.k
+		lda := k + 1
+		for _, norm := range []lapack.MatrixNorm{lapack.MaxAbs, lapack.MaxRowSum, lapack.MaxColumnSum, lapack.Frobenius} {
+			var work []float64
+			if norm == lapack.MaxColumnSum {
+				work = make([]float64, n)
+			}
+			for _, uplo := range []blas.Uplo{blas.Lower, blas.Upper} {
+				for _, diag := range []blas.Diag{blas.NonUnit, blas.Unit} {
+					name := fmt.Sprintf("%v%v%vN=%vK=%v", normToString(norm), uploToString(uplo), diagToString(diag), n, k)
+					b.Run(name, func(b *testing.B) {
+						for i := 0; i < b.N; i++ {
+							b.StopTimer()
+							a := make([]float64, n*lda)
+							for i := range a {
+								a[i] = rnd.NormFloat64()
+							}
+							b.StartTimer()
+							result = impl.Dlantb(norm, uplo, diag, bm.n, bm.k, a, lda, work)
+						}
+					})
+				}
+			}
+		}
+	}
+}

--- a/lapack/testlapack/general.go
+++ b/lapack/testlapack/general.go
@@ -1450,15 +1450,14 @@ func dlange(norm lapack.MatrixNorm, m, n int, a []float64, lda int) float64 {
 	if m == 0 || n == 0 {
 		return 0
 	}
+	var value float64
 	switch norm {
 	case lapack.MaxAbs:
-		var value float64
 		for i := 0; i < m; i++ {
 			for j := 0; j < n; j++ {
 				value = math.Max(value, math.Abs(a[i*lda+j]))
 			}
 		}
-		return value
 	case lapack.MaxColumnSum:
 		work := make([]float64, n)
 		for i := 0; i < m; i++ {
@@ -1466,13 +1465,10 @@ func dlange(norm lapack.MatrixNorm, m, n int, a []float64, lda int) float64 {
 				work[j] += math.Abs(a[i*lda+j])
 			}
 		}
-		var value float64
 		for i := 0; i < n; i++ {
 			value = math.Max(value, work[i])
 		}
-		return value
 	case lapack.MaxRowSum:
-		var value float64
 		for i := 0; i < m; i++ {
 			var sum float64
 			for j := 0; j < n; j++ {
@@ -1480,12 +1476,16 @@ func dlange(norm lapack.MatrixNorm, m, n int, a []float64, lda int) float64 {
 			}
 			value = math.Max(value, sum)
 		}
-		return value
 	case lapack.Frobenius:
-		panic("not implemented")
+		for i := 0; i < m; i++ {
+			for j := 0; j < n; j++ {
+				value = math.Hypot(value, a[i*lda+j])
+			}
+		}
 	default:
 		panic("bad MatrixNorm")
 	}
+	return value
 }
 
 // dlansb is a local implementation of Dlansb to keep code paths independent.

--- a/lapack/testlapack/general.go
+++ b/lapack/testlapack/general.go
@@ -14,6 +14,7 @@ import (
 
 	"gonum.org/v1/gonum/blas"
 	"gonum.org/v1/gonum/blas/blas64"
+	"gonum.org/v1/gonum/internal/asm/f64"
 	"gonum.org/v1/gonum/lapack"
 )
 
@@ -1478,9 +1479,8 @@ func dlange(norm lapack.MatrixNorm, m, n int, a []float64, lda int) float64 {
 		}
 	case lapack.Frobenius:
 		for i := 0; i < m; i++ {
-			for j := 0; j < n; j++ {
-				value = math.Hypot(value, a[i*lda+j])
-			}
+			row := f64.L2NormUnitary(a[i*lda : i*lda+n])
+			value = math.Hypot(value, row)
 		}
 	default:
 		panic("bad MatrixNorm")

--- a/lapack/testlapack/general.go
+++ b/lapack/testlapack/general.go
@@ -61,6 +61,43 @@ func (wl worklen) String() string {
 	return ""
 }
 
+func normToString(norm lapack.MatrixNorm) string {
+	switch norm {
+	case lapack.MaxAbs:
+		return "MaxAbs"
+	case lapack.MaxRowSum:
+		return "MaxRowSum"
+	case lapack.MaxColumnSum:
+		return "MaxColSum"
+	case lapack.Frobenius:
+		return "Frobenius"
+	default:
+		panic("invalid norm")
+	}
+}
+
+func uploToString(uplo blas.Uplo) string {
+	switch uplo {
+	case blas.Lower:
+		return "Lower"
+	case blas.Upper:
+		return "Upper"
+	default:
+		panic("invalid uplo")
+	}
+}
+
+func diagToString(diag blas.Diag) string {
+	switch diag {
+	case blas.NonUnit:
+		return "NonUnit"
+	case blas.Unit:
+		return "Unit"
+	default:
+		panic("invalid diag")
+	}
+}
+
 // nanSlice allocates a new slice of length n filled with NaN.
 func nanSlice(n int) []float64 {
 	s := make([]float64, n)


### PR DESCRIPTION
My intention was to use Dlantb and Dlansb in the banded Cholesky factorization that I've been preparing (for quite some time now). However, I've just noticed that LAPACKE provides neither Dlansb nor Dlantb, which means we can't add these functions to the lapack.Float64 interface and so can't use them in mat. This is utterly disappointing. On top of that, writing a randomized test for Dlantb, which is not it's re-implementation, is surprisingly not easy and is not much fun.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
