### PR TITLE
graph/graphs/gen: check for all node id collisions

### DIFF
--- a/graph/graphs/gen/gen_example_test.go
+++ b/graph/graphs/gen/gen_example_test.go
@@ -16,10 +16,7 @@ import (
 
 func ExampleStar_undirectedRange() {
 	dst := simple.NewUndirectedGraph()
-	err := gen.Star(dst, 0, gen.IDRange{First: 1, Last: 6})
-	if err != nil {
-		log.Fatal(err)
-	}
+	gen.Star(dst, 0, gen.IDRange{First: 1, Last: 6})
 	b, err := dot.Marshal(dst, "star", "", "\t")
 	if err != nil {
 		log.Fatal(err)
@@ -49,10 +46,7 @@ func ExampleStar_undirectedRange() {
 
 func ExampleWheel_directedRange() {
 	dst := simple.NewDirectedGraph()
-	err := gen.Wheel(dst, 0, gen.IDRange{First: 1, Last: 6})
-	if err != nil {
-		log.Fatal(err)
-	}
+	gen.Wheel(dst, 0, gen.IDRange{First: 1, Last: 6})
 	b, err := dot.Marshal(dst, "wheel", "", "\t")
 	if err != nil {
 		log.Fatal(err)
@@ -88,10 +82,7 @@ func ExampleWheel_directedRange() {
 
 func ExamplePath_directedSet() {
 	dst := simple.NewDirectedGraph()
-	err := gen.Path(dst, gen.IDSet{2, 4, 5, 9})
-	if err != nil {
-		log.Fatal(err)
-	}
+	gen.Path(dst, gen.IDSet{2, 4, 5, 9})
 	b, err := dot.Marshal(dst, "path", "", "\t")
 	if err != nil {
 		log.Fatal(err)
@@ -115,10 +106,7 @@ func ExamplePath_directedSet() {
 
 func ExampleComplete_directedSet() {
 	dst := simple.NewDirectedGraph()
-	err := gen.Complete(dst, gen.IDSet{2, 4, 5, 9})
-	if err != nil {
-		log.Fatal(err)
-	}
+	gen.Complete(dst, gen.IDSet{2, 4, 5, 9})
 	b, err := dot.Marshal(dst, "complete", "", "\t")
 	if err != nil {
 		log.Fatal(err)
@@ -155,10 +143,7 @@ func (g Bidirected) SetEdge(e graph.Edge) {
 
 func ExampleComplete_biDirectedSet() {
 	dst := simple.NewDirectedGraph()
-	err := gen.Complete(Bidirected{dst}, gen.IDSet{2, 4, 5, 9})
-	if err != nil {
-		log.Fatal(err)
-	}
+	gen.Complete(Bidirected{dst}, gen.IDSet{2, 4, 5, 9})
 	b, err := dot.Marshal(dst, "complete", "", "\t")
 	if err != nil {
 		log.Fatal(err)
@@ -191,10 +176,7 @@ func ExampleComplete_biDirectedSet() {
 
 func ExampleComplete_undirectedSet() {
 	dst := simple.NewUndirectedGraph()
-	err := gen.Complete(dst, gen.IDSet{2, 4, 5, 9})
-	if err != nil {
-		log.Fatal(err)
-	}
+	gen.Complete(dst, gen.IDSet{2, 4, 5, 9})
 	b, err := dot.Marshal(dst, "complete", "", "\t")
 	if err != nil {
 		log.Fatal(err)

--- a/graph/graphs/gen/gen_test.go
+++ b/graph/graphs/gen/gen_test.go
@@ -6,6 +6,7 @@ package gen
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -26,12 +27,25 @@ type empty struct{}
 func (r empty) Len() int       { return 0 }
 func (r empty) ID(i int) int64 { panic("called ID on empty IDer") }
 
+func panics(fn func()) (panicked bool, msg string) {
+	defer func() {
+		r := recover()
+		if r != nil {
+			panicked = true
+			msg = fmt.Sprint(r)
+		}
+	}()
+	fn()
+	return
+}
+
 func TestComplete(t *testing.T) {
 	tests := []struct {
-		name string
-		ids  IDer
-		dst  func() nodeIDGraphBuilder
-		want string
+		name   string
+		ids    IDer
+		dst    func() nodeIDGraphBuilder
+		want   string
+		panics string
 	}{
 		{
 			name: "empty",
@@ -115,13 +129,22 @@ func TestComplete(t *testing.T) {
  3 -> 4;
 }`,
 		},
+		{
+			name:   "collision",
+			ids:    IDSet{1, 2, 3, 2},
+			dst:    undirected,
+			panics: "gen: node ID collision i=1 j=3: id=2",
+		},
 	}
 
 	for _, test := range tests {
 		dst := test.dst()
-		err := Complete(dst, test.ids)
-		if err != nil {
-			t.Errorf("unexpected error constructing graph: %v", err)
+		panicked, msg := panics(func() { Complete(dst, test.ids) })
+		if msg != test.panics {
+			t.Errorf("unexpected panic message for %q: got:%q want:%q", test.name, msg, test.panics)
+		}
+		if panicked {
+			continue
 		}
 		got, err := dot.Marshal(dst, test.name, "", " ")
 		if err != nil {
@@ -135,10 +158,11 @@ func TestComplete(t *testing.T) {
 
 func TestCycle(t *testing.T) {
 	tests := []struct {
-		name string
-		ids  IDer
-		dst  func() nodeIDGraphBuilder
-		want string
+		name   string
+		ids    IDer
+		dst    func() nodeIDGraphBuilder
+		want   string
+		panics string
 	}{
 		{
 			name: "empty",
@@ -219,13 +243,22 @@ func TestCycle(t *testing.T) {
  4 -> 1;
 }`,
 		},
+		{
+			name:   "collision",
+			ids:    IDSet{1, 2, 3, 2},
+			dst:    undirected,
+			panics: "gen: node ID collision i=1 j=3: id=2",
+		},
 	}
 
 	for _, test := range tests {
 		dst := test.dst()
-		err := Cycle(dst, test.ids)
-		if err != nil {
-			t.Errorf("unexpected error constructing graph: %v", err)
+		panicked, msg := panics(func() { Cycle(dst, test.ids) })
+		if msg != test.panics {
+			t.Errorf("unexpected panic message for %q: got:%q want:%q", test.name, msg, test.panics)
+		}
+		if panicked {
+			continue
 		}
 		got, err := dot.Marshal(dst, test.name, "", " ")
 		if err != nil {
@@ -239,10 +272,11 @@ func TestCycle(t *testing.T) {
 
 func TestPath(t *testing.T) {
 	tests := []struct {
-		name string
-		ids  IDer
-		dst  func() nodeIDGraphBuilder
-		want string
+		name   string
+		ids    IDer
+		dst    func() nodeIDGraphBuilder
+		want   string
+		panics string
 	}{
 		{
 			name: "empty",
@@ -320,13 +354,22 @@ func TestPath(t *testing.T) {
  3 -> 4;
 }`,
 		},
+		{
+			name:   "collision",
+			ids:    IDSet{1, 2, 3, 2},
+			dst:    undirected,
+			panics: "gen: node ID collision i=1 j=3: id=2",
+		},
 	}
 
 	for _, test := range tests {
 		dst := test.dst()
-		err := Path(dst, test.ids)
-		if err != nil {
-			t.Errorf("unexpected error constructing graph: %v", err)
+		panicked, msg := panics(func() { Path(dst, test.ids) })
+		if msg != test.panics {
+			t.Errorf("unexpected panic message for %q: got:%q want:%q", test.name, msg, test.panics)
+		}
+		if panicked {
+			continue
 		}
 		got, err := dot.Marshal(dst, test.name, "", " ")
 		if err != nil {
@@ -345,6 +388,7 @@ func TestStar(t *testing.T) {
 		leaves IDer
 		dst    func() nodeIDGraphBuilder
 		want   string
+		panics string
 	}{
 		{
 			name:   "empty_leaves",
@@ -358,6 +402,7 @@ func TestStar(t *testing.T) {
 		},
 		{
 			name:   "single",
+			center: 0,
 			leaves: IDRange{First: 1, Last: 1},
 			dst:    undirected,
 			want: `strict graph single {
@@ -371,6 +416,7 @@ func TestStar(t *testing.T) {
 		},
 		{
 			name:   "pair_undirected",
+			center: 0,
 			leaves: IDRange{First: 1, Last: 2},
 			dst:    undirected,
 			want: `strict graph pair_undirected {
@@ -386,6 +432,7 @@ func TestStar(t *testing.T) {
 		},
 		{
 			name:   "pair_directed",
+			center: 0,
 			leaves: IDRange{First: 1, Last: 2},
 			dst:    directed,
 			want: `strict digraph pair_directed {
@@ -401,6 +448,7 @@ func TestStar(t *testing.T) {
 		},
 		{
 			name:   "quad_undirected",
+			center: 0,
 			leaves: IDRange{First: 1, Last: 4},
 			dst:    undirected,
 			want: `strict graph quad_undirected {
@@ -420,6 +468,7 @@ func TestStar(t *testing.T) {
 		},
 		{
 			name:   "quad_directed",
+			center: 0,
 			leaves: IDRange{First: 1, Last: 4},
 			dst:    directed,
 			want: `strict digraph quad_directed {
@@ -437,13 +486,30 @@ func TestStar(t *testing.T) {
  0 -> 4;
 }`,
 		},
+		{
+			name:   "center collision",
+			center: 1,
+			leaves: IDRange{First: 1, Last: 4},
+			dst:    undirected,
+			panics: "gen: node ID collision i=0 with extra: id=1",
+		},
+		{
+			name:   "leaf collision",
+			center: 0,
+			leaves: IDSet{1, 2, 3, 2},
+			dst:    undirected,
+			panics: "gen: node ID collision i=1 j=3: id=2",
+		},
 	}
 
 	for _, test := range tests {
 		dst := test.dst()
-		err := Star(dst, test.center, test.leaves)
-		if err != nil {
-			t.Errorf("unexpected error constructing graph: %v", err)
+		panicked, msg := panics(func() { Star(dst, test.center, test.leaves) })
+		if msg != test.panics {
+			t.Errorf("unexpected panic message for %q: got:%q want:%q", test.name, msg, test.panics)
+		}
+		if panicked {
+			continue
 		}
 		got, err := dot.Marshal(dst, test.name, "", " ")
 		if err != nil {
@@ -462,6 +528,7 @@ func TestWheel(t *testing.T) {
 		cycle  IDer
 		dst    func() nodeIDGraphBuilder
 		want   string
+		panics string
 	}{
 		{
 			name:   "empty_cycle",
@@ -487,9 +554,10 @@ func TestWheel(t *testing.T) {
 }`,
 		},
 		{
-			name:  "pair_undirected",
-			cycle: IDRange{First: 1, Last: 2},
-			dst:   undirected,
+			name:   "pair_undirected",
+			center: 0,
+			cycle:  IDRange{First: 1, Last: 2},
+			dst:    undirected,
 			want: `strict graph pair_undirected {
  // Node definitions.
  0;
@@ -503,9 +571,10 @@ func TestWheel(t *testing.T) {
 }`,
 		},
 		{
-			name:  "pair_directed",
-			cycle: IDRange{First: 1, Last: 2},
-			dst:   directed,
+			name:   "pair_directed",
+			center: 0,
+			cycle:  IDRange{First: 1, Last: 2},
+			dst:    directed,
 			want: `strict digraph pair_directed {
  // Node definitions.
  0;
@@ -520,9 +589,10 @@ func TestWheel(t *testing.T) {
 }`,
 		},
 		{
-			name:  "quad_undirected",
-			cycle: IDRange{First: 1, Last: 4},
-			dst:   undirected,
+			name:   "quad_undirected",
+			center: 0,
+			cycle:  IDRange{First: 1, Last: 4},
+			dst:    undirected,
 			want: `strict graph quad_undirected {
  // Node definitions.
  0;
@@ -543,9 +613,10 @@ func TestWheel(t *testing.T) {
 }`,
 		},
 		{
-			name:  "quad_directed",
-			cycle: IDRange{First: 1, Last: 4},
-			dst:   directed,
+			name:   "quad_directed",
+			center: 0,
+			cycle:  IDRange{First: 1, Last: 4},
+			dst:    directed,
 			want: `strict digraph quad_directed {
  // Node definitions.
  0;
@@ -565,13 +636,30 @@ func TestWheel(t *testing.T) {
  4 -> 1;
 }`,
 		},
+		{
+			name:   "center collision",
+			center: 1,
+			cycle:  IDRange{First: 1, Last: 4},
+			dst:    undirected,
+			panics: "gen: node ID collision i=0 with extra: id=1",
+		},
+		{
+			name:   "cycle collision",
+			center: 0,
+			cycle:  IDSet{1, 2, 3, 2},
+			dst:    undirected,
+			panics: "gen: node ID collision i=1 j=3: id=2",
+		},
 	}
 
 	for _, test := range tests {
 		dst := test.dst()
-		err := Wheel(dst, test.center, test.cycle)
-		if err != nil {
-			t.Errorf("unexpected error constructing graph: %v", err)
+		panicked, msg := panics(func() { Wheel(dst, test.center, test.cycle) })
+		if msg != test.panics {
+			t.Errorf("unexpected panic message for %q: got:%q want:%q", test.name, msg, test.panics)
+		}
+		if panicked {
+			continue
 		}
 		got, err := dot.Marshal(dst, test.name, "", " ")
 		if err != nil {
@@ -579,6 +667,35 @@ func TestWheel(t *testing.T) {
 		}
 		if !bytes.Equal(got, []byte(test.want)) {
 			t.Errorf("unexpected result for test %s:\ngot:\n%s\nwant:\n%s", test.name, got, test.want)
+		}
+	}
+}
+
+func TestCheck(t *testing.T) {
+	tests := []struct {
+		ids   IDer
+		extra []int64
+		want  string
+	}{
+		{
+			ids: IDSet{1, 2, 3, 4}, extra: []int64{1},
+			want: "gen: node ID collision i=0 with extra: id=1",
+		},
+		{
+			ids: IDSet{1, 2, 3, 4}, extra: []int64{5, 2},
+			want: "gen: node ID collision i=1 with extra j=1: id=2",
+		},
+		{
+			ids: IDSet{}, extra: []int64{1, 2, 1},
+			want: "gen: extra node ID collision i=0 j=2: id=1",
+		},
+	}
+
+	for _, test := range tests {
+		msg := fmt.Sprint(check(test.ids, test.extra...))
+		if msg != test.want {
+			t.Errorf("unexpected check panic for ids=%#v extra=%v: got:%q want:%q",
+				test.ids, test.extra, msg, test.want)
 		}
 	}
 }


### PR DESCRIPTION
This incurs a greater cost for well-behaved code, but prevents subtle errors that would otherwise not be caught, for example  cycle(1,2,3,4,5,3) not being a single cycle.

Please take a look.

Closes #1614.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
