### PR TITLE
graph/{iterator,multi}: use map iterators for lines and weighted lines

### DIFF
--- a/graph/iterator/lines_map.go
+++ b/graph/iterator/lines_map.go
@@ -1,0 +1,140 @@
+// Copyright ©2021 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !safe
+// +build !safe
+
+package iterator
+
+import "gonum.org/v1/gonum/graph"
+
+// Lines implements the graph.Lines interfaces.
+// The iteration order of Lines is randomized.
+type Lines struct {
+	lines int
+	iter  *mapIter
+	pos   int
+	curr  graph.Line
+}
+
+// NewLines returns a Lines initialized with the provided lines, a
+// map of line IDs to graph.Lines. No check is made that the keys
+// match the graph.Line IDs, and the map keys are not used.
+//
+// Behavior of the Lines is unspecified if lines is mutated after
+// the call to NewLines.
+func NewLines(lines map[int64]graph.Line) *Lines {
+	return &Lines{lines: len(lines), iter: newMapIterLines(lines)}
+}
+
+// Len returns the remaining number of lines to be iterated over.
+func (l *Lines) Len() int {
+	return l.lines - l.pos
+}
+
+// Next returns whether the next call of Line will return a valid line.
+func (l *Lines) Next() bool {
+	if l.pos >= l.lines {
+		return false
+	}
+	ok := l.iter.next()
+	if ok {
+		l.pos++
+		l.curr = l.iter.line()
+	}
+	return ok
+}
+
+// Line returns the current line of the iterator. Next must have been
+// called prior to a call to Line.
+func (l *Lines) Line() graph.Line {
+	return l.curr
+}
+
+// Reset returns the iterator to its initial state.
+func (l *Lines) Reset() {
+	l.curr = nil
+	l.pos = 0
+	l.iter.it = nil
+}
+
+// LineSlice returns all the remaining lines in the iterator and advances
+// the iterator. The order of lines within the returned slice is not
+// specified.
+func (l *Lines) LineSlice() []graph.Line {
+	if l.Len() == 0 {
+		return nil
+	}
+	lines := make([]graph.Line, 0, l.Len())
+	for l.iter.next() {
+		lines = append(lines, l.iter.line())
+	}
+	l.pos = l.lines
+	return lines
+}
+
+// WeightedLines implements the graph.WeightedLines interfaces.
+// The iteration order of WeightedLines is randomized.
+type WeightedLines struct {
+	lines int
+	iter  *mapIter
+	pos   int
+	curr  graph.WeightedLine
+}
+
+// NewWeightedLines returns a WeightedLines initialized with the provided lines, a
+// map of line IDs to graph.WeightedLines. No check is made that the keys
+// match the graph.WeightedLine IDs, and the map keys are not used.
+//
+// Behavior of the WeightedLines is unspecified if lines is mutated after
+// the call to NewWeightedLines.
+func NewWeightedLines(lines map[int64]graph.WeightedLine) *WeightedLines {
+	return &WeightedLines{lines: len(lines), iter: newMapIterWeightedLines(lines)}
+}
+
+// Len returns the remaining number of lines to be iterated over.
+func (l *WeightedLines) Len() int {
+	return l.lines - l.pos
+}
+
+// Next returns whether the next call of Line will return a valid line.
+func (l *WeightedLines) Next() bool {
+	if l.pos >= l.lines {
+		return false
+	}
+	ok := l.iter.next()
+	if ok {
+		l.pos++
+		l.curr = l.iter.weightedLine()
+	}
+	return ok
+}
+
+// WeightedLine returns the current line of the iterator. Next must have been
+// called prior to a call to WeightedLine.
+func (l *WeightedLines) WeightedLine() graph.WeightedLine {
+	return l.curr
+}
+
+// Reset returns the iterator to its initial state.
+func (l *WeightedLines) Reset() {
+	l.curr = nil
+	l.pos = 0
+	l.iter.it = nil
+}
+
+// WeightedLineSlice returns all the remaining lines in the iterator and advances
+// the iterator. The order of lines within the returned slice is not
+// specified.
+func (l *WeightedLines) WeightedLineSlice() []graph.WeightedLine {
+	if l.Len() == 0 {
+		return nil
+	}
+	lines := make([]graph.WeightedLine, 0, l.Len())
+	for l.iter.next() {
+		lines = append(lines, l.iter.weightedLine())
+	}
+	l.pos = l.lines
+	return lines
+}

