### PR TITLE
spatial/r3: add method to obtain a rotation matrix

### DIFF
--- a/spatial/r3/vector_test.go
+++ b/spatial/r3/vector_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/floats/scalar"
+	"gonum.org/v1/gonum/mat"
 )
 
 func TestAdd(t *testing.T) {
@@ -236,11 +237,32 @@ func TestRotate(t *testing.T) {
 		got := Rotate(test.v, test.alpha, test.axis)
 		if !vecApproxEqual(got, test.want, tol) {
 			t.Errorf(
-				"rotate(%v, %v, %v)= %v, want=%v",
+				"quat rotate(%v, %v, %v)= %v, want=%v",
+				test.v, test.alpha, test.axis, got, test.want,
+			)
+		}
+
+		var gotv mat.VecDense
+		gotv.MulVec(NewRotation(test.alpha, test.axis).Matrix(), vecDense(test.v))
+		got = vec(gotv)
+		if !vecApproxEqual(got, test.want, tol) {
+			t.Errorf(
+				"matrix rotate(%v, %v, %v)= %v, want=%v",
 				test.v, test.alpha, test.axis, got, test.want,
 			)
 		}
 	}
+}
+
+func vecDense(v Vec) *mat.VecDense {
+	return mat.NewVecDense(3, []float64{v.X, v.Y, v.Z})
+}
+
+func vec(v mat.VecDense) Vec {
+	if v.Len() != 3 {
+		panic(mat.ErrShape)
+	}
+	return Vec{v.AtVec(0), v.AtVec(1), v.AtVec(2)}
 }
 
 func vecIsNaN(v Vec) bool {


### PR DESCRIPTION
I have not added the matrix→quat function as this requires more thought in terms of what we should accept and is arguably less valuable; the quat→mat operation means that large sets of points can be operated on with a single matrix multiply while it's not entirely clear what you get from being able to convert a mat to a quat, and the code is more complex.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
