### PR TITLE
lapack,lapack64: remove Dlansb and Dlantb from Float64

### DIFF
--- a/lapack/lapack.go
+++ b/lapack/lapack.go
@@ -21,10 +21,8 @@ type Float64 interface {
 	Dgetri(n int, a []float64, lda int, ipiv []int, work []float64, lwork int) (ok bool)
 	Dgetrs(trans blas.Transpose, n, nrhs int, a []float64, lda int, ipiv []int, b []float64, ldb int)
 	Dggsvd3(jobU, jobV, jobQ GSVDJob, m, n, p int, a []float64, lda int, b []float64, ldb int, alpha, beta, u []float64, ldu int, v []float64, ldv int, q []float64, ldq int, work []float64, lwork int, iwork []int) (k, l int, ok bool)
-	Dlantb(norm MatrixNorm, uplo blas.Uplo, diag blas.Diag, n, k int, a []float64, lda int, work []float64) float64
 	Dlantr(norm MatrixNorm, uplo blas.Uplo, diag blas.Diag, m, n int, a []float64, lda int, work []float64) float64
 	Dlange(norm MatrixNorm, m, n int, a []float64, lda int, work []float64) float64
-	Dlansb(norm MatrixNorm, uplo blas.Uplo, n, kd int, a []float64, lda int, work []float64) float64
 	Dlansy(norm MatrixNorm, uplo blas.Uplo, n int, a []float64, lda int, work []float64) float64
 	Dlapmt(forward bool, m, n int, x []float64, ldx int, k []int)
 	Dormqr(side blas.Side, trans blas.Transpose, m, n, k int, a []float64, lda int, tau, c []float64, ldc int, work []float64, lwork int)

--- a/lapack/lapack64/lapack64.go
+++ b/lapack/lapack64/lapack64.go
@@ -409,27 +409,12 @@ func Lange(norm lapack.MatrixNorm, a blas64.General, work []float64) float64 {
 	return lapack64.Dlange(norm, a.Rows, a.Cols, a.Data, max(1, a.Stride), work)
 }
 
-// Lansb computes the specified norm of an n×n symmetric band matrix. If
-// norm == lapack.MaxColumnSum or norm == lapack.MaxRowSum, work must have length
-// at least n and this function will panic otherwise.
-// There are no restrictions on work for the other matrix norms.
-func Lansb(norm lapack.MatrixNorm, a blas64.SymmetricBand, work []float64) float64 {
-	return lapack64.Dlansb(norm, a.Uplo, a.N, a.K, a.Data, max(1, a.Stride), work)
-}
-
 // Lansy computes the specified norm of an n×n symmetric matrix. If
 // norm == lapack.MaxColumnSum or norm == lapack.MaxRowSum, work must have length
 // at least n and this function will panic otherwise.
 // There are no restrictions on work for the other matrix norms.
 func Lansy(norm lapack.MatrixNorm, a blas64.Symmetric, work []float64) float64 {
 	return lapack64.Dlansy(norm, a.Uplo, a.N, a.Data, max(1, a.Stride), work)
-}
-
-// Lantb computes the specified norm of an n×n triangular band matrix A. If
-// norm == lapack.MaxColumnSum work must have length at least n and this function
-// will panic otherwise. There are no restrictions on work for the other matrix norms.
-func Lantb(norm lapack.MatrixNorm, a blas64.TriangularBand, work []float64) float64 {
-	return lapack64.Dlantb(norm, a.Uplo, a.Diag, a.N, a.K, a.Data, max(1, a.Stride), work)
 }
 
 // Lantr computes the specified norm of an m×n trapezoidal matrix A. If


### PR DESCRIPTION
These two routines are not provided by LAPACKE and therefore
should not be part of the Float64 interface.

Closes #1428

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
