### PR TITLE
graph/traverse: fix depth first traversal order and tighten tests

### DIFF
--- a/graph/traverse/traverse.go
+++ b/graph/traverse/traverse.go
@@ -160,32 +160,27 @@ func (d *DepthFirst) Walk(g Graph, from graph.Node, until func(graph.Node) bool)
 		d.visited = make(set.Int64s)
 	}
 	d.stack.Push(from)
-	if d.Visit != nil && !d.visited.Has(from.ID()) {
-		d.Visit(from)
-	}
-	d.visited.Add(from.ID())
-
-	for d.stack.Len() > 0 {
-		t := d.stack.Pop()
-		if until != nil && until(t) {
-			return t
+	for d.stack.Len() != 0 {
+		u := d.stack.Pop()
+		uid := u.ID()
+		if d.visited.Has(uid) {
+			continue
 		}
-		tid := t.ID()
-		to := g.From(tid)
+		d.visited.Add(uid)
+		if d.Visit != nil {
+			d.Visit(u)
+		}
+		if until != nil && until(u) {
+			return u
+		}
+		to := g.From(uid)
 		for to.Next() {
-			n := to.Node()
-			nid := n.ID()
-			if d.Traverse != nil && !d.Traverse(g.Edge(tid, nid)) {
+			v := to.Node()
+			vid := v.ID()
+			if d.Traverse != nil && !d.Traverse(g.Edge(uid, vid)) {
 				continue
 			}
-			if d.visited.Has(nid) {
-				continue
-			}
-			if d.Visit != nil {
-				d.Visit(n)
-			}
-			d.visited.Add(nid)
-			d.stack.Push(n)
+			d.stack.Push(v)
 		}
 	}
 


### PR DESCRIPTION
Please take a look.

The Batagelj-Zaversnik graph traversal from 13 is removed due to the number of potential valid orderings.

Fixes #1595.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
