### PR TITLE
mat: add TriBandDense.SolveTo and SolveVecTo

### DIFF
--- a/mat/dense_test.go
+++ b/mat/dense_test.go
@@ -18,12 +18,13 @@ import (
 )
 
 func asBasicMatrix(d *Dense) Matrix              { return (*basicMatrix)(d) }
-func asBasicSymmetric(s *SymDense) Matrix        { return (*basicSymmetric)(s) }
+func asBasicSymmetric(s *SymDense) Symmetric     { return (*basicSymmetric)(s) }
 func asBasicTriangular(t *TriDense) Triangular   { return (*basicTriangular)(t) }
 func asBasicBanded(b *BandDense) Banded          { return (*basicBanded)(b) }
 func asBasicSymBanded(s *SymBandDense) SymBanded { return (*basicSymBanded)(s) }
 func asBasicTriBanded(t *TriBandDense) TriBanded { return (*basicTriBanded)(t) }
 func asBasicDiagonal(d *DiagDense) Diagonal      { return (*basicDiagonal)(d) }
+func asBasicVector(d *VecDense) Vector           { return (*basicVector)(d) }
 
 func TestNewDense(t *testing.T) {
 	t.Parallel()

--- a/mat/list_test.go
+++ b/mat/list_test.go
@@ -386,19 +386,17 @@ func makeRandOf(a Matrix, m, n int, src rand.Source) Matrix {
 		}
 		return mat
 	case *basicVector:
-		if m == 0 && n == 0 {
-			return &basicVector{}
-		}
 		if n != 1 {
 			panic(fmt.Sprintf("bad vector size: m = %v, n = %v", m, n))
 		}
-		mat := &basicVector{
-			m: make([]float64, m),
+		if m == 0 {
+			return &basicVector{}
 		}
+		mat := NewVecDense(m, nil)
 		for i := 0; i < m; i++ {
-			mat.m[i] = rnd.NormFloat64()
+			mat.SetVec(i, rnd.NormFloat64())
 		}
-		return mat
+		return asBasicVector(mat)
 	case *SymDense, *basicSymmetric:
 		if m != n {
 			panic("bad size")
@@ -584,19 +582,17 @@ func makeNaNOf(a Matrix, m, n int) Matrix {
 		}
 		return mat
 	case *basicVector:
-		if m == 0 && n == 0 {
-			return &basicVector{}
-		}
 		if n != 1 {
 			panic(fmt.Sprintf("bad vector size: m = %v, n = %v", m, n))
 		}
-		mat := &basicVector{
-			m: make([]float64, m),
+		if m == 0 {
+			return &basicVector{}
 		}
+		mat := NewVecDense(m, nil)
 		for i := 0; i < m; i++ {
-			mat.m[i] = math.NaN()
+			mat.SetVec(i, math.NaN())
 		}
-		return mat
+		return asBasicVector(mat)
 	case *SymDense, *basicSymmetric:
 		if m != n {
 			panic("bad size")
@@ -832,21 +828,13 @@ func makeCopyOf(a Matrix) Matrix {
 		copy(m.mat.Data, tri.mat.Data)
 		return returnAs(m, t)
 	case *VecDense:
-		m := &VecDense{
-			mat: blas64.Vector{
-				N:    t.mat.N,
-				Inc:  t.mat.Inc,
-				Data: make([]float64, t.mat.Inc*(t.mat.N-1)+1),
-			},
-		}
-		copy(m.mat.Data, t.mat.Data)
-		return m
+		var m VecDense
+		m.CloneFromVec(t)
+		return &m
 	case *basicVector:
-		m := &basicVector{
-			m: make([]float64, t.Len()),
-		}
-		copy(m.m, t.m)
-		return m
+		var m VecDense
+		m.CloneFromVec(t)
+		return asBasicVector(&m)
 	case *DiagDense, *basicDiagonal:
 		var diag *DiagDense
 		switch s := t.(type) {

--- a/mat/matrix_test.go
+++ b/mat/matrix_test.go
@@ -372,48 +372,6 @@ func TestDet(t *testing.T) {
 	testOneInputFunc(t, "DetVsChol", f, denseComparison, sameAnswerFloatApproxTol(1e-10), isAnyType, isWide)
 }
 
-type basicVector struct {
-	m []float64
-}
-
-func (v *basicVector) AtVec(i int) float64 {
-	if i < 0 || i >= v.Len() {
-		panic(ErrRowAccess)
-	}
-	return v.m[i]
-}
-
-func (v *basicVector) At(r, c int) float64 {
-	if c != 0 {
-		panic(ErrColAccess)
-	}
-	return v.AtVec(r)
-}
-
-func (v *basicVector) Dims() (r, c int) {
-	return v.Len(), 1
-}
-
-func (v *basicVector) T() Matrix {
-	return Transpose{v}
-}
-
-func (v *basicVector) Len() int {
-	return len(v.m)
-}
-
-type rawVector struct {
-	basicVector
-}
-
-func (v *rawVector) RawVector() blas64.Vector {
-	return blas64.Vector{
-		N:    v.Len(),
-		Data: v.basicVector.m,
-		Inc:  1,
-	}
-}
-
 func TestDot(t *testing.T) {
 	t.Parallel()
 	f := func(a, b Matrix) interface{} {
@@ -782,9 +740,9 @@ func TestMulVecToer(t *testing.T) {
 						}
 						x = dst
 					case 2:
-						x = &rawVector{basicVector{random(n)}}
+						x = &rawVector{(*basicVector)(NewVecDense(n, random(n)))}
 					case 3:
-						x = &basicVector{random(n)}
+						x = asBasicVector(NewVecDense(n, random(n)))
 					default:
 						panic("bad xType")
 					}

--- a/mat/mul_test.go
+++ b/mat/mul_test.go
@@ -218,6 +218,24 @@ func (m *basicMatrix) T() Matrix {
 	return Transpose{m}
 }
 
+type basicVector VecDense
+
+var _ Vector = &basicVector{}
+
+func (v *basicVector) At(r, c int) float64 { return (*VecDense)(v).At(r, c) }
+func (v *basicVector) AtVec(i int) float64 { return (*VecDense)(v).AtVec(i) }
+func (v *basicVector) Dims() (r, c int)    { return (*VecDense)(v).Dims() }
+func (v *basicVector) Len() int            { return (*VecDense)(v).Len() }
+func (v *basicVector) T() Matrix           { return Transpose{v} }
+
+type rawVector struct {
+	*basicVector
+}
+
+func (v *rawVector) RawVector() blas64.Vector {
+	return v.basicVector.mat
+}
+
 type basicBanded BandDense
 
 var _ Banded = &basicBanded{}


### PR DESCRIPTION
Please take a look.

I also cleaned up the `basicVector` type a bit so that the tests for `SolveTo` and `SolveVecTo` are basically identical.

Closes #1471 

cc @romanwerpachowski 

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
