### PR TITLE
lapack/gonum: prevent division of untyped ints always yielding zero in Dlasy2

### DIFF
--- a/lapack/gonum/dlasy2.go
+++ b/lapack/gonum/dlasy2.go
@@ -261,7 +261,7 @@ func (impl Implementation) Dlasy2(tranl, tranr bool, isgn, n1, n2 int, tl []floa
 
 		maxbtmp := math.Max(math.Abs(btmp[0]), math.Abs(btmp[1]))
 		maxbtmp = math.Max(maxbtmp, math.Max(math.Abs(btmp[2]), math.Abs(btmp[3])))
-		scale = 1. / 8. / maxbtmp
+		scale = (1.0 / 8.0) / maxbtmp
 		btmp[0] *= scale
 		btmp[1] *= scale
 		btmp[2] *= scale

--- a/lapack/gonum/dlasy2.go
+++ b/lapack/gonum/dlasy2.go
@@ -261,7 +261,7 @@ func (impl Implementation) Dlasy2(tranl, tranr bool, isgn, n1, n2 int, tl []floa
 
 		maxbtmp := math.Max(math.Abs(btmp[0]), math.Abs(btmp[1]))
 		maxbtmp = math.Max(maxbtmp, math.Max(math.Abs(btmp[2]), math.Abs(btmp[3])))
-		scale = 1 / 8 / maxbtmp
+		scale = 1. / 8. / maxbtmp
 		btmp[0] *= scale
 		btmp[1] *= scale
 		btmp[2] *= scale


### PR DESCRIPTION
Please take a look at the line I changed. The following operation:
```go
scale = 1 / 8 / maxbtmp
```
always yields zero. I added decimal points to `1` and `8` to fix this undesired behavior.

