### PR TITLE
 internal/asm/f64: fix bug and clean up variable names

### DIFF
--- a/internal/asm/f64/stubs_test.go
+++ b/internal/asm/f64/stubs_test.go
@@ -635,5 +635,16 @@ func TestSum(t *testing.T) {
 		if !isValidGuard(gsrc, srcGd, gdLn) {
 			t.Errorf("Test %d Guard violated in src vector %v %v", j, gsrc[:gdLn], gsrc[len(gsrc)-gdLn:])
 		}
+
+		gdLn++
+		gsrc = guardVector(v.src, srcGd, gdLn)
+		src = gsrc[gdLn : len(gsrc)-gdLn]
+		ret = Sum(src)
+		if !scalar.Same(ret, v.expect) {
+			t.Errorf("Test %d Sum error Got: %v Expected: %v", j, ret, v.expect)
+		}
+		if !isValidGuard(gsrc, srcGd, gdLn) {
+			t.Errorf("Test %d Guard violated in src vector %v %v", j, gsrc[:gdLn], gsrc[len(gsrc)-gdLn:])
+		}
 	}
 }

--- a/internal/asm/f64/sum_amd64.s
+++ b/internal/asm/f64/sum_amd64.s
@@ -36,8 +36,7 @@ TEXT ·Sum(SB), NOSPLIT, $0
 	ADDSD (X_PTR), X0 // X0 += x[0]
 	INCQ  IDX         // i++
 	DECQ  LEN         // LEN--
-	DECQ  TAIL        // TAIL--
-	JZ    sum_end     // if TAIL == 0 { return }
+	JZ    sum_end     // if LEN == 0 { return }
 
 no_trim:
 	MOVQ LEN, TAIL
@@ -45,26 +44,26 @@ no_trim:
 	JZ   sum_tail8 // if LEN == 0 { goto sum_tail8 }
 
 sum_loop: // sum 16x wide do {
-	ADDPD (SI)(AX*8), SUM      // sum_i += x[i:i+2]
-	ADDPD 16(SI)(AX*8), SUM_1
-	ADDPD 32(SI)(AX*8), SUM_2
-	ADDPD 48(SI)(AX*8), SUM_3
-	ADDPD 64(SI)(AX*8), SUM
-	ADDPD 80(SI)(AX*8), SUM_1
-	ADDPD 96(SI)(AX*8), SUM_2
-	ADDPD 112(SI)(AX*8), SUM_3
-	ADDQ  $16, IDX             // i += 16
+	ADDPD (X_PTR)(IDX*8), SUM      // sum_i += x[i:i+2]
+	ADDPD 16(X_PTR)(IDX*8), SUM_1
+	ADDPD 32(X_PTR)(IDX*8), SUM_2
+	ADDPD 48(X_PTR)(IDX*8), SUM_3
+	ADDPD 64(X_PTR)(IDX*8), SUM
+	ADDPD 80(X_PTR)(IDX*8), SUM_1
+	ADDPD 96(X_PTR)(IDX*8), SUM_2
+	ADDPD 112(X_PTR)(IDX*8), SUM_3
+	ADDQ  $16, IDX                 // i += 16
 	DECQ  LEN
-	JNZ   sum_loop             // } while --CX > 0
+	JNZ   sum_loop                 // } while --LEN > 0
 
 sum_tail8:
 	TESTQ $8, TAIL
 	JZ    sum_tail4
 
-	ADDPD (SI)(AX*8), SUM     // sum_i += x[i:i+2]
-	ADDPD 16(SI)(AX*8), SUM_1
-	ADDPD 32(SI)(AX*8), SUM_2
-	ADDPD 48(SI)(AX*8), SUM_3
+	ADDPD (X_PTR)(IDX*8), SUM     // sum_i += x[i:i+2]
+	ADDPD 16(X_PTR)(IDX*8), SUM_1
+	ADDPD 32(X_PTR)(IDX*8), SUM_2
+	ADDPD 48(X_PTR)(IDX*8), SUM_3
 	ADDQ  $8, IDX
 
 sum_tail4:
@@ -74,8 +73,8 @@ sum_tail4:
 	TESTQ $4, TAIL
 	JZ    sum_tail2
 
-	ADDPD (SI)(AX*8), SUM     // sum_i += x[i:i+2]
-	ADDPD 16(SI)(AX*8), SUM_1
+	ADDPD (X_PTR)(IDX*8), SUM     // sum_i += x[i:i+2]
+	ADDPD 16(X_PTR)(IDX*8), SUM_1
 	ADDQ  $4, IDX
 
 sum_tail2:
@@ -84,7 +83,7 @@ sum_tail2:
 	TESTQ $2, TAIL
 	JZ    sum_tail1
 
-	ADDPD (SI)(AX*8), SUM // sum_i += x[i:i+2]
+	ADDPD (X_PTR)(IDX*8), SUM // sum_i += x[i:i+2]
 	ADDQ  $2, IDX
 
 sum_tail1:
@@ -93,7 +92,7 @@ sum_tail1:
 	TESTQ $1, TAIL
 	JZ    sum_end
 
-	ADDSD (SI)(IDX*8), SUM
+	ADDSD (X_PTR)(IDX*8), SUM
 
 sum_end: // return sum
 	MOVSD SUM, ret+24(FP)


### PR DESCRIPTION
The code was jumping to end when tail == 0, but the correct thing is to jump when `LEN` is zero. `TAIL == 0` means we can start the summing pipeline. We also don't need to decrement the TAIL since we overwrite it at start of `no_trim`

This was not caught by the tests (they pass before and now). I am curious if anyone has an idea for a test case that would catch this.

I've also made the register names consistent.