### PR TITLE
lapack/gonum: fix length check in Dlaswp

### DIFF
--- a/lapack/gonum/dlaswp.go
+++ b/lapack/gonum/dlaswp.go
@@ -21,13 +21,13 @@ func (impl Implementation) Dlaswp(n int, a []float64, lda int, k1, k2 int, ipiv 
 	switch {
 	case n < 0:
 		panic(nLT0)
-	case k2 < 0:
-		panic(badK2)
-	case k1 < 0 || k2 < k1:
+	case k1 < 0:
 		panic(badK1)
+	case k2 < k1:
+		panic(badK2)
 	case lda < max(1, n):
 		panic(badLdA)
-	case len(a) < (k2-1)*lda+n:
+	case len(a) < k2*lda+n: // A must have at least k2+1 rows.
 		panic(shortA)
 	case len(ipiv) != k2+1:
 		panic(badLenIpiv)


### PR DESCRIPTION
Also, simplify checks of row indices k1 and k2.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
