### PR TITLE
all: add gccgo build constraint

### DIFF
--- a/graph/layout/isomap_noasm_test.go
+++ b/graph/layout/isomap_noasm_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build noasm safe
+// +build noasm gccgo safe
 
 package layout
 

--- a/internal/asm/c128/axpyinc_amd64.s
+++ b/internal/asm/c128/axpyinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/axpyincto_amd64.s
+++ b/internal/asm/c128/axpyincto_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/axpyunitary_amd64.s
+++ b/internal/asm/c128/axpyunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/axpyunitaryto_amd64.s
+++ b/internal/asm/c128/axpyunitaryto_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/dotcinc_amd64.s
+++ b/internal/asm/c128/dotcinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/dotcunitary_amd64.s
+++ b/internal/asm/c128/dotcunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/dotuinc_amd64.s
+++ b/internal/asm/c128/dotuinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/dotuunitary_amd64.s
+++ b/internal/asm/c128/dotuunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/dscalinc_amd64.s
+++ b/internal/asm/c128/dscalinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/dscalunitary_amd64.s
+++ b/internal/asm/c128/dscalunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/scalUnitary_amd64.s
+++ b/internal/asm/c128/scalUnitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/scalinc_amd64.s
+++ b/internal/asm/c128/scalinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c128/stubs_amd64.go
+++ b/internal/asm/c128/stubs_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 package c128
 

--- a/internal/asm/c128/stubs_noasm.go
+++ b/internal/asm/c128/stubs_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm safe
+// +build !amd64 noasm gccgo safe
 
 package c128
 

--- a/internal/asm/c64/axpyinc_amd64.s
+++ b/internal/asm/c64/axpyinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c64/axpyincto_amd64.s
+++ b/internal/asm/c64/axpyincto_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c64/axpyunitary_amd64.s
+++ b/internal/asm/c64/axpyunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c64/axpyunitaryto_amd64.s
+++ b/internal/asm/c64/axpyunitaryto_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c64/dotcinc_amd64.s
+++ b/internal/asm/c64/dotcinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c64/dotcunitary_amd64.s
+++ b/internal/asm/c64/dotcunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c64/dotuinc_amd64.s
+++ b/internal/asm/c64/dotuinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c64/dotuunitary_amd64.s
+++ b/internal/asm/c64/dotuunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/c64/stubs_amd64.go
+++ b/internal/asm/c64/stubs_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 package c64
 

--- a/internal/asm/c64/stubs_noasm.go
+++ b/internal/asm/c64/stubs_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm safe
+// +build !amd64 noasm gccgo safe
 
 package c64
 

--- a/internal/asm/f32/axpyinc_amd64.s
+++ b/internal/asm/f32/axpyinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/axpyincto_amd64.s
+++ b/internal/asm/f32/axpyincto_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/axpyunitary_amd64.s
+++ b/internal/asm/f32/axpyunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/axpyunitaryto_amd64.s
+++ b/internal/asm/f32/axpyunitaryto_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/ddotinc_amd64.s
+++ b/internal/asm/f32/ddotinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/ddotunitary_amd64.s
+++ b/internal/asm/f32/ddotunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/dotinc_amd64.s
+++ b/internal/asm/f32/dotinc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/dotunitary_amd64.s
+++ b/internal/asm/f32/dotunitary_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/ge_amd64.go
+++ b/internal/asm/f32/ge_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 package f32
 

--- a/internal/asm/f32/ge_amd64.s
+++ b/internal/asm/f32/ge_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f32/ge_noasm.go
+++ b/internal/asm/f32/ge_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm safe
+// +build !amd64 noasm gccgo safe
 
 package f32
 

--- a/internal/asm/f32/stubs_amd64.go
+++ b/internal/asm/f32/stubs_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 package f32
 

--- a/internal/asm/f32/stubs_noasm.go
+++ b/internal/asm/f32/stubs_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm safe
+// +build !amd64 noasm gccgo safe
 
 package f32
 

--- a/internal/asm/f64/abssum_amd64.s
+++ b/internal/asm/f64/abssum_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/abssuminc_amd64.s
+++ b/internal/asm/f64/abssuminc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/add_amd64.s
+++ b/internal/asm/f64/add_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/addconst_amd64.s
+++ b/internal/asm/f64/addconst_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/axpy.go
+++ b/internal/asm/f64/axpy.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm safe
+// +build !amd64 noasm gccgo safe
 
 package f64
 

