### PR TITLE
graph/path: allow incremental Bellman-Ford search

### DIFF
--- a/graph/path/bellman_ford_moore.go
+++ b/graph/path/bellman_ford_moore.go
@@ -7,17 +7,32 @@ package path
 import (
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/linear"
+	"gonum.org/v1/gonum/graph/traverse"
 )
 
 // BellmanFordFrom returns a shortest-path tree for a shortest path from u to all nodes in
 // the graph g, or false indicating that a negative cycle exists in the graph. If the graph
 // does not implement Weighted, UniformCost is used.
 //
+// If g is a graph.Graph, all nodes of the graph will be stored in the shortest-path
+// tree, otherwise only nodes reachable from u will be stored.
+//
 // The time complexity of BellmanFordFrom is O(|V|.|E|).
-func BellmanFordFrom(u graph.Node, g graph.Graph) (path Shortest, ok bool) {
-	if g.Node(u.ID()) == nil {
-		return Shortest{from: u}, true
+func BellmanFordFrom(u graph.Node, g traverse.Graph) (path Shortest, ok bool) {
+	if h, ok := g.(graph.Graph); ok {
+		if h.Node(u.ID()) == nil {
+			return Shortest{from: u}, true
+		}
+		path = newShortestFrom(u, graph.NodesOf(h.Nodes()))
+	} else {
+		if g.From(u.ID()) == graph.Empty {
+			return Shortest{from: u}, true
+		}
+		path = newShortestFrom(u, []graph.Node{u})
 	}
+	path.dist[path.indexOf[u.ID()]] = 0
+	path.negCosts = make(map[negEdge]float64)
+
 	var weight Weighting
 	if wg, ok := g.(Weighted); ok {
 		weight = wg.Weight
@@ -25,27 +40,15 @@ func BellmanFordFrom(u graph.Node, g graph.Graph) (path Shortest, ok bool) {
 		weight = UniformCost(g)
 	}
 
-	nodes := graph.NodesOf(g.Nodes())
-
-	path = newShortestFrom(u, nodes)
-	path.dist[path.indexOf[u.ID()]] = 0
-	path.negCosts = make(map[negEdge]float64)
-
 	// Queue to keep track which nodes need to be relaxed.
 	// Only nodes whose vertex distance changed in the previous iterations
 	// need to be relaxed again.
 	queue := newBellmanFordQueue(path.indexOf)
 	queue.enqueue(u)
 
-	// The maximum number of edges in a graph is |V| * (|V|-1) which is also
-	// the worst case complexity.
-	// If the queue-loop has more iterations than the maximum number of edges
-	// it indicates that we have a negative cycle.
-	maxEdges := int64(len(nodes)) * int64(len(nodes)-1)
-	var loops int64
-
 	// TODO(kortschak): Consider adding further optimisations
 	// from http://arxiv.org/abs/1111.5414.
+	var loops int64
 	for queue.len() != 0 {
 		u := queue.dequeue()
 		uid := u.ID()
@@ -55,7 +58,10 @@ func BellmanFordFrom(u graph.Node, g graph.Graph) (path Shortest, ok bool) {
 		for to.Next() {
 			v := to.Node()
 			vid := v.ID()
-			k := path.indexOf[vid]
+			k, ok := path.indexOf[vid]
+			if !ok {
+				k = path.add(v)
+			}
 			w, ok := weight(uid, vid)
 			if !ok {
 				panic("bellman-ford: unexpected invalid weight")
@@ -71,6 +77,10 @@ func BellmanFordFrom(u graph.Node, g graph.Graph) (path Shortest, ok bool) {
 			}
 		}
 
+		// The maximum number of edges in the relaxed subgraph is |V_r| * (|V_r|-1).
+		// If the queue-loop has more iterations than the maximum number of edges
+		// it indicates that we have a negative cycle.
+		maxEdges := int64(len(path.nodes)) * int64(len(path.nodes)-1)
 		if loops > maxEdges {
 			path.hasNegativeCycle = true
 			return path, false
@@ -85,11 +95,25 @@ func BellmanFordFrom(u graph.Node, g graph.Graph) (path Shortest, ok bool) {
 // the graph g, or false indicating that a negative cycle exists in the graph. If the graph
 // does not implement Weighted, UniformCost is used.
 //
+// If g is a graph.Graph, all nodes of the graph will be stored in the shortest-path
+// tree, otherwise only nodes reachable from u will be stored.
+//
 // The time complexity of BellmanFordAllFrom is O(|V|.|E|).
-func BellmanFordAllFrom(u graph.Node, g graph.Graph) (path ShortestAlts, ok bool) {
-	if g.Node(u.ID()) == nil {
-		return ShortestAlts{from: u}, true
+func BellmanFordAllFrom(u graph.Node, g traverse.Graph) (path ShortestAlts, ok bool) {
+	if h, ok := g.(graph.Graph); ok {
+		if h.Node(u.ID()) == nil {
+			return ShortestAlts{from: u}, true
+		}
+		path = newShortestAltsFrom(u, graph.NodesOf(h.Nodes()))
+	} else {
+		if g.From(u.ID()) == graph.Empty {
+			return ShortestAlts{from: u}, true
+		}
+		path = newShortestAltsFrom(u, []graph.Node{u})
 	}
+	path.dist[path.indexOf[u.ID()]] = 0
+	path.negCosts = make(map[negEdge]float64)
+
 	var weight Weighting
 	if wg, ok := g.(Weighted); ok {
 		weight = wg.Weight
@@ -97,27 +121,15 @@ func BellmanFordAllFrom(u graph.Node, g graph.Graph) (path ShortestAlts, ok bool
 		weight = UniformCost(g)
 	}
 
-	nodes := graph.NodesOf(g.Nodes())
-
-	path = newShortestAltsFrom(u, nodes)
-	path.dist[path.indexOf[u.ID()]] = 0
-	path.negCosts = make(map[negEdge]float64)
-
 	// Queue to keep track which nodes need to be relaxed.
 	// Only nodes whose vertex distance changed in the previous iterations
 	// need to be relaxed again.
 	queue := newBellmanFordQueue(path.indexOf)
 	queue.enqueue(u)
 
-	// The maximum number of edges in a graph is |V| * (|V|-1) which is also
-	// the worst case complexity.
-	// If the queue-loop has more iterations than the maximum number of edges
-	// it indicates that we have a negative cycle.
-	maxEdges := int64(len(nodes)) * int64(len(nodes)-1)
-	var loops int64
-
 	// TODO(kortschak): Consider adding further optimisations
 	// from http://arxiv.org/abs/1111.5414.
+	var loops int64
 	for queue.len() != 0 {
 		u := queue.dequeue()
 		uid := u.ID()
@@ -125,7 +137,10 @@ func BellmanFordAllFrom(u graph.Node, g graph.Graph) (path ShortestAlts, ok bool
 
 		for _, v := range graph.NodesOf(g.From(uid)) {
 			vid := v.ID()
-			k := path.indexOf[vid]
+			k, ok := path.indexOf[vid]
+			if !ok {
+				k = path.add(v)
+			}
 			w, ok := weight(uid, vid)
 			if !ok {
 				panic("bellman-ford: unexpected invalid weight")
@@ -143,6 +158,10 @@ func BellmanFordAllFrom(u graph.Node, g graph.Graph) (path ShortestAlts, ok bool
 			}
 		}
 
+		// The maximum number of edges in the relaxed subgraph is |V_r| * (|V_r|-1).
+		// If the queue-loop has more iterations than the maximum number of edges
+		// it indicates that we have a negative cycle.
+		maxEdges := int64(len(path.nodes)) * int64(len(path.nodes)-1)
 		if loops > maxEdges {
 			path.hasNegativeCycle = true
 			return path, false
@@ -167,9 +186,20 @@ type bellmanFordQueue struct {
 
 // enqueue adds a node to the bellmanFordQueue.
 func (q *bellmanFordQueue) enqueue(n graph.Node) {
-	i := q.indexOf[n.ID()]
-	if q.onQueue[i] {
-		panic("bellman-ford: already queued")
+	i, ok := q.indexOf[n.ID()]
+	switch {
+	case !ok:
+		panic("bellman-ford: unknown node")
+	case i < len(q.onQueue):
+		if q.onQueue[i] {
+			panic("bellman-ford: already queued")
+		}
+	case i == len(q.onQueue):
+		q.onQueue = append(q.onQueue, false)
+	case i < cap(q.onQueue):
+		q.onQueue = q.onQueue[:i+1]
+	default:
+		q.onQueue = append(q.onQueue, make([]bool, i-len(q.onQueue)+1)...)
 	}
 	q.onQueue[i] = true
 	q.queue.Enqueue(n)
@@ -186,7 +216,13 @@ func (q *bellmanFordQueue) dequeue() graph.Node {
 func (q *bellmanFordQueue) len() int { return q.queue.Len() }
 
 // has returns whether a node with the given id is in the queue.
-func (q bellmanFordQueue) has(id int64) bool { return q.onQueue[q.indexOf[id]] }
+func (q bellmanFordQueue) has(id int64) bool {
+	idx, ok := q.indexOf[id]
+	if !ok || idx >= len(q.onQueue) {
+		return false
+	}
+	return q.onQueue[idx]
+}
 
 // newBellmanFordQueue creates a new bellmanFordQueue.
 func newBellmanFordQueue(indexOf map[int64]int) bellmanFordQueue {

--- a/graph/path/bellman_ford_moore_test.go
+++ b/graph/path/bellman_ford_moore_test.go
@@ -13,6 +13,7 @@ import (
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/path/internal/testgraphs"
+	"gonum.org/v1/gonum/graph/traverse"
 )
 
 func TestBellmanFordFrom(t *testing.T) {
@@ -23,49 +24,57 @@ func TestBellmanFordFrom(t *testing.T) {
 			g.SetWeightedEdge(e)
 		}
 
-		pt, ok := BellmanFordFrom(test.Query.From(), g.(graph.Graph))
-		if test.HasNegativeCycle {
-			if ok {
-				t.Errorf("%q: expected negative cycle", test.Name)
+		for _, tg := range []struct {
+			typ string
+			g   traverse.Graph
+		}{
+			{"complete", g.(graph.Graph)},
+			{"incremental", incremental{g.(graph.Weighted)}},
+		} {
+			pt, ok := BellmanFordFrom(test.Query.From(), tg.g)
+			if test.HasNegativeCycle {
+				if ok {
+					t.Errorf("%q %s: expected negative cycle", test.Name, tg.typ)
+				}
+			} else if !ok {
+				t.Fatalf("%q %s: unexpected negative cycle", test.Name, tg.typ)
 			}
-		} else if !ok {
-			t.Fatalf("%q: unexpected negative cycle", test.Name)
-		}
 
-		if pt.From().ID() != test.Query.From().ID() {
-			t.Fatalf("%q: unexpected from node ID: got:%d want:%d", test.Name, pt.From().ID(), test.Query.From().ID())
-		}
-
-		p, weight := pt.To(test.Query.To().ID())
-		if weight != test.Weight {
-			t.Errorf("%q: unexpected weight from To: got:%f want:%f",
-				test.Name, weight, test.Weight)
-		}
-		if weight := pt.WeightTo(test.Query.To().ID()); !math.IsInf(test.Weight, -1) && weight != test.Weight {
-			t.Errorf("%q: unexpected weight from Weight: got:%f want:%f",
-				test.Name, weight, test.Weight)
-		}
-
-		var got []int64
-		for _, n := range p {
-			got = append(got, n.ID())
-		}
-		ok = len(got) == 0 && len(test.WantPaths) == 0
-		for _, sp := range test.WantPaths {
-			if reflect.DeepEqual(got, sp) {
-				ok = true
-				break
+			if pt.From().ID() != test.Query.From().ID() {
+				t.Fatalf("%q %s: unexpected from node ID: got:%d want:%d", test.Name, tg.typ, pt.From().ID(), test.Query.From().ID())
 			}
-		}
-		if !ok {
-			t.Errorf("%q: unexpected shortest path:\ngot: %v\nwant from:%v",
-				test.Name, p, test.WantPaths)
-		}
 
-		np, weight := pt.To(test.NoPathFor.To().ID())
-		if pt.From().ID() == test.NoPathFor.From().ID() && (np != nil || !math.IsInf(weight, 1)) {
-			t.Errorf("%q: unexpected path:\ngot: path=%v weight=%f\nwant:path=<nil> weight=+Inf",
-				test.Name, np, weight)
+			p, weight := pt.To(test.Query.To().ID())
+			if weight != test.Weight {
+				t.Errorf("%q %s: unexpected weight from To: got:%f want:%f",
+					test.Name, tg.typ, weight, test.Weight)
+			}
+			if weight := pt.WeightTo(test.Query.To().ID()); !math.IsInf(test.Weight, -1) && weight != test.Weight {
+				t.Errorf("%q %s: unexpected weight from Weight: got:%f want:%f",
+					test.Name, tg.typ, weight, test.Weight)
+			}
+
+			var got []int64
+			for _, n := range p {
+				got = append(got, n.ID())
+			}
+			ok = len(got) == 0 && len(test.WantPaths) == 0
+			for _, sp := range test.WantPaths {
+				if reflect.DeepEqual(got, sp) {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				t.Errorf("%q %s: unexpected shortest path:\ngot: %v\nwant from:%v",
+					test.Name, tg.typ, p, test.WantPaths)
+			}
+
+			np, weight := pt.To(test.NoPathFor.To().ID())
+			if pt.From().ID() == test.NoPathFor.From().ID() && (np != nil || !math.IsInf(weight, 1)) {
+				t.Errorf("%q %s: unexpected path:\ngot: path=%v weight=%f\nwant:path=<nil> weight=+Inf",
+					test.Name, tg.typ, np, weight)
+			}
 		}
 	}
 }
@@ -78,88 +87,96 @@ func TestBellmanFordAllFrom(t *testing.T) {
 			g.SetWeightedEdge(e)
 		}
 
-		pt, ok := BellmanFordAllFrom(test.Query.From(), g.(graph.Graph))
-		if test.HasNegativeCycle {
-			if ok {
-				t.Errorf("%q: expected negative cycle", test.Name)
+		for _, tg := range []struct {
+			typ string
+			g   traverse.Graph
+		}{
+			{"complete", g.(graph.Graph)},
+			{"incremental", incremental{g.(graph.Weighted)}},
+		} {
+			pt, ok := BellmanFordAllFrom(test.Query.From(), tg.g)
+			if test.HasNegativeCycle {
+				if ok {
+					t.Errorf("%q %s: expected negative cycle", test.Name, tg.typ)
+				}
+			} else if !ok {
+				t.Fatalf("%q %s: unexpected negative cycle", test.Name, tg.typ)
 			}
-		} else if !ok {
-			t.Fatalf("%q: unexpected negative cycle", test.Name)
-		}
 
-		if pt.From().ID() != test.Query.From().ID() {
-			t.Fatalf("%q: unexpected from node ID: got:%d want:%d", test.Name, pt.From().ID(), test.Query.From().ID())
-		}
-
-		// Test single path results.
-		p, weight, unique := pt.To(test.Query.To().ID())
-		if weight != test.Weight {
-			t.Errorf("%q: unexpected weight from To: got:%f want:%f",
-				test.Name, weight, test.Weight)
-		}
-		if weight := pt.WeightTo(test.Query.To().ID()); !math.IsInf(test.Weight, -1) && weight != test.Weight {
-			t.Errorf("%q: unexpected weight from Weight: got:%f want:%f",
-				test.Name, weight, test.Weight)
-		}
-
-		var gotPath []int64
-		for _, n := range p {
-			gotPath = append(gotPath, n.ID())
-		}
-		ok = len(gotPath) == 0 && len(test.WantPaths) == 0
-		for _, sp := range test.WantPaths {
-			if reflect.DeepEqual(gotPath, sp) {
-				ok = true
-				break
+			if pt.From().ID() != test.Query.From().ID() {
+				t.Fatalf("%q %s: unexpected from node ID: got:%d want:%d", test.Name, tg.typ, pt.From().ID(), test.Query.From().ID())
 			}
-		}
-		if !ok {
-			t.Errorf("%q: unexpected shortest path:\ngot: %v\nwant from:%v",
-				test.Name, p, test.WantPaths)
-		}
-		if unique != test.HasUniquePath {
-			t.Errorf("%q: unexpected uniqueness from To: got:%t want:%t (%d paths)",
-				test.Name, unique, test.HasUniquePath, len(test.WantPaths))
-		}
 
-		// Test multiple path results.
-		paths, weight := pt.AllTo(test.Query.To().ID())
-		if weight != test.Weight {
-			t.Errorf("%q: unexpected weight from AllTo: got:%f want:%f",
-				test.Name, weight, test.Weight)
-		}
-		if weight := pt.WeightTo(test.Query.To().ID()); !math.IsInf(test.Weight, -1) && weight != test.Weight {
-			t.Errorf("%q: unexpected weight from Weight: got:%f want:%f",
-				test.Name, weight, test.Weight)
-		}
+			// Test single path results.
+			p, weight, unique := pt.To(test.Query.To().ID())
+			if weight != test.Weight {
+				t.Errorf("%q %s: unexpected weight from To: got:%f want:%f",
+					test.Name, tg.typ, weight, test.Weight)
+			}
+			if weight := pt.WeightTo(test.Query.To().ID()); !math.IsInf(test.Weight, -1) && weight != test.Weight {
+				t.Errorf("%q %s: unexpected weight from Weight: got:%f want:%f",
+					test.Name, tg.typ, weight, test.Weight)
+			}
 
-		var gotPaths [][]int64
-		if len(paths) != 0 {
-			gotPaths = make([][]int64, len(paths))
-		}
-		for i, p := range paths {
-			for _, v := range p {
-				gotPaths[i] = append(gotPaths[i], v.ID())
+			var gotPath []int64
+			for _, n := range p {
+				gotPath = append(gotPath, n.ID())
 			}
-		}
-		if test.HasNegativeCycleInPath {
-			if gotPaths != nil {
-				t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant: []",
-					test.Name, gotPaths)
+			ok = len(gotPath) == 0 && len(test.WantPaths) == 0
+			for _, sp := range test.WantPaths {
+				if reflect.DeepEqual(gotPath, sp) {
+					ok = true
+					break
+				}
 			}
-		} else {
-			sort.Sort(ordered.BySliceValues(gotPaths))
-			if !reflect.DeepEqual(gotPaths, test.WantPaths) {
-				t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
-					test.Name, gotPaths, test.WantPaths)
+			if !ok {
+				t.Errorf("%q %s: unexpected shortest path:\ngot: %v\nwant from:%v",
+					test.Name, tg.typ, p, test.WantPaths)
 			}
-		}
+			if unique != test.HasUniquePath {
+				t.Errorf("%q %s: unexpected uniqueness from To: got:%t want:%t (%d paths)",
+					test.Name, tg.typ, unique, test.HasUniquePath, len(test.WantPaths))
+			}
 
-		// Test absent paths.
-		np, weight, unique := pt.To(test.NoPathFor.To().ID())
-		if pt.From().ID() == test.NoPathFor.From().ID() && !(np == nil && math.IsInf(weight, 1) && !unique) {
-			t.Errorf("%q: unexpected path:\ngot: path=%v weight=%f unique=%t\nwant:path=<nil> weight=+Inf unique=false",
-				test.Name, np, weight, unique)
+			// Test multiple path results.
+			paths, weight := pt.AllTo(test.Query.To().ID())
+			if weight != test.Weight {
+				t.Errorf("%q %s: unexpected weight from AllTo: got:%f want:%f",
+					test.Name, tg.typ, weight, test.Weight)
+			}
+			if weight := pt.WeightTo(test.Query.To().ID()); !math.IsInf(test.Weight, -1) && weight != test.Weight {
+				t.Errorf("%q %s: unexpected weight from Weight: got:%f want:%f",
+					test.Name, tg.typ, weight, test.Weight)
+			}
+
+			var gotPaths [][]int64
+			if len(paths) != 0 {
+				gotPaths = make([][]int64, len(paths))
+			}
+			for i, p := range paths {
+				for _, v := range p {
+					gotPaths[i] = append(gotPaths[i], v.ID())
+				}
+			}
+			if test.HasNegativeCycleInPath {
+				if gotPaths != nil {
+					t.Errorf("testing %q %s: unexpected shortest paths:\ngot: %v\nwant: []",
+						test.Name, tg.typ, gotPaths)
+				}
+			} else {
+				sort.Sort(ordered.BySliceValues(gotPaths))
+				if !reflect.DeepEqual(gotPaths, test.WantPaths) {
+					t.Errorf("testing %q %s: unexpected shortest paths:\ngot: %v\nwant:%v",
+						test.Name, tg.typ, gotPaths, test.WantPaths)
+				}
+			}
+
+			// Test absent paths.
+			np, weight, unique := pt.To(test.NoPathFor.To().ID())
+			if pt.From().ID() == test.NoPathFor.From().ID() && !(np == nil && math.IsInf(weight, 1) && !unique) {
+				t.Errorf("%q %s: unexpected path:\ngot: path=%v weight=%f unique=%t\nwant:path=<nil> weight=+Inf unique=false",
+					test.Name, tg.typ, np, weight, unique)
+			}
 		}
 	}
 }

--- a/graph/path/bench_test.go
+++ b/graph/path/bench_test.go
@@ -12,6 +12,7 @@ import (
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/graphs/gen"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/graph/traverse"
 )
 
 var (
@@ -170,11 +171,22 @@ func BenchmarkBellmanFordFrom(b *testing.B) {
 		{"2000 full", gnpDirected_2000_full()},
 	}
 
+	type incremental struct {
+		traverse.Graph
+	}
 	for _, bm := range benchmarks {
-		b.Run(bm.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				BellmanFordFrom(bm.graph.Node(0), bm.graph)
-			}
-		})
+		for _, tg := range []struct {
+			typ string
+			g   traverse.Graph
+		}{
+			{g: bm.graph},
+			{typ: " incremental", g: incremental{bm.graph}},
+		} {
+			b.Run(bm.name+tg.typ, func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					BellmanFordFrom(bm.graph.Node(0), tg.g)
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
This completes something that I had intended to do a couple of years ago (#486), but thought wasn't efficiently feasible. It is.

This makes time limited Bellman-Ford searches a possibility (this is used for example in routing decisions where there is a limited amount of time allocated to finding the best route).

Please take a look.

\<thinks\>Maybe A* is possible\</thinks\>

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
