### PR TITLE
add lapack Dlagv2

### DIFF
--- a/lapack/gonum/dlagv2.go
+++ b/lapack/gonum/dlagv2.go
@@ -1,0 +1,209 @@
+// Copyright ©2021 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+import (
+	"math"
+
+	"gonum.org/v1/gonum/blas/blas64"
+)
+
+// Dlagv2 computes the Generalized Schur factorization of a real 2-by-2
+// matrix pencil (A,B) where B is upper triangular. This routine
+// computes orthogonal (rotation) matrices given by CSL, SNL and CSR,
+// SNR such that
+//
+// 1) if the pencil (A,B) has two real eigenvalues (include 0/0 or 1/0 types), then
+//  [ a11 a12 ] := [  CSL  SNL ] [ a11 a12 ] [  CSR -SNR ]
+//  [  0  a22 ]    [ -SNL  CSL ] [ a21 a22 ] [  SNR  CSR ]
+//
+//  [ b11 b12 ] := [  CSL  SNL ] [ b11 b12 ] [  CSR -SNR ]
+//  [  0  b22 ]    [ -SNL  CSL ] [  0  b22 ] [  SNR  CSR ],
+// 2) if the pencil (A,B) has a pair of complex conjugate eigenvalues, then
+//  [ a11 a12 ] := [  CSL  SNL ] [ a11 a12 ] [  CSR -SNR ]
+//  [ a21 a22 ]    [ -SNL  CSL ] [ a21 a22 ] [  SNR  CSR ]
+//
+//  [ b11  0  ] := [  CSL  SNL ] [ b11 b12 ] [  CSR -SNR ]
+//  [  0  b22 ]    [ -SNL  CSL ] [  0  b22 ] [  SNR  CSR ]
+// where b11 >= b22 > 0.
+//
+// On exit, A is overwritten by the A-part of the generalized Schur form
+// and B is overwritten by the B-part of the generalized Schur form.
+//
+// (alphar(k)+imag*alphai(k))/beta(k) are the eigenvalues of the
+// pencil (A,B), k=0,1 where imag = sqrt(-1). Note that beta(k) may
+// be zero. They are solely outputs and will be overwritten.
+//
+// Returned floats are cosines (cs) and sines (sn) of left (l) and right (r)
+// rotation matrices.
+//
+// Dlagv2 is an internal routine. It is exported for testing purposes.
+func (impl Implementation) Dlagv2(a []float64, lda int, b []float64, ldb int, alphar, alphai, beta []float64) (csl, snl, csr, snr float64) {
+	const safmin = dlamchS
+	const ulp = dlamchP
+
+	// Shorthand float64 routines.
+	var (
+		max = math.Max
+		abs = math.Abs
+	)
+	// Scale A.
+	anorm := max(abs(a[0*lda+0])+abs(a[1*lda+0]),
+		abs(a[0*lda+1])+abs(a[1*lda+1]))
+	anorm = max(anorm, safmin)
+	ascale := 1. / anorm
+	a[0*lda+0] *= ascale
+	a[0*lda+1] *= ascale
+	a[1*lda+0] *= ascale
+	a[1*lda+1] *= ascale
+
+	// Scale B.
+	bnorm := max(abs(b[0*ldb+0]),
+		abs(b[0*ldb+1])+abs(b[1*ldb+1]))
+	bnorm = max(bnorm, safmin)
+	bscale := 1. / bnorm
+	b[0*lda+0] *= bscale
+	b[0*lda+1] *= bscale
+	b[1*lda+1] *= bscale
+
+	bi := blas64.Implementation()
+	// Values returned by Dlag2 used to calculate rotation matrix.
+	var wi, wr1, scale1 float64
+	switch {
+	// Check if A can be deflated.
+	case abs(a[1*lda+0]) <= ulp:
+		// wi,snr,snl = 0,0,0 (are already zero)
+		csl, csr = 1, 1
+		a[1*lda+0] = 0
+		b[1*lda+0] = 0
+
+		// Check if B is singular.
+	case abs(b[0*lda+0]) <= ulp:
+		// snr,wi = 0,0 (are already zero)
+		csl, snl, _ = impl.Dlartg(a[0*lda+0], a[1*lda+0])
+		csr = 1
+		bi.Drot(2, a[0*lda+0:], 1, a[1*lda+0:], 1, csl, snl)
+		bi.Drot(2, b[0*ldb+0:], 1, b[1*ldb+0:], 1, csl, snl)
+		a[1*lda+0] = 0
+		b[0*ldb+0] = 0
+		b[1*ldb+0] = 0
+
+	case abs(b[1*ldb+1]) <= ulp:
+		// snl,wi = 0,0 (are already zero)
+		csr, snr, _ = impl.Dlartg(a[1*lda+1], a[1*lda+0])
+		snr *= -1
+		bi.Drot(2, a[0*lda+0:], lda, a[0*lda+1:], lda, csr, snr)
+		bi.Drot(2, b[0*ldb+0:], ldb, b[0*ldb+1:], ldb, csr, snr)
+		csl = 1
+		a[1*lda+0] = 0
+		b[1*ldb+0] = 0
+		b[1*ldb+1] = 0
+
+		// B is nonsingular, first compute the eigenvalues of (A,B).
+	default:
+		// scale1, _, wr1, _, wi = impl.Dlag2(a, lda, b, ldb)
+		csl, snl, csr, snr = impl.dlagv2aux(a, lda, b, ldb, scale1, wr1, wi)
+
+	}
+
+	// Unscaling.
+	a[0*lda+0] *= anorm
+	a[0*lda+1] *= anorm
+	a[1*lda+0] *= anorm
+	a[1*lda+1] *= anorm
+
+	b[0*ldb+0] *= bnorm
+	b[0*ldb+1] *= bnorm
+	b[1*ldb+0] *= bnorm
+	b[1*ldb+1] *= bnorm
+
+	if wi == 0 {
+		alphar[0] = a[0*lda+0]
+		alphar[1] = a[1*lda+1]
+		alphai[0] = 0
+		alphai[1] = 0
+		beta[0] = b[0*ldb+0]
+		beta[1] = b[1*ldb+1]
+	} else {
+		alphar[0] = anorm * wr1 / scale1 / bnorm
+		alphai[0] = anorm * wi / scale1 / bnorm
+		alphar[1] = alphar[0]
+		alphai[1] = -alphai[0]
+		beta[0] = 1
+		beta[1] = 1
+	}
+
+	return csl, snl, csr, snr
+}
+
+// dlagv2aux solves for eigenvalues of (A,B) using first eigenvalue
+// returned by Dlag2.
+//
+// dlagv2aux is an internal auxiliary routine used in exported Implementation.Dlagv2.
+func (impl Implementation) dlagv2aux(a []float64, lda int, b []float64, ldb int, scale1, wr1, wi float64) (csl, snl, csr, snr float64) {
+	bi := blas64.Implementation()
+
+	// Shorthand float64 routines.
+	var (
+		max = math.Max
+		abs = math.Abs
+	)
+
+	// A pair of complex conjugate eigenvalues: first compute the SVD of the matrix B.
+	if wi != 0 {
+		_, _, snr, csr, snl, csl = impl.Dlasv2(b[0], b[1], b[lda+1])
+		// Form (A,B) := Q(A,B)Z**T where Q is left rotation matrix and
+		// Z is right rotation matrix computed from Dlasv2
+		bi.Drot(2, a[0:], 1, a[lda:], 1, csl, snl)
+		bi.Drot(2, b[0:], 1, b[ldb:], 1, csl, snl)
+
+		bi.Drot(2, a[0:], lda, a[1:], lda, csr, snr)
+		bi.Drot(2, b[0:], ldb, b[1:], ldb, csr, snr)
+
+		b[lda] = 0
+		b[1] = 0
+		return csl, snl, csr, snr
+	}
+
+	// Got real eigenvalues from Dlag2.
+	h1 := scale1*a[0] - wr1*b[0]
+	h2 := scale1*a[1] - wr1*b[1]
+	h3 := scale1*a[lda+1] - wr1*b[ldb+1]
+
+	rr := impl.Dlapy2(h1, h2)
+	qq := impl.Dlapy2(scale1*a[lda], h3)
+	if rr > qq {
+		// Find right rotation matrix to zero 0,0 element of (sA - wB).
+		csr, snr, _ = impl.Dlartg(h2, h1)
+	} else {
+		// Find right rotation matrix to zero 1,0 element of (sA - wB).
+		csr, snr, _ = impl.Dlartg(h3, scale1*a[lda])
+	}
+	snr *= -1
+	bi.Drot(2, a[0:], lda, a[1:], lda, csr, snr)
+	bi.Drot(2, b[0:], ldb, b[1:], ldb, csr, snr)
+
+	// Compute norms of A and B.
+	h1 = max(abs(a[0])+abs(a[1]),
+		abs(a[lda])+abs(a[lda+1]))
+
+	h2 = max(abs(b[0])+abs(b[1]),
+		abs(b[ldb])+abs(b[ldb+1])) // b[lda] may be non-zero after rotations.
+
+	if scale1*h1 >= abs(wr1)*h2 {
+		// Find left rotation matrix Q to zero out B[1,0].
+		csl, snl, _ = impl.Dlartg(b[0], b[ldb])
+	} else {
+		// Find left rotation matrix Q to zero out A[1,0]
+		csl, snl, _ = impl.Dlartg(a[0], a[lda])
+	}
+
+	bi.Drot(2, a[0:], 1, a[lda:], 1, csl, snl)
+	bi.Drot(2, b[0:], 1, b[ldb:], 1, csl, snl)
+
+	a[lda] = 0
+	b[lda] = 0
+	return csl, snl, csr, snr
+}

