### PR TITLE
travis: remove all non-arm64 targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,8 @@ go:
 
 os:
  - linux
- - osx
- - windows
 
 arch:
- - amd64
  - arm64
 
 env:
@@ -29,62 +26,14 @@ env:
   - TAGS="-tags bounds"
   - TAGS="-tags noasm"
   - TAGS="-tags safe"
-  - FORCE_GOARCH=386
 
 cache:
  directories:
   - $HOME/.cache/go-build
   - $HOME/gopath/pkg/mod
 
-git:
- depth: 1
- autocrlf: input
-
 matrix:
  fast_finish: true
- exclude:
-  - os: linux
-    arch: arm64
-    env: TAGS="-tags bounds"
-  - os: linux
-    arch: arm64
-    env: TAGS="-tags noasm"
-  - os: linux
-    arch: arm64
-    env: TAGS="-tags safe"
-  - os: linux
-    arch: arm64
-    env: FORCE_GOARCH=386
-
-  - os: osx
-    env: TAGS="-tags bounds"
-  - os: osx
-    env: TAGS="-tags noasm"
-  - os: osx
-    env: TAGS="-tags safe"
-  - os: osx
-    env: FORCE_GOARCH=386
-
-  - os: osx
-    arch: arm64
-
-  - os: osx
-    go: master
-
-  - os: windows
-    env: TAGS="-tags bounds"
-  - os: windows
-    env: TAGS="-tags noasm"
-  - os: windows
-    env: TAGS="-tags safe"
-  - os: windows
-    env: FORCE_GOARCH=386
-
-  - os: windows
-    arch: arm64
-
-  - os: windows
-    go: master
  allow_failures:
   - go: master
 


### PR DESCRIPTION
Travis have been entirely non-responsive to support requests to follow up on their promise to provide us with either hold-over credits to allow tests to continue or provide OSS plans. If they do eventually get around to it the cost of testing is pretty high (we burned through 10,000 in a few weeks), so this change is to direct what they give us where it will be most useful, arm64 which is not currently supported by GitHub actions.

After this is merged (based on faith rather than testing), I'll reorganise the files in .travis/ so that it's more obvious that they are shared with other CI service configurations.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
