### PR TITLE
graph/{multi,simple,testgraph}: add support for ID-specified node addition

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -146,6 +146,18 @@ type NodeAdder interface {
 	AddNode(Node)
 }
 
+// NodeWithIDer is a graph that can return potentially new nodes with
+// a defined ID.
+type NodeWithIDer interface {
+	// NodeWithID returns a Node with the given ID if possible.
+	// A nil Node will be returned if no Node exists or
+	// can be created.
+	// If a non-nil Node is returned that is not already in the
+	// graph NodeWithID will return true for new and the Node
+	// must be added to the graph before use.
+	NodeWithID(id int64) (n Node, new bool)
+}
+
 // NodeRemover is an interface for removing nodes from a graph.
 type NodeRemover interface {
 	// RemoveNode removes the node with the given ID

--- a/graph/multi/directed.go
+++ b/graph/multi/directed.go
@@ -187,6 +187,17 @@ func (g *DirectedGraph) Nodes() graph.Nodes {
 	return iterator.NewNodes(g.nodes)
 }
 
+// NodeWithID returns a Node with the given ID if possible. If a graph.Node
+// is returned that is not already in the graph NodeWithID will return true
+// for new and the graph.Node must be added to the graph before use.
+func (g *DirectedGraph) NodeWithID(id int64) (n graph.Node, new bool) {
+	n, ok := g.nodes[id]
+	if ok {
+		return n, false
+	}
+	return Node(id), true
+}
+
 // RemoveLine removes the line with the given end point and line IDs from the graph, leaving
 // the terminal nodes. If the line does not exist it is a no-op.
 func (g *DirectedGraph) RemoveLine(fid, tid, id int64) {

--- a/graph/multi/undirected.go
+++ b/graph/multi/undirected.go
@@ -196,6 +196,17 @@ func (g *UndirectedGraph) Nodes() graph.Nodes {
 	return iterator.NewNodes(g.nodes)
 }
 
+// NodeWithID returns a Node with the given ID if possible. If a graph.Node
+// is returned that is not already in the graph NodeWithID will return true
+// for new and the graph.Node must be added to the graph before use.
+func (g *UndirectedGraph) NodeWithID(id int64) (n graph.Node, new bool) {
+	n, ok := g.nodes[id]
+	if ok {
+		return n, false
+	}
+	return Node(id), true
+}
+
 // RemoveLine removes the line with the given end point and line Ids from the graph, leaving
 // the terminal nodes. If the line does not exist it is a no-op.
 func (g *UndirectedGraph) RemoveLine(fid, tid, id int64) {

--- a/graph/multi/weighted_directed.go
+++ b/graph/multi/weighted_directed.go
@@ -195,6 +195,17 @@ func (g *WeightedDirectedGraph) Nodes() graph.Nodes {
 	return iterator.NewNodes(g.nodes)
 }
 
+// NodeWithID returns a Node with the given ID if possible. If a graph.Node
+// is returned that is not already in the graph NodeWithID will return true
+// for new and the graph.Node must be added to the graph before use.
+func (g *WeightedDirectedGraph) NodeWithID(id int64) (n graph.Node, new bool) {
+	n, ok := g.nodes[id]
+	if ok {
+		return n, false
+	}
+	return Node(id), true
+}
+
 // RemoveLine removes the line with the given end point and line IDs from the graph,
 // leaving the terminal nodes. If the line does not exist it is a no-op.
 func (g *WeightedDirectedGraph) RemoveLine(fid, tid, id int64) {

--- a/graph/multi/weighted_undirected.go
+++ b/graph/multi/weighted_undirected.go
@@ -202,6 +202,17 @@ func (g *WeightedUndirectedGraph) Nodes() graph.Nodes {
 	return iterator.NewNodes(g.nodes)
 }
 
+// NodeWithID returns a Node with the given ID if possible. If a graph.Node
+// is returned that is not already in the graph NodeWithID will return true
+// for new and the graph.Node must be added to the graph before use.
+func (g *WeightedUndirectedGraph) NodeWithID(id int64) (n graph.Node, new bool) {
+	n, ok := g.nodes[id]
+	if ok {
+		return n, false
+	}
+	return Node(id), true
+}
+
 // RemoveLine removes the line with the given end point and line IDs from the graph,
 // leaving the terminal nodes. If the line does not exist it is a no-op.
 func (g *WeightedUndirectedGraph) RemoveLine(fid, tid, id int64) {

--- a/graph/simple/directed.go
+++ b/graph/simple/directed.go
@@ -139,6 +139,17 @@ func (g *DirectedGraph) Nodes() graph.Nodes {
 	return iterator.NewNodes(g.nodes)
 }
 
+// NodeWithID returns a Node with the given ID if possible. If a graph.Node
+// is returned that is not already in the graph NodeWithID will return true
+// for new and the graph.Node must be added to the graph before use.
+func (g *DirectedGraph) NodeWithID(id int64) (n graph.Node, new bool) {
+	n, ok := g.nodes[id]
+	if ok {
+		return n, false
+	}
+	return Node(id), true
+}
+
 // RemoveEdge removes the edge with the given end point IDs from the graph, leaving the terminal
 // nodes. If the edge does not exist it is a no-op.
 func (g *DirectedGraph) RemoveEdge(fid, tid int64) {

--- a/graph/simple/undirected.go
+++ b/graph/simple/undirected.go
@@ -144,6 +144,17 @@ func (g *UndirectedGraph) Nodes() graph.Nodes {
 	return iterator.NewNodes(g.nodes)
 }
 
+// NodeWithID returns a Node with the given ID if possible. If a graph.Node
+// is returned that is not already in the graph NodeWithID will return true
+// for new and the graph.Node must be added to the graph before use.
+func (g *UndirectedGraph) NodeWithID(id int64) (n graph.Node, new bool) {
+	n, ok := g.nodes[id]
+	if ok {
+		return n, false
+	}
+	return Node(id), true
+}
+
 // RemoveEdge removes the edge with the given end IDs from the graph, leaving the terminal nodes.
 // If the edge does not exist it is a no-op.
 func (g *UndirectedGraph) RemoveEdge(fid, tid int64) {

--- a/graph/simple/weighted_directed.go
+++ b/graph/simple/weighted_directed.go
@@ -143,6 +143,17 @@ func (g *WeightedDirectedGraph) Nodes() graph.Nodes {
 	return iterator.NewNodes(g.nodes)
 }
 
+// NodeWithID returns a Node with the given ID if possible. If a graph.Node
+// is returned that is not already in the graph NodeWithID will return true
+// for new and the graph.Node must be added to the graph before use.
+func (g *WeightedDirectedGraph) NodeWithID(id int64) (n graph.Node, new bool) {
+	n, ok := g.nodes[id]
+	if ok {
+		return n, false
+	}
+	return Node(id), true
+}
+
 // RemoveEdge removes the edge with the given end point IDs from the graph, leaving the terminal
 // nodes. If the edge does not exist it is a no-op.
 func (g *WeightedDirectedGraph) RemoveEdge(fid, tid int64) {

--- a/graph/simple/weighted_undirected.go
+++ b/graph/simple/weighted_undirected.go
@@ -142,6 +142,17 @@ func (g *WeightedUndirectedGraph) Nodes() graph.Nodes {
 	return iterator.NewNodes(g.nodes)
 }
 
+// NodeWithID returns a Node with the given ID if possible. If a graph.Node
+// is returned that is not already in the graph NodeWithID will return true
+// for new and the graph.Node must be added to the graph before use.
+func (g *WeightedUndirectedGraph) NodeWithID(id int64) (n graph.Node, new bool) {
+	n, ok := g.nodes[id]
+	if ok {
+		return n, false
+	}
+	return Node(id), true
+}
+
 // RemoveEdge removes the edge with the given end point IDs from the graph, leaving the terminal
 // nodes. If the edge does not exist  it is a no-op.
 func (g *WeightedUndirectedGraph) RemoveEdge(fid, tid int64) {


### PR DESCRIPTION
I'm not sure about the placement of the `NodeWithIDer` interface. Given that we need to have it in testgraph, I'm thinking that maybe it *should* just go in graph.

Please take a look.

Updates #1582.

/cc @mattConn 

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
