### PR TITLE
ci: lie to codecov action about the origin of the report

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -25,6 +25,11 @@ jobs:
     env:
         GO111MODULE: on
         GOPATH: ${{ github.workspace }}
+        # We lie to the codecov action with this to sneak the PR number into the correct place.
+        # See https://github.com/codecov/codecov-bash/blob/23d483627d43bca0b7de38a17a554b0d8ef59f6b/codecov#L822-L857
+        GITHUB_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        GITHUB_HEAD_REF: refs/heads/master
+        GITHUB_SHA: ${{ github.event.pull_request.merge_commit_sha }}
     defaults:
         run:
             working-directory: ${{ env.GOPATH }}/src/gonum.org/v1/gonum
@@ -61,3 +66,5 @@ jobs:
     - name: Upload-Coverage
       if: matrix.platform == 'ubuntu-latest'
       uses: codecov/codecov-action@v1
+      with:
+        env_vars: GITHUB_REF,GITHUB_HEAD_REF,GITHUB_SHA


### PR DESCRIPTION
This is another leap into the darkness.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
