### PR TITLE
lapack/testlapack: add benchmark for Dlangb

### DIFF
--- a/lapack/gonum/bench_test.go
+++ b/lapack/gonum/bench_test.go
@@ -11,4 +11,5 @@ import (
 )
 
 func BenchmarkDgeev(b *testing.B)  { testlapack.DgeevBenchmark(b, impl) }
+func BenchmarkDlangb(b *testing.B) { testlapack.DlangbBenchmark(b, impl) }
 func BenchmarkDlantb(b *testing.B) { testlapack.DlantbBenchmark(b, impl) }

--- a/lapack/testlapack/dlangb_bench.go
+++ b/lapack/testlapack/dlangb_bench.go
@@ -1,0 +1,94 @@
+// Copyright ©2021 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/exp/rand"
+
+	"gonum.org/v1/gonum/lapack"
+)
+
+func DlangbBenchmark(b *testing.B, impl Dlangber) {
+	const (
+		safmin = dlamchS
+		safmax = 1 / safmin
+		ulp    = dlamchP
+		smlnum = safmin / ulp
+		bignum = safmax * ulp
+	)
+
+	rnd := rand.New(rand.NewSource(1))
+	for _, bm := range []struct {
+		n, k int
+	}{
+		{n: 1000, k: 0},
+		{n: 1000, k: 1},
+		{n: 1000, k: 2},
+		{n: 1000, k: 5},
+		{n: 1000, k: 8},
+		{n: 1000, k: 10},
+		{n: 1000, k: 20},
+		{n: 1000, k: 30},
+		{n: 10000, k: 0},
+		{n: 10000, k: 1},
+		{n: 10000, k: 2},
+		{n: 10000, k: 5},
+		{n: 10000, k: 8},
+		{n: 10000, k: 10},
+		{n: 10000, k: 30},
+		{n: 10000, k: 60},
+		{n: 10000, k: 100},
+	} {
+		n := bm.n
+		k := bm.k
+		lda := 2*k + 1
+		aCopy := make([]float64, n*lda)
+		for i := range aCopy {
+			aCopy[i] = 1 - 2*rnd.Float64()
+		}
+		a := make([]float64, len(aCopy))
+
+		for _, norm := range []lapack.MatrixNorm{lapack.MaxAbs, lapack.MaxRowSum, lapack.MaxColumnSum} {
+			name := fmt.Sprintf("%v_N=%v_K=%v", normToString(norm), n, k)
+			b.Run(name, func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					result = impl.Dlangb(norm, n, n, k, k, a, lda)
+				}
+			})
+		}
+
+		// Frobenius norm is benchmarked separately because its execution time
+		// depends on the element magnitude.
+		norm := lapack.Frobenius
+		for _, scale := range []string{"Small", "Medium", "Big"} {
+			name := fmt.Sprintf("%v_N=%v_K=%v_%v", normToString(norm), n, k, scale)
+			var scl float64
+			switch scale {
+			default:
+				scl = 1
+			case "Small":
+				scl = smlnum
+			case "Big":
+				scl = bignum
+			}
+			// Scale some elements so that the matrix contains a mix of small
+			// and medium, all medium, or big and medium values.
+			copy(a, aCopy)
+			for i := range a {
+				if i%2 == 0 {
+					a[i] *= scl
+				}
+			}
+			b.Run(name, func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					result = impl.Dlangb(norm, n, n, k, k, a, lda)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
Comparison between Dlangb implemented with work slice and without work slice:
```
» benchstat dlangb-bench-with-work.txt dlangb-bench-without-work.txt 
name                              old time/op  new time/op   delta
Dlangb/MaxColSum_N=1000_K=0-4     5.57µs ± 5%   9.80µs ± 1%  +75.91%  (p=0.008 n=5+5)
Dlangb/MaxColSum_N=1000_K=1-4     8.08µs ± 0%  13.15µs ± 2%  +62.71%  (p=0.008 n=5+5)
Dlangb/MaxColSum_N=1000_K=2-4     10.4µs ± 0%   16.3µs ± 0%  +56.56%  (p=0.029 n=4+4)
Dlangb/MaxColSum_N=1000_K=30-4    71.6µs ± 0%   44.4µs ± 2%  -37.95%  (p=0.016 n=4+5)
Dlangb/MaxColSum_N=10000_K=0-4    48.5µs ± 3%   79.8µs ± 0%  +64.74%  (p=0.008 n=5+5)
Dlangb/MaxColSum_N=10000_K=1-4    71.5µs ± 3%  117.3µs ± 2%  +64.17%  (p=0.008 n=5+5)
Dlangb/MaxColSum_N=10000_K=2-4    92.8µs ± 0%  153.3µs ± 0%  +65.17%  (p=0.029 n=4+4)
Dlangb/MaxColSum_N=10000_K=100-4  2.52ms ± 1%   1.92ms ± 0%  -23.82%  (p=0.008 n=5+5)
```
The result is inconclusive, for small bandwidths the work-slice version is faster, for larger bandwidths the version without the work slice (current master) is faster. Maybe I should add more bandwidths to see where the tipping point is.

Closes #1624 .

Please take a look.


<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
