### PR TITLE
stat/combin: allow Binomial tests to pass on GOARCH=386

### DIFF
--- a/stat/combin/combin_test.go
+++ b/stat/combin/combin_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"unsafe"
 
 	"gonum.org/v1/gonum/floats/scalar"
 )
@@ -81,7 +82,12 @@ func TestBinomial(t *testing.T) {
 		}
 	}
 	var (
-		n    = 61
+		// Ensure that we have enough space to represent results.
+		// TODO(kortschak): Replace the unsafe.Sizeof(int(0)) expression with
+		// sizeof.Int if https://github.com/golang/go/issues/29982 is
+		// implemented. See also https://github.com/golang/go/issues/40168.
+		n = int(unsafe.Sizeof(int(0))*8 - 3)
+
 		want big.Int
 		got  big.Int
 	)


### PR DESCRIPTION
Please take a look.

Updates #1444.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
