### PR TITLE
lapack/gonum: fix link to gonum/mat in package doc

### DIFF
--- a/lapack/gonum/doc.go
+++ b/lapack/gonum/doc.go
@@ -23,6 +23,6 @@
 // The full LAPACK capability has not been implemented at present. The full
 // API is very large, containing approximately 200 functions for double precision
 // alone. Future additions will be focused on supporting the Gonum matrix
-// package (https://godoc.org/github.com/gonum/matrix/mat64), though pull requests
+// package (https://godoc.org/gonum.org/v1/gonum/mat), though pull requests
 // with implementations and tests for LAPACK function are encouraged.
 package gonum // import "gonum.org/v1/gonum/lapack/gonum"


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