--- a/graph/iterator/lines_map_safe.go
+++ b/graph/iterator/lines_map_safe.go
@@ -1,0 +1,146 @@
+// Copyright ©2021 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build safe
+// +build safe
+
+package iterator
+
+import (
+	"reflect"
+
+	"gonum.org/v1/gonum/graph"
+)
+
+// Lines implements the graph.Lines interfaces.
+// The iteration order of Lines is randomized.
+type Lines struct {
+	lines reflect.Value
+	iter  *reflect.MapIter
+	pos   int
+	curr  graph.Line
+}
+
+// NewLines returns a Lines initialized with the provided lines, a
+// map of line IDs to graph.Lines. No check is made that the keys
+// match the graph.Line IDs, and the map keys are not used.
+//
+// Behavior of the Lines is unspecified if lines is mutated after
+// the call to NewLines.
+func NewLines(lines map[int64]graph.Line) *Lines {
+	rv := reflect.ValueOf(lines)
+	return &Lines{lines: rv, iter: rv.MapRange()}
+}
+
+// Len returns the remaining number of lines to be iterated over.
+func (l *Lines) Len() int {
+	return l.lines.Len() - l.pos
+}
+
+// Next returns whether the next call of Line will return a valid line.
+func (l *Lines) Next() bool {
+	if l.pos >= l.lines.Len() {
+		return false
+	}
+	ok := l.iter.Next()
+	if ok {
+		l.pos++
+		l.curr = l.iter.Value().Interface().(graph.Line)
+	}
+	return ok
+}
+
+// Line returns the current line of the iterator. Next must have been
+// called prior to a call to Line.
+func (l *Lines) Line() graph.Line {
+	return l.curr
+}
+
+// Reset returns the iterator to its initial state.
+func (l *Lines) Reset() {
+	l.curr = nil
+	l.pos = 0
+	l.iter = l.lines.MapRange()
+}
+
+// LineSlice returns all the remaining lines in the iterator and advances
+// the iterator. The order of lines within the returned slice is not
+// specified.
+func (l *Lines) LineSlice() []graph.Line {
+	if l.Len() == 0 {
+		return nil
+	}
+	lines := make([]graph.Line, 0, l.Len())
+	for l.iter.Next() {
+		lines = append(lines, l.iter.Value().Interface().(graph.Line))
+	}
+	l.pos = l.lines.Len()
+	return lines
+}
+
+// WeightedLines implements the graph.WeightedLines interfaces.
+// The iteration order of WeightedLines is randomized.
+type WeightedLines struct {
+	lines reflect.Value
+	iter  *reflect.MapIter
+	pos   int
+	curr  graph.WeightedLine
+}
+
+// NewWeightedLines returns a WeightedLines initialized with the provided lines, a
+// map of line IDs to graph.WeightedLines. No check is made that the keys
+// match the graph.WeightedLine IDs, and the map keys are not used.
+//
+// Behavior of the WeightedLines is unspecified if lines is mutated after
+// the call to NewWeightedLines.
+func NewWeightedLines(lines map[int64]graph.WeightedLine) *WeightedLines {
+	rv := reflect.ValueOf(lines)
+	return &WeightedLines{lines: rv, iter: rv.MapRange()}
+}
+
+// Len returns the remaining number of lines to be iterated over.
+func (l *WeightedLines) Len() int {
+	return l.lines.Len() - l.pos
+}
+
+// Next returns whether the next call of WeightedLine will return a valid line.
+func (l *WeightedLines) Next() bool {
+	if l.pos >= l.lines.Len() {
+		return false
+	}
+	ok := l.iter.Next()
+	if ok {
+		l.pos++
+		l.curr = l.iter.Value().Interface().(graph.WeightedLine)
+	}
+	return ok
+}
+
+// WeightedLine returns the current line of the iterator. Next must have been
+// called prior to a call to WeightedLine.
+func (l *WeightedLines) WeightedLine() graph.WeightedLine {
+	return l.curr
+}
+
+// Reset returns the iterator to its initial state.
+func (l *WeightedLines) Reset() {
+	l.curr = nil
+	l.pos = 0
+	l.iter = l.lines.MapRange()
+}
+
+// WeightedLineSlice returns all the remaining lines in the iterator and advances
+// the iterator. The order of lines within the returned slice is not
+// specified.
+func (l *WeightedLines) WeightedLineSlice() []graph.WeightedLine {
+	if l.Len() == 0 {
+		return nil
+	}
+	lines := make([]graph.WeightedLine, 0, l.Len())
+	for l.iter.Next() {
+		lines = append(lines, l.iter.Value().Interface().(graph.WeightedLine))
+	}
+	l.pos = l.lines.Len()
+	return lines
+}

