### PR TITLE
spatial/{r2,r3}: drop use of subtests

### DIFF
--- a/spatial/r2/vector_test.go
+++ b/spatial/r2/vector_test.go
@@ -22,16 +22,13 @@ func TestAdd(t *testing.T) {
 		{Vec{1, -3}, Vec{1, -6}, Vec{2, -9}},
 		{Vec{1, 2}, Vec{-1, -2}, Vec{}},
 	} {
-		t.Run("", func(t *testing.T) {
-			got := test.v1.Add(test.v2)
-
-			if got != test.want {
-				t.Fatalf(
-					"error: %v + %v: got=%v, want=%v",
-					test.v1, test.v2, got, test.want,
-				)
-			}
-		})
+		got := test.v1.Add(test.v2)
+		if got != test.want {
+			t.Errorf(
+				"error: %v + %v: got=%v, want=%v",
+				test.v1, test.v2, got, test.want,
+			)
+		}
 	}
 }
 
@@ -46,15 +43,13 @@ func TestSub(t *testing.T) {
 		{Vec{1, -3}, Vec{1, -6}, Vec{0, 3}},
 		{Vec{1, 2}, Vec{1, 2}, Vec{}},
 	} {
-		t.Run("", func(t *testing.T) {
-			got := test.v1.Sub(test.v2)
-			if got != test.want {
-				t.Fatalf(
-					"error: %v - %v: got=%v, want=%v",
-					test.v1, test.v2, got, test.want,
-				)
-			}
-		})
+		got := test.v1.Sub(test.v2)
+		if got != test.want {
+			t.Errorf(
+				"error: %v - %v: got=%v, want=%v",
+				test.v1, test.v2, got, test.want,
+			)
+		}
 	}
 }
 
@@ -72,14 +67,12 @@ func TestScale(t *testing.T) {
 		{2, Vec{1, -3}, Vec{2, -6}},
 		{10, Vec{1, 2}, Vec{10, 20}},
 	} {
-		t.Run("", func(t *testing.T) {
-			got := test.v.Scale(test.a)
-			if got != test.want {
-				t.Fatalf(
-					"error: %v * %v: got=%v, want=%v",
-					test.a, test.v, got, test.want)
-			}
-		})
+		got := test.v.Scale(test.a)
+		if got != test.want {
+			t.Errorf(
+				"error: %v * %v: got=%v, want=%v",
+				test.a, test.v, got, test.want)
+		}
 	}
 }
 
@@ -95,26 +88,24 @@ func TestDot(t *testing.T) {
 		{Vec{1, 1}, Vec{-1, -1}, -2},
 		{Vec{1, 2}, Vec{-0.3, 0.4}, 0.5},
 	} {
-		t.Run("", func(t *testing.T) {
-			{
-				got := test.u.Dot(test.v)
-				if got != test.want {
-					t.Fatalf(
-						"error: %v · %v: got=%v, want=%v",
-						test.u, test.v, got, test.want,
-					)
-				}
+		{
+			got := test.u.Dot(test.v)
+			if got != test.want {
+				t.Errorf(
+					"error: %v · %v: got=%v, want=%v",
+					test.u, test.v, got, test.want,
+				)
 			}
-			{
-				got := test.v.Dot(test.u)
-				if got != test.want {
-					t.Fatalf(
-						"error: %v · %v: got=%v, want=%v",
-						test.v, test.u, got, test.want,
-					)
-				}
+		}
+		{
+			got := test.v.Dot(test.u)
+			if got != test.want {
+				t.Errorf(
+					"error: %v · %v: got=%v, want=%v",
+					test.v, test.u, got, test.want,
+				)
 			}
-		})
+		}
 	}
 }
 
@@ -129,15 +120,13 @@ func TestCross(t *testing.T) {
 		{Vec{1, 2}, Vec{-4, 5}, 13},
 		{Vec{1, 2}, Vec{2, 3}, -1},
 	} {
-		t.Run("", func(t *testing.T) {
-			got := test.v1.Cross(test.v2)
-			if got != test.want {
-				t.Fatalf(
-					"error: %v × %v = %v, want %v",
-					test.v1, test.v2, got, test.want,
-				)
-			}
-		})
+		got := test.v1.Cross(test.v2)
+		if got != test.want {
+			t.Errorf(
+				"error: %v × %v = %v, want %v",
+				test.v1, test.v2, got, test.want,
+			)
+		}
 	}
 }
 
