### PR TITLE
Prevent possibility of panic in self-referential graphs

### DIFF
--- a/graph/encoding/dot/decode.go
+++ b/graph/encoding/dot/decode.go
@@ -84,7 +84,7 @@ func copyGraph(dst encoding.Builder, src *ast.Graph) (err error) {
 		case error:
 			err = e
 		default:
-			panic(e)
+			err = fmt.Errorf(fmt.Sprintf("error decoding graph %s", e))
 		}
 	}()
 	gen := &simpleGraph{

--- a/graph/encoding/dot/decode_test.go
+++ b/graph/encoding/dot/decode_test.go
@@ -393,6 +393,19 @@ func TestMultigraphDecoding(t *testing.T) {
 	}
 }
 
+func TestSelfReference(t *testing.T) {
+	var dst encoding.Builder = simple.NewDirectedGraph()
+
+	err := Unmarshal([]byte(selfReferentialGraph), dst)
+	if err == nil || err.Error() != "error decoding graph simple: adding self edge" {
+		t.Errorf("got unexpected error '%s'", err)
+	}
+}
+
+const selfReferentialGraph = `digraph {
+	1 -> 1
+}`
+
 const directedMultigraph = `digraph {
 	// Node definitions.
 	0;


### PR DESCRIPTION
Decoding can panic in self-referential graphs. This panic is not caught. Since graphs may be untrusted input, this is dangerous.

This PR replaces the panic with an error.