### PR TITLE
dsp/fourier: add radix-2 and radix-4 in-place FFTs

### DIFF
--- a/dsp/fourier/fourier_test.go
+++ b/dsp/fourier/fourier_test.go
@@ -391,7 +391,12 @@ func equalApprox(a, b []complex128, tol float64) bool {
 }
 
 func BenchmarkRealFFTCoefficients(b *testing.B) {
-	for _, n := range []int{4, 100, 256, 4000, 4096, 1e6, 1 << 20, 1 << 24} {
+	var sizes []int
+	for n := 16; n < 1<<24; n <<= 3 {
+		sizes = append(sizes, n)
+	}
+	sizes = append(sizes, 100, 4000, 1e6)
+	for _, n := range sizes {
 		fft := NewFFT(n)
 		seq := randFloats(n, rand.NewSource(1))
 		dst := make([]complex128, n/2+1)
@@ -405,7 +410,12 @@ func BenchmarkRealFFTCoefficients(b *testing.B) {
 }
 
 func BenchmarkRealFFTSequence(b *testing.B) {
-	for _, n := range []int{4, 100, 256, 4000, 4096, 1e6, 1 << 20, 1 << 24} {
+	var sizes []int
+	for n := 16; n < 1<<24; n <<= 3 {
+		sizes = append(sizes, n)
+	}
+	sizes = append(sizes, 100, 4000, 1e6)
+	for _, n := range sizes {
 		fft := NewFFT(n)
 		coeff := randComplexes(n/2+1, rand.NewSource(1))
 		dst := make([]float64, n)
@@ -419,7 +429,12 @@ func BenchmarkRealFFTSequence(b *testing.B) {
 }
 
 func BenchmarkCmplxFFTCoefficients(b *testing.B) {
-	for _, n := range []int{4, 100, 256, 4000, 4096, 1e6, 1 << 20, 1 << 24} {
+	var sizes []int
+	for n := 16; n < 1<<24; n <<= 3 {
+		sizes = append(sizes, n)
+	}
+	sizes = append(sizes, 100, 4000, 1e6)
+	for _, n := range sizes {
 		fft := NewCmplxFFT(n)
 		d := randComplexes(n, rand.NewSource(1))
 
@@ -432,7 +447,12 @@ func BenchmarkCmplxFFTCoefficients(b *testing.B) {
 }
 
 func BenchmarkCmplxFFTSequence(b *testing.B) {
-	for _, n := range []int{4, 100, 256, 4000, 4096, 1e6, 1 << 20, 1 << 24} {
+	var sizes []int
+	for n := 16; n < 1<<24; n <<= 3 {
+		sizes = append(sizes, n)
+	}
+	sizes = append(sizes, 100, 4000, 1e6)
+	for _, n := range sizes {
 		fft := NewCmplxFFT(n)
 		d := randComplexes(n, rand.NewSource(1))
 

--- a/dsp/fourier/radix24.go
+++ b/dsp/fourier/radix24.go
@@ -1,0 +1,343 @@
+// Copyright ©2020 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fourier
+
+import (
+	"math"
+	"math/bits"
+	"math/cmplx"
+)
+
+// CoefficientsRadix2 computes the Fourier coefficients of the input
+// sequence, converting the time series in seq into the frequency spectrum,
+// in place and returning it. This transform is unnormalized; a call to
+// CoefficientsRadix2 followed by a call of SequenceRadix2 will multiply the
+// input sequence by the length of the sequence.
+//
+// CoefficientsRadix2 does not allocate, requiring that FFT twiddle factors
+// be calculated lazily. For performance reasons, this is done by successive
+// multiplication, so numerical accuracies can accumulate for large inputs.
+// If accuracy is needed, the FFT or CmplxFFT types should be used.
+//
+// If the length of seq is not an integer power of 2, CoefficientsRadix2 will
+// panic.
+func CoefficientsRadix2(seq []complex128) []complex128 {
+	x := seq
+	switch len(x) {
+	default:
+		if bits.OnesCount(uint(len(x))) != 1 {
+			panic("fourier: radix-2 fft called with non-power 2 length")
+		}
+
+	case 0, 1:
+		return x
+
+	case 2:
+		x[0], x[1] =
+			x[0]+x[1],
+			x[0]-x[1]
+		return x
+
+	case 4:
+		t := x[1] + x[3]
+		u := x[2]
+		v := negi(x[1] - x[3])
+		x[0], x[1], x[2], x[3] =
+			x[0]+u+t,
+			x[0]-u+v,
+			x[0]+u-t,
+			x[0]-u-v
+		return x
+	}
+
+	bitReversePermute(x)
+
+	for k := 0; k < len(x); k += 4 {
+		t := x[k+2] + x[k+3]
+		u := x[k+1]
+		v := negi(x[k+2] - x[k+3])
+		x[k], x[k+1], x[k+2], x[k+3] =
+			x[k]+u+t,
+			x[k]-u+v,
+			x[k]+u-t,
+			x[k]-u-v
+	}
+
+	for m := 4; m < len(x); m *= 2 {
+		f := swap(complex(math.Sincos(-math.Pi / float64(m))))
+		for k := 0; k < len(x); k += 2 * m {
+			w := 1 + 0i
+			for j := 0; j < m; j++ {
+				i := j + k
+
+				u := w * x[i+m]
+				x[i], x[i+m] =
+					x[i]+u,
+					x[i]-u
+
+				w *= f
+			}
+		}
+	}
+
+	return x
+}
+
+// bitReversePermute performs a bit-reversal permutation on x.
+func bitReversePermute(x []complex128) {
+	if len(x) < 2 || bits.OnesCount(uint(len(x))) != 1 {
+		panic("fourier: invalid bitReversePermute call")
+	}
+	lz := bits.LeadingZeros(uint(len(x) - 1))
+	i := 0
+	for ; i < len(x)/2; i++ {
+		j := int(bits.Reverse(uint(i)) >> lz)
+		if i < j {
+			x[i], x[j] = x[j], x[i]
+		}
+	}
+	for i++; i < len(x); i += 2 {
+		j := int(bits.Reverse(uint(i)) >> lz)
+		if i < j {
+			x[i], x[j] = x[j], x[i]
+		}
+	}
+}
+
+// SequenceRadix2 computes the real periodic sequence from the Fourier
+// coefficients, converting the frequency spectrum in coeff into a time
+// series, in place and returning it. This transform is unnormalized; a
+// call to CoefficientsRadix2 followed by a call of SequenceRadix2 will
+// multiply the input sequence by the length of the sequence.
+//
+// SequenceRadix2 does not allocate, requiring that FFT twiddle factors
+// be calculated lazily. For performance reasons, this is done by successive
+// multiplication, so numerical accuracies can accumulate for large inputs.
+// If accuracy is needed, the FFT or CmplxFFT types should be used.
+//
+// If the length of coeff is not an integer power of 2, SequenceRadix2
+// will panic.
+func SequenceRadix2(coeff []complex128) []complex128 {
+	x := coeff
+	for i, j := 1, len(x)-1; i < j; i, j = i+1, j-1 {
+		x[i], x[j] = x[j], x[i]
+	}
+
+	CoefficientsRadix2(x)
+	return x
+}
+
+// PadRadix2 returns the values in x in a slice that is an integer
+// power of 2 long. If x already has an integer power of 2 length
+// it is returned unaltered.
+func PadRadix2(x []complex128) []complex128 {
+	if len(x) == 0 {
+		return x
+	}
+	b := bits.Len(uint(len(x)))
+	if len(x) == 1<<(b-1) {
+		return x
+	}
+	p := make([]complex128, 1<<b)
+	copy(p, x)
+	return p
+}
+
+// TrimRadix2 returns the largest slice of x that is has an integer
+// power of 2 length, and a slice holding the remaining elements.
+func TrimRadix2(x []complex128) (even, remains []complex128) {
+	if len(x) == 0 {
+		return x, nil
+	}
+	n := 1 << (bits.Len(uint(len(x))) - 1)
+	return x[:n], x[n:]
+}
+
+// CoefficientsRadix4 computes the Fourier coefficients of the input
+// sequence, converting the time series in seq into the frequency spectrum,
+// in place and returning it. This transform is unnormalized; a call to
+// CoefficientsRadix4 followed by a call of SequenceRadix4 will multiply the
+// input sequence by the length of the sequence.
+//
+// CoefficientsRadix4 does not allocate, requiring that FFT twiddle factors
+// be calculated lazily. For performance reasons, this is done by successive
+// multiplication, so numerical accuracies can accumulate for large inputs.
+// If accuracy is needed, the FFT or CmplxFFT types should be used.
+//
+// If the length of seq is not an integer power of 4, CoefficientsRadix4 will
+// panic.
+func CoefficientsRadix4(seq []complex128) []complex128 {
+	x := seq
+	switch len(x) {
+	default:
+		if bits.OnesCount(uint(len(x))) != 1 || bits.TrailingZeros(uint(len(x)))&0x1 != 0 {
+			panic("fourier: radix-4 fft called with non-power 4 length")
+		}
+
+	case 0, 1:
+		return x
+
+	case 4:
+		t := x[1] + x[3]
+		u := x[2]
+		v := negi(x[1] - x[3])
+		x[0], x[1], x[2], x[3] =
+			x[0]+u+t,
+			x[0]-u+v,
+			x[0]+u-t,
+			x[0]-u-v
+		return x
+	}
+
+	bitPairReversePermute(x)
+
+	for k := 0; k < len(x); k += 4 {
+		t := x[k+1] + x[k+3]
+		u := x[k+2]
+		v := negi(x[k+1] - x[k+3])
+		x[k], x[k+1], x[k+2], x[k+3] =
+			x[k]+u+t,
+			x[k]-u+v,
+			x[k]+u-t,
+			x[k]-u-v
+	}
+
+	for m := 4; m < len(x); m *= 4 {
+		f := swap(complex(math.Sincos((-math.Pi / 2) / float64(m))))
+		for k := 0; k < len(x); k += m * 4 {
+			w := 1 + 0i
+			w2 := w
+			w3 := w2
+			for j := 0; j < m; j++ {
+				i := j + k
+
+				t := x[i+m]*w + x[i+3*m]*w3
+				u := x[i+2*m] * w2
+				v := negi(x[i+m]*w - x[i+3*m]*w3)
+				x[i], x[i+m], x[i+2*m], x[i+3*m] =
+					x[i]+u+t,
+					x[i]-u+v,
+					x[i]+u-t,
+					x[i]-u-v
+
+				wt := f
+				w *= wt
+				wt *= f
+				w2 *= wt
+				wt *= f
+				w3 *= wt
+			}
+		}
+	}
+
+	return x
+}
+
+// bitPairReversePermute performs a bit pair-reversal permutation on x.
+func bitPairReversePermute(x []complex128) {
+	if len(x) < 4 || bits.OnesCount(uint(len(x))) != 1 || bits.TrailingZeros(uint(len(x)))&0x1 != 0 {
+		panic("fourier: invalid bitPairReversePermute call")
+	}
+	lz := bits.LeadingZeros(uint(len(x) - 1))
+	i := 0
+	for ; i < 3*len(x)/4; i++ {
+		j := int(reversePairs(uint(i)) >> lz)
+		if i < j {
+			x[i], x[j] = x[j], x[i]
+		}
+	}
+	for i++; i < len(x); i += 2 {
+		j := int(reversePairs(uint(i)) >> lz)
+		if i < j {
+			x[i], x[j] = x[j], x[i]
+		}
+	}
+}
+
+// SequenceRadix4 computes the real periodic sequence from the Fourier
+// coefficients, converting the frequency spectrum in coeff into a time
+// series, in place and returning it. This transform is unnormalized; a
+// call to CoefficientsRadix4 followed by a call of SequenceRadix4 will
+// multiply the input sequence by the length of the sequence.
+//
+// SequenceRadix4 does not allocate, requiring that FFT twiddle factors
+// be calculated lazily. For performance reasons, this is done by successive
+// multiplication, so numerical accuracies can accumulate for large inputs.
+// If accuracy is needed, the FFT or CmplxFFT types should be used.
+//
+// If the length of coeff is not an integer power of 4, SequenceRadix4
+// will panic.
+func SequenceRadix4(coeff []complex128) []complex128 {
+	x := coeff
+	for i, j := 1, len(x)-1; i < j; i, j = i+1, j-1 {
+		x[i], x[j] = x[j], x[i]
+	}
+
+	CoefficientsRadix4(x)
+	return x
+}
+
+// PadRadix4 returns the values in x in a slice that is an integer
+// power of 4 long. If x already has an integer power of 4 length
+// it is returned unaltered.
+func PadRadix4(x []complex128) []complex128 {
+	if len(x) == 0 {
+		return x
+	}
+	b := bits.Len(uint(len(x)))
+	if len(x) == 1<<(b-1) && b&0x1 == 1 {
+		return x
+	}
+	p := make([]complex128, 1<<((b+1)&^0x1))
+	copy(p, x)
+	return p
+}
+
+// TrimRadix4 returns the largest slice of x that is has an integer
+// power of 4 length, and a slice holding the remaining elements.
+func TrimRadix4(x []complex128) (even, remains []complex128) {
+	if len(x) == 0 {
+		return x, nil
+	}
+	n := 1 << ((bits.Len(uint(len(x))) - 1) &^ 0x1)
+	return x[:n], x[n:]
+}
+
+// reversePairs returns the value of x with its bit pairs in reversed order.
+func reversePairs(x uint) uint {
+	if bits.UintSize == 32 {
+		return uint(reversePairs32(uint32(x)))
+	}
+	return uint(reversePairs64(uint64(x)))
+}
+
+const (
+	m1 = 0x3333333333333333
+	m2 = 0x0f0f0f0f0f0f0f0f
+)
+
+// reversePairs32 returns the value of x with its bit pairs in reversed order.
+func reversePairs32(x uint32) uint32 {
+	const m = 1<<32 - 1
+	x = x>>2&(m1&m) | x&(m1&m)<<2
+	x = x>>4&(m2&m) | x&(m2&m)<<4
+	return bits.ReverseBytes32(x)
+}
+
+// reversePairs64 returns the value of x with its bit pairs in reversed order.
+func reversePairs64(x uint64) uint64 {
+	const m = 1<<64 - 1
+	x = x>>2&(m1&m) | x&(m1&m)<<2
+	x = x>>4&(m2&m) | x&(m2&m)<<4
+	return bits.ReverseBytes64(x)
+}
+
+func negi(c complex128) complex128 {
+	return cmplx.Conj(swap(c))
+}
+
+func swap(c complex128) complex128 {
+	return complex(imag(c), real(c))
+}

--- a/dsp/fourier/radix24_test.go
+++ b/dsp/fourier/radix24_test.go
@@ -1,0 +1,290 @@
+// Copyright ©2020 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fourier
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"strconv"
+	"testing"
+
+	"golang.org/x/exp/rand"
+
+	"gonum.org/v1/gonum/cmplxs"
+)
+
+func TestCoefficients(t *testing.T) {
+	const tol = 1e-8
+
+	src := rand.NewSource(1)
+	for n := 4; n < 1<<20; n <<= 1 {
+		for i := 0; i < 10; i++ {
+			t.Run(fmt.Sprintf("Radix2/%d", n), func(t *testing.T) {
+				d := randComplexes(n, src)
+				fft := NewCmplxFFT(n)
+				want := fft.Coefficients(nil, d)
+				CoefficientsRadix2(d)
+				got := d
+				if !cmplxs.EqualApprox(got, want, tol) {
+					t.Errorf("unexpected result for n=%d |got-want|^2=%g", n, cmplxs.Distance(got, want, 2))
+				}
+
+				want = fft.Sequence(nil, got)
+				scale(1/float64(n), want)
+
+				SequenceRadix2(got)
+				scale(1/float64(n), got)
+
+				if !cmplxs.EqualApprox(got, want, tol) {
+					t.Errorf("unexpected ifft result for n=%d |got-want|^2=%g", n, cmplxs.Distance(got, want, 2))
+				}
+			})
+			if bits.Len(uint(n))&0x1 == 0 {
+				continue
+			}
+			t.Run(fmt.Sprintf("Radix4/%d", n), func(t *testing.T) {
+				d := randComplexes(n, src)
+				fft := NewCmplxFFT(n)
+				want := fft.Coefficients(nil, d)
+				CoefficientsRadix4(d)
+				got := d
+				if !cmplxs.EqualApprox(got, want, tol) {
+					t.Errorf("unexpected fft result for n=%d |got-want|^2=%g", n, cmplxs.Distance(got, want, 2))
+				}
+
+				want = fft.Sequence(nil, got)
+				scale(1/float64(n), want)
+
+				SequenceRadix4(got)
+				scale(1/float64(n), got)
+
+				if !cmplxs.EqualApprox(got, want, tol) {
+					t.Errorf("unexpected ifft result for n=%d |got-want|^2=%g", n, cmplxs.Distance(got, want, 2))
+				}
+			})
+		}
+	}
+}
+
+func TestSequence(t *testing.T) {
+	const tol = 1e-10
+
+	src := rand.NewSource(1)
+	for n := 4; n < 1<<20; n <<= 1 {
+		for i := 0; i < 10; i++ {
+			t.Run(fmt.Sprintf("Radix2/%d", n), func(t *testing.T) {
+				d := randComplexes(n, src)
+				want := make([]complex128, n)
+				copy(want, d)
+				SequenceRadix2(CoefficientsRadix2(d))
+				got := d
+
+				scale(1/float64(n), got)
+
+				if !cmplxs.EqualApprox(got, want, tol) {
+					t.Errorf("unexpected result for ifft(fft(d)) n=%d |got-want|^2=%g", n, cmplxs.Distance(got, want, 2))
+				}
+			})
+			if bits.Len(uint(n))&0x1 == 0 {
+				continue
+			}
+			t.Run(fmt.Sprintf("Radix4/%d", n), func(t *testing.T) {
+				d := randComplexes(n, src)
+				want := make([]complex128, n)
+				copy(want, d)
+				SequenceRadix4(CoefficientsRadix4(d))
+				got := d
+
+				scale(1/float64(n), got)
+
+				if !cmplxs.EqualApprox(got, want, tol) {
+					t.Errorf("unexpected result for ifft(fft(d)) n=%d |got-want|^2=%g", n, cmplxs.Distance(got, want, 2))
+				}
+			})
+		}
+	}
+}
+
+func scale(f float64, c []complex128) {
+	for i, v := range c {
+		c[i] = complex(f*real(v), f*imag(v))
+	}
+}
+
+func TestBitReversePermute(t *testing.T) {
+	for n := 2; n <= 1024; n <<= 1 {
+		x := make([]complex128, n)
+		for i := range x {
+			x[i] = complex(float64(i), float64(i))
+		}
+		bitReversePermute(x)
+		for i, got := range x {
+			j := bits.Reverse(uint(i)) >> bits.LeadingZeros(uint(n-1))
+			want := complex(float64(j), float64(j))
+			if got != want {
+				t.Errorf("unexpected value at %d: got:%f want:%f", i, got, want)
+			}
+		}
+	}
+}
+
+func TestPadRadix2(t *testing.T) {
+	for n := 1; n <= 1025; n++ {
+		x := make([]complex128, n)
+		y := PadRadix2(x)
+		if bits.OnesCount(uint(len(y))) != 1 {
+			t.Errorf("unexpected length of padded slice: not a power of 2: %d", len(y))
+		}
+		if len(x) == len(y) && &y[0] != &x[0] {
+			t.Errorf("unexpected new allocation for power of 2 input length: len(x)=%d", n)
+		}
+		if len(y) < len(x) {
+			t.Errorf("unexpected short result: len(y)=%d < len(x)=%d", len(y), len(x))
+		}
+	}
+}
+
+func TestTrimRadix2(t *testing.T) {
+	for n := 1; n <= 1025; n++ {
+		x := make([]complex128, n)
+		y, r := TrimRadix2(x)
+		if bits.OnesCount(uint(len(y))) != 1 {
+			t.Errorf("unexpected length of trimmed slice: not a power of 2: %d", len(y))
+		}
+		if len(y)+len(r) != len(x) {
+			t.Errorf("unexpected total result: len(y)=%d + len(r)%d != len(x)=%d", len(y), len(r), len(x))
+		}
+		if len(x) == len(y) && &y[0] != &x[0] {
+			t.Errorf("unexpected new allocation for power of 2 input length: len(x)=%d", n)
+		}
+		if len(y) > len(x) {
+			t.Errorf("unexpected long result: len(y)=%d > len(x)=%d", len(y), len(x))
+		}
+	}
+}
+
+func TestBitPairReversePermute(t *testing.T) {
+	for n := 4; n <= 1024; n <<= 2 {
+		x := make([]complex128, n)
+		for i := range x {
+			x[i] = complex(float64(i), float64(i))
+		}
+		bitPairReversePermute(x)
+		for i, got := range x {
+			j := reversePairs(uint(i)) >> bits.LeadingZeros(uint(n-1))
+			want := complex(float64(j), float64(j))
+			if got != want {
+				t.Errorf("unexpected value at %d: got:%f want:%f", i, got, want)
+			}
+		}
+	}
+}
+
+func TestReversePairs(t *testing.T) {
+	rnd := rand.New(rand.NewSource(1))
+	for i := 0; i < 1000; i++ {
+		x := uint(rnd.Uint64())
+		got := reversePairs(x)
+		want := naiveReversePairs(x)
+		if got != want {
+			t.Errorf("unexpected bit-pair reversal for 0b%064b:\ngot: 0b%064b\nwant:0b%064b", x, got, want)
+		}
+	}
+}
+
+// naiveReversePairs does a bit-pair reversal by formatting as a base-4 string,
+// reversing the digits of the formatted number and then re-parsing the value.
+func naiveReversePairs(x uint) uint {
+	// Format the number as a quaternary, padded with zeros.
+	// We avoid the leftpad issue by doing it ourselves.
+	b := strconv.AppendUint(bytes.Repeat([]byte("0"), 32), uint64(x), 4)
+	b = b[len(b)-32:]
+
+	// Reverse the quits.
+	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+
+	// Re-parse the reversed number.
+	y, err := strconv.ParseUint(string(b), 4, 64)
+	if err != nil {
+		panic(fmt.Sprintf("unexpected parse error: %v", err))
+	}
+	return uint(y)
+}
+
+func TestPadRadix4(t *testing.T) {
+	for n := 1; n <= 1025; n++ {
+		x := make([]complex128, n)
+		y := PadRadix4(x)
+		if bits.OnesCount(uint(len(y))) != 1 || bits.Len(uint(len(y)))&0x1 == 0 {
+			t.Errorf("unexpected length of padded slice: not a power of 4: %d", len(y))
+		}
+		if len(x) == len(y) && &y[0] != &x[0] {
+			t.Errorf("unexpected new allocation for power of 2 input length: len(x)=%d", n)
+		}
+		if len(y) < len(x) {
+			t.Errorf("unexpected short result: len(y)=%d < len(x)=%d", len(y), len(x))
+		}
+	}
+}
+
+func TestTrimRadix4(t *testing.T) {
+	for n := 1; n <= 1025; n++ {
+		x := make([]complex128, n)
+		y, r := TrimRadix4(x)
+		if bits.OnesCount(uint(len(y))) != 1 || bits.Len(uint(len(y)))&0x1 == 0 {
+			t.Errorf("unexpected length of trimmed slice: not a power of 4: %d", len(y))
+		}
+		if len(y)+len(r) != len(x) {
+			t.Errorf("unexpected total result: len(y)=%d + len(r)%d != len(x)=%d", len(y), len(r), len(x))
+		}
+		if len(x) == len(y) && &y[0] != &x[0] {
+			t.Errorf("unexpected new allocation for power of 2 input length: len(x)=%d", n)
+		}
+		if len(y) > len(x) {
+			t.Errorf("unexpected long result: len(y)=%d > len(x)=%d", len(y), len(x))
+		}
+	}
+}
+
+func BenchmarkCoefficients(b *testing.B) {
+	for n := 16; n < 1<<24; n <<= 3 {
+		d := randComplexes(n, rand.NewSource(1))
+		b.Run(fmt.Sprintf("Radix2/%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				CoefficientsRadix2(d)
+			}
+		})
+		if bits.Len(uint(n))&0x1 == 0 {
+			continue
+		}
+		b.Run(fmt.Sprintf("Radix4/%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				CoefficientsRadix4(d)
+			}
+		})
+	}
+}
+
+func BenchmarkSequence(b *testing.B) {
+	for n := 16; n < 1<<24; n <<= 3 {
+		d := randComplexes(n, rand.NewSource(1))
+		b.Run(fmt.Sprintf("Radix2/%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				SequenceRadix2(d)
+			}
+		})
+		if bits.Len(uint(n))&0x1 == 0 {
+			continue
+		}
+		b.Run(fmt.Sprintf("Radix4/%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				SequenceRadix4(d)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The comments in #1456 about FFT packages was what spurred me to look at cleaning up dsp/internal/fftpack, but I also spent some time thinking about my comment https://github.com/gonum/gonum/pull/1456#issuecomment-693677437 regarding the desire to have a non-radix constrained implementation. I still think this is true since it makes life easier for the general user, but it doesn't preclude us from providing radix-2 and radix-4 FFTs.

These are faster than the current implementation (even with the improvements made in #1463), and they don't allocate, but they do behave the same way as the `Coefficients` and `Sequence` methods on the FFT types we have which the exception that they are less numerically precise (this comes from the approach used to generate the twiddle factors by successive powers rather than an allocated look-up table or `cmplx.Exp` calls ~~(this isn't noted in the docs, but I can add a note to that effect)~~).

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