@@ -154,11 +143,9 @@ func TestNorm(t *testing.T) {
 		{Vec{1, 1e-16}, 1},
 		{Vec{4.3145006366056343748277397783556100978621924913975e-196, 4.3145006366056343748277397783556100978621924913975e-196}, 6.101625315155041e-196},
 	} {
-		t.Run("", func(t *testing.T) {
-			if got, want := Norm(test.v), test.want; got != want {
-				t.Fatalf("|%v| = %v, want %v", test.v, got, want)
-			}
-		})
+		if got, want := Norm(test.v), test.want; got != want {
+			t.Errorf("|%v| = %v, want %v", test.v, got, want)
+		}
 	}
 }
 
@@ -176,11 +163,9 @@ func TestNorm2(t *testing.T) {
 		// This will underflow and return zero.
 		{Vec{4.3145006366056343748277397783556100978621924913975e-196, 4.3145006366056343748277397783556100978621924913975e-196}, 0},
 	} {
-		t.Run("", func(t *testing.T) {
-			if got, want := Norm2(test.v), test.want; got != want {
-				t.Fatalf("|%v|^2 = %v, want %v", test.v, got, want)
-			}
-		})
+		if got, want := Norm2(test.v), test.want; got != want {
+			t.Errorf("|%v|^2 = %v, want %v", test.v, got, want)
+		}
 	}
 }
 
@@ -199,21 +184,19 @@ func TestUnit(t *testing.T) {
 		{Vec{1, 1e16}, Vec{1e-16, 1}},
 		{Vec{1e4, math.MaxFloat32 - 1}, Vec{0, 1}},
 	} {
-		t.Run("", func(t *testing.T) {
-			got := Unit(test.v)
-			if !vecApproxEqual(got, test.want) {
-				t.Fatalf(
-					"Unit(%v) = %v, want %v",
-					test.v, got, test.want,
-				)
-			}
-			if vecIsNaN(got) {
-				return
-			}
-			if n, want := Norm(got), 1.0; n != want {
-				t.Fatalf("|%v| = %v, want 1", got, n)
-			}
-		})
+		got := Unit(test.v)
+		if !vecApproxEqual(got, test.want) {
+			t.Errorf(
+				"Unit(%v) = %v, want %v",
+				test.v, got, test.want,
+			)
+		}
+		if vecIsNaN(got) {
+			return
+		}
+		if n, want := Norm(got), 1.0; n != want {
+			t.Errorf("|%v| = %v, want 1", got, n)
+		}
 	}
 }
 
@@ -228,15 +211,13 @@ func TestCos(t *testing.T) {
 		{Vec{1, 0}, Vec{0, 1}, 0},
 		{Vec{1, 0}, Vec{-1, 0}, -1},
 	} {
-		t.Run("", func(t *testing.T) {
-			tol := 1e-14
-			got := Cos(test.v1, test.v2)
-			if !scalar.EqualWithinAbs(got, test.want, tol) {
-				t.Fatalf("cos(%v, %v)= %v, want %v",
-					test.v1, test.v2, got, test.want,
-				)
-			}
-		})
+		tol := 1e-14
+		got := Cos(test.v1, test.v2)
+		if !scalar.EqualWithinAbs(got, test.want, tol) {
+			t.Errorf("cos(%v, %v)= %v, want %v",
+				test.v1, test.v2, got, test.want,
+			)
+		}
 	}
 }
 

