### PR TITLE
spatial/r3: use lightweight matrix for rotations

### DIFF
--- a/spatial/r3/vector.go
+++ b/spatial/r3/vector.go
@@ -7,6 +7,7 @@ package r3
 import (
 	"math"
 
+	"gonum.org/v1/gonum/blas/blas64"
 	"gonum.org/v1/gonum/mat"
 	"gonum.org/v1/gonum/num/quat"
 )
@@ -155,9 +156,32 @@ func (r Rotation) Matrix() mat.Matrix {
 	ijm := im * jm
 	jkm := jm * km
 	kim := km * im
-	return mat.NewDense(3, 3, []float64{
+	return &matrix{
 		1 - 2*(jm2+km2), 2 * (ijm - rkm), 2 * (kim + rjm),
 		2 * (ijm + rkm), 1 - 2*(im2+km2), 2 * (jkm - rim),
 		2 * (kim - rjm), 2 * (jkm + rim), 1 - 2*(im2+jm2),
-	})
+	}
+}
+
+// matrix is a 3×3 rotation matrix.
+type matrix [9]float64
+
+var (
+	_ mat.Matrix      = (*matrix)(nil)
+	_ mat.RawMatrixer = (*matrix)(nil)
+)
+
+func (m *matrix) At(i, j int) float64 {
+	if uint(i) >= 3 {
+		panic(mat.ErrRowAccess)
+	}
+	if uint(j) >= 3 {
+		panic(mat.ErrColAccess)
+	}
+	return m[i*3+j]
+}
+func (m *matrix) Dims() (r, c int) { return 3, 3 }
+func (m *matrix) T() mat.Matrix    { return mat.Transpose{Matrix: m} }
+func (m *matrix) RawMatrix() blas64.General {
+	return blas64.General{Rows: 3, Cols: 3, Data: m[:], Stride: 3}
 }


### PR DESCRIPTION
I'm not completely convinced that this is worth doing yet, but it is here.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
