### PR TITLE
codecov: change override branch to master

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -65,4 +65,4 @@ jobs:
       with:
         override_pr: ${{ github.event.pull_request.number }}
         override_commit: ${{ github.event.pull_request.merge_commit_sha }}
-        override_branch: "refs/heads/master"
+        override_branch: "master"


### PR DESCRIPTION
This is to investigate the recent failure to upload coverage reports (failure starts after March 23) after merging into master as the master branch. This is required due to the model codecov uses to calculate coverage changes.

The change here was suggested by codecov support as an experiment.

It will make no difference to the outcome of the PR coverage, but may make a difference to the merged coverage report and so we won't know until this is merged.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