--- a/spatial/r3/vector_test.go
+++ b/spatial/r3/vector_test.go
@@ -22,16 +22,13 @@ func TestAdd(t *testing.T) {
 		{Vec{1, -3, 5}, Vec{1, -6, -6}, Vec{2, -9, -1}},
 		{Vec{1, 2, 3}, Vec{-1, -2, -3}, Vec{}},
 	} {
-		t.Run("", func(t *testing.T) {
-			got := test.v1.Add(test.v2)
-
-			if got != test.want {
-				t.Fatalf(
-					"error: %v + %v: got=%v, want=%v",
-					test.v1, test.v2, got, test.want,
-				)
-			}
-		})
+		got := test.v1.Add(test.v2)
+		if got != test.want {
+			t.Errorf(
+				"error: %v + %v: got=%v, want=%v",
+				test.v1, test.v2, got, test.want,
+			)
+		}
 	}
 }
 
@@ -46,15 +43,13 @@ func TestSub(t *testing.T) {
 		{Vec{1, -3, 5}, Vec{1, -6, -6}, Vec{0, 3, 11}},
 		{Vec{1, 2, 3}, Vec{1, 2, 3}, Vec{}},
 	} {
-		t.Run("", func(t *testing.T) {
-			got := test.v1.Sub(test.v2)
-			if got != test.want {
-				t.Fatalf(
-					"error: %v - %v: got=%v, want=%v",
-					test.v1, test.v2, got, test.want,
-				)
-			}
-		})
+		got := test.v1.Sub(test.v2)
+		if got != test.want {
+			t.Errorf(
+				"error: %v - %v: got=%v, want=%v",
+				test.v1, test.v2, got, test.want,
+			)
+		}
 	}
 }
 
@@ -72,14 +67,12 @@ func TestScale(t *testing.T) {
 		{2, Vec{1, -3, 5}, Vec{2, -6, 10}},
 		{10, Vec{1, 2, 3}, Vec{10, 20, 30}},
 	} {
-		t.Run("", func(t *testing.T) {
-			got := test.v.Scale(test.a)
-			if got != test.want {
-				t.Fatalf(
-					"error: %v * %v: got=%v, want=%v",
-					test.a, test.v, got, test.want)
-			}
-		})
+		got := test.v.Scale(test.a)
+		if got != test.want {
+			t.Errorf(
+				"error: %v * %v: got=%v, want=%v",
+				test.a, test.v, got, test.want)
+		}
 	}
 }
 
@@ -95,26 +88,24 @@ func TestDot(t *testing.T) {
 		{Vec{1, 1, 1}, Vec{-1, -1, -1}, -3},
 		{Vec{1, 2, 2}, Vec{-0.3, 0.4, -1.2}, -1.9},
 	} {
-		t.Run("", func(t *testing.T) {
-			{
-				got := test.u.Dot(test.v)
-				if got != test.want {
-					t.Fatalf(
-						"error: %v · %v: got=%v, want=%v",
-						test.u, test.v, got, test.want,
-					)
-				}
+		{
+			got := test.u.Dot(test.v)
+			if got != test.want {
+				t.Errorf(
+					"error: %v · %v: got=%v, want=%v",
+					test.u, test.v, got, test.want,
+				)
 			}
-			{
-				got := test.v.Dot(test.u)
-				if got != test.want {
-					t.Fatalf(
-						"error: %v · %v: got=%v, want=%v",
-						test.v, test.u, got, test.want,
-					)
-				}
+		}
+		{
+			got := test.v.Dot(test.u)
+			if got != test.want {
+				t.Errorf(
+					"error: %v · %v: got=%v, want=%v",
+					test.v, test.u, got, test.want,
+				)
 			}
-		})
+		}
 	}
 }
 
@@ -129,15 +120,13 @@ func TestCross(t *testing.T) {
 		{Vec{1, 2, 3}, Vec{1, 2, 3}, Vec{}},
 		{Vec{1, 2, 3}, Vec{2, 3, 4}, Vec{-1, 2, -1}},
 	} {
-		t.Run("", func(t *testing.T) {
-			got := test.v1.Cross(test.v2)
-			if got != test.want {
-				t.Fatalf(
-					"error: %v × %v = %v, want %v",
-					test.v1, test.v2, got, test.want,
-				)
-			}
-		})
+		got := test.v1.Cross(test.v2)
+		if got != test.want {
+			t.Errorf(
+				"error: %v × %v = %v, want %v",
+				test.v1, test.v2, got, test.want,
+			)
+		}
 	}
 }
 
