### PR TITLE
ci: use new codecov action API to fix coverage report issues

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -25,11 +25,6 @@ jobs:
     env:
         GO111MODULE: on
         GOPATH: ${{ github.workspace }}
-        # We lie to the codecov action with this to sneak the PR number into the correct place.
-        # See https://github.com/codecov/codecov-bash/blob/23d483627d43bca0b7de38a17a554b0d8ef59f6b/codecov#L822-L857
-        GITHUB_REF: refs/pull/${{ github.event.pull_request.number }}/merge
-        GITHUB_HEAD_REF: refs/heads/master
-        GITHUB_SHA: ${{ github.event.pull_request.merge_commit_sha }}
     defaults:
         run:
             working-directory: ${{ env.GOPATH }}/src/gonum.org/v1/gonum
@@ -65,6 +60,8 @@ jobs:
 
     - name: Upload-Coverage
       if: matrix.platform == 'ubuntu-latest'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v1.2
       with:
-        env_vars: GITHUB_REF,GITHUB_HEAD_REF,GITHUB_SHA
+        override_pr: ${{ github.event.pull_request.number }}
+        override_commit: ${{ github.event.pull_request.merge_commit_sha }}
+        override_branch: "refs/heads/master"


### PR DESCRIPTION
Hopefully this is going to work. Again, we won't know until it's merged.

The [new API](https://github.com/codecov/codecov-action#arguments) was added at least in part to address the issue we have been having, so thanks to Codecov for that.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
