### PR TITLE
mat: fix GrowSym behaviour for Reset matrices

### DIFF
--- a/mat/symmetric.go
+++ b/mat/symmetric.go
@@ -600,7 +600,7 @@ func (s *SymDense) GrowSym(n int) Symmetric {
 	}
 	var v SymDense
 	n += s.mat.N
-	if n > s.cap {
+	if s.IsEmpty() || n > s.cap {
 		v.mat = blas64.Symmetric{
 			N:      n,
 			Stride: n,

--- a/mat/symmetric_test.go
+++ b/mat/symmetric_test.go
@@ -685,6 +685,12 @@ func TestViewGrowSquare(t *testing.T) {
 				}
 			}
 		}
+
+		s.Reset()
+		rg := s.GrowSym(n).(*SymDense)
+		if rg.mat.Stride < n {
+			t.Errorf("unexpected stride after GrowSym on empty matrix: got:%d want >= %d", rg.mat.Stride, n)
+		}
 	}
 }
 

--- a/stat/statmat_test.go
+++ b/stat/statmat_test.go
@@ -88,8 +88,8 @@ func TestCovarianceMatrix(t *testing.T) {
 				}
 			}
 		}
-
 	}
+
 	if !panics(func() { CovarianceMatrix(nil, mat.NewDense(5, 2, nil), []float64{}) }) {
 		t.Errorf("CovarianceMatrix did not panic with weight size mismatch")
 	}
@@ -98,6 +98,13 @@ func TestCovarianceMatrix(t *testing.T) {
 	}
 	if !panics(func() { CovarianceMatrix(nil, mat.NewDense(2, 2, []float64{1, 2, 3, 4}), []float64{1, -1}) }) {
 		t.Errorf("CovarianceMatrix did not panic with negative weights")
+	}
+	if panics(func() {
+		dst := mat.NewSymDense(4, nil)
+		dst.Reset()
+		CovarianceMatrix(dst, mat.NewDense(2, 2, []float64{1, 2, 3, 4}), nil)
+	}) {
+		t.Errorf("CovarianceMatrix panics with reset destination")
 	}
 }
 
@@ -307,9 +314,11 @@ func randMat(r, c int) mat.Matrix {
 }
 
 func benchmarkCovarianceMatrix(b *testing.B, m mat.Matrix) {
+	var res mat.SymDense
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		CovarianceMatrix(nil, m, nil)
+		res.Reset()
+		CovarianceMatrix(&res, m, nil)
 	}
 }
 func benchmarkCovarianceMatrixWeighted(b *testing.B, m mat.Matrix) {
@@ -318,9 +327,11 @@ func benchmarkCovarianceMatrixWeighted(b *testing.B, m mat.Matrix) {
 	for i := range wts {
 		wts[i] = 0.5
 	}
+	var res mat.SymDense
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		CovarianceMatrix(nil, m, wts)
+		res.Reset()
+		CovarianceMatrix(&res, m, wts)
 	}
 }
 func benchmarkCovarianceMatrixInPlace(b *testing.B, m mat.Matrix) {


### PR DESCRIPTION
Also fix CovarianceMatrix benchmarks in stat that found this.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
