### PR TITLE
mat: format complex dense matrices

### DIFF
--- a/mat/format.go
+++ b/mat/format.go
@@ -173,25 +173,25 @@ func format(m formattable, prefix string, margin int, dot byte, squeeze bool, fs
 		fmt.Fprintf(fs, "Dims(%d, %d)\n", rows, cols)
 	}
 
+	var buf = make([]byte, 0, 4)
 	for i := 0; i < rows; i++ {
 		if !first {
 			fmt.Fprint(fs, prefix)
 		}
 		first = false
-		var el string
 		switch {
 		case rows == 1:
 			fmt.Fprint(fs, "[")
-			el = "]"
+			buf = append(buf[:0], []byte("]")...)
 		case i == 0:
 			fmt.Fprint(fs, "⎡")
-			el = "⎤\n"
+			buf = append(buf[:0], []byte("⎤\n")...)
 		case i < rows-1:
 			fmt.Fprint(fs, "⎢")
-			el = "⎥\n"
+			buf = append(buf[:0], []byte("⎥\n")...)
 		default:
 			fmt.Fprint(fs, "⎣")
-			el = "⎦"
+			buf = append(buf[:0], []byte("⎦")...)
 		}
 
 		for j := 0; j < cols; j++ {
@@ -213,7 +213,7 @@ func format(m formattable, prefix string, margin int, dot byte, squeeze bool, fs
 			}
 		}
 
-		fmt.Fprint(fs, el)
+		fs.Write(buf)
 
 		if i >= printed-1 && i < rows-printed && 2*printed < rows {
 			i = rows - printed - 1
@@ -274,21 +274,21 @@ func formatMATLAB(m formattable, prefix string, _ int, _ byte, squeeze bool, fs 
 		return
 	}
 
+	var buf = make([]byte, 0, 4)
 	for i := 0; i < rows; i++ {
-		var el string
 		switch {
 		case rows == 1:
 			fmt.Fprint(fs, "[")
-			el = "]"
+			buf = append(buf[:0], []byte("]")...)
 		case i == 0:
 			fmt.Fprint(fs, "[\n"+prefix+" ")
-			el = "\n"
+			buf = append(buf[:0], []byte("\n")...)
 		case i < rows-1:
 			fmt.Fprint(fs, prefix+" ")
-			el = "\n"
+			buf = append(buf[:0], []byte("\n")...)
 		default:
 			fmt.Fprint(fs, prefix+" ")
-			el = "\n" + prefix + "]"
+			buf = append(buf[:0], []byte("\n"+prefix+"]")...)
 		}
 
 		for j := 0; j < cols; j++ {
@@ -300,7 +300,7 @@ func formatMATLAB(m formattable, prefix string, _ int, _ byte, squeeze bool, fs 
 			}
 		}
 
-		fmt.Fprint(fs, el)
+		fs.Write(buf)
 	}
 }
 
@@ -361,24 +361,24 @@ func formatPython(m formattable, prefix string, _ int, _ byte, squeeze bool, fs 
 		return
 	}
 
+	var buf = make([]byte, 0, 4)
 	for i := 0; i < rows; i++ {
 		if i != 0 {
 			fmt.Fprint(fs, prefix)
 		}
-		var el string
 		switch {
 		case rows == 1:
 			fmt.Fprint(fs, "[")
-			el = "]"
+			buf = append(buf[:0], []byte("]")...)
 		case i == 0:
 			fmt.Fprint(fs, "[[")
-			el = "],\n"
+			buf = append(buf[:0], []byte("],\n")...)
 		case i < rows-1:
 			fmt.Fprint(fs, " [")
-			el = "],\n"
+			buf = append(buf[:0], []byte("],\n")...)
 		default:
 			fmt.Fprint(fs, " [")
-			el = "]]"
+			buf = append(buf[:0], []byte("]]")...)
 		}
 
 		for j := 0; j < cols; j++ {
@@ -390,7 +390,7 @@ func formatPython(m formattable, prefix string, _ int, _ byte, squeeze bool, fs 
 			}
 		}
 
-		fmt.Fprint(fs, el)
+		fs.Write(buf)
 	}
 }
 

--- a/mat/format.go
+++ b/mat/format.go
@@ -243,20 +243,20 @@ func formatMATLAB(m formattable, prefix string, _ int, _ byte, squeeze bool, fs 
 			fmt.Fprintf(fs, "%%!%c(%T=Dims(%d, %d))", c, m.Mat(), rows, cols)
 			return
 		}
-		fs.Write([]byte{'['})
+		fmt.Fprint(fs, "[")
 		for i := 0; i < rows; i++ {
 			if i != 0 {
-				fs.Write([]byte("; "))
+				fmt.Fprint(fs, "; ")
 			}
 			for j := 0; j < cols; j++ {
 				if j != 0 {
-					fs.Write([]byte{' '})
+					fmt.Fprint(fs, " ")
 				}
 				f = m.RevalueFormatter(f, i, j)
 				f.Format(fs, c)
 			}
 		}
