### PR TITLE
graph/{multi,simple,testgraph}: fix edge reversal tests and multi.WeightUndirected

### DIFF
--- a/graph/multi/directed_test.go
+++ b/graph/multi/directed_test.go
@@ -50,25 +50,25 @@ func directedBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, _, _ fl
 
 func TestDirected(t *testing.T) {
 	t.Run("EdgeExistence", func(t *testing.T) {
-		testgraph.EdgeExistence(t, directedBuilder)
+		testgraph.EdgeExistence(t, directedBuilder, reversesEdges)
 	})
 	t.Run("LineExistence", func(t *testing.T) {
-		testgraph.LineExistence(t, directedBuilder, true)
+		testgraph.LineExistence(t, directedBuilder, usesEmpty, reversesEdges)
 	})
 	t.Run("NodeExistence", func(t *testing.T) {
 		testgraph.NodeExistence(t, directedBuilder)
 	})
 	t.Run("ReturnAdjacentNodes", func(t *testing.T) {
-		testgraph.ReturnAdjacentNodes(t, directedBuilder, true)
+		testgraph.ReturnAdjacentNodes(t, directedBuilder, usesEmpty, reversesEdges)
 	})
 	t.Run("ReturnAllLines", func(t *testing.T) {
-		testgraph.ReturnAllLines(t, directedBuilder, true)
+		testgraph.ReturnAllLines(t, directedBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllNodes", func(t *testing.T) {
-		testgraph.ReturnAllNodes(t, directedBuilder, true)
+		testgraph.ReturnAllNodes(t, directedBuilder, usesEmpty)
 	})
 	t.Run("ReturnNodeSlice", func(t *testing.T) {
-		testgraph.ReturnNodeSlice(t, directedBuilder, true)
+		testgraph.ReturnNodeSlice(t, directedBuilder, usesEmpty)
 	})
 
 	t.Run("AddNodes", func(t *testing.T) {

--- a/graph/multi/undirected_test.go
+++ b/graph/multi/undirected_test.go
@@ -17,6 +17,11 @@ import (
 	"gonum.org/v1/gonum/graph/testgraph"
 )
 
+const (
+	usesEmpty     = true
+	reversesEdges = true
+)
+
 func undirectedBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, _, _ float64) (g graph.Graph, n []graph.Node, e []testgraph.Edge, s, a float64, ok bool) {
 	seen := set.NewNodes()
 	ug := multi.NewUndirectedGraph()
@@ -50,25 +55,25 @@ func undirectedBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, _, _ 
 
 func TestUndirected(t *testing.T) {
 	t.Run("EdgeExistence", func(t *testing.T) {
-		testgraph.EdgeExistence(t, undirectedBuilder)
+		testgraph.EdgeExistence(t, undirectedBuilder, reversesEdges)
 	})
 	t.Run("LineExistence", func(t *testing.T) {
-		testgraph.LineExistence(t, directedBuilder, true)
+		testgraph.LineExistence(t, undirectedBuilder, usesEmpty, reversesEdges)
 	})
 	t.Run("NodeExistence", func(t *testing.T) {
 		testgraph.NodeExistence(t, undirectedBuilder)
 	})
 	t.Run("ReturnAdjacentNodes", func(t *testing.T) {
-		testgraph.ReturnAdjacentNodes(t, undirectedBuilder, true)
+		testgraph.ReturnAdjacentNodes(t, undirectedBuilder, usesEmpty, reversesEdges)
 	})
 	t.Run("ReturnAllLines", func(t *testing.T) {
-		testgraph.ReturnAllLines(t, undirectedBuilder, true)
+		testgraph.ReturnAllLines(t, undirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllNodes", func(t *testing.T) {
-		testgraph.ReturnAllNodes(t, undirectedBuilder, true)
+		testgraph.ReturnAllNodes(t, undirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnNodeSlice", func(t *testing.T) {
-		testgraph.ReturnNodeSlice(t, undirectedBuilder, true)
+		testgraph.ReturnNodeSlice(t, undirectedBuilder, usesEmpty)
 	})
 
 	t.Run("AddNodes", func(t *testing.T) {

--- a/graph/multi/weighted_directed_test.go
+++ b/graph/multi/weighted_directed_test.go
@@ -60,28 +60,28 @@ func weightedDirectedBuilder(nodes []graph.Node, edges []testgraph.WeightedLine,
 
 func TestWeightedDirected(t *testing.T) {
 	t.Run("EdgeExistence", func(t *testing.T) {
-		testgraph.EdgeExistence(t, weightedDirectedBuilder)
+		testgraph.EdgeExistence(t, weightedDirectedBuilder, reversesEdges)
 	})
 	t.Run("LineExistence", func(t *testing.T) {
-		testgraph.LineExistence(t, directedBuilder, true)
+		testgraph.LineExistence(t, directedBuilder, usesEmpty, reversesEdges)
 	})
 	t.Run("NodeExistence", func(t *testing.T) {
 		testgraph.NodeExistence(t, weightedDirectedBuilder)
 	})
 	t.Run("ReturnAdjacentNodes", func(t *testing.T) {
-		testgraph.ReturnAdjacentNodes(t, weightedDirectedBuilder, true)
+		testgraph.ReturnAdjacentNodes(t, weightedDirectedBuilder, usesEmpty, reversesEdges)
 	})
 	t.Run("ReturnAllLines", func(t *testing.T) {
-		testgraph.ReturnAllLines(t, weightedDirectedBuilder, true)
+		testgraph.ReturnAllLines(t, weightedDirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllNodes", func(t *testing.T) {
-		testgraph.ReturnAllNodes(t, weightedDirectedBuilder, true)
+		testgraph.ReturnAllNodes(t, weightedDirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllWeightedLines", func(t *testing.T) {
-		testgraph.ReturnAllWeightedLines(t, weightedDirectedBuilder, true)
+		testgraph.ReturnAllWeightedLines(t, weightedDirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnNodeSlice", func(t *testing.T) {
-		testgraph.ReturnNodeSlice(t, weightedDirectedBuilder, true)
+		testgraph.ReturnNodeSlice(t, weightedDirectedBuilder, usesEmpty)
 	})
 	t.Run("Weight", func(t *testing.T) {
 		testgraph.Weight(t, weightedDirectedBuilder)

--- a/graph/multi/weighted_undirected.go
+++ b/graph/multi/weighted_undirected.go
@@ -135,18 +135,14 @@ func (g *WeightedUndirectedGraph) Lines(uid, vid int64) graph.Lines {
 
 // LinesBetween returns the lines between nodes x and y.
 func (g *WeightedUndirectedGraph) LinesBetween(xid, yid int64) graph.Lines {
-	edge := g.lines[xid][yid]
-	if len(edge) == 0 {
+	if !g.HasEdgeBetween(xid, yid) {
 		return graph.Empty
 	}
 	var lines []graph.Line
-	seen := make(map[int64]struct{})
-	for _, l := range edge {
-		lid := l.ID()
-		if _, ok := seen[lid]; ok {
-			continue
+	for _, l := range g.lines[xid][yid] {
+		if l.From().ID() != xid {
+			l = l.ReversedLine().(graph.WeightedLine)
 		}
-		seen[lid] = struct{}{}
 		lines = append(lines, l)
 	}
 	return iterator.NewOrderedLines(lines)
@@ -337,18 +333,11 @@ func (g *WeightedUndirectedGraph) WeightedLines(uid, vid int64) graph.WeightedLi
 
 // WeightedLinesBetween returns the lines between nodes x and y.
 func (g *WeightedUndirectedGraph) WeightedLinesBetween(xid, yid int64) graph.WeightedLines {
-	edge := g.lines[xid][yid]
-	if len(edge) == 0 {
+	if !g.HasEdgeBetween(xid, yid) {
 		return graph.Empty
 	}
 	var lines []graph.WeightedLine
-	seen := make(map[int64]struct{})
-	for _, l := range edge {
-		lid := l.ID()
-		if _, ok := seen[lid]; ok {
-			continue
-		}
-		seen[lid] = struct{}{}
+	for _, l := range g.lines[xid][yid] {
 		if l.From().ID() != xid {
 			l = l.ReversedLine().(graph.WeightedLine)
 		}

--- a/graph/multi/weighted_undirected_test.go
+++ b/graph/multi/weighted_undirected_test.go
@@ -60,28 +60,28 @@ func weightedUndirectedBuilder(nodes []graph.Node, edges []testgraph.WeightedLin
 
 func TestWeightedUndirected(t *testing.T) {
 	t.Run("EdgeExistence", func(t *testing.T) {
-		testgraph.EdgeExistence(t, weightedUndirectedBuilder)
+		testgraph.EdgeExistence(t, weightedUndirectedBuilder, reversesEdges)
 	})
 	t.Run("LineExistence", func(t *testing.T) {
-		testgraph.LineExistence(t, directedBuilder, true)
+		testgraph.LineExistence(t, weightedUndirectedBuilder, usesEmpty, reversesEdges)
 	})
 	t.Run("NodeExistence", func(t *testing.T) {
 		testgraph.NodeExistence(t, weightedUndirectedBuilder)
 	})
 	t.Run("ReturnAdjacentNodes", func(t *testing.T) {
-		testgraph.ReturnAdjacentNodes(t, weightedUndirectedBuilder, true)
+		testgraph.ReturnAdjacentNodes(t, weightedUndirectedBuilder, usesEmpty, reversesEdges)
 	})
 	t.Run("ReturnAllLines", func(t *testing.T) {
-		testgraph.ReturnAllLines(t, weightedUndirectedBuilder, true)
+		testgraph.ReturnAllLines(t, weightedUndirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllNodes", func(t *testing.T) {
-		testgraph.ReturnAllNodes(t, weightedUndirectedBuilder, true)
+		testgraph.ReturnAllNodes(t, weightedUndirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllWeightedLines", func(t *testing.T) {
-		testgraph.ReturnAllWeightedLines(t, weightedUndirectedBuilder, true)
+		testgraph.ReturnAllWeightedLines(t, weightedUndirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnNodeSlice", func(t *testing.T) {
-		testgraph.ReturnNodeSlice(t, weightedUndirectedBuilder, true)
+		testgraph.ReturnNodeSlice(t, weightedUndirectedBuilder, usesEmpty)
 	})
 	t.Run("Weight", func(t *testing.T) {
 		testgraph.Weight(t, weightedUndirectedBuilder)

--- a/graph/simple/densegraph_test.go
+++ b/graph/simple/densegraph_test.go
@@ -69,31 +69,31 @@ func TestDirectedMatrix(t *testing.T) {
 		testgraph.AdjacencyMatrix(t, directedMatrixBuilder)
 	})
 	t.Run("EdgeExistence", func(t *testing.T) {
-		testgraph.EdgeExistence(t, directedMatrixBuilder)
+		testgraph.EdgeExistence(t, directedMatrixBuilder, reversesEdges)
 	})
 	t.Run("NodeExistence", func(t *testing.T) {
 		testgraph.NodeExistence(t, directedMatrixBuilder)
 	})
 	t.Run("ReturnAdjacentNodes", func(t *testing.T) {
-		testgraph.ReturnAdjacentNodes(t, directedMatrixBuilder, true)
+		testgraph.ReturnAdjacentNodes(t, directedMatrixBuilder, usesEmpty, reversesEdges)
 	})
 	t.Run("ReturnAllEdges", func(t *testing.T) {
-		testgraph.ReturnAllEdges(t, directedMatrixBuilder, true)
+		testgraph.ReturnAllEdges(t, directedMatrixBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllNodes", func(t *testing.T) {
-		testgraph.ReturnAllNodes(t, directedMatrixBuilder, true)
+		testgraph.ReturnAllNodes(t, directedMatrixBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllWeightedEdges", func(t *testing.T) {
-		testgraph.ReturnAllWeightedEdges(t, directedMatrixBuilder, true)
+		testgraph.ReturnAllWeightedEdges(t, directedMatrixBuilder, usesEmpty)
 	})
 	t.Run("ReturnEdgeSlice", func(t *testing.T) {
-		testgraph.ReturnEdgeSlice(t, directedMatrixBuilder, true)
+		testgraph.ReturnEdgeSlice(t, directedMatrixBuilder, usesEmpty)
 	})
 	t.Run("ReturnWeightedEdgeSlice", func(t *testing.T) {
-		testgraph.ReturnWeightedEdgeSlice(t, directedMatrixBuilder, true)
+		testgraph.ReturnWeightedEdgeSlice(t, directedMatrixBuilder, usesEmpty)
 	})
 	t.Run("ReturnNodeSlice", func(t *testing.T) {
-		testgraph.ReturnNodeSlice(t, directedMatrixBuilder, true)
+		testgraph.ReturnNodeSlice(t, directedMatrixBuilder, usesEmpty)
 	})
 	t.Run("Weight", func(t *testing.T) {
 		testgraph.Weight(t, directedMatrixBuilder)
@@ -188,31 +188,31 @@ func TestDirectedMatrixFrom(t *testing.T) {
 		testgraph.AdjacencyMatrix(t, directedMatrixFromBuilder)
 	})
 	t.Run("EdgeExistence", func(t *testing.T) {
-		testgraph.EdgeExistence(t, directedMatrixFromBuilder)
+		testgraph.EdgeExistence(t, directedMatrixFromBuilder, reversesEdges)
 	})
 	t.Run("NodeExistence", func(t *testing.T) {
 		testgraph.NodeExistence(t, directedMatrixFromBuilder)
 	})
 	t.Run("ReturnAdjacentNodes", func(t *testing.T) {
-		testgraph.ReturnAdjacentNodes(t, directedMatrixFromBuilder, true)
+		testgraph.ReturnAdjacentNodes(t, directedMatrixFromBuilder, usesEmpty, reversesEdges)
 	})
 	t.Run("ReturnAllEdges", func(t *testing.T) {
-		testgraph.ReturnAllEdges(t, directedMatrixFromBuilder, true)
+		testgraph.ReturnAllEdges(t, directedMatrixFromBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllNodes", func(t *testing.T) {
-		testgraph.ReturnAllNodes(t, directedMatrixFromBuilder, true)
+		testgraph.ReturnAllNodes(t, directedMatrixFromBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllWeightedEdges", func(t *testing.T) {
-		testgraph.ReturnAllWeightedEdges(t, directedMatrixFromBuilder, true)
+		testgraph.ReturnAllWeightedEdges(t, directedMatrixFromBuilder, usesEmpty)
 	})
 	t.Run("ReturnEdgeSlice", func(t *testing.T) {
-		testgraph.ReturnEdgeSlice(t, directedMatrixFromBuilder, true)
+		testgraph.ReturnEdgeSlice(t, directedMatrixFromBuilder, usesEmpty)
 	})
 	t.Run("ReturnWeightedEdgeSlice", func(t *testing.T) {
-		testgraph.ReturnWeightedEdgeSlice(t, directedMatrixFromBuilder, true)
+		testgraph.ReturnWeightedEdgeSlice(t, directedMatrixFromBuilder, usesEmpty)
 	})
 	t.Run("ReturnNodeSlice", func(t *testing.T) {
-		testgraph.ReturnNodeSlice(t, directedMatrixFromBuilder, true)
+		testgraph.ReturnNodeSlice(t, directedMatrixFromBuilder, usesEmpty)
 	})
 	t.Run("Weight", func(t *testing.T) {
 		testgraph.Weight(t, directedMatrixFromBuilder)
@@ -320,31 +320,31 @@ func TestUnirectedMatrix(t *testing.T) {
 		testgraph.AdjacencyMatrix(t, undirectedMatrixBuilder)
 	})
 	t.Run("EdgeExistence", func(t *testing.T) {
-		testgraph.EdgeExistence(t, undirectedMatrixBuilder)
+		testgraph.EdgeExistence(t, undirectedMatrixBuilder, reversesEdges)
 	})
 	t.Run("NodeExistence", func(t *testing.T) {
 		testgraph.NodeExistence(t, undirectedMatrixBuilder)
 	})
 	t.Run("ReturnAdjacentNodes", func(t *testing.T) {
-		testgraph.ReturnAdjacentNodes(t, undirectedMatrixBuilder, true)
+		testgraph.ReturnAdjacentNodes(t, undirectedMatrixBuilder, usesEmpty, reversesEdges)
 	})
 	t.Run("ReturnAllEdges", func(t *testing.T) {
-		testgraph.ReturnAllEdges(t, undirectedMatrixBuilder, true)
+		testgraph.ReturnAllEdges(t, undirectedMatrixBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllNodes", func(t *testing.T) {
-		testgraph.ReturnAllNodes(t, undirectedMatrixBuilder, true)
+		testgraph.ReturnAllNodes(t, undirectedMatrixBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllWeightedEdges", func(t *testing.T) {
-		testgraph.ReturnAllWeightedEdges(t, undirectedMatrixBuilder, true)
+		testgraph.ReturnAllWeightedEdges(t, undirectedMatrixBuilder, usesEmpty)
 	})
 	t.Run("ReturnEdgeSlice", func(t *testing.T) {
-		testgraph.ReturnEdgeSlice(t, undirectedMatrixBuilder, true)
+		testgraph.ReturnEdgeSlice(t, undirectedMatrixBuilder, usesEmpty)
 	})
 	t.Run("ReturnWeightedEdgeSlice", func(t *testing.T) {
-		testgraph.ReturnWeightedEdgeSlice(t, undirectedMatrixBuilder, true)
+		testgraph.ReturnWeightedEdgeSlice(t, undirectedMatrixBuilder, usesEmpty)
 	})
 	t.Run("ReturnNodeSlice", func(t *testing.T) {
-		testgraph.ReturnNodeSlice(t, undirectedMatrixBuilder, true)
+		testgraph.ReturnNodeSlice(t, undirectedMatrixBuilder, usesEmpty)
 	})
 	t.Run("Weight", func(t *testing.T) {
 		testgraph.Weight(t, undirectedMatrixBuilder)
@@ -439,31 +439,31 @@ func TestUndirectedMatrixFrom(t *testing.T) {
 		testgraph.AdjacencyMatrix(t, undirectedMatrixFromBuilder)
 	})
 	t.Run("EdgeExistence", func(t *testing.T) {
-		testgraph.EdgeExistence(t, undirectedMatrixFromBuilder)
+		testgraph.EdgeExistence(t, undirectedMatrixFromBuilder, reversesEdges)
 	})
 	t.Run("NodeExistence", func(t *testing.T) {
 		testgraph.NodeExistence(t, undirectedMatrixFromBuilder)
 	})
 	t.Run("ReturnAdjacentNodes", func(t *testing.T) {
-		testgraph.ReturnAdjacentNodes(t, undirectedMatrixFromBuilder, true)
+		testgraph.ReturnAdjacentNodes(t, undirectedMatrixFromBuilder, usesEmpty, reversesEdges)
 	})
 	t.Run("ReturnAllEdges", func(t *testing.T) {
-		testgraph.ReturnAllEdges(t, undirectedMatrixFromBuilder, true)
+		testgraph.ReturnAllEdges(t, undirectedMatrixFromBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllNodes", func(t *testing.T) {
-		testgraph.ReturnAllNodes(t, undirectedMatrixFromBuilder, true)
+		testgraph.ReturnAllNodes(t, undirectedMatrixFromBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllWeightedEdges", func(t *testing.T) {
-		testgraph.ReturnAllWeightedEdges(t, undirectedMatrixFromBuilder, true)
+		testgraph.ReturnAllWeightedEdges(t, undirectedMatrixFromBuilder, usesEmpty)
 	})
 	t.Run("ReturnEdgeSlice", func(t *testing.T) {
-		testgraph.ReturnEdgeSlice(t, undirectedMatrixFromBuilder, true)
+		testgraph.ReturnEdgeSlice(t, undirectedMatrixFromBuilder, usesEmpty)
 	})
 	t.Run("ReturnWeightedEdgeSlice", func(t *testing.T) {
-		testgraph.ReturnWeightedEdgeSlice(t, undirectedMatrixFromBuilder, true)
+		testgraph.ReturnWeightedEdgeSlice(t, undirectedMatrixFromBuilder, usesEmpty)
 	})
 	t.Run("ReturnNodeSlice", func(t *testing.T) {
-		testgraph.ReturnNodeSlice(t, undirectedMatrixFromBuilder, true)
+		testgraph.ReturnNodeSlice(t, undirectedMatrixFromBuilder, usesEmpty)
 	})
 	t.Run("Weight", func(t *testing.T) {
 		testgraph.Weight(t, undirectedMatrixFromBuilder)

--- a/graph/simple/directed_test.go
+++ b/graph/simple/directed_test.go
@@ -55,25 +55,25 @@ func directedBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, _, _ fl
 
 func TestDirected(t *testing.T) {
 	t.Run("EdgeExistence", func(t *testing.T) {
-		testgraph.EdgeExistence(t, directedBuilder)
+		testgraph.EdgeExistence(t, directedBuilder, reversesEdges)
 	})
 	t.Run("NodeExistence", func(t *testing.T) {
 		testgraph.NodeExistence(t, directedBuilder)
 	})
 	t.Run("ReturnAdjacentNodes", func(t *testing.T) {
-		testgraph.ReturnAdjacentNodes(t, directedBuilder, true)
+		testgraph.ReturnAdjacentNodes(t, directedBuilder, usesEmpty, reversesEdges)
 	})
 	t.Run("ReturnAllEdges", func(t *testing.T) {
-		testgraph.ReturnAllEdges(t, directedBuilder, true)
+		testgraph.ReturnAllEdges(t, directedBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllNodes", func(t *testing.T) {
-		testgraph.ReturnAllNodes(t, directedBuilder, true)
+		testgraph.ReturnAllNodes(t, directedBuilder, usesEmpty)
 	})
 	t.Run("ReturnEdgeSlice", func(t *testing.T) {
-		testgraph.ReturnEdgeSlice(t, directedBuilder, true)
+		testgraph.ReturnEdgeSlice(t, directedBuilder, usesEmpty)
 	})
 	t.Run("ReturnNodeSlice", func(t *testing.T) {
-		testgraph.ReturnNodeSlice(t, directedBuilder, true)
+		testgraph.ReturnNodeSlice(t, directedBuilder, usesEmpty)
 	})
 
 	t.Run("AddNodes", func(t *testing.T) {

--- a/graph/simple/undirected_test.go
+++ b/graph/simple/undirected_test.go
@@ -16,6 +16,11 @@ import (
 	"gonum.org/v1/gonum/graph/testgraph"
 )
 
+const (
+	usesEmpty     = true
+	reversesEdges = true
+)
+
 func undirectedBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, _, _ float64) (g graph.Graph, n []graph.Node, e []testgraph.Edge, s, a float64, ok bool) {
 	seen := set.NewNodes()
 	ug := simple.NewUndirectedGraph()
@@ -55,25 +60,25 @@ func undirectedBuilder(nodes []graph.Node, edges []testgraph.WeightedLine, _, _ 
 
 func TestUndirected(t *testing.T) {
 	t.Run("EdgeExistence", func(t *testing.T) {
-		testgraph.EdgeExistence(t, undirectedBuilder)
+		testgraph.EdgeExistence(t, undirectedBuilder, reversesEdges)
 	})
 	t.Run("NodeExistence", func(t *testing.T) {
 		testgraph.NodeExistence(t, undirectedBuilder)
 	})
 	t.Run("ReturnAdjacentNodes", func(t *testing.T) {
-		testgraph.ReturnAdjacentNodes(t, undirectedBuilder, true)
+		testgraph.ReturnAdjacentNodes(t, undirectedBuilder, usesEmpty, reversesEdges)
 	})
 	t.Run("ReturnAllEdges", func(t *testing.T) {
-		testgraph.ReturnAllEdges(t, undirectedBuilder, true)
+		testgraph.ReturnAllEdges(t, undirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllNodes", func(t *testing.T) {
-		testgraph.ReturnAllNodes(t, undirectedBuilder, true)
+		testgraph.ReturnAllNodes(t, undirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnEdgeSlice", func(t *testing.T) {
-		testgraph.ReturnEdgeSlice(t, undirectedBuilder, true)
+		testgraph.ReturnEdgeSlice(t, undirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnNodeSlice", func(t *testing.T) {
-		testgraph.ReturnNodeSlice(t, undirectedBuilder, true)
+		testgraph.ReturnNodeSlice(t, undirectedBuilder, usesEmpty)
 	})
 
 	t.Run("AddNodes", func(t *testing.T) {

--- a/graph/simple/weighted_directed_test.go
+++ b/graph/simple/weighted_directed_test.go
@@ -55,31 +55,31 @@ func weightedDirectedBuilder(nodes []graph.Node, edges []testgraph.WeightedLine,
 
 func TestWeightedDirected(t *testing.T) {
 	t.Run("EdgeExistence", func(t *testing.T) {
-		testgraph.EdgeExistence(t, weightedDirectedBuilder)
+		testgraph.EdgeExistence(t, weightedDirectedBuilder, reversesEdges)
 	})
 	t.Run("NodeExistence", func(t *testing.T) {
 		testgraph.NodeExistence(t, weightedDirectedBuilder)
 	})
 	t.Run("ReturnAdjacentNodes", func(t *testing.T) {
-		testgraph.ReturnAdjacentNodes(t, weightedDirectedBuilder, true)
+		testgraph.ReturnAdjacentNodes(t, weightedDirectedBuilder, usesEmpty, reversesEdges)
 	})
 	t.Run("ReturnAllEdges", func(t *testing.T) {
-		testgraph.ReturnAllEdges(t, weightedDirectedBuilder, true)
+		testgraph.ReturnAllEdges(t, weightedDirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllNodes", func(t *testing.T) {
-		testgraph.ReturnAllNodes(t, weightedDirectedBuilder, true)
+		testgraph.ReturnAllNodes(t, weightedDirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllWeightedEdges", func(t *testing.T) {
-		testgraph.ReturnAllWeightedEdges(t, weightedDirectedBuilder, true)
+		testgraph.ReturnAllWeightedEdges(t, weightedDirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnEdgeSlice", func(t *testing.T) {
-		testgraph.ReturnEdgeSlice(t, weightedDirectedBuilder, true)
+		testgraph.ReturnEdgeSlice(t, weightedDirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnWeightedEdgeSlice", func(t *testing.T) {
-		testgraph.ReturnWeightedEdgeSlice(t, weightedDirectedBuilder, true)
+		testgraph.ReturnWeightedEdgeSlice(t, weightedDirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnNodeSlice", func(t *testing.T) {
-		testgraph.ReturnNodeSlice(t, weightedDirectedBuilder, true)
+		testgraph.ReturnNodeSlice(t, weightedDirectedBuilder, usesEmpty)
 	})
 	t.Run("Weight", func(t *testing.T) {
 		testgraph.Weight(t, weightedDirectedBuilder)

--- a/graph/simple/weighted_undirected_test.go
+++ b/graph/simple/weighted_undirected_test.go
@@ -55,31 +55,31 @@ func weightedUndirectedBuilder(nodes []graph.Node, edges []testgraph.WeightedLin
 
 func TestWeightedUndirected(t *testing.T) {
 	t.Run("EdgeExistence", func(t *testing.T) {
-		testgraph.EdgeExistence(t, weightedUndirectedBuilder)
+		testgraph.EdgeExistence(t, weightedUndirectedBuilder, reversesEdges)
 	})
 	t.Run("NodeExistence", func(t *testing.T) {
 		testgraph.NodeExistence(t, weightedUndirectedBuilder)
 	})
 	t.Run("ReturnAdjacentNodes", func(t *testing.T) {
-		testgraph.ReturnAdjacentNodes(t, weightedUndirectedBuilder, true)
+		testgraph.ReturnAdjacentNodes(t, weightedUndirectedBuilder, usesEmpty, reversesEdges)
 	})
 	t.Run("ReturnAllEdges", func(t *testing.T) {
-		testgraph.ReturnAllEdges(t, weightedUndirectedBuilder, true)
+		testgraph.ReturnAllEdges(t, weightedUndirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllNodes", func(t *testing.T) {
-		testgraph.ReturnAllNodes(t, weightedUndirectedBuilder, true)
+		testgraph.ReturnAllNodes(t, weightedUndirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnAllWeightedEdges", func(t *testing.T) {
-		testgraph.ReturnAllWeightedEdges(t, weightedUndirectedBuilder, true)
+		testgraph.ReturnAllWeightedEdges(t, weightedUndirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnEdgeSlice", func(t *testing.T) {
-		testgraph.ReturnEdgeSlice(t, weightedUndirectedBuilder, true)
+		testgraph.ReturnEdgeSlice(t, weightedUndirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnWeightedEdgeSlice", func(t *testing.T) {
-		testgraph.ReturnWeightedEdgeSlice(t, weightedUndirectedBuilder, true)
+		testgraph.ReturnWeightedEdgeSlice(t, weightedUndirectedBuilder, usesEmpty)
 	})
 	t.Run("ReturnNodeSlice", func(t *testing.T) {
-		testgraph.ReturnNodeSlice(t, weightedUndirectedBuilder, true)
+		testgraph.ReturnNodeSlice(t, weightedUndirectedBuilder, usesEmpty)
 	})
 	t.Run("Weight", func(t *testing.T) {
 		testgraph.Weight(t, weightedUndirectedBuilder)

--- a/graph/testgraph/testgraph.go
+++ b/graph/testgraph/testgraph.go
@@ -1771,20 +1771,20 @@ func AddLines(t *testing.T, n int, g LineAdder, newNode func(id int64) graph.Nod
 	}
 
 	rnd := rand.New(rand.NewSource(1))
-	seen := make(set.Int64s)
+	seen := make(tripleInt64s)
 	for i := 0; i < n; i++ {
 		u := newNode(rnd.Int63n(int64(n)))
 		v := newNode(rnd.Int63n(int64(n)))
 		prev := g.Lines(u.ID(), v.ID())
 		l := g.NewLine(u, v)
-		if seen.Has(l.ID()) {
+		if seen.has(u.ID(), v.ID(), l.ID()) {
 			t.Fatalf("NewLine returned an existing line: %#v", l)
 		}
 		if g.Lines(u.ID(), v.ID()).Len() != prev.Len() {
 			t.Fatalf("NewLine added a line: %#v", l)
 		}
 		g.SetLine(l)
-		seen.Add(l.ID())
+		seen.add(u.ID(), v.ID(), l.ID())
 		if g.Lines(u.ID(), v.ID()).Len() != prev.Len()+1 {
 			t.Fatalf("SetLine failed to add line: %#v", l)
 		}
@@ -1835,20 +1835,20 @@ func AddWeightedLines(t *testing.T, n int, g WeightedLineAdder, w float64, newNo
 	}
 
 	rnd := rand.New(rand.NewSource(1))
-	seen := make(set.Int64s)
+	seen := make(tripleInt64s)
 	for i := 0; i < n; i++ {
 		u := newNode(rnd.Int63n(int64(n)))
 		v := newNode(rnd.Int63n(int64(n)))
 		prev := g.Lines(u.ID(), v.ID())
 		l := g.NewWeightedLine(u, v, w)
-		if seen.Has(l.ID()) {
+		if seen.has(u.ID(), v.ID(), l.ID()) {
 			t.Fatalf("NewWeightedLine returned an existing line: %#v", l)
 		}
 		if g.Lines(u.ID(), v.ID()).Len() != prev.Len() {
 			t.Fatalf("NewWeightedLine added a line: %#v", l)
 		}
 		g.SetWeightedLine(l)
-		seen.Add(l.ID())
+		seen.add(u.ID(), v.ID(), l.ID())
 		curr := g.Lines(u.ID(), v.ID())
 		if curr.Len() != prev.Len()+1 {
 			t.Fatalf("SetWeightedLine failed to add line: %#v", l)
@@ -2130,4 +2130,18 @@ func (n *RandomNodes) Reset() {
 	n.state = rand.New(rand.NewSource(n.seed))
 	n.seen = make(set.Int64s)
 	n.count = 0
+}
+
+// tripleInt64s is a set of [3]int64 identifiers.
+type tripleInt64s map[[3]int64]struct{}
+
+// add inserts an element into the set.
+func (s tripleInt64s) add(x, y, z int64) {
+	s[[3]int64{x, y, z}] = struct{}{}
+}
+
+// has reports the existence of the element in the set.
+func (s tripleInt64s) has(x, y, z int64) bool {
+	_, ok := s[[3]int64{x, y, z}]
+	return ok
 }


### PR DESCRIPTION
See https://github.com/gonum/gonum/pull/1519#discussion_r533874263 for context behind optional relaxation of edge reversal.

See https://github.com/gonum/gonum/issues/1517 for the background behind line ID allocation.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