@@ -152,11 +141,9 @@ func TestNorm(t *testing.T) {
 		{Vec{1, 1e-16, 1e-32}, 1},
 		{Vec{-0, 4.3145006366056343748277397783556100978621924913975e-196, 4.3145006366056343748277397783556100978621924913975e-196}, 6.101625315155041e-196},
 	} {
-		t.Run("", func(t *testing.T) {
-			if got, want := Norm(test.v), test.want; got != want {
-				t.Fatalf("|%v| = %v, want %v", test.v, got, want)
-			}
-		})
+		if got, want := Norm(test.v), test.want; got != want {
+			t.Errorf("|%v| = %v, want %v", test.v, got, want)
+		}
 	}
 }
 
@@ -174,11 +161,9 @@ func TestNorm2(t *testing.T) {
 		// This will underflow and return zero.
 		{Vec{-0, 4.3145006366056343748277397783556100978621924913975e-196, 4.3145006366056343748277397783556100978621924913975e-196}, 0},
 	} {
-		t.Run("", func(t *testing.T) {
-			if got, want := Norm2(test.v), test.want; got != want {
-				t.Fatalf("|%v|^2 = %v, want %v", test.v, got, want)
-			}
-		})
+		if got, want := Norm2(test.v), test.want; got != want {
+			t.Errorf("|%v|^2 = %v, want %v", test.v, got, want)
+		}
 	}
 }
 
@@ -193,21 +178,19 @@ func TestUnit(t *testing.T) {
 		{Vec{1, 1, 1}, Vec{1. / math.Sqrt(3), 1. / math.Sqrt(3), 1. / math.Sqrt(3)}},
 		{Vec{1, 1e-16, 1e-32}, Vec{1, 1e-16, 1e-32}},
 	} {
-		t.Run("", func(t *testing.T) {
-			got := Unit(test.v)
-			if !vecEqual(got, test.want) {
-				t.Fatalf(
-					"Normalize(%v) = %v, want %v",
-					test.v, got, test.want,
-				)
-			}
-			if test.v == (Vec{}) {
-				return
-			}
-			if n, want := Norm(got), 1.0; n != want {
-				t.Fatalf("|%v| = %v, want 1", got, n)
-			}
-		})
+		got := Unit(test.v)
+		if !vecEqual(got, test.want) {
+			t.Errorf(
+				"Normalize(%v) = %v, want %v",
+				test.v, got, test.want,
+			)
+		}
+		if test.v == (Vec{}) {
+			return
+		}
+		if n, want := Norm(got), 1.0; n != want {
+			t.Errorf("|%v| = %v, want 1", got, n)
+		}
 	}
 }
 
@@ -224,15 +207,13 @@ func TestCos(t *testing.T) {
 		{Vec{1, 0, 0}, Vec{0, 1, 1}, 0},
 		{Vec{1, 0, 0}, Vec{-1, 0, 0}, -1},
 	} {
-		t.Run("", func(t *testing.T) {
-			tol := 1e-14
-			got := Cos(test.v1, test.v2)
-			if !scalar.EqualWithinAbs(got, test.want, tol) {
-				t.Fatalf("cos(%v, %v)= %v, want %v",
-					test.v1, test.v2, got, test.want,
-				)
-			}
-		})
+		tol := 1e-14
+		got := Cos(test.v1, test.v2)
+		if !scalar.EqualWithinAbs(got, test.want, tol) {
+			t.Errorf("cos(%v, %v)= %v, want %v",
+				test.v1, test.v2, got, test.want,
+			)
+		}
 	}
 }
 


### PR DESCRIPTION
Please take a look.

as discussed in https://github.com/gonum/gonum/pull/1516#discussion_r532921011.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