-		fs.Write([]byte{']'})
+		fmt.Fprint(fs, "]")
 		return
 	}
 
@@ -324,26 +324,26 @@ func formatPython(m formattable, prefix string, _ int, _ byte, squeeze bool, fs 
 			fmt.Fprintf(fs, "%%!%c(%T=Dims(%d, %d))", c, m.Mat(), rows, cols)
 			return
 		}
-		fs.Write([]byte{'['})
+		fmt.Fprint(fs, "[")
 		if rows > 1 {
-			fs.Write([]byte{'['})
+			fmt.Fprint(fs, "[")
 		}
 		for i := 0; i < rows; i++ {
 			if i != 0 {
-				fs.Write([]byte("], ["))
+				fmt.Fprint(fs, "], [")
 			}
 			for j := 0; j < cols; j++ {
 				if j != 0 {
-					fs.Write([]byte(", "))
+					fmt.Fprint(fs, ", ")
 				}
 				f = m.RevalueFormatter(f, i, j)
 				f.Format(fs, c)
 			}
 		}
 		if rows > 1 {
-			fs.Write([]byte{']'})
+			fmt.Fprint(fs, "]")
 		}
-		fs.Write([]byte{']'})
+		fmt.Fprint(fs, "]")
 		return
 	}
 

--- a/mat/format.go
+++ b/mat/format.go
@@ -32,6 +32,8 @@ type formatter struct {
 	format func(m Matrix, prefix string, margin int, dot byte, squeeze bool, fs fmt.State, c rune)
 }
 
+var _ fmt.Formatter = (*formatter)(nil)
+
 // FormatOption is a functional option for matrix formatting.
 type FormatOption func(*formatter)
 
