### PR TITLE
 internal/asm/f32: add assembly Sum implementation

### DIFF
--- a/internal/asm/f32/stubs_amd64.go
+++ b/internal/asm/f32/stubs_amd64.go
@@ -66,3 +66,11 @@ func DotUnitary(x, y []float32) (sum float32)
 //  }
 //  return sum
 func DotInc(x, y []float32, n, incX, incY, ix, iy uintptr) (sum float32)
+
+// Sum is
+//  var sum float32
+//  for _, v := range x {
+// 		sum += v
+//  }
+//  return sum
+func Sum(x []float32) float32

--- a/internal/asm/f32/stubs_noasm.go
+++ b/internal/asm/f32/stubs_noasm.go
@@ -111,3 +111,17 @@ func DdotInc(x, y []float32, n, incX, incY, ix, iy uintptr) (sum float64) {
 	}
 	return
 }
+
+// Sum is
+//  var sum float32
+//  for _, v := range x {
+//  	sum += v
+//  }
+//  return sum
+func Sum(x []float32) float32 {
+	var sum float32
+	for _, v := range x {
+		sum += v
+	}
+	return sum
+}

--- a/internal/asm/f32/stubs_test.go
+++ b/internal/asm/f32/stubs_test.go
@@ -150,3 +150,63 @@ func TestAxpyIncTo(t *testing.T) {
 		checkValidIncGuard(t, v.dst, 0, int(v.incDst), gdLn)
 	}
 }
+
+func TestSum(t *testing.T) {
+	var srcGd float32 = -1
+	for j, v := range []struct {
+		src    []float32
+		expect float32
+	}{
+		{
+			src:    []float32{},
+			expect: 0,
+		},
+		{
+			src:    []float32{1},
+			expect: 1,
+		},
+		{
+			src:    []float32{nan},
+			expect: nan,
+		},
+		{
+			src:    []float32{1, 2, 3},
+			expect: 6,
+		},
+		{
+			src:    []float32{1, -4, 3},
+			expect: 0,
+		},
+		{
+			src:    []float32{1, 2, 3, 4},
+			expect: 10,
+		},
+		{
+			src:    []float32{1, 1, nan, 1, 1},
+			expect: nan,
+		},
+		{
+			src:    []float32{inf, 4, nan, -inf, 9},
+			expect: nan,
+		},
+		{
+			src:    []float32{1, 1, 1, 1, 9, 1, 1, 1, 2, 1, 1, 1, 1, 1, 5, 1},
+			expect: 29,
+		},
+		{
+			src:    []float32{1, 1, 1, 1, 9, 1, 1, 1, 2, 1, 1, 1, 1, 1, 5, 11, 1, 1, 1, 9, 1, 1, 1, 2, 1, 1, 1, 1, 1, 5, 1},
+			expect: 67,
+		},
+	} {
+		gdLn := 4 + j%2
+		gsrc := guardVector(v.src, srcGd, gdLn)
+		src := gsrc[gdLn : len(gsrc)-gdLn]
+		ret := Sum(src)
+		if !same(ret, v.expect) {
+			t.Errorf("Test %d Sum error Got: %v Expected: %v", j, ret, v.expect)
+		}
+		if !isValidGuard(gsrc, srcGd, gdLn) {
+			t.Errorf("Test %d Guard violated in src vector %v %v", j, gsrc[:gdLn], gsrc[len(gsrc)-gdLn:])
+		}
+	}
+}

--- a/internal/asm/f32/stubs_test.go
+++ b/internal/asm/f32/stubs_test.go
@@ -198,15 +198,17 @@ func TestSum(t *testing.T) {
 			expect: 67,
 		},
 	} {
-		gdLn := 4 + j%2
-		gsrc := guardVector(v.src, srcGd, gdLn)
-		src := gsrc[gdLn : len(gsrc)-gdLn]
-		ret := Sum(src)
-		if !same(ret, v.expect) {
-			t.Errorf("Test %d Sum error Got: %v Expected: %v", j, ret, v.expect)
-		}
-		if !isValidGuard(gsrc, srcGd, gdLn) {
-			t.Errorf("Test %d Guard violated in src vector %v %v", j, gsrc[:gdLn], gsrc[len(gsrc)-gdLn:])
+		for _, i := range [4]int{0, 1, 2, 3} {
+			gdLn := 4 + j%4 + i
+			gsrc := guardVector(v.src, srcGd, gdLn)
+			src := gsrc[gdLn : len(gsrc)-gdLn]
+			ret := Sum(src)
+			if !same(ret, v.expect) {
+				t.Errorf("Test %d Sum error Got: %v Expected: %v", j, ret, v.expect)
+			}
+			if !isValidGuard(gsrc, srcGd, gdLn) {
+				t.Errorf("Test %d Guard violated in src vector %v %v", j, gsrc[:gdLn], gsrc[len(gsrc)-gdLn:])
+			}
 		}
 	}
 }

--- a/internal/asm/f32/sum_amd64.s
+++ b/internal/asm/f32/sum_amd64.s
@@ -39,7 +39,7 @@ sum_align: // Align on 16-byte boundary do {
 	DECQ  LEN                 // LEN--
 	JZ    sum_end             // if LEN == 0 { return }
 	ADDQ  $4, TAIL            // TAIL += 4
-	JNZ   sum_align           //  } while TAIL < 0
+	JNZ   sum_align           // } while TAIL < 0
 
 no_trim:
 	MOVQ LEN, TAIL

