### PR TITLE
all: replace uses of deprecated ioutil functions

### DIFF
--- a/graph/flow/control_flow_bench_test.go
+++ b/graph/flow/control_flow_bench_test.go
@@ -7,7 +7,6 @@ package flow
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -30,7 +29,7 @@ var slta = flag.Bool("slta", false, "specify DominatorsSLT benchmark")
 func BenchmarkDominators(b *testing.B) {
 	testdata := filepath.FromSlash("./testdata/flow")
 
-	fis, err := ioutil.ReadDir(testdata)
+	fis, err := os.ReadDir(testdata)
 	if err != nil {
 		if os.IsNotExist(err) {
 			b.Skipf("no control flow testdata: %v", err)
@@ -45,7 +44,7 @@ func BenchmarkDominators(b *testing.B) {
 		}
 		test := name[:len(name)-len(ext)]
 
-		data, err := ioutil.ReadFile(filepath.Join(testdata, name))
+		data, err := os.ReadFile(filepath.Join(testdata, name))
 		if err != nil {
 			b.Errorf("failed to open control flow case: %v", err)
 			continue

--- a/graph/formats/cytoscapejs/cytoscapejs_test.go
+++ b/graph/formats/cytoscapejs/cytoscapejs_test.go
@@ -6,7 +6,7 @@ package cytoscapejs
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -50,7 +50,7 @@ var cytoscapejsElementsTests = []struct {
 
 func TestUnmarshalElements(t *testing.T) {
 	for _, test := range cytoscapejsElementsTests {
-		data, err := ioutil.ReadFile(filepath.Join("testdata", test.path))
+		data, err := os.ReadFile(filepath.Join("testdata", test.path))
 		if err != nil {
 			t.Errorf("failed to read %q: %v", test.path, err)
 			continue
@@ -89,7 +89,7 @@ func TestUnmarshalElements(t *testing.T) {
 
 func TestMarshalElements(t *testing.T) {
 	for _, test := range cytoscapejsElementsTests {
-		data, err := ioutil.ReadFile(filepath.Join("testdata", test.path))
+		data, err := os.ReadFile(filepath.Join("testdata", test.path))
 		if err != nil {
 			t.Errorf("failed to read %q: %v", test.path, err)
 			continue
@@ -267,7 +267,7 @@ var cytoscapejsNodeEdgeTests = []struct {
 
 func TestUnmarshalNodeEdge(t *testing.T) {
 	for _, test := range cytoscapejsNodeEdgeTests {
-		data, err := ioutil.ReadFile(filepath.Join("testdata", test.path))
+		data, err := os.ReadFile(filepath.Join("testdata", test.path))
 		if err != nil {
 			t.Errorf("failed to read %q: %v", test.path, err)
 			continue
@@ -328,7 +328,7 @@ func TestUnmarshalNodeEdge(t *testing.T) {
 
 func TestMarshalNodeEdge(t *testing.T) {
 	for _, test := range cytoscapejsNodeEdgeTests {
-		data, err := ioutil.ReadFile(filepath.Join("testdata", test.path))
+		data, err := os.ReadFile(filepath.Join("testdata", test.path))
 		if err != nil {
 			t.Errorf("failed to read %q: %v", test.path, err)
 			continue

--- a/graph/formats/dot/ast/ast_test.go
+++ b/graph/formats/dot/ast/ast_test.go
@@ -12,7 +12,7 @@ package ast_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"gonum.org/v1/gonum/graph/formats/dot"
@@ -68,7 +68,7 @@ func TestParseFile(t *testing.T) {
 		if len(g.out) > 0 {
 			out = g.out
 		}
-		buf, err := ioutil.ReadFile(out)
+		buf, err := os.ReadFile(out)
 		if err != nil {
 			t.Errorf("%q: unable to read file; %v", g.in, err)
 			continue

--- a/graph/formats/dot/dot.go
+++ b/graph/formats/dot/dot.go
@@ -15,7 +15,7 @@ package dot
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"gonum.org/v1/gonum/graph/formats/dot/ast"
 	"gonum.org/v1/gonum/graph/formats/dot/internal/lexer"
@@ -24,7 +24,7 @@ import (
 
 // ParseFile parses the given Graphviz DOT file into an AST.
 func ParseFile(path string) (*ast.File, error) {
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func ParseFile(path string) (*ast.File, error) {
 
 // Parse parses the given Graphviz DOT file into an AST, reading from r.
 func Parse(r io.Reader) (*ast.File, error) {
-	buf, err := ioutil.ReadAll(r)
+	buf, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/graph/formats/dot/internal/astx/astx_test.go
+++ b/graph/formats/dot/internal/astx/astx_test.go
@@ -12,7 +12,7 @@ package astx_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"gonum.org/v1/gonum/graph/formats/dot"
@@ -72,7 +72,7 @@ func TestParseFile(t *testing.T) {
 		if len(g.out) > 0 {
 			out = g.out
 		}
-		buf, err := ioutil.ReadFile(out)
+		buf, err := os.ReadFile(out)
 		if err != nil {
 			t.Errorf("%q: unable to read file; %v", g.in, err)
 			continue

--- a/graph/formats/dot/internal/lexer/lexer_test.go
+++ b/graph/formats/dot/internal/lexer/lexer_test.go
@@ -13,7 +13,6 @@ package lexer_test
 import (
 	"archive/zip"
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -41,7 +40,7 @@ func TestParseFile(t *testing.T) {
 		if len(g.out) > 0 {
 			out = g.out
 		}
-		buf, err := ioutil.ReadFile(out)
+		buf, err := os.ReadFile(out)
 		if err != nil {
 			t.Errorf("%q: unable to read file; %v", g.in, err)
 			continue

--- a/graph/formats/dot/internal/parser/parser_test.go
+++ b/graph/formats/dot/internal/parser/parser_test.go
@@ -13,7 +13,6 @@ package parser_test
 import (
 	"archive/zip"
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -74,7 +73,7 @@ func TestParseFile(t *testing.T) {
 		if len(g.out) > 0 {
 			out = g.out
 		}
-		buf, err := ioutil.ReadFile(out)
+		buf, err := os.ReadFile(out)
 		if err != nil {
 			t.Errorf("%q: unable to read file; %v", g.in, err)
 			continue

--- a/graph/formats/dot/internal/paste_copyright.go
+++ b/graph/formats/dot/internal/paste_copyright.go
@@ -16,7 +16,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -43,13 +42,13 @@ func main() {
 			return nil
 		}
 
-		content, err := ioutil.ReadFile(path)
+		content, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
 
 		content = bytes.Replace(content, location, copyright, 1)
-		return ioutil.WriteFile(path, content, info.Mode())
+		return os.WriteFile(path, content, info.Mode())
 	})
 
 	if err != nil {

--- a/graph/formats/gexf12/gexf_test.go
+++ b/graph/formats/gexf12/gexf_test.go
@@ -6,7 +6,7 @@ package gexf12
 
 import (
 	"encoding/xml"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -430,7 +430,7 @@ var gexfExampleTests = []struct {
 
 func TestUnmarshal(t *testing.T) {
 	for _, test := range gexfExampleTests {
-		data, err := ioutil.ReadFile(filepath.Join("testdata", test.path))
+		data, err := os.ReadFile(filepath.Join("testdata", test.path))
 		if err != nil {
 			t.Errorf("failed to read %q: %v", test.path, err)
 			continue

--- a/graph/formats/rdf/urna_test.go
+++ b/graph/formats/rdf/urna_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,7 +39,7 @@ func TestURNA(t *testing.T) {
 			for _, path := range glob {
 				name := filepath.Base(path)
 				golden := strings.TrimSuffix(path, "-in.nq") + test.truth
-				want, err := ioutil.ReadFile(golden)
+				want, err := os.ReadFile(golden)
 				if err != nil {
 					if !os.IsNotExist(err) {
 						t.Errorf("Failed to read golden data: %v", err)

--- a/graph/formats/sigmajs/sigmajs_test.go
+++ b/graph/formats/sigmajs/sigmajs_test.go
@@ -6,7 +6,7 @@ package sigmajs
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -253,7 +253,7 @@ var sigmajsExampleTests = []struct {
 
 func TestUnmarshal(t *testing.T) {
 	for _, test := range sigmajsExampleTests {
-		data, err := ioutil.ReadFile(filepath.Join("testdata", test.path))
+		data, err := os.ReadFile(filepath.Join("testdata", test.path))
 		if err != nil {
 			t.Errorf("failed to read %q: %v", test.path, err)
 			continue
@@ -305,7 +305,7 @@ func attrPaths(dst []string, prefix string, m map[string]interface{}) []string {
 
 func TestMarshal(t *testing.T) {
 	for _, test := range sigmajsExampleTests {
-		data, err := ioutil.ReadFile(filepath.Join("testdata", test.path))
+		data, err := os.ReadFile(filepath.Join("testdata", test.path))
 		if err != nil {
 			t.Errorf("failed to read %q: %v", test.path, err)
 			continue

--- a/graph/layout/layout_test.go
+++ b/graph/layout/layout_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"image"
 	"image/png"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -60,13 +59,13 @@ func checkRenderedLayout(t *testing.T, path string) (ok bool) {
 
 	// Read the images we've just generated and check them against the
 	// Golden Images.
-	got, err := ioutil.ReadFile(path)
+	got, err := os.ReadFile(path)
 	if err != nil {
 		t.Errorf("failed to read %s: %v", path, err)
 		return true
 	}
 	golden := goldenPath(path)
-	want, err := ioutil.ReadFile(golden)
+	want, err := os.ReadFile(golden)
 	if err != nil {
 		t.Errorf("failed to read golden file %s: %v", golden, err)
 		return true

--- a/mat/io_test.go
+++ b/mat/io_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding"
 	"encoding/binary"
 	"io"
-	"io/ioutil"
 	"math"
 	"testing"
 
@@ -639,7 +638,7 @@ func marshalBinaryToBenchDense(b *testing.B, size int) {
 		data[i] = float64(i)
 	}
 	m := NewDense(1, size, data)
-	w := ioutil.Discard
+	w := io.Discard
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
@@ -749,7 +748,7 @@ func marshalBinaryToBenchVecDense(b *testing.B, size int) {
 		data[i] = float64(i)
 	}
 	vec := NewVecDense(size, data)
-	w := ioutil.Discard
+	w := io.Discard
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {

--- a/unit/constant/generate_defined_types.go
+++ b/unit/constant/generate_defined_types.go
@@ -13,7 +13,6 @@ import (
 	"go/format"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -65,7 +64,7 @@ func main() {
 		if strings.Contains(fn, "_test") {
 			continue
 		}
-		b, err := ioutil.ReadFile(fn)
+		b, err := os.ReadFile(fn)
 		if bytes.Contains(b, []byte("+build ignore")) {
 			continue
 		}


### PR DESCRIPTION
Please take a look.

This is ready to apply when Go1.15 is no longer supported.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
