### PR TITLE
dsp/fourier,stat/samplemv: fix 32 bit architecture bugs

### DIFF
--- a/dsp/fourier/radix24_test.go
+++ b/dsp/fourier/radix24_test.go
@@ -10,6 +10,7 @@ import (
 	"math/bits"
 	"strconv"
 	"testing"
+	"unsafe"
 
 	"golang.org/x/exp/rand"
 
@@ -198,10 +199,12 @@ func TestReversePairs(t *testing.T) {
 // naiveReversePairs does a bit-pair reversal by formatting as a base-4 string,
 // reversing the digits of the formatted number and then re-parsing the value.
 func naiveReversePairs(x uint) uint {
+	bits := int(unsafe.Sizeof(uint(0)) * 8)
+
 	// Format the number as a quaternary, padded with zeros.
 	// We avoid the leftpad issue by doing it ourselves.
-	b := strconv.AppendUint(bytes.Repeat([]byte("0"), 32), uint64(x), 4)
-	b = b[len(b)-32:]
+	b := strconv.AppendUint(bytes.Repeat([]byte("0"), bits/2), uint64(x), 4)
+	b = b[len(b)-bits/2:]
 
 	// Reverse the quits.
 	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {

--- a/stat/samplemv/halton.go
+++ b/stat/samplemv/halton.go
@@ -63,18 +63,18 @@ func halton(batch *mat.Dense, kind HaltonKind, q distmv.Quantiler, src rand.Sour
 	case Owen:
 		for j := 0; j < d; j++ {
 			b := nthPrime(j)
-			div := 1
+			div := int64(1)
 			b2r := 1 / float64(b)
 			for 1-b2r < 1 {
 				p := perm(b)
 				for i := 0; i < n; i++ {
-					dig := (i / div) % b
+					dig := (int64(i) / div) % int64(b)
 					pdig := float64(p[dig])
 					v := batch.At(i, j)
 					v += pdig * b2r
 					batch.Set(i, j, v)
 				}
-				div *= b
+				div *= int64(b)
 				b2r /= float64(b)
 			}
 		}


### PR DESCRIPTION
The Halton fix is pretty hacky, but I've spent a fair bit of time looking through the Halton code and the R original and I'm not completely happy with my understanding of the relationship between the two (input from @btracey would be helpful here). I also think that the behaviour of the R code depends on R's sloppy behaviour in implicitly converting between `double` and `integer` types and allowing the use of `double` values to index into arrays.

Please take a look.

Updates #1444

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
