### PR TITLE
lapack/gonum: check for overflow in Dtgsja

### DIFF
--- a/lapack/gonum/dtgsja.go
+++ b/lapack/gonum/dtgsja.go
@@ -326,10 +326,8 @@ func (impl Implementation) Dtgsja(jobU, jobV, jobQ lapack.GSVDJob, m, p, n, k, l
 				for i := 0; i < min(l, m-k); i++ {
 					a1 := a[(k+i)*lda+n-l+i]
 					b1 := b[i*ldb+n-l+i]
-
-					if a1 != 0 {
-						gamma := b1 / a1
-
+					gamma := b1 / a1
+					if !math.IsInf(gamma, 0) {
 						// Change sign if necessary.
 						if gamma < 0 {
 							bi.Dscal(l-i, -1, b[i*ldb+n-l+i:], 1)


### PR DESCRIPTION
Please take a look.

I don't have a failing test case for this change but it was done in the reference in https://github.com/Reference-LAPACK/lapack/pull/502 and looks like a safe change to make. The PR references a test case for CGGSVD3 which does trigger a failure but it looks like a deficiency of our test (too strict by not taking into account the norm of the input matrices).

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
