### PR TITLE
cmplxs,floats,internal/asm: don't use global rand state

### DIFF
--- a/cmplxs/cmplxs_test.go
+++ b/cmplxs/cmplxs_test.go
@@ -1108,17 +1108,19 @@ func TestSum(t *testing.T) {
 	}
 }
 
-func randomSlice(l int) []complex128 {
+func randomSlice(l int, src rand.Source) []complex128 {
+	rnd := rand.New(src)
 	s := make([]complex128, l)
 	for i := range s {
-		s[i] = complex(rand.Float64(), rand.Float64())
+		s[i] = complex(rnd.Float64(), rnd.Float64())
 	}
 	return s
 }
 
 func benchmarkAdd(b *testing.B, size int) {
-	s1 := randomSlice(size)
-	s2 := randomSlice(size)
+	src := rand.NewSource(1)
+	s1 := randomSlice(size, src)
+	s2 := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Add(s1, s2)
@@ -1130,9 +1132,10 @@ func BenchmarkAddLarge(b *testing.B) { benchmarkAdd(b, Large) }
 func BenchmarkAddHuge(b *testing.B)  { benchmarkAdd(b, Huge) }
 
 func benchmarkAddTo(b *testing.B, size int) {
-	s1 := randomSlice(size)
-	s2 := randomSlice(size)
-	dst := randomSlice(size)
+	src := rand.NewSource(1)
+	s1 := randomSlice(size, src)
+	s2 := randomSlice(size, src)
+	dst := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		AddTo(dst, s1, s2)
@@ -1144,8 +1147,9 @@ func BenchmarkAddToLarge(b *testing.B) { benchmarkAddTo(b, Large) }
 func BenchmarkAddToHuge(b *testing.B)  { benchmarkAddTo(b, Huge) }
 
 func benchmarkCumProd(b *testing.B, size int) {
-	s := randomSlice(size)
-	dst := randomSlice(size)
+	src := rand.NewSource(1)
+	s := randomSlice(size, src)
+	dst := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		CumProd(dst, s)
@@ -1157,8 +1161,9 @@ func BenchmarkCumProdLarge(b *testing.B) { benchmarkCumProd(b, Large) }
 func BenchmarkCumProdHuge(b *testing.B)  { benchmarkCumProd(b, Huge) }
 
 func benchmarkCumSum(b *testing.B, size int) {
-	s := randomSlice(size)
-	dst := randomSlice(size)
+	src := rand.NewSource(1)
+	s := randomSlice(size, src)
+	dst := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		CumSum(dst, s)
@@ -1170,8 +1175,9 @@ func BenchmarkCumSumLarge(b *testing.B) { benchmarkCumSum(b, Large) }
 func BenchmarkCumSumHuge(b *testing.B)  { benchmarkCumSum(b, Huge) }
 
 func benchmarkDiv(b *testing.B, size int) {
-	s := randomSlice(size)
-	dst := randomSlice(size)
+	src := rand.NewSource(1)
+	s := randomSlice(size, src)
+	dst := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Div(dst, s)
@@ -1183,9 +1189,10 @@ func BenchmarkDivLarge(b *testing.B) { benchmarkDiv(b, Large) }
 func BenchmarkDivHuge(b *testing.B)  { benchmarkDiv(b, Huge) }
 
 func benchmarkDivTo(b *testing.B, size int) {
-	s1 := randomSlice(size)
-	s2 := randomSlice(size)
-	dst := randomSlice(size)
+	src := rand.NewSource(1)
+	s1 := randomSlice(size, src)
+	s2 := randomSlice(size, src)
+	dst := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		DivTo(dst, s1, s2)
@@ -1197,8 +1204,9 @@ func BenchmarkDivToLarge(b *testing.B) { benchmarkDivTo(b, Large) }
 func BenchmarkDivToHuge(b *testing.B)  { benchmarkDivTo(b, Huge) }
 
 func benchmarkSub(b *testing.B, size int) {
-	s1 := randomSlice(size)
-	s2 := randomSlice(size)
+	src := rand.NewSource(1)
+	s1 := randomSlice(size, src)
+	s2 := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Sub(s1, s2)
@@ -1210,9 +1218,10 @@ func BenchmarkSubLarge(b *testing.B) { benchmarkSub(b, Large) }
 func BenchmarkSubHuge(b *testing.B)  { benchmarkSub(b, Huge) }
 
 func benchmarkSubTo(b *testing.B, size int) {
-	s1 := randomSlice(size)
-	s2 := randomSlice(size)
-	dst := randomSlice(size)
+	src := rand.NewSource(1)
+	s1 := randomSlice(size, src)
+	s2 := randomSlice(size, src)
+	dst := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		SubTo(dst, s1, s2)
@@ -1224,8 +1233,9 @@ func BenchmarkSubToLarge(b *testing.B) { benchmarkSubTo(b, Large) }
 func BenchmarkSubToHuge(b *testing.B)  { benchmarkSubTo(b, Huge) }
 
 func benchmarkDot(b *testing.B, size int) {
-	s1 := randomSlice(size)
-	s2 := randomSlice(size)
+	src := rand.NewSource(1)
+	s1 := randomSlice(size, src)
+	s2 := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Dot(s1, s2)
@@ -1237,9 +1247,10 @@ func BenchmarkDotLarge(b *testing.B) { benchmarkDot(b, Large) }
 func BenchmarkDotHuge(b *testing.B)  { benchmarkDot(b, Huge) }
 
 func benchmarkAddScaledTo(b *testing.B, size int) {
-	dst := randomSlice(size)
-	y := randomSlice(size)
-	s := randomSlice(size)
+	src := rand.NewSource(1)
+	dst := randomSlice(size, src)
+	y := randomSlice(size, src)
+	s := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		AddScaledTo(dst, y, 2.3, s)
@@ -1251,7 +1262,8 @@ func BenchmarkAddScaledToLarge(b *testing.B)  { benchmarkAddScaledTo(b, Large) }
 func BenchmarkAddScaledToHuge(b *testing.B)   { benchmarkAddScaledTo(b, Huge) }
 
 func benchmarkScale(b *testing.B, size int) {
-	dst := randomSlice(size)
+	src := rand.NewSource(1)
+	dst := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i += 2 {
 		Scale(2.0, dst)
@@ -1264,7 +1276,8 @@ func BenchmarkScaleLarge(b *testing.B)  { benchmarkScale(b, Large) }
 func BenchmarkScaleHuge(b *testing.B)   { benchmarkScale(b, Huge) }
 
 func benchmarkNorm2(b *testing.B, size int) {
-	s := randomSlice(size)
+	src := rand.NewSource(1)
+	s := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Norm(s, 2)

--- a/floats/floats_test.go
+++ b/floats/floats_test.go
@@ -1576,16 +1576,18 @@ func TestSumCompensated(t *testing.T) {
 	}
 }
 
-func randomSlice(l int) []float64 {
+func randomSlice(l int, src rand.Source) []float64 {
+	rnd := rand.New(src)
 	s := make([]float64, l)
 	for i := range s {
-		s[i] = rand.Float64()
+		s[i] = rnd.Float64()
 	}
 	return s
 }
 
 func benchmarkMin(b *testing.B, size int) {
-	s := randomSlice(size)
+	src := rand.NewSource(1)
+	s := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Min(s)
@@ -1597,8 +1599,9 @@ func BenchmarkMinLarge(b *testing.B) { benchmarkMin(b, Large) }
 func BenchmarkMinHuge(b *testing.B)  { benchmarkMin(b, Huge) }
 
 func benchmarkAdd(b *testing.B, size int) {
-	s1 := randomSlice(size)
-	s2 := randomSlice(size)
+	src := rand.NewSource(1)
+	s1 := randomSlice(size, src)
+	s2 := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Add(s1, s2)
@@ -1610,9 +1613,10 @@ func BenchmarkAddLarge(b *testing.B) { benchmarkAdd(b, Large) }
 func BenchmarkAddHuge(b *testing.B)  { benchmarkAdd(b, Huge) }
 
 func benchmarkAddTo(b *testing.B, size int) {
-	s1 := randomSlice(size)
-	s2 := randomSlice(size)
-	dst := randomSlice(size)
+	src := rand.NewSource(1)
+	s1 := randomSlice(size, src)
+	s2 := randomSlice(size, src)
+	dst := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		AddTo(dst, s1, s2)
@@ -1624,8 +1628,9 @@ func BenchmarkAddToLarge(b *testing.B) { benchmarkAddTo(b, Large) }
 func BenchmarkAddToHuge(b *testing.B)  { benchmarkAddTo(b, Huge) }
 
 func benchmarkCumProd(b *testing.B, size int) {
-	s := randomSlice(size)
-	dst := randomSlice(size)
+	src := rand.NewSource(1)
+	s := randomSlice(size, src)
+	dst := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		CumProd(dst, s)
@@ -1637,8 +1642,9 @@ func BenchmarkCumProdLarge(b *testing.B) { benchmarkCumProd(b, Large) }
 func BenchmarkCumProdHuge(b *testing.B)  { benchmarkCumProd(b, Huge) }
 
 func benchmarkCumSum(b *testing.B, size int) {
-	s := randomSlice(size)
-	dst := randomSlice(size)
+	src := rand.NewSource(1)
+	s := randomSlice(size, src)
+	dst := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		CumSum(dst, s)
@@ -1650,8 +1656,9 @@ func BenchmarkCumSumLarge(b *testing.B) { benchmarkCumSum(b, Large) }
 func BenchmarkCumSumHuge(b *testing.B)  { benchmarkCumSum(b, Huge) }
 
 func benchmarkDiv(b *testing.B, size int) {
-	s := randomSlice(size)
-	dst := randomSlice(size)
+	src := rand.NewSource(1)
+	s := randomSlice(size, src)
+	dst := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Div(dst, s)
@@ -1663,9 +1670,10 @@ func BenchmarkDivLarge(b *testing.B) { benchmarkDiv(b, Large) }
 func BenchmarkDivHuge(b *testing.B)  { benchmarkDiv(b, Huge) }
 
 func benchmarkDivTo(b *testing.B, size int) {
-	s1 := randomSlice(size)
-	s2 := randomSlice(size)
-	dst := randomSlice(size)
+	src := rand.NewSource(1)
+	s1 := randomSlice(size, src)
+	s2 := randomSlice(size, src)
+	dst := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		DivTo(dst, s1, s2)
@@ -1677,8 +1685,9 @@ func BenchmarkDivToLarge(b *testing.B) { benchmarkDivTo(b, Large) }
 func BenchmarkDivToHuge(b *testing.B)  { benchmarkDivTo(b, Huge) }
 
 func benchmarkSub(b *testing.B, size int) {
-	s1 := randomSlice(size)
-	s2 := randomSlice(size)
+	src := rand.NewSource(1)
+	s1 := randomSlice(size, src)
+	s2 := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Sub(s1, s2)
@@ -1690,9 +1699,10 @@ func BenchmarkSubLarge(b *testing.B) { benchmarkSub(b, Large) }
 func BenchmarkSubHuge(b *testing.B)  { benchmarkSub(b, Huge) }
 
 func benchmarkSubTo(b *testing.B, size int) {
-	s1 := randomSlice(size)
-	s2 := randomSlice(size)
-	dst := randomSlice(size)
+	src := rand.NewSource(1)
+	s1 := randomSlice(size, src)
+	s2 := randomSlice(size, src)
+	dst := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		SubTo(dst, s1, s2)
@@ -1704,7 +1714,8 @@ func BenchmarkSubToLarge(b *testing.B) { benchmarkSubTo(b, Large) }
 func BenchmarkSubToHuge(b *testing.B)  { benchmarkSubTo(b, Huge) }
 
 func benchmarkLogSumExp(b *testing.B, size int) {
-	s := randomSlice(size)
+	src := rand.NewSource(1)
+	s := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		LogSumExp(s)
@@ -1716,8 +1727,9 @@ func BenchmarkLogSumExpLarge(b *testing.B) { benchmarkLogSumExp(b, Large) }
 func BenchmarkLogSumExpHuge(b *testing.B)  { benchmarkLogSumExp(b, Huge) }
 
 func benchmarkDot(b *testing.B, size int) {
-	s1 := randomSlice(size)
-	s2 := randomSlice(size)
+	src := rand.NewSource(1)
+	s1 := randomSlice(size, src)
+	s2 := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Dot(s1, s2)
@@ -1729,9 +1741,10 @@ func BenchmarkDotLarge(b *testing.B) { benchmarkDot(b, Large) }
 func BenchmarkDotHuge(b *testing.B)  { benchmarkDot(b, Huge) }
 
 func benchmarkAddScaledTo(b *testing.B, size int) {
-	dst := randomSlice(size)
-	y := randomSlice(size)
-	s := randomSlice(size)
+	src := rand.NewSource(1)
+	dst := randomSlice(size, src)
+	y := randomSlice(size, src)
+	s := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		AddScaledTo(dst, y, 2.3, s)
@@ -1743,7 +1756,8 @@ func BenchmarkAddScaledToLarge(b *testing.B)  { benchmarkAddScaledTo(b, Large) }
 func BenchmarkAddScaledToHuge(b *testing.B)   { benchmarkAddScaledTo(b, Huge) }
 
 func benchmarkScale(b *testing.B, size int) {
-	dst := randomSlice(size)
+	src := rand.NewSource(1)
+	dst := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i += 2 {
 		Scale(2.0, dst)
@@ -1756,7 +1770,8 @@ func BenchmarkScaleLarge(b *testing.B)  { benchmarkScale(b, Large) }
 func BenchmarkScaleHuge(b *testing.B)   { benchmarkScale(b, Huge) }
 
 func benchmarkNorm2(b *testing.B, size int) {
-	s := randomSlice(size)
+	src := rand.NewSource(1)
+	s := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Norm(s, 2)
@@ -1768,7 +1783,8 @@ func BenchmarkNorm2Large(b *testing.B)  { benchmarkNorm2(b, Large) }
 func BenchmarkNorm2Huge(b *testing.B)   { benchmarkNorm2(b, Huge) }
 
 func benchmarkSumCompensated(b *testing.B, size int) {
-	s := randomSlice(size)
+	src := rand.NewSource(1)
+	s := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		SumCompensated(s)
@@ -1781,7 +1797,8 @@ func BenchmarkSumCompensatedLarge(b *testing.B)  { benchmarkSumCompensated(b, La
 func BenchmarkSumCompensatedHuge(b *testing.B)   { benchmarkSumCompensated(b, Huge) }
 
 func benchmarkSum(b *testing.B, size int) {
-	s := randomSlice(size)
+	src := rand.NewSource(1)
+	s := randomSlice(size, src)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Sum(s)

--- a/internal/asm/c128/asm_test.go
+++ b/internal/asm/c128/asm_test.go
@@ -9,8 +9,6 @@ import (
 	"math/cmplx"
 	"testing"
 
-	"golang.org/x/exp/rand"
-
 	"gonum.org/v1/gonum/cmplxs/cscalar"
 	"gonum.org/v1/gonum/floats/scalar"
 )
@@ -104,14 +102,3 @@ func sameCmplxApprox(a, b complex128, tol float64) bool {
 var ( // Offset sets for testing alignment handling in Unitary assembly functions.
 	align1 = []int{0, 1}
 )
-
-func randomSlice(n, inc int) []complex128 {
-	if inc < 0 {
-		inc = -inc
-	}
-	x := make([]complex128, (n-1)*inc+1)
-	for i := range x {
-		x[i] = complex(rand.Float64(), rand.Float64())
-	}
-	return x
-}

--- a/internal/asm/c128/l2norm_test.go
+++ b/internal/asm/c128/l2norm_test.go
@@ -137,7 +137,7 @@ func BenchmarkL2NormNetlib(b *testing.B) {
 		{"L2NormUnitaryNetlib", netlib},
 		{"L2NormUnitary", L2NormUnitary},
 	}
-	x[0] = randomSlice(1, 1)[0] // replace the leading zero (edge case)
+	x[0] = 4 // replace the leading zero (edge case)
 	for _, test := range tests {
 		for _, ln := range []uintptr{1, 3, 10, 30, 1e2, 3e2, 1e3, 3e3, 1e4, 3e4, 1e5} {
 			b.Run(fmt.Sprintf("%s-%d", test.name, ln), func(b *testing.B) {

--- a/internal/asm/c64/asm_test.go
+++ b/internal/asm/c64/asm_test.go
@@ -7,8 +7,6 @@ package c64_test
 import (
 	"testing"
 
-	"golang.org/x/exp/rand"
-
 	"gonum.org/v1/gonum/cmplxs/cscalar"
 	"gonum.org/v1/gonum/floats/scalar"
 	"gonum.org/v1/gonum/internal/cmplx64"
@@ -109,14 +107,3 @@ func sameCmplxApprox(a, b complex64, tol float32) bool {
 var ( // Offset sets for testing alignment handling in Unitary assembly functions.
 	align1 = []int{0, 1}
 )
-
-func randomSlice(n, inc int) []complex64 {
-	if inc < 0 {
-		inc = -inc
-	}
-	x := make([]complex64, (n-1)*inc+1)
-	for i := range x {
-		x[i] = complex(float32(rand.Float64()), float32(rand.Float64()))
-	}
-	return x
-}

--- a/internal/asm/c64/l2norm_test.go
+++ b/internal/asm/c64/l2norm_test.go
@@ -138,7 +138,7 @@ func BenchmarkL2NormNetlib(b *testing.B) {
 		{"L2NormUnitaryNetlib", netlib},
 		{"L2NormUnitary", L2NormUnitary},
 	}
-	x[0] = randomSlice(1, 1)[0] // replace the leading zero (edge case)
+	x[0] = 4 // replace the leading zero (edge case)
 	for _, test := range tests {
 		for _, ln := range []uintptr{1, 3, 10, 30, 1e2, 3e2, 1e3, 3e3, 1e4, 3e4, 1e5} {
 			b.Run(fmt.Sprintf("%s-%d", test.name, ln), func(b *testing.B) {


### PR DESCRIPTION
Please take a look.

Random constant used in internal/asm taken from published value.

Closes #1299.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