--- a/lapack/gonum/dlagv2.go
+++ b/lapack/gonum/dlagv2.go
@@ -41,6 +41,19 @@ import (
 //
 // Dlagv2 is an internal routine. It is exported for testing purposes.
 func (impl Implementation) Dlagv2(a []float64, lda int, b []float64, ldb int, alphar, alphai, beta []float64) (csl, snl, csr, snr float64) {
+	switch {
+	case lda < 2:
+		panic(badLdA)
+	case ldb < 2:
+		panic(badLdB)
+	case len(a) < 4:
+		panic(shortA)
+	case len(b) < 4:
+		panic(shortB)
+	case len(alphar) < 2 || len(alphai) < 2:
+		panic(short)
+	}
+
 	const (
 		safmin = dlamchS
 		ulp    = dlamchP

--- a/lapack/gonum/dlagv2.go
+++ b/lapack/gonum/dlagv2.go
@@ -51,7 +51,9 @@ func (impl Implementation) Dlagv2(a []float64, lda int, b []float64, ldb int, al
 	case len(b) < 4:
 		panic(shortB)
 	case len(alphar) < 2 || len(alphai) < 2:
-		panic(short)
+		panic(badLenAlpha)
+	case len(beta) < 2:
+		panic(badLenBeta)
 	}
 
 	const (

--- a/lapack/gonum/dlagv2.go
+++ b/lapack/gonum/dlagv2.go
@@ -10,22 +10,22 @@ import (
 	"gonum.org/v1/gonum/blas/blas64"
 )
 
-// Dlagv2 computes the Generalized Schur factorization of a real 2-by-2
+// Dlagv2 computes the Generalized Schur factorization of a real 2×2
 // matrix pencil (A,B) where B is upper triangular. This routine
 // computes orthogonal (rotation) matrices given by CSL, SNL and CSR,
 // SNR such that
 //
 // 1) if the pencil (A,B) has two real eigenvalues (include 0/0 or 1/0 types), then
-//  [ a11 a12 ] := [  CSL  SNL ] [ a11 a12 ] [  CSR -SNR ]
+//  [ a11 a12 ] = [  CSL  SNL ] [ a11 a12 ] [  CSR -SNR ]
 //  [  0  a22 ]    [ -SNL  CSL ] [ a21 a22 ] [  SNR  CSR ]
 //
-//  [ b11 b12 ] := [  CSL  SNL ] [ b11 b12 ] [  CSR -SNR ]
+//  [ b11 b12 ] = [  CSL  SNL ] [ b11 b12 ] [  CSR -SNR ]
 //  [  0  b22 ]    [ -SNL  CSL ] [  0  b22 ] [  SNR  CSR ],
 // 2) if the pencil (A,B) has a pair of complex conjugate eigenvalues, then
-//  [ a11 a12 ] := [  CSL  SNL ] [ a11 a12 ] [  CSR -SNR ]
+//  [ a11 a12 ] = [  CSL  SNL ] [ a11 a12 ] [  CSR -SNR ]
 //  [ a21 a22 ]    [ -SNL  CSL ] [ a21 a22 ] [  SNR  CSR ]
 //
-//  [ b11  0  ] := [  CSL  SNL ] [ b11 b12 ] [  CSR -SNR ]
+//  [ b11  0  ] = [  CSL  SNL ] [ b11 b12 ] [  CSR -SNR ]
 //  [  0  b22 ]    [ -SNL  CSL ] [  0  b22 ] [  SNR  CSR ]
 // where b11 >= b22 > 0.
 //
@@ -41,91 +41,84 @@ import (
 //
 // Dlagv2 is an internal routine. It is exported for testing purposes.
 func (impl Implementation) Dlagv2(a []float64, lda int, b []float64, ldb int, alphar, alphai, beta []float64) (csl, snl, csr, snr float64) {
-	const safmin = dlamchS
-	const ulp = dlamchP
-
-	// Shorthand float64 routines.
-	var (
-		max = math.Max
-		abs = math.Abs
+	const (
+		safmin = dlamchS
+		ulp    = dlamchP
 	)
+
 	// Scale A.
-	anorm := max(abs(a[0*lda+0])+abs(a[1*lda+0]),
-		abs(a[0*lda+1])+abs(a[1*lda+1]))
-	anorm = max(anorm, safmin)
-	ascale := 1. / anorm
-	a[0*lda+0] *= ascale
-	a[0*lda+1] *= ascale
-	a[1*lda+0] *= ascale
-	a[1*lda+1] *= ascale
+	anorm := math.Max(math.Abs(a[0])+math.Abs(a[lda]),
+		math.Abs(a[1])+math.Abs(a[lda+1]))
+	anorm = math.Max(anorm, safmin)
+	ascale := 1 / anorm
+	a[0] *= ascale
+	a[1] *= ascale
+	a[lda] *= ascale
+	a[lda+1] *= ascale
 
 	// Scale B.
-	bnorm := max(abs(b[0*ldb+0]),
-		abs(b[0*ldb+1])+abs(b[1*ldb+1]))
-	bnorm = max(bnorm, safmin)
-	bscale := 1. / bnorm
-	b[0*lda+0] *= bscale
-	b[0*lda+1] *= bscale
-	b[1*lda+1] *= bscale
+	bnorm := math.Max(math.Abs(b[0]),
+		math.Abs(b[1])+math.Abs(b[ldb+1]))
+	bnorm = math.Max(bnorm, safmin)
+	bscale := 1 / bnorm
+	b[0] *= bscale
+	b[1] *= bscale
+	b[lda+1] *= bscale
 
 	bi := blas64.Implementation()
-	// Values returned by Dlag2 used to calculate rotation matrix.
 	var wi, wr1, scale1 float64
 	switch {
 	// Check if A can be deflated.
-	case abs(a[1*lda+0]) <= ulp:
-		// wi,snr,snl = 0,0,0 (are already zero)
+	case math.Abs(a[lda]) <= ulp:
 		csl, csr = 1, 1
-		a[1*lda+0] = 0
-		b[1*lda+0] = 0
+		a[lda] = 0
+		b[lda] = 0
 
-		// Check if B is singular.
-	case abs(b[0*lda+0]) <= ulp:
-		// snr,wi = 0,0 (are already zero)
-		csl, snl, _ = impl.Dlartg(a[0*lda+0], a[1*lda+0])
+	// Check if B is singular.
+	case math.Abs(b[0]) <= ulp:
+		csl, snl, _ = impl.Dlartg(a[0], a[lda])
 		csr = 1
-		bi.Drot(2, a[0*lda+0:], 1, a[1*lda+0:], 1, csl, snl)
-		bi.Drot(2, b[0*ldb+0:], 1, b[1*ldb+0:], 1, csl, snl)
-		a[1*lda+0] = 0
-		b[0*ldb+0] = 0
-		b[1*ldb+0] = 0
+		bi.Drot(2, a, 1, a[lda:], 1, csl, snl)
+		bi.Drot(2, b, 1, b[ldb:], 1, csl, snl)
+		a[lda] = 0
+		b[0] = 0
+		b[ldb] = 0
 
-	case abs(b[1*ldb+1]) <= ulp:
-		// snl,wi = 0,0 (are already zero)
-		csr, snr, _ = impl.Dlartg(a[1*lda+1], a[1*lda+0])
+	case math.Abs(b[ldb+1]) <= ulp:
+
+		csr, snr, _ = impl.Dlartg(a[lda+1], a[lda+0])
 		snr *= -1
-		bi.Drot(2, a[0*lda+0:], lda, a[0*lda+1:], lda, csr, snr)
-		bi.Drot(2, b[0*ldb+0:], ldb, b[0*ldb+1:], ldb, csr, snr)
+		bi.Drot(2, a, lda, a[1:], lda, csr, snr)
+		bi.Drot(2, b, ldb, b[1:], ldb, csr, snr)
 		csl = 1
-		a[1*lda+0] = 0
-		b[1*ldb+0] = 0
-		b[1*ldb+1] = 0
+		a[lda] = 0
+		b[ldb] = 0
+		b[ldb+1] = 0
 
-		// B is nonsingular, first compute the eigenvalues of (A,B).
+	// B is nonsingular, first compute the eigenvalues of (A,B).
 	default:
-		// scale1, _, wr1, _, wi = impl.Dlag2(a, lda, b, ldb)
+		scale1, _, wr1, _, wi = impl.Dlag2(a, lda, b, ldb)
 		csl, snl, csr, snr = impl.dlagv2aux(a, lda, b, ldb, scale1, wr1, wi)
-
 	}
 
 	// Unscaling.
-	a[0*lda+0] *= anorm
-	a[0*lda+1] *= anorm
-	a[1*lda+0] *= anorm
-	a[1*lda+1] *= anorm
+	a[0] *= anorm
+	a[1] *= anorm
+	a[lda] *= anorm
+	a[lda+1] *= anorm
 
-	b[0*ldb+0] *= bnorm
-	b[0*ldb+1] *= bnorm
-	b[1*ldb+0] *= bnorm
-	b[1*ldb+1] *= bnorm
+	b[0] *= bnorm
+	b[1] *= bnorm
+	b[ldb] *= bnorm
+	b[ldb+1] *= bnorm
 
 	if wi == 0 {
-		alphar[0] = a[0*lda+0]
-		alphar[1] = a[1*lda+1]
+		alphar[0] = a[0]
+		alphar[1] = a[lda+1]
 		alphai[0] = 0
 		alphai[1] = 0
-		beta[0] = b[0*ldb+0]
-		beta[1] = b[1*ldb+1]
+		beta[0] = b[0]
+		beta[1] = b[ldb+1]
 	} else {
 		alphar[0] = anorm * wr1 / scale1 / bnorm
 		alphai[0] = anorm * wi / scale1 / bnorm
@@ -144,13 +137,6 @@ func (impl Implementation) Dlagv2(a []float64, lda int, b []float64, ldb int, al
 // dlagv2aux is an internal auxiliary routine used in exported Implementation.Dlagv2.
 func (impl Implementation) dlagv2aux(a []float64, lda int, b []float64, ldb int, scale1, wr1, wi float64) (csl, snl, csr, snr float64) {
 	bi := blas64.Implementation()
-
-	// Shorthand float64 routines.
-	var (
-		max = math.Max
-		abs = math.Abs
-	)
-
 	// A pair of complex conjugate eigenvalues: first compute the SVD of the matrix B.
 	if wi != 0 {
 		_, _, snr, csr, snl, csl = impl.Dlasv2(b[0], b[1], b[lda+1])
@@ -158,7 +144,6 @@ func (impl Implementation) dlagv2aux(a []float64, lda int, b []float64, ldb int,
 		// Z is right rotation matrix computed from Dlasv2
 		bi.Drot(2, a[0:], 1, a[lda:], 1, csl, snl)
 		bi.Drot(2, b[0:], 1, b[ldb:], 1, csl, snl)
-
 		bi.Drot(2, a[0:], lda, a[1:], lda, csr, snr)
 		bi.Drot(2, b[0:], ldb, b[1:], ldb, csr, snr)
 
@@ -182,17 +167,17 @@ func (impl Implementation) dlagv2aux(a []float64, lda int, b []float64, ldb int,
 		csr, snr, _ = impl.Dlartg(h3, scale1*a[lda])
 	}
 	snr *= -1
-	bi.Drot(2, a[0:], lda, a[1:], lda, csr, snr)
-	bi.Drot(2, b[0:], ldb, b[1:], ldb, csr, snr)
+	bi.Drot(2, a, lda, a[1:], lda, csr, snr)
+	bi.Drot(2, b, ldb, b[1:], ldb, csr, snr)
 
 	// Compute norms of A and B.
-	h1 = max(abs(a[0])+abs(a[1]),
-		abs(a[lda])+abs(a[lda+1]))
+	h1 = math.Max(math.Abs(a[0])+math.Abs(a[1]),
+		math.Abs(a[lda])+math.Abs(a[lda+1]))
 
-	h2 = max(abs(b[0])+abs(b[1]),
-		abs(b[ldb])+abs(b[ldb+1])) // b[lda] may be non-zero after rotations.
+	h2 = math.Max(math.Abs(b[0])+math.Abs(b[1]),
+		math.Abs(b[ldb])+math.Abs(b[ldb+1])) // b[lda] may be non-zero after rotations.
 
-	if scale1*h1 >= abs(wr1)*h2 {
+	if scale1*h1 >= math.Abs(wr1)*h2 {
 		// Find left rotation matrix Q to zero out B[1,0].
 		csl, snl, _ = impl.Dlartg(b[0], b[ldb])
 	} else {
@@ -200,8 +185,8 @@ func (impl Implementation) dlagv2aux(a []float64, lda int, b []float64, ldb int,
 		csl, snl, _ = impl.Dlartg(a[0], a[lda])
 	}
 
-	bi.Drot(2, a[0:], 1, a[lda:], 1, csl, snl)
-	bi.Drot(2, b[0:], 1, b[ldb:], 1, csl, snl)
+	bi.Drot(2, a, 1, a[lda:], 1, csl, snl)
+	bi.Drot(2, b, 1, b[ldb:], 1, csl, snl)
 
 	a[lda] = 0
 	b[lda] = 0


### PR DESCRIPTION
ARE issue #1651 

This branch is still under work. It would require Dlag2 (#1665) to be merged into master to implement tests.

I've added a private (lower cased) method called `dlagv2aux` to simplify `Dlagv2`'s implementation and make it more readable. If this is a non-permissible act it can be implemented as in the reference but do note readability will suffer greatly.

Tests pending, as mentioned above.