### PR TITLE
lapack: add Dlagtm

### DIFF
--- a/lapack/gonum/dlagtm.go
+++ b/lapack/gonum/dlagtm.go
@@ -1,0 +1,109 @@
+// Copyright ©2020 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+import "gonum.org/v1/gonum/blas"
+
+// Dlagtm performs one of the matrix-matrix operations
+//  C = alpha * A * B + beta * C   if trans == blas.NoTrans
+//  C = alpha * Aᵀ * B + beta * C  if trans == blas.Trans or blas.ConjTrans
+// where A is an m×m tridiagonal matrix represented by its diagonals dl, d, du,
+// B and C are m×n dense matrices, and alpha and beta are scalars.
+func (impl Implementation) Dlagtm(trans blas.Transpose, m, n int, alpha float64, dl, d, du []float64, b []float64, ldb int, beta float64, c []float64, ldc int) {
+	switch {
+	case trans != blas.NoTrans && trans != blas.Trans && trans != blas.ConjTrans:
+		panic(badTrans)
+	case m < 0:
+		panic(mLT0)
+	case n < 0:
+		panic(nLT0)
+	case ldb < max(1, n):
+		panic(badLdB)
+	case ldc < max(1, n):
+		panic(badLdC)
+	}
+
+	if m == 0 || n == 0 {
+		return
+	}
+
+	switch {
+	case len(dl) < m-1:
+		panic(shortDL)
+	case len(d) < m:
+		panic(shortD)
+	case len(du) < m-1:
+		panic(shortDU)
+	case len(b) < (m-1)*ldb+n:
+		panic(shortB)
+	case len(c) < (m-1)*ldc+n:
+		panic(shortC)
+	}
+
+	if beta != 1 {
+		if beta == 0 {
+			for i := 0; i < m; i++ {
+				ci := c[i*ldc : i*ldc+n]
+				for j := range ci {
+					ci[j] = 0
+				}
+			}
+		} else {
+			for i := 0; i < m; i++ {
+				ci := c[i*ldc : i*ldc+n]
+				for j := range ci {
+					ci[j] *= beta
+				}
+			}
+		}
+	}
+
+	if alpha == 0 {
+		return
+	}
+
+	if m == 1 {
+		if alpha == 1 {
+			for j := 0; j < n; j++ {
+				c[j] += d[0] * b[j]
+			}
+		} else {
+			for j := 0; j < n; j++ {
+				c[j] += alpha * d[0] * b[j]
+			}
+		}
+		return
+	}
+
+	if trans != blas.NoTrans {
+		dl, du = du, dl
+	}
+
+	if alpha == 1 {
+		for j := 0; j < n; j++ {
+			c[j] += d[0]*b[j] + du[0]*b[ldb+j]
+		}
+		for i := 1; i < m-1; i++ {
+			for j := 0; j < n; j++ {
+				c[i*ldc+j] += dl[i-1]*b[(i-1)*ldb+j] + d[i]*b[i*ldb+j] + du[i]*b[(i+1)*ldb+j]
+			}
+		}
+		for j := 0; j < n; j++ {
+			c[(m-1)*ldc+j] += dl[m-2]*b[(m-2)*ldb+j] + d[m-1]*b[(m-1)*ldb+j]
+		}
+	} else {
+		for j := 0; j < n; j++ {
+			c[j] += alpha * (d[0]*b[j] + du[0]*b[ldb+j])
+		}
+		for i := 1; i < m-1; i++ {
+			for j := 0; j < n; j++ {
+				c[i*ldc+j] += alpha * (dl[i-1]*b[(i-1)*ldb+j] + d[i]*b[i*ldb+j] + du[i]*b[(i+1)*ldb+j])
+			}
+		}
+		for j := 0; j < n; j++ {
+			c[(m-1)*ldc+j] += alpha * (dl[m-2]*b[(m-2)*ldb+j] + d[m-1]*b[(m-1)*ldb+j])
+		}
+	}
+}