--- a/graph/iterator/lines_test.go
+++ b/graph/iterator/lines_test.go
@@ -6,6 +6,7 @@ package iterator_test
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -13,12 +14,63 @@ import (
 	"gonum.org/v1/gonum/graph/simple"
 )
 
-type line struct{ f, t int }
+type line struct{ f, t, id int64 }
 
 func (l line) From() graph.Node         { return simple.Node(l.f) }
 func (l line) To() graph.Node           { return simple.Node(l.t) }
-func (l line) ReversedLine() graph.Line { return line{f: l.t, t: l.f} }
-func (l line) ID() int64                { return 1 }
+func (l line) ReversedLine() graph.Line { l.f, l.t = l.t, l.f; return l }
+func (l line) ID() int64                { return l.id }
+
+var linesTests = []struct {
+	lines map[int64]graph.Line
+}{
+	{lines: nil},
+	{lines: map[int64]graph.Line{1: line{f: 1, t: 2, id: 1}}},
+	{lines: map[int64]graph.Line{1: line{f: 1, t: 2, id: 1}, 2: line{f: 2, t: 3, id: 2}, 3: line{f: 3, t: 4, id: 3}, 4: line{f: 4, t: 5, id: 4}}},
+	{lines: map[int64]graph.Line{4: line{f: 5, t: 4, id: 4}, 3: line{f: 4, t: 3, id: 3}, 2: line{f: 3, t: 2, id: 2}, 1: line{f: 2, t: 1, id: 1}}},
+}
+
+func TestLinesIterate(t *testing.T) {
+	for _, test := range linesTests {
+		it := iterator.NewLines(test.lines)
+		for i := 0; i < 2; i++ {
+			if it.Len() != len(test.lines) {
+				t.Errorf("unexpected iterator length for round %d: got:%d want:%d", i, it.Len(), len(test.lines))
+			}
+			var got map[int64]graph.Line
+			if it.Len() != 0 {
+				got = make(map[int64]graph.Line)
+			}
+			for it.Next() {
+				got[it.Line().ID()] = it.Line()
+			}
+			want := test.lines
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("unexpected iterator output for round %d: got:%#v want:%#v", i, got, want)
+			}
+			it.Reset()
+		}
+	}
+}
+
+func TestLinesSlice(t *testing.T) {
+	for _, test := range linesTests {
+		it := iterator.NewLines(test.lines)
+		for i := 0; i < 2; i++ {
+			got := it.LineSlice()
+			var want []graph.Line
+			for _, l := range test.lines {
+				want = append(want, l)
+			}
+			sort.Slice(got, func(i, j int) bool { return got[i].ID() < got[j].ID() })
+			sort.Slice(want, func(i, j int) bool { return want[i].ID() < want[j].ID() })
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("unexpected iterator output for round %d: got:%#v want:%#v", i, got, want)
+			}
+			it.Reset()
+		}
+	}
+}
 
 var orderedLinesTests = []struct {
 	lines []graph.Line
@@ -64,15 +116,66 @@ func TestOrderedLinesSlice(t *testing.T) {
 }
 
 type weightedLine struct {
-	f, t int
-	w    float64
+	f, t, id int64
+	w        float64
 }
 
 func (l weightedLine) From() graph.Node         { return simple.Node(l.f) }
 func (l weightedLine) To() graph.Node           { return simple.Node(l.t) }
 func (l weightedLine) ReversedLine() graph.Line { l.f, l.t = l.t, l.f; return l }
 func (l weightedLine) Weight() float64          { return l.w }
-func (l weightedLine) ID() int64                { return 1 }
+func (l weightedLine) ID() int64                { return l.id }
+
+var weightedLinesTests = []struct {
+	lines map[int64]graph.WeightedLine
+}{
+	{lines: nil},
+	{lines: map[int64]graph.WeightedLine{2: weightedLine{f: 1, t: 2, w: 1, id: 2}}},
+	{lines: map[int64]graph.WeightedLine{2: weightedLine{f: 1, t: 2, w: 1, id: 2}, 4: weightedLine{f: 2, t: 3, w: 2, id: 4}, 6: weightedLine{f: 3, t: 4, w: 3, id: 6}, 8: weightedLine{f: 4, t: 5, w: 4, id: 8}}},
+	{lines: map[int64]graph.WeightedLine{8: weightedLine{f: 5, t: 4, w: 4, id: 8}, 6: weightedLine{f: 4, t: 3, w: 3, id: 6}, 4: weightedLine{f: 3, t: 2, w: 2, id: 4}, 2: weightedLine{f: 2, t: 1, w: 1, id: 2}}},
+}
+
+func TestWeightedLinesIterate(t *testing.T) {
+	for _, test := range weightedLinesTests {
+		it := iterator.NewWeightedLines(test.lines)
+		for i := 0; i < 2; i++ {
+			if it.Len() != len(test.lines) {
+				t.Errorf("unexpected iterator length for round %d: got:%d want:%d", i, it.Len(), len(test.lines))
+			}
+			var got map[int64]graph.WeightedLine
+			if it.Len() != 0 {
+				got = make(map[int64]graph.WeightedLine)
+			}
+			for it.Next() {
+				got[it.WeightedLine().ID()] = it.WeightedLine()
+			}
+			want := test.lines
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("unexpected iterator output for round %d: got:%#v want:%#v", i, got, want)
+			}
+			it.Reset()
+		}
+	}
+}
+
+func TestWeightedLinesSlice(t *testing.T) {
+	for _, test := range weightedLinesTests {
+		it := iterator.NewWeightedLines(test.lines)
+		for i := 0; i < 2; i++ {
+			got := it.WeightedLineSlice()
+			var want []graph.WeightedLine
+			for _, l := range test.lines {
+				want = append(want, l)
+			}
+			sort.Slice(got, func(i, j int) bool { return got[i].ID() < got[j].ID() })
+			sort.Slice(want, func(i, j int) bool { return want[i].ID() < want[j].ID() })
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("unexpected iterator output for round %d: got:%#v want:%#v", i, got, want)
+			}
+			it.Reset()
+		}
+	}
+}
 
 var orderedWeightedLinesTests = []struct {
 	lines []graph.WeightedLine

--- a/graph/iterator/map.go
+++ b/graph/iterator/map.go
@@ -28,31 +28,44 @@ type emptyInterface struct {
 }
 
 // newMapIterNodes returns a range iterator for a map of nodes.
+// The returned mapIter must not have its line or weightedLine methods called.
 func newMapIterNodes(m map[int64]graph.Node) *mapIter {
 	return &mapIter{m: eface(m)}
 }
 
 // newMapIterEdges returns a range iterator for a map of edges.
-// The returned mapIter must not have its node method called.
+// The returned mapIter must not have its node, line or weightedLine methods called.
 func newMapIterEdges(m map[int64]graph.Edge) *mapIter {
 	return &mapIter{m: eface(m)}
 }
 
-// newMapIterWeightedEdges returns a range iterator for a map of edges.
-// The returned mapIter must not have its node method called.
-func newMapIterWeightedEdges(m map[int64]graph.WeightedEdge) *mapIter {
+// newMapIterLines returns a range iterator for a map of line.
+// The returned mapIter must not have its node or weightedLine method called.
+func newMapIterLines(m map[int64]graph.Line) *mapIter {
 	return &mapIter{m: eface(m)}
 }
 
-// newMapIterLines returns a range iterator for a map of edges.
-// The returned mapIter must not have its node method called.
-func newMapIterLines(m map[int64]map[int64]graph.Line) *mapIter {
+// newMapIterWeightedLines returns a range iterator for a map of line.
+// The returned mapIter must not have its node, line or weightedLine methods called.
+func newMapIterWeightedLines(m map[int64]graph.WeightedLine) *mapIter {
 	return &mapIter{m: eface(m)}
 }
 
-// newMapIterWeightedLines returns a range iterator for a map of edges.
-// The returned mapIter must not have its node method called.
-func newMapIterWeightedLines(m map[int64]map[int64]graph.WeightedLine) *mapIter {
+// newMapIterByWeightedEdges returns a range iterator for a map of edges.
+// The returned mapIter must not have its node, line or weightedLine methods called.
+func newMapIterByWeightedEdges(m map[int64]graph.WeightedEdge) *mapIter {
+	return &mapIter{m: eface(m)}
+}
+
+// newMapIterByLines returns a range iterator for a map of edges.
+// The returned mapIter must not have its node, line or weightedLine methods called.
+func newMapIterByLines(m map[int64]map[int64]graph.Line) *mapIter {
+	return &mapIter{m: eface(m)}
+}
+
+// newMapIterByWeightedLines returns a range iterator for a map of edges.
+// The returned mapIter must not have its node, line or weightedLine methods called.
+func newMapIterByWeightedLines(m map[int64]map[int64]graph.WeightedLine) *mapIter {
 	return &mapIter{m: eface(m)}
 }
 
@@ -80,6 +93,28 @@ func (it *mapIter) node() graph.Node {
 		panic("mapIter.node called on exhausted iterator")
 	}
 	return *(*graph.Node)(mapiterelem(it.it))
+}
+
+// line returns the value of the iterator's current map entry.
+func (it *mapIter) line() graph.Line {
+	if it.it == nil {
+		panic("mapIter.line called before next")
+	}
+	if mapiterkey(it.it) == nil {
+		panic("mapIter.line called on exhausted iterator")
+	}
+	return *(*graph.Line)(mapiterelem(it.it))
+}
+
+// weightedLine returns the value of the iterator's current map entry.
+func (it *mapIter) weightedLine() graph.WeightedLine {
+	if it.it == nil {
+		panic("mapIter.weightedLine called before next")
+	}
+	if mapiterkey(it.it) == nil {
+		panic("mapIter.weightedLine called on exhausted iterator")
+	}
+	return *(*graph.WeightedLine)(mapiterelem(it.it))
 }
 
 // next advances the map iterator and reports whether there is another

--- a/graph/iterator/nodes_map.go
+++ b/graph/iterator/nodes_map.go
@@ -23,7 +23,7 @@ type Nodes struct {
 // match the graph.Node IDs, and the map keys are not used.
 //
 // Behavior of the Nodes is unspecified if nodes is mutated after
-// the call the NewNodes.
+// the call to NewNodes.
 func NewNodes(nodes map[int64]graph.Node) *Nodes {
 	return &Nodes{nodes: len(nodes), iter: newMapIterNodes(nodes)}
 }
@@ -92,7 +92,7 @@ type NodesByEdge struct {
 // and the map keys are not used.
 //
 // Behavior of the NodesByEdge is unspecified if nodes or edges
-// is mutated after the call the NewNodes.
+// is mutated after the call to NewNodes.
 func NewNodesByEdge(nodes map[int64]graph.Node, edges map[int64]graph.Edge) *NodesByEdge {
 	return &NodesByEdge{nodes: nodes, edges: len(edges), iter: newMapIterEdges(edges)}
 }
@@ -105,7 +105,7 @@ func NewNodesByEdge(nodes map[int64]graph.Node, edges map[int64]graph.Edge) *Nod
 // and the map keys are not used.
 //
 // Behavior of the NodesByEdge is unspecified if nodes or edges
-// is mutated after the call the NewNodes.
+// is mutated after the call to NewNodes.
 func NewNodesByWeightedEdge(nodes map[int64]graph.Node, edges map[int64]graph.WeightedEdge) *NodesByEdge {
 	return &NodesByEdge{nodes: nodes, edges: len(edges), iter: newMapIterByWeightedEdges(edges)}
 }
@@ -118,7 +118,7 @@ func NewNodesByWeightedEdge(nodes map[int64]graph.Node, edges map[int64]graph.We
 // and the map keys are not used.
 //
 // Behavior of the NodesByEdge is unspecified if nodes or lines
-// is mutated after the call the NewNodes.
+// is mutated after the call to NewNodes.
 func NewNodesByLines(nodes map[int64]graph.Node, lines map[int64]map[int64]graph.Line) *NodesByEdge {
 	return &NodesByEdge{nodes: nodes, edges: len(lines), iter: newMapIterByLines(lines)}
 }
@@ -131,7 +131,7 @@ func NewNodesByLines(nodes map[int64]graph.Node, lines map[int64]map[int64]graph
 // and the map keys are not used.
 //
 // Behavior of the NodesByEdge is unspecified if nodes or lines
-// is mutated after the call the NewNodes.
+// is mutated after the call to NewNodes.
 func NewNodesByWeightedLines(nodes map[int64]graph.Node, lines map[int64]map[int64]graph.WeightedLine) *NodesByEdge {
 	return &NodesByEdge{nodes: nodes, edges: len(lines), iter: newMapIterByWeightedLines(lines)}
 }

--- a/graph/iterator/nodes_map.go
+++ b/graph/iterator/nodes_map.go
@@ -107,7 +107,7 @@ func NewNodesByEdge(nodes map[int64]graph.Node, edges map[int64]graph.Edge) *Nod
 // Behavior of the NodesByEdge is unspecified if nodes or edges
 // is mutated after the call the NewNodes.
 func NewNodesByWeightedEdge(nodes map[int64]graph.Node, edges map[int64]graph.WeightedEdge) *NodesByEdge {
-	return &NodesByEdge{nodes: nodes, edges: len(edges), iter: newMapIterWeightedEdges(edges)}
+	return &NodesByEdge{nodes: nodes, edges: len(edges), iter: newMapIterByWeightedEdges(edges)}
 }
 
 // NewNodesByLines returns a NodesByEdge initialized with the
@@ -120,7 +120,7 @@ func NewNodesByWeightedEdge(nodes map[int64]graph.Node, edges map[int64]graph.We
 // Behavior of the NodesByEdge is unspecified if nodes or lines
 // is mutated after the call the NewNodes.
 func NewNodesByLines(nodes map[int64]graph.Node, lines map[int64]map[int64]graph.Line) *NodesByEdge {
-	return &NodesByEdge{nodes: nodes, edges: len(lines), iter: newMapIterLines(lines)}
+	return &NodesByEdge{nodes: nodes, edges: len(lines), iter: newMapIterByLines(lines)}
 }
 
 // NewNodesByWeightedLines returns a NodesByEdge initialized with the
@@ -133,7 +133,7 @@ func NewNodesByLines(nodes map[int64]graph.Node, lines map[int64]map[int64]graph
 // Behavior of the NodesByEdge is unspecified if nodes or lines
 // is mutated after the call the NewNodes.
 func NewNodesByWeightedLines(nodes map[int64]graph.Node, lines map[int64]map[int64]graph.WeightedLine) *NodesByEdge {
-	return &NodesByEdge{nodes: nodes, edges: len(lines), iter: newMapIterWeightedLines(lines)}
+	return &NodesByEdge{nodes: nodes, edges: len(lines), iter: newMapIterByWeightedLines(lines)}
 }
 
 // Len returns the remaining number of nodes to be iterated over.

--- a/graph/iterator/nodes_map_safe.go
+++ b/graph/iterator/nodes_map_safe.go
@@ -27,7 +27,7 @@ type Nodes struct {
 // match the graph.Node IDs, and the map keys are not used.
 //
 // Behavior of the Nodes is unspecified if nodes is mutated after
-// the call the NewNodes.
+// the call to NewNodes.
 func NewNodes(nodes map[int64]graph.Node) *Nodes {
 	rv := reflect.ValueOf(nodes)
 	return &Nodes{nodes: rv, iter: rv.MapRange()}
@@ -97,7 +97,7 @@ type NodesByEdge struct {
 // and the map keys are not used.
 //
 // Behavior of the NodesByEdge is unspecified if nodes or edges
-// is mutated after the call the NewNodes.
+// is mutated after the call to NewNodes.
 func NewNodesByEdge(nodes map[int64]graph.Node, edges map[int64]graph.Edge) *NodesByEdge {
 	rv := reflect.ValueOf(edges)
 	return &NodesByEdge{nodes: nodes, edges: rv, iter: rv.MapRange()}
@@ -111,7 +111,7 @@ func NewNodesByEdge(nodes map[int64]graph.Node, edges map[int64]graph.Edge) *Nod
 // and the map keys are not used.
 //
 // Behavior of the NodesByEdge is unspecified if nodes or edges
-// is mutated after the call the NewNodes.
+// is mutated after the call to NewNodes.
 func NewNodesByWeightedEdge(nodes map[int64]graph.Node, edges map[int64]graph.WeightedEdge) *NodesByEdge {
 	rv := reflect.ValueOf(edges)
 	return &NodesByEdge{nodes: nodes, edges: rv, iter: rv.MapRange()}
@@ -125,7 +125,7 @@ func NewNodesByWeightedEdge(nodes map[int64]graph.Node, edges map[int64]graph.We
 // and the map keys are not used.
 //
 // Behavior of the NodesByEdge is unspecified if nodes or lines
-// is mutated after the call the NewNodes.
+// is mutated after the call to NewNodes.
 func NewNodesByLines(nodes map[int64]graph.Node, lines map[int64]map[int64]graph.Line) *NodesByEdge {
 	rv := reflect.ValueOf(lines)
 	return &NodesByEdge{nodes: nodes, edges: rv, iter: rv.MapRange()}
@@ -139,7 +139,7 @@ func NewNodesByLines(nodes map[int64]graph.Node, lines map[int64]map[int64]graph
 // and the map keys are not used.
 //
 // Behavior of the NodesByEdge is unspecified if nodes or lines
-// is mutated after the call the NewNodes.
+// is mutated after the call to NewNodes.
 func NewNodesByWeightedLines(nodes map[int64]graph.Node, lines map[int64]map[int64]graph.WeightedLine) *NodesByEdge {
 	rv := reflect.ValueOf(lines)
 	return &NodesByEdge{nodes: nodes, edges: rv, iter: rv.MapRange()}

--- a/graph/multi/directed.go
+++ b/graph/multi/directed.go
@@ -69,24 +69,24 @@ func (g *DirectedGraph) Edge(uid, vid int64) graph.Edge {
 
 // Edges returns all the edges in the graph. Each edge in the returned slice
 // is a multi.Edge.
+//
+// The returned graph.Edges is only valid until the next mutation of
+// the receiver.
 func (g *DirectedGraph) Edges() graph.Edges {
 	if len(g.nodes) == 0 {
 		return graph.Empty
 	}
 	var edges []graph.Edge
-	for _, u := range g.nodes {
-		for _, e := range g.from[u.ID()] {
-			var lines []graph.Line
-			for _, l := range e {
-				lines = append(lines, l)
+	for uid, u := range g.nodes {
+		for vid, lines := range g.from[u.ID()] {
+			if len(lines) == 0 {
+				continue
 			}
-			if len(lines) != 0 {
-				edges = append(edges, Edge{
-					F:     g.Node(u.ID()),
-					T:     g.Node(lines[0].To().ID()),
-					Lines: iterator.NewOrderedLines(lines),
-				})
-			}
+			edges = append(edges, Edge{
+				F:     g.Node(uid),
+				T:     g.Node(vid),
+				Lines: iterator.NewLines(lines),
+			})
 		}
 	}
 	if len(edges) == 0 {

--- a/graph/multi/undirected.go
+++ b/graph/multi/undirected.go
@@ -72,31 +72,29 @@ func (g *UndirectedGraph) EdgeBetween(xid, yid int64) graph.Edge {
 
 // Edges returns all the edges in the graph. Each edge in the returned slice
 // is a multi.Edge.
+//
+// The returned graph.Edges is only valid until the next mutation of
+// the receiver.
 func (g *UndirectedGraph) Edges() graph.Edges {
 	if len(g.lines) == 0 {
 		return graph.Empty
 	}
 	var edges []graph.Edge
 	for xid, u := range g.lines {
-		for yid, e := range u {
+		for yid, lines := range u {
 			if yid < xid {
 				// Do not consider lines when the To node ID is
 				// before the From node ID. Both orientations
 				// are stored.
 				continue
 			}
-			// TODO(kortschak): Add iterator.Lines and use that here.
-			if len(e) == 0 {
+			if len(lines) == 0 {
 				continue
-			}
-			lines := make([]graph.Line, 0, len(e))
-			for _, l := range e {
-				lines = append(lines, l)
 			}
 			edges = append(edges, Edge{
 				F:     g.Node(xid),
 				T:     g.Node(yid),
-				Lines: iterator.NewOrderedLines(lines),
+				Lines: iterator.NewLines(lines),
 			})
 		}
 	}

--- a/graph/multi/weighted_directed.go
+++ b/graph/multi/weighted_directed.go
@@ -74,25 +74,25 @@ func (g *WeightedDirectedGraph) Edge(uid, vid int64) graph.Edge {
 
 // Edges returns all the edges in the graph. Each edge in the returned slice
 // is a multi.WeightedEdge.
+//
+// The returned graph.Edges is only valid until the next mutation of
+// the receiver.
 func (g *WeightedDirectedGraph) Edges() graph.Edges {
 	if len(g.nodes) == 0 {
 		return graph.Empty
 	}
 	var edges []graph.Edge
-	for _, u := range g.nodes {
-		for _, e := range g.from[u.ID()] {
-			var lines []graph.WeightedLine
-			for _, l := range e {
-				lines = append(lines, l)
+	for uid, u := range g.nodes {
+		for vid, lines := range g.from[u.ID()] {
+			if len(lines) == 0 {
+				continue
 			}
-			if len(lines) != 0 {
-				edges = append(edges, WeightedEdge{
-					F:             g.Node(u.ID()),
-					T:             g.Node(lines[0].To().ID()),
-					WeightedLines: iterator.NewOrderedWeightedLines(lines),
-					WeightFunc:    g.EdgeWeightFunc,
-				})
-			}
+			edges = append(edges, WeightedEdge{
+				F:             g.Node(uid),
+				T:             g.Node(vid),
+				WeightedLines: iterator.NewWeightedLines(lines),
+				WeightFunc:    g.EdgeWeightFunc,
+			})
 		}
 	}
 	if len(edges) == 0 {
@@ -334,25 +334,25 @@ func (g *WeightedDirectedGraph) WeightedEdge(uid, vid int64) graph.WeightedEdge 
 
 // WeightedEdges returns all the edges in the graph. Each edge in the returned slice
 // is a multi.WeightedEdge.
+//
+// The returned graph.WeightedEdges is only valid until the next mutation of
+// the receiver.
 func (g *WeightedDirectedGraph) WeightedEdges() graph.WeightedEdges {
 	if len(g.nodes) == 0 {
 		return graph.Empty
 	}
 	var edges []graph.WeightedEdge
-	for _, u := range g.nodes {
-		for _, e := range g.from[u.ID()] {
-			var lines []graph.WeightedLine
-			for _, l := range e {
-				lines = append(lines, l)
+	for uid, u := range g.nodes {
+		for vid, lines := range g.from[u.ID()] {
+			if len(lines) == 0 {
+				continue
 			}
-			if len(lines) != 0 {
-				edges = append(edges, WeightedEdge{
-					F:             g.Node(u.ID()),
-					T:             g.Node(lines[0].To().ID()),
-					WeightedLines: iterator.NewOrderedWeightedLines(lines),
-					WeightFunc:    g.EdgeWeightFunc,
-				})
-			}
+			edges = append(edges, WeightedEdge{
+				F:             g.Node(uid),
+				T:             g.Node(vid),
+				WeightedLines: iterator.NewWeightedLines(lines),
+				WeightFunc:    g.EdgeWeightFunc,
+			})
 		}
 	}
 	if len(edges) == 0 {

--- a/graph/multi/weighted_undirected.go
+++ b/graph/multi/weighted_undirected.go
@@ -76,32 +76,30 @@ func (g *WeightedUndirectedGraph) EdgeBetween(xid, yid int64) graph.Edge {
 }
 
 // Edges returns all the edges in the graph. Each edge in the returned slice
-// is a multi.Edge.
+// is a multi.WeightedEdge.
+//
+// The returned graph.Edges is only valid until the next mutation of
+// the receiver.
 func (g *WeightedUndirectedGraph) Edges() graph.Edges {
 	if len(g.lines) == 0 {
 		return graph.Empty
 	}
 	var edges []graph.Edge
 	for xid, u := range g.lines {
-		for yid, e := range u {
+		for yid, lines := range u {
 			if yid < xid {
 				// Do not consider lines when the To node ID is
 				// before the From node ID. Both orientations
 				// are stored.
 				continue
 			}
-			// TODO(kortschak): Add iterator.WeightedLines and use that here.
-			if len(e) == 0 {
+			if len(lines) == 0 {
 				continue
-			}
-			lines := make([]graph.WeightedLine, 0, len(e))
-			for _, l := range e {
-				lines = append(lines, l)
 			}
 			edges = append(edges, WeightedEdge{
 				F:             g.Node(xid),
 				T:             g.Node(yid),
-				WeightedLines: iterator.NewOrderedWeightedLines(lines),
+				WeightedLines: iterator.NewWeightedLines(lines),
 				WeightFunc:    g.EdgeWeightFunc,
 			})
 		}
@@ -341,32 +339,30 @@ func (g *WeightedUndirectedGraph) WeightedEdgeBetween(xid, yid int64) graph.Weig
 }
 
 // WeightedEdges returns all the edges in the graph. Each edge in the returned slice
-// is a multi.Edge.
+// is a multi.WeightedEdge.
+//
+// The returned graph.WeightedEdges is only valid until the next mutation of
+// the receiver.
 func (g *WeightedUndirectedGraph) WeightedEdges() graph.WeightedEdges {
 	if len(g.lines) == 0 {
 		return graph.Empty
 	}
 	var edges []graph.WeightedEdge
 	for xid, u := range g.lines {
-		for yid, e := range u {
+		for yid, lines := range u {
 			if yid < xid {
 				// Do not consider lines when the To node ID is
 				// before the From node ID. Both orientations
 				// are stored.
 				continue
 			}
-			// TODO(kortschak): Add iterator.WeightedLines and use that here.
-			if len(e) == 0 {
+			if len(lines) == 0 {
 				continue
-			}
-			lines := make([]graph.WeightedLine, 0, len(e))
-			for _, l := range e {
-				lines = append(lines, l)
 			}
 			edges = append(edges, WeightedEdge{
 				F:             g.Node(xid),
 				T:             g.Node(yid),
-				WeightedLines: iterator.NewOrderedWeightedLines(lines),
+				WeightedLines: iterator.NewWeightedLines(lines),
 				WeightFunc:    g.EdgeWeightFunc,
 			})
 		}


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
