### PR TITLE
graph/encoding/dot: don't propagate edge setting panics when unmarshaling DOT

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2.3.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.28

--- a/graph/encoding/dot/decode.go
+++ b/graph/encoding/dot/decode.go
@@ -275,6 +275,16 @@ func applyPortsToEdge(from ast.Vertex, to *ast.Edge, edge basicEdge) {
 func (gen *simpleGraph) addEdgeStmt(dst encoding.Builder, stmt *ast.EdgeStmt) {
 	fs := gen.addVertex(dst, stmt.From)
 	ts := gen.addEdge(dst, stmt.To, stmt.Attrs)
+	defer func() {
+		switch e := recover().(type) {
+		case nil:
+			// Do nothing.
+		case error:
+			panic(e)
+		default:
+			panic(fmt.Errorf("panic setting edge: %v", e))
+		}
+	}()
 	for _, f := range fs {
 		for _, t := range ts {
 			edge := dst.NewEdge(f, t)


### PR DESCRIPTION
This is a counter proposal for #1503 

Please take a look.

Closes #1503 

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