--- a/lapack/gonum/lapack_test.go
+++ b/lapack/gonum/lapack_test.go
@@ -183,6 +183,11 @@ func TestDlags2(t *testing.T) {
 	testlapack.Dlags2Test(t, impl)
 }
 
+func TestDlagtm(t *testing.T) {
+	t.Parallel()
+	testlapack.DlagtmTest(t, impl)
+}
+
 func TestDlahqr(t *testing.T) {
 	t.Parallel()
 	testlapack.DlahqrTest(t, impl)

--- a/lapack/lapack64/lapack64.go
+++ b/lapack/lapack64/lapack64.go
@@ -420,6 +420,18 @@ func Ggsvd3(jobU, jobV, jobQ lapack.GSVDJob, a, b blas64.General, alpha, beta []
 	return lapack64.Dggsvd3(jobU, jobV, jobQ, a.Rows, a.Cols, b.Rows, a.Data, max(1, a.Stride), b.Data, max(1, b.Stride), alpha, beta, u.Data, max(1, u.Stride), v.Data, max(1, v.Stride), q.Data, max(1, q.Stride), work, lwork, iwork)
 }
 
+// Lagtm performs one of the matrix-matrix operations
+//  C = alpha * A * B + beta * C   if trans == blas.NoTrans
+//  C = alpha * Aᵀ * B + beta * C  if trans == blas.Trans or blas.ConjTrans
+// where A is an m×m tridiagonal matrix represented by its diagonals dl, d, du,
+// B and C are m×n dense matrices, and alpha and beta are scalars.
+//
+// Dlagtm is not part of the lapack.Float64 interface and so calls to Lagtm are
+// always executed by the Gonum implementation.
+func Lagtm(trans blas.Transpose, alpha float64, a Tridiagonal, b blas64.General, beta float64, c blas64.General) {
+	gonum.Implementation{}.Dlagtm(trans, c.Rows, c.Cols, alpha, a.DL, a.D, a.DU, b.Data, max(1, b.Stride), beta, c.Data, max(1, c.Stride))
+}
+
 // Lange computes the matrix norm of the general m×n matrix A. The input norm
 // specifies the norm computed.
 //  lapack.MaxAbs: the maximum absolute value of an element.

--- a/lapack/testlapack/dlagtm.go
+++ b/lapack/testlapack/dlagtm.go
@@ -1,0 +1,127 @@
+// Copyright ©2020 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/exp/rand"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/blas64"
+	"gonum.org/v1/gonum/floats"
+	"gonum.org/v1/gonum/lapack"
+)
+
+type Dlagtmer interface {
+	Dlagtm(trans blas.Transpose, m, n int, alpha float64, dl, d, du []float64, b []float64, ldb int, beta float64, c []float64, ldc int)
+}
+
+func DlagtmTest(t *testing.T, impl Dlagtmer) {
+	rnd := rand.New(rand.NewSource(1))
+	for _, trans := range []blas.Transpose{blas.NoTrans, blas.Trans, blas.ConjTrans} {
+		t.Run(transToString(trans), func(t *testing.T) {
+			for _, m := range []int{0, 1, 2, 3, 4, 5, 10} {
+				for _, n := range []int{0, 1, 2, 3, 4, 5, 10} {
+					for _, ldb := range []int{max(1, n), n + 3} {
+						for _, ldc := range []int{max(1, n), n + 4} {
+							for _, alpha := range []float64{0, 1, rnd.NormFloat64()} {
+								for _, beta := range []float64{0, 1, rnd.NormFloat64()} {
+									dlagtmTest(t, impl, rnd, trans, m, n, ldb, ldc, alpha, beta)
+								}
+							}
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func dlagtmTest(t *testing.T, impl Dlagtmer, rnd *rand.Rand, trans blas.Transpose, m, n int, ldb, ldc int, alpha, beta float64) {
+	const (
+		tol   = 1e-14
+		extra = 10
+	)
+
+	name := fmt.Sprintf("Case m=%v,n=%v,ldb=%v,ldc=%v,alpha=%v,beta=%v", m, n, ldb, ldc, alpha, beta)
+
+	// Generate three random diagonals.
+	dl := randomSlice(n+extra, rnd)
+	dlCopy := make([]float64, len(dl))
+	copy(dlCopy, dl)
+
+	d := randomSlice(n+1+extra, rnd)
+	dCopy := make([]float64, len(d))
+	copy(dCopy, d)
+
+	du := randomSlice(n+extra, rnd)
+	duCopy := make([]float64, len(du))
+	copy(duCopy, du)
+
+	b := randomGeneral(m, n, ldb, rnd)
+	bCopy := cloneGeneral(b)
+
+	got := randomGeneral(m, n, ldc, rnd)
+	want := cloneGeneral(got)
+
+	// Deal with zero-sized matrices early.
+	if m == 0 || n == 0 {
+		impl.Dlagtm(trans, m, n, alpha, dl, d, du, b.Data, b.Stride, beta, got.Data, got.Stride)
+		if !floats.Same(dl, dlCopy) {
+			t.Errorf("%v: unexpected modification in dl", name)
+		}
+		if !floats.Same(d, dCopy) {
+			t.Errorf("%v: unexpected modification in d", name)
+		}
+		if !floats.Same(du, duCopy) {
+			t.Errorf("%v: unexpected modification in du", name)
+		}
+		if !floats.Same(b.Data, bCopy.Data) {
+			t.Errorf("%v: unexpected modification in B", name)
+		}
+		if !floats.Same(got.Data, want.Data) {
+			t.Errorf("%v: unexpected modification in C", name)
+		}
+		return
+	}
+
+	impl.Dlagtm(trans, m, n, alpha, dl, d, du, b.Data, b.Stride, beta, got.Data, got.Stride)
+
+	if !floats.Same(dl, dlCopy) {
+		t.Errorf("%v: unexpected modification in dl", name)
+	}
+	if !floats.Same(d, dCopy) {
+		t.Errorf("%v: unexpected modification in d", name)
+	}
+	if !floats.Same(du, duCopy) {
+		t.Errorf("%v: unexpected modification in du", name)
+	}
+	if !floats.Same(b.Data, bCopy.Data) {
+		t.Errorf("%v: unexpected modification in B", name)
+	}
+
+	// Generate a dense representation of the matrix and compute the wanted result.
+	a := zeros(m, m, m)
+	for i := 0; i < m-1; i++ {
+		a.Data[i*a.Stride+i] = d[i]
+		a.Data[i*a.Stride+i+1] = du[i]
+		a.Data[(i+1)*a.Stride+i] = dl[i]
+	}
+	a.Data[(m-1)*a.Stride+m-1] = d[m-1]
+
+	blas64.Gemm(trans, blas.NoTrans, alpha, a, b, beta, want)
+
+	for i := 0; i < m; i++ {
+		for j := 0; j < n; j++ {
+			got.Data[i*got.Stride+j] -= want.Data[i*want.Stride+j]
+		}
+	}
+	diff := dlange(lapack.MaxColumnSum, got.Rows, got.Cols, got.Data, got.Stride)
+	if diff > tol {
+		t.Errorf("%v: unexpected result; diff=%v, want<=%v", name, diff, tol)
+	}
+}


### PR DESCRIPTION
This is just a draft for now because:

* `Dlagtm` takes a `trans` parameter but with the tridiagonal matrices the caller can easily handle tranposes by swapping the arguments for `dl` and `du`. This is actually what the solve/factorization calls like `Dgtsv` et al. do, they don't take a `trans` parameter. Since Lapacke doesn't wrap this call anyway, we have more freedom of departing from the Lapack interface for tridiagonal matrices (which feels like it didn't receive much attention anyway) and remove the parameter here.
* Lapack's `DLAGTM` assumes that `alpha` and `beta` are in `{-1,0,1}` but I don't see a reason to not support any values. This would be another deviation from the reference Lapack. I think we should do it but would like to check first.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