@@ -507,10 +509,14 @@ type widther interface {
 
 type uniformWidth int
 
+var _ widther = (*uniformWidth)(nil)
+
 func (u *uniformWidth) width(_ int) int   { return int(*u) }
 func (u *uniformWidth) setWidth(_, w int) { *u = uniformWidth(w) }
 
 type columnWidth []int
+
+var _ widther = (*columnWidth)(nil)
 
 func (c columnWidth) width(i int) int   { return c[i] }
 func (c columnWidth) setWidth(i, w int) { c[i] = w }

--- a/mat/format.go
+++ b/mat/format.go
@@ -19,7 +19,7 @@ func Formatted(m Matrix, options ...FormatOption) fmt.Formatter {
 	for _, o := range options {
 		o(&f)
 	}
-	return f
+	return &f
 }
 
 type formatter struct {

--- a/mat/format.go
+++ b/mat/format.go
@@ -21,6 +21,19 @@ func Formatted(m Matrix, options ...FormatOption) fmt.Formatter {
 	return &f
 }
 
+// CFormatted returns a fmt.Formatter for the complex-valued matrix m using the
+// given options.
+func CFormatted(m CMatrix, options ...FormatOption) fmt.Formatter {
+	f := formatter{
+		matrix: formattableCMatrix{mat: m},
+		dot:    '.',
+	}
+	for _, o := range options {
+		o(&f)
+	}
+	return &f
+}
+
 // formatter is a matrix formatter that satisfies the fmt.Formatter interface
 type formatter struct {
 	matrix  formattable
@@ -122,6 +135,25 @@ func (m formattableMatrix) RevalueFormatter(f fmt.Formatter, i, j int) fmt.Forma
 }
 func (m formattableMatrix) ValueFormatter(i, j int, options ...vFormatOption) fmt.Formatter {
 	return formattedFloat(m.mat.At(i, j), options...)
+}
+
+// formattableCMatrix is a formattable for complex-valued matrices, those that
+// satisfy the CMatrix interface
+type formattableCMatrix struct{ mat CMatrix }
+
+var _ formattable = (*formattableCMatrix)(nil)
+
+func (m formattableCMatrix) Dims() (r, c int) { return m.mat.Dims() }
+func (m formattableCMatrix) Mat() tabular     { return m.mat }
+func (m formattableCMatrix) NewValueFormatter(options ...vFormatOption) fmt.Formatter {
+	return formattedComplex(0, options...)
+}
+func (m formattableCMatrix) RevalueFormatter(f fmt.Formatter, i, j int) fmt.Formatter {
+	f.(*complexFormatter).value = m.mat.At(i, j)
+	return f
+}
+func (m formattableCMatrix) ValueFormatter(i, j int, options ...vFormatOption) fmt.Formatter {
+	return formattedComplex(m.mat.At(i, j), options...)
 }
 
 // tabular type is a two-dimensional array having rows and columns with table

--- a/mat/format_test.go
+++ b/mat/format_test.go
@@ -7,9 +7,12 @@ package mat
 import (
 	"fmt"
 	"math"
+	"math/cmplx"
 	"testing"
 
 	"golang.org/x/exp/rand"
+
+	"gonum.org/v1/gonum/blas/cblas128"
 )
 
 func TestFormat(t *testing.T) {
@@ -241,6 +244,269 @@ func TestFormat(t *testing.T) {
 	}
 }
 
+func TestCFormat(t *testing.T) {
+	t.Parallel()
+	type rp struct {
+		format string
+		output string
+	}
+	for i, test := range []struct {
+		m   fmt.Formatter
+		rep []rp
+	}{
+		// Dense matrix representation with complex data
+		{
+			m: CFormatted(NewCDense(3, 3, []complex128{0, 0, 0, 0, 0, 0, 0, 0, 0})),
+			rep: []rp{
+				{"%v", "⎡0i  0i  0i⎤\n⎢0i  0i  0i⎥\n⎣0i  0i  0i⎦"},
+				{"% f", "⎡.  .  .⎤\n⎢.  .  .⎥\n⎣.  .  .⎦"},
+				{"%#v", fmt.Sprintf("%#v", NewCDense(3, 3, nil))},
+				{"%s", "%!s(*mat.CDense=Dims(3, 3))"},
+			},
+		},
+		{
+			m: CFormatted(NewCDense(3, 3, []complex128{1, 1, 1, 1, 1, 1, 1, 1, 1})),
+			rep: []rp{
+				{"%v", "⎡1+0i  1+0i  1+0i⎤\n⎢1+0i  1+0i  1+0i⎥\n⎣1+0i  1+0i  1+0i⎦"},
+				{"% f", "⎡1+0i  1+0i  1+0i⎤\n⎢1+0i  1+0i  1+0i⎥\n⎣1+0i  1+0i  1+0i⎦"},
+				{"%#v", fmt.Sprintf("%#v", NewCDense(3, 3, []complex128{1, 1, 1, 1, 1, 1, 1, 1, 1}))},
+			},
+		},
+		{
+			m: CFormatted(NewCDense(3, 3, []complex128{1, 1, 1, 1, 1, 1, 1, 1, 1}), Prefix("\t")),
+			rep: []rp{
+				{"%v", "⎡1+0i  1+0i  1+0i⎤\n\t⎢1+0i  1+0i  1+0i⎥\n\t⎣1+0i  1+0i  1+0i⎦"},
+				{"% f", "⎡1+0i  1+0i  1+0i⎤\n\t⎢1+0i  1+0i  1+0i⎥\n\t⎣1+0i  1+0i  1+0i⎦"},
+				{"%#v", fmt.Sprintf("%#v", NewCDense(3, 3, []complex128{1, 1, 1, 1, 1, 1, 1, 1, 1}))},
+			},
+		},
+		{
+			m: CFormatted(NewCDense(3, 3, []complex128{1, 0, 0, 0, 1, 0, 0, 0, 1})),
+			rep: []rp{
+				{"%v", "⎡1+0i    0i    0i⎤\n⎢  0i  1+0i    0i⎥\n⎣  0i    0i  1+0i⎦"},
+				{"% f", "⎡1+0i     .     .⎤\n⎢   .  1+0i     .⎥\n⎣   .     .  1+0i⎦"},
+				{"%#v", fmt.Sprintf("%#v", NewCDense(3, 3, []complex128{1, 0, 0, 0, 1, 0, 0, 0, 1}))},
+			},
+		},
+		{
+			m: CFormatted(NewCDense(2, 3, []complex128{1 + 2i, 3 + 4i, 5 + 6i, 7 + 8i, 9 + 10i, 11 + 12i})),
+			rep: []rp{
+				{"%v", "⎡  1+2i    3+4i    5+6i⎤\n⎣  7+8i   9+10i  11+12i⎦"},
+				{"% f", "⎡  1+2i    3+4i    5+6i⎤\n⎣  7+8i   9+10i  11+12i⎦"},
+				{"%#v", fmt.Sprintf("%#v", NewCDense(2, 3, []complex128{1 + 2i, 3 + 4i, 5 + 6i, 7 + 8i, 9 + 10i, 11 + 12i}))},
+			},
+		},
+		{
+			m: CFormatted(NewCDense(3, 2, []complex128{1 + 2i, 3 + 4i, 5 + 6i, 7 + 8i, 9 + 10i, 11 + 12i})),
+			rep: []rp{
+				{"%v", "⎡  1+2i    3+4i⎤\n⎢  5+6i    7+8i⎥\n⎣ 9+10i  11+12i⎦"},
+				{"% f", "⎡  1+2i    3+4i⎤\n⎢  5+6i    7+8i⎥\n⎣ 9+10i  11+12i⎦"},
+				{"%#v", fmt.Sprintf("%#v", NewCDense(3, 2, []complex128{1 + 2i, 3 + 4i, 5 + 6i, 7 + 8i, 9 + 10i, 11 + 12i}))},
+			},
+		},
+		{
+			m: func() fmt.Formatter {
+				M, N := 2, 3
+				m := NewCDense(M, N, []complex128{0 + 0i, 1 + 2i, 3 + 4i, 5 + 6i, 7 + 8i, 9 + 10i})
+				for i := 0; i < M; i++ {
+					for j := 0; j < N; j++ {
+						m.Set(i, j, cmplx.Sqrt(m.At(i, j)))
+					}
+				}
+				return CFormatted(m)
+			}(),
+			rep: []rp{
+				{"%v", "⎡                                   0i  1.272019649514069+0.7861513777574233i                                   2+1i⎤\n⎣2.5308348104831593+1.185379617655596i   2.9690188457413544+1.34724641634978i  3.350643523793132+1.4922506570736884i⎦"},
+				{"%.2f", "⎡     0.00i  1.27+0.79i  2.00+1.00i⎤\n⎣2.53+1.19i  2.97+1.35i  3.35+1.49i⎦"},
+				{"% f", "⎡                                    .  1.272019649514069+0.7861513777574233i                                   2+1i⎤\n⎣2.5308348104831593+1.185379617655596i   2.9690188457413544+1.34724641634978i  3.350643523793132+1.4922506570736884i⎦"},
+				{"%#v", fmt.Sprintf("%#v", NewCDense(2, 3, []complex128{
+					(0 + 0i), (1.272019649514069 + 0.7861513777574233i),
+					(2 + 1i), (2.5308348104831593 + 1.185379617655596i),
+					(2.9690188457413544 + 1.34724641634978i), (3.350643523793132 + 1.4922506570736884i),
+				}))},
+			},
+		},
+		{
+			m: func() fmt.Formatter {
+				M, N := 3, 2
+				m := NewCDense(M, N, []complex128{0 + 0i, 1 + 2i, 3 + 4i, 5 + 6i, 7 + 8i, 9 + 10i})
+				for i := 0; i < M; i++ {
+					for j := 0; j < N; j++ {
+						m.Set(i, j, cmplx.Sqrt(m.At(i, j)))
+					}
+				}
+				return CFormatted(m)
+			}(),
+			rep: []rp{
+				{"%v", "⎡                                   0i  1.272019649514069+0.7861513777574233i⎤\n⎢                                 2+1i  2.5308348104831593+1.185379617655596i⎥\n⎣ 2.9690188457413544+1.34724641634978i  3.350643523793132+1.4922506570736884i⎦"},
+				{"%.2f", "⎡     0.00i  1.27+0.79i⎤\n⎢2.00+1.00i  2.53+1.19i⎥\n⎣2.97+1.35i  3.35+1.49i⎦"},
+				{"% f", "⎡                                    .  1.272019649514069+0.7861513777574233i⎤\n⎢                                 2+1i  2.5308348104831593+1.185379617655596i⎥\n⎣ 2.9690188457413544+1.34724641634978i  3.350643523793132+1.4922506570736884i⎦"},
+				{"%#v", fmt.Sprintf("%#v", NewCDense(3, 2, []complex128{
+					(0 + 0i), (1.272019649514069 + 0.7861513777574233i),
+					(2 + 1i), (2.5308348104831593 + 1.185379617655596i),
+					(2.9690188457413544 + 1.34724641634978i), (3.350643523793132 + 1.4922506570736884i),
+				}))},
+			},
+		},
+		{
+			m: func() fmt.Formatter {
+				M, N := 2, 3
+				m := NewCDense(M, N, []complex128{0 + 0i, 1 + 2i, 3 + 4i, 5 + 6i, 7 + 8i, 9 + 10i})
+				for i := 0; i < M; i++ {
+					for j := 0; j < N; j++ {
+						m.Set(i, j, cmplx.Sqrt(m.At(i, j)))
+					}
+				}
+				return CFormatted(m, Squeeze())
+			}(),
+			rep: []rp{
+				{"%v", "⎡                                   0i  1.272019649514069+0.7861513777574233i                                   2+1i⎤\n⎣2.5308348104831593+1.185379617655596i   2.9690188457413544+1.34724641634978i  3.350643523793132+1.4922506570736884i⎦"},
+				{"%.2f", "⎡     0.00i  1.27+0.79i  2.00+1.00i⎤\n⎣2.53+1.19i  2.97+1.35i  3.35+1.49i⎦"},
+				{"% f", "⎡                                    .  1.272019649514069+0.7861513777574233i                                   2+1i⎤\n⎣2.5308348104831593+1.185379617655596i   2.9690188457413544+1.34724641634978i  3.350643523793132+1.4922506570736884i⎦"},
+				{"%#v", fmt.Sprintf("%#v", NewCDense(2, 3, []complex128{
+					(0 + 0i), (1.272019649514069 + 0.7861513777574233i),
+					(2 + 1i), (2.5308348104831593 + 1.185379617655596i),
+					(2.9690188457413544 + 1.34724641634978i), (3.350643523793132 + 1.4922506570736884i),
+				}))},
+			},
+		},
+		{
+			m: func() fmt.Formatter {
+				M, N := 1, 10
+				m := NewCDense(M, N, nil)
+				for i := 0; i < M*N; i++ {
+					m.Set(i%M, int(i/M), complex(float64(1+i*2), float64(2+i*2)))
+				}
+				return CFormatted(m, Excerpt(3))
+			}(),
+			rep: []rp{
+				{"%v", "Dims(1, 10)\n[  1+2i    3+4i    5+6i  ...  ...  15+16i  17+18i  19+20i]"},
+			},
+		},
+		{
+			m: func() fmt.Formatter {
+				M, N := 10, 1
+				m := NewCDense(M, N, nil)
+				for i := 0; i < M*N; i++ {
+					m.Set(i%M, int(i/M), complex(float64(1+i*2), float64(2+i*2)))
+				}
+				return CFormatted(m, Excerpt(3))
+			}(),
+			rep: []rp{
+				{"%v", "Dims(10, 1)\n⎡  1+2i⎤\n⎢  3+4i⎥\n⎢  5+6i⎥\n .\n .\n .\n⎢15+16i⎥\n⎢17+18i⎥\n⎣19+20i⎦"},
+			},
+		},
+		{
+			m: func() fmt.Formatter {
+				M, N := 10, 10
+				m := NewCDense(M, N, nil)
+				for i := 0; i < M*N; i++ {
+					m.Set(i%M, int(i/M), complex(float64(i%10), float64(i%10)))
+				}
+				return CFormatted(m, Excerpt(1))
+			}(),
+			rep: []rp{
+				{"%v", "Dims(10, 10)\n⎡  0i  ...  ...    0i⎤\n .\n .\n .\n⎣9+9i  ...  ...  9+9i⎦"},
+			},
+		},
+		{
+			m: CFormatted(NewCDense(4, 1, []complex128{1 + 2i, 3 + 4i, 5 + 6i, 7 + 8i}), FormatMATLAB()),
+			rep: []rp{
+				{"%v", "[1+2i; 3+4i; 5+6i; 7+8i]"},
+				{"%#v", "[\n 1+2i\n 3+4i\n 5+6i\n 7+8i\n]"},
+				{"%s", "%!s(*mat.CDense=Dims(4, 1))"},
+				{"%#s", "%!s(*mat.CDense=Dims(4, 1))"},
+			},
+		},
+		{
+			m: CFormatted(NewCDense(1, 4, []complex128{1 + 2i, 3 + 4i, 5 + 6i, 7 + 8i}), FormatMATLAB()),
+			rep: []rp{
+				{"%v", "[1+2i 3+4i 5+6i 7+8i]"},
+				{"%#v", "[1+2i 3+4i 5+6i 7+8i]"},
+			},
+		},
+		{
+			m: CFormatted(NewCDense(2, 2, []complex128{1 + 2i, 3 + 4i, 5 + 6i, 7 + 8i}), FormatMATLAB()),
+			rep: []rp{
+				{"%v", "[1+2i 3+4i; 5+6i 7+8i]"},
+				{"%#v", "[\n 1+2i 3+4i\n 5+6i 7+8i\n]"},
+			},
+		},
+		{
+			m: CFormatted(NewCDense(4, 1, []complex128{1 + 2i, -3 + 4i, 5 + 6i, 7 + 8i}), FormatMATLAB()),
+			rep: []rp{
+				{"%v", "[1+2i; -3+4i; 5+6i; 7+8i]"},
+				{"%#v", "[\n  1+2i\n -3+4i\n  5+6i\n  7+8i\n]"},
+			},
+		},
+		{
+			m: CFormatted(NewCDense(1, 4, []complex128{1 + 2i, -3 + 4i, 5 + 6i, 7 + 8i}), FormatMATLAB()),
+			rep: []rp{
+				{"%v", "[1+2i -3+4i 5+6i 7+8i]"},
+				{"%#v", "[ 1+2i -3+4i  5+6i  7+8i]"},
+			},
+		},
+		{
+			m: CFormatted(NewCDense(2, 2, []complex128{1 + 2i, -3 + 4i, 5 + 6i, 7 + 8i}), FormatMATLAB()),
+			rep: []rp{
+				{"%v", "[1+2i -3+4i; 5+6i 7+8i]"},
+				{"%#v", "[\n  1+2i -3+4i\n  5+6i  7+8i\n]"},
+			},
+		},
+		{
+			m: CFormatted(NewCDense(4, 1, []complex128{1 + 2i, 3 + 4i, 5 + 6i, 7 + 8i}), FormatPython()),
+			rep: []rp{
+				{"%v", "[[1+2j], [3+4j], [5+6j], [7+8j]]"},
+				{"%#v", "[[1+2j],\n [3+4j],\n [5+6j],\n [7+8j]]"},
+				{"%s", "%!s(*mat.CDense=Dims(4, 1))"},
+				{"%#s", "%!s(*mat.CDense=Dims(4, 1))"},
+			},
+		},
+		{
+			m: CFormatted(NewCDense(1, 4, []complex128{1 + 2i, 3 + 4i, 5 + 6i, 7 + 8i}), FormatPython()),
+			rep: []rp{
+				{"%v", "[1+2j, 3+4j, 5+6j, 7+8j]"},
+				{"%#v", "[1+2j, 3+4j, 5+6j, 7+8j]"},
+			},
+		},
+		{
+			m: CFormatted(NewCDense(2, 2, []complex128{1 + 2i, 3 + 4i, 5 + 6i, 7 + 8i}), FormatPython()),
+			rep: []rp{
+				{"%v", "[[1+2j, 3+4j], [5+6j, 7+8j]]"},
+				{"%#v", "[[1+2j, 3+4j],\n [5+6j, 7+8j]]"},
+			},
+		},
+		{
+			m: CFormatted(NewCDense(4, 1, []complex128{1 + 2i, -3 + 4i, 5 + 6i, 7 + 8i}), FormatPython()),
+			rep: []rp{
+				{"%v", "[[1+2j], [-3+4j], [5+6j], [7+8j]]"},
+				{"%#v", "[[ 1+2j],\n [-3+4j],\n [ 5+6j],\n [ 7+8j]]"},
+			},
+		},
+		{
+			m: CFormatted(NewCDense(1, 4, []complex128{1 + 2i, -3 + 4i, 5 + 6i, 7 + 8i}), FormatPython()),
+			rep: []rp{
+				{"%v", "[1+2j, -3+4j, 5+6j, 7+8j]"},
+				{"%#v", "[ 1+2j, -3+4j,  5+6j,  7+8j]"},
+			},
+		},
+		{
+			m: CFormatted(NewCDense(2, 2, []complex128{1 + 2i, -3 + 4i, 5 + 6i, 7 + 8i}), FormatPython()),
+			rep: []rp{
+				{"%v", "[[1+2j, -3+4j], [5+6j, 7+8j]]"},
+				{"%#v", "[[ 1+2j, -3+4j],\n [ 5+6j,  7+8j]]"},
+			},
+		},
+	} {
+		for j, rp := range test.rep {
+			got := fmt.Sprintf(rp.format, test.m)
+			if got != rp.output {
+				t.Errorf("unexpected format result test %d part %d:\ngot:\n%s\nwant:\n%s", i, j, got, rp.output)
+			}
+		}
+	}
+}
+
 func benchmarkFormat(b *testing.B, size int) {
 	src := rand.NewSource(1)
 	a, _ := randDense(size, 1.0, src)
@@ -253,3 +519,31 @@ func benchmarkFormat(b *testing.B, size int) {
 func BenchmarkFormat10(b *testing.B)   { benchmarkFormat(b, 10) }
 func BenchmarkFormat100(b *testing.B)  { benchmarkFormat(b, 100) }
 func BenchmarkFormat1000(b *testing.B) { benchmarkFormat(b, 1000) }
+
+func benchmarkCFormat(b *testing.B, size int) {
+	a := &CDense{
+		mat: cblas128.General{
+			Rows:   size,
+			Cols:   size,
+			Stride: size,
+			Data:   make([]complex128, size*size),
+		},
+		capRows: size,
+		capCols: size,
+	}
+	src := rand.NewSource(1)
+	rnd := rand.New(src)
+	for i := 0; i < size; i++ {
+		for j := 0; j < size; j++ {
+			a.set(i, j, complex(rnd.Float64(), rnd.Float64()))
+		}
+	}
+	b.ResetTimer()
+	for k := 0; k < b.N; k++ {
+		_ = fmt.Sprintf("%v", CFormatted(a))
+	}
+}
+
+func BenchmarkCFormat10(b *testing.B)   { benchmarkCFormat(b, 10) }
+func BenchmarkCFormat100(b *testing.B)  { benchmarkCFormat(b, 100) }
+func BenchmarkCFormat1000(b *testing.B) { benchmarkCFormat(b, 1000) }

--- a/mat/format_test.go
+++ b/mat/format_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"math"
 	"testing"
+
+	"golang.org/x/exp/rand"
 )
 
 func TestFormat(t *testing.T) {
@@ -238,3 +240,16 @@ func TestFormat(t *testing.T) {
 		}
 	}
 }
+
+func benchmarkFormat(b *testing.B, size int) {
+	src := rand.NewSource(1)
+	a, _ := randDense(size, 1.0, src)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = fmt.Sprintf("%v", Formatted(a))
+	}
+}
+
+func BenchmarkFormat10(b *testing.B)   { benchmarkFormat(b, 10) }
+func BenchmarkFormat100(b *testing.B)  { benchmarkFormat(b, 100) }
+func BenchmarkFormat1000(b *testing.B) { benchmarkFormat(b, 1000) }

--- a/mat/format_value.go
+++ b/mat/format_value.go
@@ -1,0 +1,143 @@
+// Copyright ©2021 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mat
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+)
+
+const (
+	syntaxDefault = iota
+	syntaxMATLAB
+	syntaxPython
+
+	defaultDotByte = '.'
+)
+
+// valueFormatter is a type that can set options for formatting values and that
+// satisfies the fmt.Formatter interface.
+type valueFormatter interface {
+	fmt.Formatter
+
+	setDotByte(b byte)
+	setSyntax(s int)
+}
+
+// vFormatOption is a functional option for value formatting.
+type vFormatOption func(valueFormatter)
+
+// vDotByte sets the dot character to b. The dot character is used to replace a
+// value if the result is printed with the fmt ' ' verb flag. Without a DotByte
+// option, the default dot character is '.'.
+func vDotByte(b byte) vFormatOption {
+	return func(f valueFormatter) { f.setDotByte(b) }
+}
+
+// vFormatMATLAB sets the printing behavior to output MATLAB syntax. If MATLAB
+// syntax is specified, the ' ' verb flag is ignored.
+func vFormatMATLAB() vFormatOption {
+	return func(f valueFormatter) { f.setSyntax(syntaxMATLAB) }
+}
+
+// vFormatPython sets the printing behavior to output Python syntax. If Python
+// syntax is specified, the ' ' verb flag is ignored.
+func vFormatPython() vFormatOption {
+	return func(f valueFormatter) { f.setSyntax(syntaxPython) }
+}
+
+// formattedFloat returns a fmt.Formatter for the floating point value v using
+// the given options.
+func formattedFloat(v float64, options ...vFormatOption) fmt.Formatter {
+	f := floatFormatter{
+		value:  v,
+		buf:    make([]byte, 0, 64),
+		dot:    defaultDotByte,
+		syntax: syntaxDefault,
+	}
+	for _, o := range options {
+		o(&f)
+	}
+	return &f
+}
+
+// floatFormatter formats 64-bit a floating point value and satifies the
+// valueFormatter interface. A floatFormatter utilizes an internal buffer while
+// generating formatting output and this buffer persists with the formatter.
+// For this reason, and because a floatFormatter might be reused or revalued,
+// the floatFormatter embeds an exclusion lock.
+type floatFormatter struct {
+	sync.Mutex
+
+	value  float64
+	buf    []byte
+	dot    byte
+	syntax int
+
+	format func(v float64, buf []byte, dot byte, syntax int, fs fmt.State, c rune)
+}
+
+var _ valueFormatter = (*floatFormatter)(nil)
+
+// Format satisfies the fmt.Formatter interface.
+func (f *floatFormatter) Format(fs fmt.State, c rune) {
+	f.Lock()
+	defer f.Unlock()
+
+	if f.format == nil {
+		f.format = formatFloat
+	}
+	f.format(f.value, f.buf, f.dot, f.syntax, fs, c)
+}
+
+func (f *floatFormatter) setDotByte(b byte) { f.dot = b }
+func (f *floatFormatter) setSyntax(s int)   { f.syntax = s }
+
+// formatFloat prints a representation of v to the fs io.Writer.  The format
+// character c specifies the numerical representation; valid values are those
+// for float64 specified in the fmt package, with their associated flags. In
+// addition to this, a space preceding a verb indicates that zero values should
+// be represented by the dot character.
+//
+// formatFloat will not provide Go syntax output
+func formatFloat(v float64, buf []byte, dot byte, syntax int, fs fmt.State, c rune) {
+	buf = buf[:0]
+
+	if (v == 0) && (syntax == syntaxDefault) && fs.Flag(' ') {
+		buf = append(buf, dot)
+	} else {
+		prec, ok := fs.Precision()
+		if !ok {
+			prec = -1
+		}
+
+		if c == 'v' {
+			c = 'g'
+		}
+
+		if (v >= 0) && fs.Flag('+') {
+			buf = append(buf, '+')
+		}
+
+		buf = strconv.AppendFloat(buf, v, byte(c), prec, 64)
+	}
+
+	width, ok := fs.Width()
+	if ok && (width > len(buf)) {
+		if fs.Flag('-') {
+			fs.Write(buf)
+			for i := 0; i < width-len(buf); i++ {
+				fmt.Fprintf(fs, " ")
+			}
+			return
+		}
+		for i := 0; i < width-len(buf); i++ {
+			fmt.Fprintf(fs, " ")
+		}
+	}
+
+	fs.Write(buf)
+}

