### PR TITLE
stat/distuv: improve Pareto.Rand performance, also adding Pareto.Rand benchmark

### DIFF
--- a/stat/distuv/pareto.go
+++ b/stat/distuv/pareto.go
@@ -104,7 +104,7 @@ func (p Pareto) Rand() float64 {
 	} else {
 		rnd = rand.New(p.Src).ExpFloat64()
 	}
-	return math.Exp(math.Log(p.Xm) + 1/p.Alpha*rnd)
+	return p.Xm * math.Exp(rnd/p.Alpha)
 }
 
 // StdDev returns the standard deviation of the probability distribution.

--- a/stat/distuv/pareto_test.go
+++ b/stat/distuv/pareto_test.go
@@ -204,3 +204,11 @@ func TestParetoNotExists(t *testing.T) {
 		t.Errorf("Expected standard deviation == +Inf for Alpha == 1, got %v", stdDev)
 	}
 }
+
+func BenchmarkParetoRand(b *testing.B) {
+	src := rand.New(rand.NewSource(1))
+	p := Pareto{1, 1, src}
+	for i := 0; i < b.N; i++ {
+		p.Rand()
+	}
+}


### PR DESCRIPTION
Please take a look.

Just removes an unnecessary math.Log call.

benchstat:
```
name        old time/op  new time/op  delta
ParetoRand  38.0ns ± 8%  24.4ns ± 2%  -35.72%  (p=0.000 n=9+10)
```