### PR TITLE
testlapack: consolidate floating-point constants

### DIFF
--- a/lapack/testlapack/dgeev.go
+++ b/lapack/testlapack/dgeev.go
@@ -769,10 +769,9 @@ func residualRightEV(a, e blas64.General, wr, wi []float64) float64 {
 	}
 	bi.Dgemm(blas.NoTrans, blas.NoTrans, n, n, n, 1, a.Data, a.Stride, e.Data, e.Stride, -1, r, ldr)
 
-	unfl := dlamchS
-	ulp := dlamchE
-	anorm := math.Max(dlange(lapack.MaxColumnSum, n, n, a.Data, a.Stride), unfl)
-	enorm := math.Max(dlange(lapack.MaxColumnSum, n, n, e.Data, e.Stride), ulp)
+	const eps = dlamchE
+	anorm := math.Max(dlange(lapack.MaxColumnSum, n, n, a.Data, a.Stride), safmin)
+	enorm := math.Max(dlange(lapack.MaxColumnSum, n, n, e.Data, e.Stride), eps)
 	errnorm := dlange(lapack.MaxColumnSum, n, n, r, ldr) / enorm
 	if anorm > errnorm {
 		return errnorm / anorm
@@ -824,10 +823,9 @@ func residualLeftEV(a, e blas64.General, wr, wi []float64) float64 {
 	}
 	bi.Dgemm(blas.Trans, blas.NoTrans, n, n, n, 1, a.Data, a.Stride, e.Data, e.Stride, -1, r, ldr)
 
-	unfl := dlamchS
-	ulp := dlamchE
-	anorm := math.Max(dlange(lapack.MaxRowSum, n, n, a.Data, a.Stride), unfl)
-	enorm := math.Max(dlange(lapack.MaxColumnSum, n, n, e.Data, e.Stride), ulp)
+	const eps = dlamchE
+	anorm := math.Max(dlange(lapack.MaxRowSum, n, n, a.Data, a.Stride), safmin)
+	enorm := math.Max(dlange(lapack.MaxColumnSum, n, n, e.Data, e.Stride), eps)
 	errnorm := dlange(lapack.MaxColumnSum, n, n, r, ldr) / enorm
 	if anorm > errnorm {
 		return errnorm / anorm

--- a/lapack/testlapack/dgesvd.go
+++ b/lapack/testlapack/dgesvd.go
@@ -96,15 +96,12 @@ func dgesvdTest(t *testing.T, impl Dgesvder, m, n, mtype int, tol float64) {
 			false,                  // signs of s[i] are not randomly flipped
 			1, rnd)                 // random numbers are drawn uniformly from [0,1)
 		// Decide scale factor for the singular values based on the matrix type.
-		ulp := dlamchP
-		unfl := dlamchS
-		ovfl := 1 / unfl
 		aNorm = 1
 		if mtype == 4 {
-			aNorm = unfl / ulp
+			aNorm = smlnum
 		}
 		if mtype == 5 {
-			aNorm = ovfl * ulp
+			aNorm = bignum
 		}
 		// Scale singular values so that the maximum singular value is
 		// equal to aNorm (we know that the singular values are

--- a/lapack/testlapack/dlangb_bench.go
+++ b/lapack/testlapack/dlangb_bench.go
@@ -14,14 +14,6 @@ import (
 )
 
 func DlangbBenchmark(b *testing.B, impl Dlangber) {
-	const (
-		safmin = dlamchS
-		safmax = 1 / safmin
-		ulp    = dlamchP
-		smlnum = safmin / ulp
-		bignum = safmax * ulp
-	)
-
 	rnd := rand.New(rand.NewSource(1))
 	for _, bm := range []struct {
 		n, k int

--- a/lapack/testlapack/dlartg.go
+++ b/lapack/testlapack/dlartg.go
@@ -15,23 +15,21 @@ type Dlartger interface {
 }
 
 func DlartgTest(t *testing.T, impl Dlartger) {
-	const tol = 20 * dlamchP
+	const tol = 20 * ulp
 
-	safmin := dlamchS
-	safmax := 1 / safmin
 	values := []float64{
 		-safmax,
-		-1 / dlamchP,
+		-1 / ulp,
 		-1,
 		-1.0 / 3,
-		-dlamchP,
+		-ulp,
 		-safmin,
 		0,
 		safmin,
-		dlamchP,
+		ulp,
 		1.0 / 3,
 		1,
-		1 / dlamchP,
+		1 / ulp,
 		safmax,
 		math.Inf(-1),
 		math.Inf(1),

--- a/lapack/testlapack/dlassq.go
+++ b/lapack/testlapack/dlassq.go
@@ -19,13 +19,6 @@ type Dlassqer interface {
 }
 
 func DlassqTest(t *testing.T, impl Dlassqer) {
-	const (
-		safmin = dlamchS
-		safmax = 1 / safmin
-		ulp    = dlamchP
-		smlnum = safmin / ulp
-		bignum = safmax * ulp
-	)
 	values := []float64{
 		0,
 		2 * safmin,

--- a/lapack/testlapack/dlatbs.go
+++ b/lapack/testlapack/dlatbs.go
@@ -134,9 +134,12 @@ func dlatbsResidual(uplo blas.Uplo, trans blas.Transpose, diag blas.Diag, n, kd 
 		}
 	}
 
+	const (
+		eps  = dlamchE
+		tiny = safmin
+	)
+
 	bi := blas64.Implementation()
-	eps := dlamchE
-	smlnum := dlamchS
 
 	ix := bi.Idamax(n, x, 1)
 	xNorm := math.Max(1, math.Abs(x[ix]))
@@ -150,14 +153,14 @@ func dlatbsResidual(uplo blas.Uplo, trans blas.Transpose, diag blas.Diag, n, kd 
 
 	ix = bi.Idamax(n, resid, 1)
 	residNorm := math.Abs(resid[ix])
-	if residNorm*smlnum <= xNorm {
+	if residNorm*tiny <= xNorm {
 		if xNorm > 0 {
 			residNorm /= xNorm
 		}
 	} else if residNorm > 0 {
 		residNorm = 1 / eps
 	}
-	if residNorm*smlnum <= tnorm {
+	if residNorm*tiny <= tnorm {
 		if tnorm > 0 {
 			residNorm /= tnorm
 		}

--- a/lapack/testlapack/dlatrs.go
+++ b/lapack/testlapack/dlatrs.go
@@ -103,8 +103,11 @@ func dlatrsResidual(uplo blas.Uplo, trans blas.Transpose, diag blas.Diag, n int,
 		}
 	}
 
-	eps := dlamchE
-	smlnum := dlamchS
+	const (
+		eps  = dlamchE
+		tiny = safmin
+	)
+
 	bi := blas64.Implementation()
 
 	// Compute norm(trans(A)*x-scale*b) / (norm(trans(A))*norm(x)*eps)
@@ -124,14 +127,14 @@ func dlatrsResidual(uplo blas.Uplo, trans blas.Transpose, diag blas.Diag, n int,
 	resid = math.Abs(work[ix])
 	ix = bi.Idamax(n, x, 1)
 	xnorm = math.Abs(x[ix])
-	if resid*smlnum <= xnorm {
+	if resid*tiny <= xnorm {
 		if xnorm > 0 {
 			resid /= xnorm
 		}
 	} else if resid > 0 {
 		resid = 1 / eps
 	}
-	if resid*smlnum <= tnorm {
+	if resid*tiny <= tnorm {
 		if tnorm > 0 {
 			resid /= tnorm
 		}

--- a/lapack/testlapack/general.go
+++ b/lapack/testlapack/general.go
@@ -24,6 +24,12 @@ const (
 	dlamchP = dlamchB * dlamchE
 	// dlamchS is the smallest normal number. For IEEE this is 2^{-1022}.
 	dlamchS = 0x1p-1022
+
+	safmin = dlamchS
+	safmax = 1 / safmin
+	ulp    = dlamchP
+	smlnum = safmin / ulp
+	bignum = safmax * ulp
 )
 
 func max(a, b int) int {


### PR DESCRIPTION
I prefer the more descriptive names than the `dlamch*` names and I think it's useful to have them at package level instead of scattered around in functions.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
