### PR TITLE
stat/distuv: Improve Gamma.Rand performance in alpha >1 case

### DIFF
--- a/stat/distuv/beta_test.go
+++ b/stat/distuv/beta_test.go
@@ -49,7 +49,7 @@ func TestBetaRand(t *testing.T) {
 func testBeta(t *testing.T, b Beta, i int) {
 	const (
 		tol  = 1e-2
-		n    = 5e4
+		n    = 1e5
 		bins = 10
 	)
 	x := make([]float64, n)

--- a/stat/distuv/gamma.go
+++ b/stat/distuv/gamma.go
@@ -219,11 +219,17 @@ func (g Gamma) Rand() float64 {
 		d := a - 1.0/3
 		c := 1 / (3 * math.Sqrt(d))
 		for {
-			u := -exprnd()
 			x := normrnd()
 			v := 1 + x*c
+			if v <= 0.0 {
+				continue
+			}
 			v = v * v * v
-			if u < 0.5*x*x+d*(1-v+math.Log(v)) {
+			u := unifrnd()
+			if u < 1.0-0.0331*(x*x)*(x*x) {
+				return d * v / b
+			}
+			if math.Log(u) < 0.5*x*x+d*(1-v+math.Log(v)) {
 				return d * v / b
 			}
 		}

--- a/stat/distuv/gamma_test.go
+++ b/stat/distuv/gamma_test.go
@@ -5,6 +5,7 @@
 package distuv
 
 import (
+	"fmt"
 	"math"
 	"sort"
 	"testing"
@@ -114,5 +115,22 @@ func TestGammaPanics(t *testing.T) {
 	g = Gamma{0, 1, nil}
 	if !panics(func() { g.Rand() }) {
 		t.Errorf("Expected Rand panic for Alpha <= 0")
+	}
+}
+
+func BenchmarkGammaRand(b *testing.B) {
+	src := rand.New(rand.NewSource(1))
+	for i, g := range []Gamma{
+		{Alpha: 0.1, Beta: 0.8, Src: src},
+		{Alpha: 0.5, Beta: 0.8, Src: src},
+		{Alpha: 1, Beta: 1, Src: src},
+		{Alpha: 1.6, Beta: 0.4, Src: src},
+		{Alpha: 30, Beta: 1.7, Src: src},
+	} {
+		b.Run(fmt.Sprintf("case %d", i), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				g.Rand()
+			}
+		})
 	}
 }

--- a/stat/distuv/inversegamma_test.go
+++ b/stat/distuv/inversegamma_test.go
@@ -42,7 +42,7 @@ func TestInverseGamma(t *testing.T) {
 func testInverseGamma(t *testing.T, f InverseGamma, i int) {
 	const (
 		tol  = 1e-2
-		n    = 1e6
+		n    = 2e6
 		bins = 50
 	)
 	x := make([]float64, n)

--- a/stat/distuv/studentst_test.go
+++ b/stat/distuv/studentst_test.go
@@ -50,7 +50,7 @@ func TestStudentsT(t *testing.T) {
 func testStudentsT(t *testing.T, c StudentsT, i int) {
 	const (
 		tol  = 1e-2
-		n    = 1e5
+		n    = 3e5
 		bins = 50
 	)
 	x := make([]float64, n)


### PR DESCRIPTION
Please take a look.

Fixes #1453.

benchstat (from the new GammaRand benchmark):
```
name              old time/op  new time/op  delta
GammaRand/case_0  90.3ns ± 5%  91.1ns ± 3%     ~     (p=0.152 n=10+8)
GammaRand/case_1   215ns ± 4%   213ns ± 3%     ~     (p=0.238 n=10+10)
GammaRand/case_2  25.5ns ± 3%  25.7ns ± 3%     ~     (p=0.534 n=9+10)
GammaRand/case_3  72.4ns ± 4%  48.5ns ± 5%  -32.97%  (p=0.000 n=9+10)
GammaRand/case_4  72.0ns ± 6%  47.1ns ± 6%  -34.50%  (p=0.000 n=10+10)
```

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