--- a/internal/asm/f32/sum_amd64.s
+++ b/internal/asm/f32/sum_amd64.s
@@ -78,18 +78,18 @@ sum_tail4:
 	ADDQ  $4, IDX
 
 sum_tail2:
-	HADDPS SUM, SUM           // sum_i[:2] += sum_i[2:4]
-	HADDPS SUM, SUM           // sum_i[0] += sum_i[1]
+	HADDPS SUM, SUM            // sum_i[:2] += sum_i[2:4]
 
 	TESTQ $2, TAIL
 	JZ    sum_tail1
 
-	ADDSS (X_PTR)(IDX*4), SUM // sum_i += x[i:i+1]
-	ADDQ  $1, IDX
-	ADDSS (X_PTR)(IDX*4), SUM // sum_i += x[i:i+1]
-	ADDQ  $1, IDX
+	MOVSD (X_PTR)(IDX*4), SUM_1 // reuse SUM_1
+	ADDPS SUM_1, SUM            // sum_i += x[i:i+2]
+	ADDQ  $2, IDX
 
 sum_tail1:
+	HADDPS SUM, SUM // sum_i[0] += sum_i[1]
+
 	TESTQ $1, TAIL
 	JZ    sum_end
 

--- a/internal/asm/f32/sum_amd64.s
+++ b/internal/asm/f32/sum_amd64.s
@@ -1,0 +1,101 @@
+// Copyright ©2021 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !noasm,!gccgo,!safe
+
+#include "textflag.h"
+
+#define X_PTR SI
+#define IDX AX
+#define LEN CX
+#define TAIL BX
+#define SUM X0
+#define SUM_1 X1
+#define SUM_2 X2
+#define SUM_3 X3
+
+// func Sum(x []float32) float32
+TEXT ·Sum(SB), NOSPLIT, $0
+	MOVQ x_base+0(FP), X_PTR // X_PTR = &x
+	MOVQ x_len+8(FP), LEN    // LEN = len(x)
+	XORQ IDX, IDX            // i = 0
+	PXOR SUM, SUM            // p_sum_i = 0
+	CMPQ LEN, $0             // if LEN == 0 { return 0 }
+	JE   sum_end
+
+	PXOR SUM_1, SUM_1
+	PXOR SUM_2, SUM_2
+	PXOR SUM_3, SUM_3
+
+	MOVQ X_PTR, TAIL // Check memory alignment
+	ANDQ $15, TAIL   // TAIL = &x % 16
+	JZ   no_trim     // if TAIL == 0 { goto no_trim }
+	SUBQ $16, TAIL
+
+sum_align:
+	// Align on 16-byte boundary
+	ADDSS (X_PTR)(IDX*4), SUM // SUM += x[0]
+	INCQ  IDX         // i++
+	DECQ  LEN         // LEN--
+	JZ    sum_end     // if LEN == 0 { return }
+	ADDQ  $4, TAIL
+	JNZ   sum_align
+
+no_trim:
+	MOVQ LEN, TAIL
+	SHRQ $4, LEN   // LEN = floor( n / 16 )
+	JZ   sum_tail8 // if LEN == 0 { goto sum_tail8 }
+
+
+sum_loop: // sum 16x wide do {
+	ADDPS (X_PTR)(IDX*4), SUM      // sum_i += x[i:i+4]
+	ADDPS 16(X_PTR)(IDX*4), SUM_1
+	ADDPS 32(X_PTR)(IDX*4), SUM_2
+	ADDPS 48(X_PTR)(IDX*4), SUM_3
+
+	ADDQ  $16, IDX             // i += 16
+	DECQ  LEN
+	JNZ   sum_loop             // } while --LEN > 0
+
+sum_tail8:
+	ADDPS SUM_3, SUM
+	ADDPS SUM_2, SUM_1
+
+	TESTQ $8, TAIL
+	JZ    sum_tail4
+
+	ADDPS (X_PTR)(IDX*4), SUM     // sum_i += x[i:i+4]
+	ADDPS 16(X_PTR)(IDX*4), SUM_1
+	ADDQ  $8, IDX
+
+sum_tail4:
+	ADDPS SUM_1, SUM
+
+	TESTQ $4, TAIL
+	JZ    sum_tail2
+
+	ADDPS (X_PTR)(IDX*4), SUM     // sum_i += x[i:i+4]
+	ADDQ  $4, IDX
+
+sum_tail2:
+	HADDPS SUM, SUM // sum_i[:2] += sum_i[2:4]
+	HADDPS SUM, SUM // sum_i[0] += sum_i[1]
+
+	TESTQ $2, TAIL
+	JZ    sum_tail1
+
+	ADDSS (X_PTR)(IDX*4), SUM // sum_i += x[i:i+1]
+	ADDQ  $1, IDX
+	ADDSS (X_PTR)(IDX*4), SUM // sum_i += x[i:i+1]
+	ADDQ  $1, IDX
+
+sum_tail1:
+	TESTQ $1, TAIL
+	JZ    sum_end
+
+	ADDSS (X_PTR)(IDX*4), SUM
+
+sum_end: // return sum
+	MOVSS SUM, ret+24(FP)
+	RET


### PR DESCRIPTION
Tests pass, implementation based on https://github.com/gonum/gonum/blob/master/internal/asm/f64/sum_amd64.s (including taking over the respective tests).

I know `f32` isn't really exposed, but I hope that in the future maybe it will be. At the moment I simply copy it over ("vendor") and noticed this functionality was missing.