### PR TITLE
ci: add action for uploading coverage report on PR merge

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,63 @@
+name: Codecov
+
+on:
+  pull_request:
+    branches: [ master ]
+    types:
+      - closed
+
+jobs:
+
+  build:
+    name: Build
+    if: github.event.pull_request.merged == true
+    strategy:
+      matrix:
+        go-version: [1.15.x, 1.14.x]
+        platform: [ubuntu-latest]
+        env:
+          - TAGS=""
+          - TAGS="-tags bounds"
+          - TAGS="-tags noasm"
+          - TAGS="-tags safe"
+
+    runs-on: ${{ matrix.platform }}
+    env:
+        GO111MODULE: on
+        GOPATH: ${{ github.workspace }}
+    defaults:
+        run:
+            working-directory: ${{ env.GOPATH }}/src/gonum.org/v1/gonum
+
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Cache-Go
+      uses: actions/cache@v1
+      with:
+        path: |
+            ~/go/pkg/mod              # Module download cache
+            ~/.cache/go-build         # Build cache (Linux)
+            ~/Library/Caches/go-build # Build cache (Mac)
+            '%LocalAppData%\go-build' # Build cache (Windows)
+
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+          path: ${{ env.GOPATH }}/src/gonum.org/v1/gonum
+
+    - name: Coverage
+      if: matrix.platform == 'ubuntu-latest'
+      run: |
+        ./.github/workflows/test-coverage.sh
+
+    - name: Upload-Coverage
+      if: matrix.platform == 'ubuntu-latest'
+      uses: codecov/codecov-action@v1


### PR DESCRIPTION
We have been missing base reports since the migration from travis since GitHub Actions (per default) don't run on merge. This and the rebase/squash merge policy that we use means that the reports that have been uploaded to Codecov are never relevant to future reports since they are always off the master branch. This does a run of coverage only when a PR is closed and the closure was a merge. It only does this for the tags and only for ubuntu, but the infrastructure for extension is left in in case we want to extend to macOS later.

No change will be visible in the pre-merge stage of this PR (unfortunately).

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
