### PR TITLE
graph/iterator: fix Len for depleted ImplicitNodesIterator

### DIFF
--- a/graph/iterator/nodes.go
+++ b/graph/iterator/nodes.go
@@ -389,6 +389,9 @@ func NewImplicitNodes(beg, end int, new func(id int) graph.Node) *ImplicitNodes 
 
 // Len returns the remaining number of nodes to be iterated over.
 func (n *ImplicitNodes) Len() int {
+	if n.end <= n.curr {
+		return 0
+	}
 	return n.end - n.curr - 1
 }
 

--- a/graph/iterator/nodes_test.go
+++ b/graph/iterator/nodes_test.go
@@ -98,6 +98,9 @@ func TestImplicitNodesIterate(t *testing.T) {
 					t.Errorf("unexpected iterator length during iteration for round %d: got:%d want:%d", i, it.Len(), (test.end-test.beg)-len(got))
 				}
 			}
+			if it.Len() != 0 {
+				t.Errorf("unexpected depleted iterator length for round %d: got:%d want:0", i, it.Len())
+			}
 			if !reflect.DeepEqual(got, test.want) {
 				t.Errorf("unexpected iterator output for round %d: got:%#v want:%#v", i, got, test.want)
 			}


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