--- a/mat/format_value.go
+++ b/mat/format_value.go
@@ -141,3 +141,113 @@ func formatFloat(v float64, buf []byte, dot byte, syntax int, fs fmt.State, c ru
 
 	fs.Write(buf)
 }
+
+// formattedComplex returns a fmt.Formatter for the complex value v using
+// the given options.
+func formattedComplex(v complex128, options ...vFormatOption) fmt.Formatter {
+	f := complexFormatter{
+		value:  v,
+		buf:    make([]byte, 0, 128),
+		dot:    defaultDotByte,
+		syntax: syntaxDefault,
+	}
+	for _, o := range options {
+		o(&f)
+	}
+	return &f
+}
+
+// floatComplex formats 128-bit complex value and satifies the valueFormatter
+// interface. A complexFormatter utilizes an internal buffer while generating
+// formatting output and this buffer persists with the formatter. For this
+// reason, and because a complexFormatter might be reused or revalued,
+// the complexFormatter embeds an exclusion lock.
+type complexFormatter struct {
+	sync.Mutex
+
+	value  complex128
+	buf    []byte
+	dot    byte
+	syntax int
+
+	format func(v complex128, buf []byte, dot byte, syntax int, fs fmt.State, c rune)
+}
+
+var _ valueFormatter = (*complexFormatter)(nil)
+
+// Format satisfies the fmt.Formatter interface.
+func (f *complexFormatter) Format(fs fmt.State, c rune) {
+	f.Lock()
+	defer f.Unlock()
+
+	if f.format == nil {
+		f.format = formatComplex
+	}
+	f.format(f.value, f.buf, f.dot, f.syntax, fs, c)
+}
+
+func (f *complexFormatter) setDotByte(b byte) { f.dot = b }
+func (f *complexFormatter) setSyntax(s int)   { f.syntax = s }
+
+// formatComplex prints a representation of v to the fs io.Writer.  The format
+// character c specifies the numerical representation; valid values are those
+// for float64 specified in the fmt package, with their associated flags. In
+// addition to this, a space preceding a verb indicates that zero values should
+// be represented by the dot character.
+//
+// formatComplex will not provide Go syntax output
+func formatComplex(v complex128, buf []byte, dot byte, syntax int, fs fmt.State, c rune) {
+	buf = buf[:0]
+
+	if (v == 0) && (syntax == syntaxDefault) && fs.Flag(' ') {
+		buf = append(buf, dot)
+	} else {
+		prec, ok := fs.Precision()
+		if !ok {
+			prec = -1
+		}
+
+		if c == 'v' {
+			c = 'g'
+		}
+
+		if (real(v) >= 0) && fs.Flag('+') {
+			buf = append(buf, '+')
+		}
+
+		// append real component
+		if real(v) != 0 {
+			buf = strconv.AppendFloat(buf, real(v), byte(c), prec, 64)
+		}
+
+		if (imag(v) >= 0) && ((real(v) != 0) || fs.Flag('+')) {
+			buf = append(buf, '+')
+		}
+
+		// append imaginary component
+		buf = strconv.AppendFloat(buf, imag(v), byte(c), prec, 64)
+
+		// append notation for imaginary component
+		if syntax == syntaxPython {
+			buf = append(buf, 'j')
+		} else {
+			buf = append(buf, 'i')
+		}
+	}
+
+	width, ok := fs.Width()
+	if ok && (width > len(buf)) {
+		if fs.Flag('-') {
+			fs.Write(buf)
+			for i := 0; i < width-len(buf); i++ {
+				fmt.Fprintf(fs, " ")
+			}
+			return
+		}
+		for i := 0; i < width-len(buf); i++ {
+			fmt.Fprintf(fs, " ")
+		}
+	}
+
+	fs.Write(buf)
+}


