### PR TITLE
graph/community: add threshold for modularity gain

### DIFF
--- a/graph/community/louvain_common.go
+++ b/graph/community/louvain_common.go
@@ -357,9 +357,8 @@ const (
 	negativeWeight = "community: unexpected negative edge weight"
 	positiveWeight = "community: unexpected positive edge weight"
 
-	// Threshold for modularity change.
-	// If a modularity gain is lower than this value, we assume there is no gain.
-	modularityEpsilon = 0.0000001
+	// deltaQtol is the tolerance for progression of the local moving heuristic's improvement of Q.
+	deltaQtol = 1e-15
 )
 
 // positiveWeightFuncFor returns a constructed weight function for the

--- a/graph/community/louvain_common.go
+++ b/graph/community/louvain_common.go
@@ -356,6 +356,10 @@ func (s *slice) TakeMin(p *int) bool {
 const (
 	negativeWeight = "community: unexpected negative edge weight"
 	positiveWeight = "community: unexpected positive edge weight"
+
+	// Threshold for modularity change.
+	// If a modularity gain is lower than this value, we assume there is no gain.
+	modularityEpsilon = 0.0000001
 )
 
 // positiveWeightFuncFor returns a constructed weight function for the

--- a/graph/community/louvain_directed.go
+++ b/graph/community/louvain_directed.go
@@ -544,7 +544,7 @@ func (l *directedLocalMover) localMovingHeuristic(rnd func(int) int) (done bool)
 		l.shuffle(rnd)
 		for _, n := range l.nodes {
 			dQ, dst, src := l.deltaQ(n)
-			if dQ <= 0 {
+			if dQ <= modularityEpsilon {
 				continue
 			}
 			l.move(dst, src)

--- a/graph/community/louvain_directed.go
+++ b/graph/community/louvain_directed.go
@@ -544,7 +544,7 @@ func (l *directedLocalMover) localMovingHeuristic(rnd func(int) int) (done bool)
 		l.shuffle(rnd)
 		for _, n := range l.nodes {
 			dQ, dst, src := l.deltaQ(n)
-			if dQ <= modularityEpsilon {
+			if dQ <= deltaQtol {
 				continue
 			}
 			l.move(dst, src)

--- a/graph/community/louvain_directed_multiplex.go
+++ b/graph/community/louvain_directed_multiplex.go
@@ -747,7 +747,7 @@ func (l *directedMultiplexLocalMover) localMovingHeuristic(rnd func(int) int) (d
 		l.shuffle(rnd)
 		for _, n := range l.nodes {
 			dQ, dst, src := l.deltaQ(n)
-			if dQ <= 0 {
+			if dQ <= modularityEpsilon {
 				continue
 			}
 			l.move(dst, src)

--- a/graph/community/louvain_directed_multiplex.go
+++ b/graph/community/louvain_directed_multiplex.go
@@ -747,7 +747,7 @@ func (l *directedMultiplexLocalMover) localMovingHeuristic(rnd func(int) int) (d
 		l.shuffle(rnd)
 		for _, n := range l.nodes {
 			dQ, dst, src := l.deltaQ(n)
-			if dQ <= modularityEpsilon {
+			if dQ <= deltaQtol {
 				continue
 			}
 			l.move(dst, src)

--- a/graph/community/louvain_undirected.go
+++ b/graph/community/louvain_undirected.go
@@ -486,7 +486,7 @@ func (l *undirectedLocalMover) localMovingHeuristic(rnd func(int) int) (done boo
 		l.shuffle(rnd)
 		for _, n := range l.nodes {
 			dQ, dst, src := l.deltaQ(n)
-			if dQ <= 0 {
+			if dQ <= modularityEpsilon {
 				continue
 			}
 			l.move(dst, src)

--- a/graph/community/louvain_undirected.go
+++ b/graph/community/louvain_undirected.go
@@ -486,7 +486,7 @@ func (l *undirectedLocalMover) localMovingHeuristic(rnd func(int) int) (done boo
 		l.shuffle(rnd)
 		for _, n := range l.nodes {
 			dQ, dst, src := l.deltaQ(n)
-			if dQ <= modularityEpsilon {
+			if dQ <= deltaQtol {
 				continue
 			}
 			l.move(dst, src)

--- a/graph/community/louvain_undirected_multiplex.go
+++ b/graph/community/louvain_undirected_multiplex.go
@@ -686,7 +686,7 @@ func (l *undirectedMultiplexLocalMover) localMovingHeuristic(rnd func(int) int) 
 		l.shuffle(rnd)
 		for _, n := range l.nodes {
 			dQ, dst, src := l.deltaQ(n)
-			if dQ <= modularityEpsilon {
+			if dQ <= deltaQtol {
 				continue
 			}
 			l.move(dst, src)

--- a/graph/community/louvain_undirected_multiplex.go
+++ b/graph/community/louvain_undirected_multiplex.go
@@ -686,7 +686,7 @@ func (l *undirectedMultiplexLocalMover) localMovingHeuristic(rnd func(int) int) 
 		l.shuffle(rnd)
 		for _, n := range l.nodes {
 			dQ, dst, src := l.deltaQ(n)
-			if dQ <= 0 {
+			if dQ <= modularityEpsilon {
 				continue
 			}
 			l.move(dst, src)


### PR DESCRIPTION
Added modularityEpsilon constant and using it in all "localMovingHeuristic" implementations.
Addresses issue https://github.com/gonum/gonum/issues/1488

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
