### PR TITLE
graph/encoding/{digraph6,graph6}: allow packages to build on 32-bit arches

### DIFF
--- a/graph/encoding/digraph6/digraph6.go
+++ b/graph/encoding/digraph6/digraph6.go
@@ -57,7 +57,12 @@ func Encode(g graph.Graph) Graph {
 
 	var buf strings.Builder
 	buf.WriteByte('&')
-	switch {
+	// digraph6 specifies graphs of order up to 68719476735
+	// which overflows int on 32 bit architectures. We know
+	// that on those machines n will not be this large, since
+	// it came from a length, but explicitly convert to 64
+	// bits to allow the package to build on those architectures.
+	switch n := int64(n); {
 	case n < 63:
 		buf.WriteByte(byte(n) + 63)
 	case n < 258048:

--- a/graph/encoding/digraph6/digraph6.go
+++ b/graph/encoding/digraph6/digraph6.go
@@ -57,11 +57,11 @@ func Encode(g graph.Graph) Graph {
 
 	var buf strings.Builder
 	buf.WriteByte('&')
-	// digraph6 specifies graphs of order up to 68719476735
-	// which overflows int on 32 bit architectures. We know
-	// that on those machines n will not be this large, since
-	// it came from a length, but explicitly convert to 64
-	// bits to allow the package to build on those architectures.
+	// digraph6 specifies graphs of order up to 2^36-1 which
+	// overflows int on 32-bit architectures. We know that on
+	// those machines n will not be this large, since it came
+	// from a length, but explicitly convert to 64 bits to
+	// allow the package to build on those architectures.
 	switch n := int64(n); {
 	case n < 63:
 		buf.WriteByte(byte(n) + 63)

--- a/graph/encoding/graph6/graph6.go
+++ b/graph/encoding/graph6/graph6.go
@@ -58,7 +58,12 @@ func Encode(g graph.Graph) Graph {
 	}
 
 	var buf strings.Builder
-	switch {
+	// graph6 specifies graphs of order up to 68719476735
+	// which overflows int on 32 bit architectures. We know
+	// that on those machines n will not be this large, since
+	// it came from a length, but explicitly convert to 64
+	// bits to allow the package to build on those architectures.
+	switch n := int64(n); {
 	case n < 63:
 		buf.WriteByte(byte(n) + 63)
 	case n < 258048:

--- a/graph/encoding/graph6/graph6.go
+++ b/graph/encoding/graph6/graph6.go
@@ -58,11 +58,11 @@ func Encode(g graph.Graph) Graph {
 	}
 
 	var buf strings.Builder
-	// graph6 specifies graphs of order up to 68719476735
-	// which overflows int on 32 bit architectures. We know
-	// that on those machines n will not be this large, since
-	// it came from a length, but explicitly convert to 64
-	// bits to allow the package to build on those architectures.
+	// graph6 specifies graphs of order up to 2^36-1 which
+	// overflows int on 32-bit architectures. We know that on
+	// those machines n will not be this large, since it came
+	// from a length, but explicitly convert to 64 bits to
+	// allow the package to build on those architectures.
 	switch n := int64(n); {
 	case n < 63:
 		buf.WriteByte(byte(n) + 63)


### PR DESCRIPTION
Please take a look.

Fixes #1444.

/cc @pterjan

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