### PR DESCRIPTION
Please take a look.

This PR adds a `CFormat` function in gonum/mat to format complex dense matrices; this function is intended to complement the current `Format` function.  Relevant issue #641 and a relevant PR #1414, although that PR appears to have stalled.  Further, PR #1414 takes the approach of wholesale duplicating `format.go`, which may not be preferred.

Summary:

Following https://github.com/gonum/gonum/pull/1414#issuecomment-666282217, an objective was to avoid code duplication while implementing a formatter for complex matrices.  To summarize the proposed approach:  value formatters are added for formatting floats and complex numbers, which are then used during matrix formatting.  Since these value formatters satisfy the `fmt.Formatter` interface, `fmt.State` can be passed, offering simplification in several areas (e.g., re-construction of a format string is no longer necessary).  As it would be inefficient to spin up a a new formatter for each element in a matrix, a value formatter holds a buffer for reuse.

To tackle widthing, a `state` type is proposed (satisfying `fmt.State`) that can be fit to a matrix and that stores information on column widths, using the existing widther type. As before, iterating through matrix elements is required.   After a call to `At`, a `state` will respond to subsequent `Width` calls with the relevant column width.  Recommendations toward improving implementation are appreciated.

Notwithstanding the need for additional internal types, this feels simpler to me on the whole and I believe this approach should make extending to new syntaxes or data types easier, if desired.  Thanks for reviewing -- will address feedback/comments. 

Bench:

I've included a few benchmarks below.  These compare the current and proposed implementation when formatting 10x10, 100x100 and 1000x1000 dense matrices.

| implementation | benchmark           |  iter |            time |          bytes |           alloc |
| :------------- | :------------------ | ----: | --------------: | -------------: | --------------: |
| current        | BenchmarkFormat10   | 36134 |     33063 ns/op |      2693 B/op |    16 allocs/op |
| current        | BenchmarkFormat100  |   358 |   3747403 ns/op |   1672025 B/op |   137 allocs/op |
| current        | BenchmarkFormat1000 |     3 | 334034817 ns/op | 163557800 B/op |  1066 allocs/op |
| proposed       | BenchmarkFormat10   | 22086 |     54554 ns/op |      2886 B/op |    19 allocs/op |
| proposed       | BenchmarkFormat100  |   170 |   7072273 ns/op |   1670752 B/op |    49 allocs/op |
| proposed       | BenchmarkFormat1000 |     2 | 697675398 ns/op | 163542896 B/op |    80 allocs/op |

