### PR TITLE
codecov: make coverage report relative to root of the repo

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "src/gonum.org/v1/gonum/::"


### PR DESCRIPTION
The reports can't link to the source code because that have `src/gonum.org/v1/gonum/` prefix. This should fix that.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
