### PR TITLE
stat/distuv: improve Poisson.Rand performance for Lambda >= 10

### DIFF
--- a/stat/distuv/poisson_test.go
+++ b/stat/distuv/poisson_test.go
@@ -5,6 +5,7 @@
 package distuv
 
 import (
+	"fmt"
 	"math"
 	"sort"
 	"testing"
@@ -157,5 +158,24 @@ func testPoisson(t *testing.T, p Poisson, i int) {
 		if math.Abs(cdf+surv-1) > 1e-10 {
 			t.Errorf("Mismatch between CDF and Survival at %g", xx)
 		}
+	}
+}
+
+func BenchmarkPoissonRand(b *testing.B) {
+	src := rand.New(rand.NewSource(1))
+	for i, p := range []Poisson{
+		{100, src},
+		{15, src},
+		{10, src},
+		{9.9, src},
+		{3, src},
+		{1.5, src},
+		{0.9, src},
+	} {
+		b.Run(fmt.Sprintf("case %d", i), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				p.Rand()
+			}
+		})
 	}
 }

--- a/stat/distuv/poisson_test.go
+++ b/stat/distuv/poisson_test.go
@@ -121,7 +121,7 @@ func TestPoisson(t *testing.T) {
 func testPoisson(t *testing.T, p Poisson, i int) {
 	const (
 		tol = 1e-2
-		n   = 1e6
+		n   = 2e6
 	)
 	x := make([]float64, n)
 	generateSamples(x, p)


### PR DESCRIPTION
Please take a look.

benchstat:
```
name                old time/op  new time/op  delta
PoissonRand/case_0   297ns ± 5%    76ns ±10%  -74.56%  (p=0.000 n=10+10)
PoissonRand/case_1   284ns ± 6%   107ns ± 7%  -62.21%  (p=0.000 n=10+10)
PoissonRand/case_2   284ns ± 6%   118ns ± 4%  -58.34%  (p=0.000 n=10+10)
PoissonRand/case_3   236ns ± 3%   239ns ± 6%     ~     (p=0.381 n=10+10)
PoissonRand/case_4   105ns ± 6%   107ns ± 8%     ~     (p=0.236 n=10+10)
PoissonRand/case_5  73.8ns ± 4%  75.1ns ± 4%     ~     (p=0.148 n=10+10)
PoissonRand/case_6  60.3ns ± 5%  60.9ns ± 5%     ~     (p=0.307 n=10+10)
```

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
