### PR TITLE
stat/distuv: don't use global rand state for test

### DIFF
--- a/stat/distuv/exponential_test.go
+++ b/stat/distuv/exponential_test.go
@@ -45,7 +45,7 @@ func TestExponentialProb(t *testing.T) {
 
 func TestExponentialFitPrior(t *testing.T) {
 	t.Parallel()
-	testConjugateUpdate(t, func() ConjugateUpdater { return &Exponential{Rate: 13.7} })
+	testConjugateUpdate(t, func() ConjugateUpdater { return &Exponential{Rate: 13.7, Src: rand.NewSource(1)} })
 }
 
 func TestExponential(t *testing.T) {


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
