### PR TITLE
lapack/testlapack: fix typo in test for Dgesc2

### DIFF
--- a/lapack/testlapack/dgesc2.go
+++ b/lapack/testlapack/dgesc2.go
@@ -77,7 +77,7 @@ func testDgesc2(t *testing.T, impl Dgesc2er, rnd *rand.Rand, n, lda int, big boo
 		t.Errorf("%v: unexpected modification in ipiv", name)
 	}
 	if !intsEqual(jpiv, jpivCopy) {
-		t.Errorf("%v: unexpected modification in ipiv", name)
+		t.Errorf("%v: unexpected modification in jpiv", name)
 	}
 
 	if scale <= 0 || 1 < scale {


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