--- a/internal/asm/f64/axpyinc_amd64.s
+++ b/internal/asm/f64/axpyinc_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/axpyincto_amd64.s
+++ b/internal/asm/f64/axpyincto_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/axpyunitary_amd64.s
+++ b/internal/asm/f64/axpyunitary_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/axpyunitaryto_amd64.s
+++ b/internal/asm/f64/axpyunitaryto_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/cumprod_amd64.s
+++ b/internal/asm/f64/cumprod_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/cumsum_amd64.s
+++ b/internal/asm/f64/cumsum_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/div_amd64.s
+++ b/internal/asm/f64/div_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/divto_amd64.s
+++ b/internal/asm/f64/divto_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/dot.go
+++ b/internal/asm/f64/dot.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm safe
+// +build !amd64 noasm gccgo safe
 
 package f64
 

--- a/internal/asm/f64/dot_amd64.s
+++ b/internal/asm/f64/dot_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/ge_amd64.go
+++ b/internal/asm/f64/ge_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 package f64
 

--- a/internal/asm/f64/ge_noasm.go
+++ b/internal/asm/f64/ge_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm safe
+// +build !amd64 noasm gccgo safe
 
 package f64
 

--- a/internal/asm/f64/gemvN_amd64.s
+++ b/internal/asm/f64/gemvN_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/gemvT_amd64.s
+++ b/internal/asm/f64/gemvT_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/ger_amd64.s
+++ b/internal/asm/f64/ger_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/l1norm_amd64.s
+++ b/internal/asm/f64/l1norm_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/l2norm_amd64.s
+++ b/internal/asm/f64/l2norm_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/l2norm_noasm.go
+++ b/internal/asm/f64/l2norm_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm safe
+// +build !amd64 noasm gccgo safe
 
 package f64
 

--- a/internal/asm/f64/l2normdist_amd64.s
+++ b/internal/asm/f64/l2normdist_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/l2norminc_amd64.s
+++ b/internal/asm/f64/l2norminc_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/linfnorm_amd64.s
+++ b/internal/asm/f64/linfnorm_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/scal.go
+++ b/internal/asm/f64/scal.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm safe
+// +build !amd64 noasm gccgo safe
 
 package f64
 

--- a/internal/asm/f64/scalinc_amd64.s
+++ b/internal/asm/f64/scalinc_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/scalincto_amd64.s
+++ b/internal/asm/f64/scalincto_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/scalunitary_amd64.s
+++ b/internal/asm/f64/scalunitary_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/scalunitaryto_amd64.s
+++ b/internal/asm/f64/scalunitaryto_amd64.s
@@ -34,7 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/asm/f64/stubs_amd64.go
+++ b/internal/asm/f64/stubs_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 package f64
 

--- a/internal/asm/f64/stubs_noasm.go
+++ b/internal/asm/f64/stubs_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 noasm safe
+// +build !amd64 noasm gccgo safe
 
 package f64
 

--- a/internal/asm/f64/sum_amd64.s
+++ b/internal/asm/f64/sum_amd64.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/math32/sqrt.go
+++ b/internal/math32/sqrt.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64,!arm64 noasm safe
+// +build !amd64,!arm64 noasm gccgo safe
 
 package math32
 

--- a/internal/math32/sqrt_amd64.go
+++ b/internal/math32/sqrt_amd64.go
@@ -6,7 +6,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 package math32
 

--- a/internal/math32/sqrt_amd64.s
+++ b/internal/math32/sqrt_amd64.s
@@ -6,7 +6,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 

--- a/internal/math32/sqrt_arm64.go
+++ b/internal/math32/sqrt_arm64.go
@@ -6,7 +6,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 package math32
 

--- a/internal/math32/sqrt_arm64.s
+++ b/internal/math32/sqrt_arm64.s
@@ -6,7 +6,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !noasm,!safe
+// +build !noasm,!gccgo,!safe
 
 #include "textflag.h"
 


### PR DESCRIPTION
This is a synonym for noasm since gccgo (and gollvm) do not use plan9 assembly, so we just prevent those compilers from looking at asm files.

Please take a look.

Fixes #1452.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
