### PR TITLE
ci: make cache works by removing comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,29 +56,27 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
 
-    - name: Cache-Go
-      uses: actions/cache@v1
-      
-      with:
-        # In order:
-        # * Module download cache
-        # * Build cache (Linux)
-        # * Build cache (Mac)
-        # * Build cache (Windows)
-        path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/Library/Caches/go-build
-            '%LocalAppData%\go-build'
-
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-
     - name: Checkout code
       uses: actions/checkout@v2
       with:
           path: ${{ env.GOPATH }}/src/gonum.org/v1/gonum
+
+    - name: Cache-Go
+      uses: actions/cache@v2
+      with:
+        # In order:
+        # * Module download cache 
+        # * Build cache (Linux)
+        # * Build cache (Mac)
+        # * Build cache (Windows)
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+          ~/Library/Caches/go-build
+          '%LocalAppData%\go-build'
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
     - name: Check copyrights+imports+formatting+generate
       if: matrix.platform == 'ubuntu-latest' && matrix.tags == ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,18 @@ jobs:
 
     - name: Cache-Go
       uses: actions/cache@v1
+      
       with:
+        # In order:
+        # * Module download cache
+        # * Build cache (Linux)
+        # * Build cache (Mac)
+        # * Build cache (Windows)
         path: |
-            ~/go/pkg/mod              # Module download cache
-            ~/.cache/go-build         # Build cache (Linux)
-            ~/Library/Caches/go-build # Build cache (Mac)
-            '%LocalAppData%\go-build' # Build cache (Windows)
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            '%LocalAppData%\go-build'
 
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -39,11 +39,16 @@ jobs:
     - name: Cache-Go
       uses: actions/cache@v1
       with:
+        # In order:
+        # * Module download cache
+        # * Build cache (Linux)
+        # * Build cache (Mac)
+        # * Build cache (Windows)
         path: |
-            ~/go/pkg/mod              # Module download cache
-            ~/.cache/go-build         # Build cache (Linux)
-            ~/Library/Caches/go-build # Build cache (Mac)
-            '%LocalAppData%\go-build' # Build cache (Windows)
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            '%LocalAppData%\go-build'
 
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -36,8 +36,13 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
 
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        path: ${{ env.GOPATH }}/src/gonum.org/v1/gonum
+
     - name: Cache-Go
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         # In order:
         # * Module download cache
@@ -45,19 +50,13 @@ jobs:
         # * Build cache (Mac)
         # * Build cache (Windows)
         path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/Library/Caches/go-build
-            '%LocalAppData%\go-build'
-
+          ~/go/pkg/mod
+          ~/.cache/go-build
+          ~/Library/Caches/go-build
+          '%LocalAppData%\go-build'
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-          path: ${{ env.GOPATH }}/src/gonum.org/v1/gonum
 
     - name: Coverage
       if: matrix.platform == 'ubuntu-latest'


### PR DESCRIPTION
The path is a multiline string, which includes comments in its value. This
means that the caching was not working at all, because it would include
the comment in the path. Here I'm moving the comments, which fixes the
caching so it works.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
