### PR TITLE
README: fix link to supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     name: Build
     strategy:
       matrix:
+        # Do not move this line; it is referred to by README.md.
+        # Versions of Go that are explicitly supported by Gonum.
         go-version: [1.17.x, 1.16.x]
         platform: [ubuntu-latest, macos-latest]
         force-goarch: ["", "386"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ go get -u gonum.org/v1/gonum/...
 
 ## Supported Go versions
 
-Gonum supports and tests using the gc compiler on the [two most recent Go releases](https://github.com/gonum/gonum/blob/master/.travis.yml#L8-L12) on Linux (386, amd64 and arm64), macOS and Windows (both on amd64).
+Gonum supports and tests using the gc compiler on the [two most recent Go releases](https://github.com/gonum/gonum/blob/master/.github/workflows/ci.yml#L14-15) on Linux (386, amd64 and arm64), macOS and Windows (both on amd64).
 
 ## Release schedule
 


### PR DESCRIPTION
Please take a look.

The link looks like an off-by-one, but is not; it points to the line "Versions of Go that..." and the version list.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
