### PR TITLE
lapack: add Dlatdf

### DIFF
--- a/lapack/gonum/dlatdf.go
+++ b/lapack/gonum/dlatdf.go
@@ -1,0 +1,161 @@
+package gonum
+
+import (
+	"math"
+
+	"gonum.org/v1/gonum/blas/blas64"
+	"gonum.org/v1/gonum/lapack"
+)
+
+// Contributors: Bo Kagstrom and Lars Westin,
+// Generalized Schur Methods with Condition Estimators for
+// Solving the Generalized Sylvester Equation, IEEE Transactions
+// on Automatic Control, Vol. 34, No. 7, July 1989, pp 745-751.
+
+// Dlatdf uses the LU factorization of the n×n matrix Z computed by Dgetc2 and
+// computes a contribution to the reciprocal Dif-estimate by solving
+//  Z * x = b for x
+// and choosing the rhs b such that the norm of x is as large as possible.
+// On entry rhs = b holds the contribution from earlier solved sub-systems, and on return rhs = x.
+//
+// The factorization of Z returned by Dgetc2 has the form
+//  Z = P*L*U*Q,
+// where P and Q are permutation matrices. L is lower triangular with
+// unit diagonal elements and U is upper triangular.
+//
+// On entry ipiv and jpiv are n length slices. On exit the pivot indices where row i has
+// been interchanged with ipiv[i] and column j interchanged with column jpiv[j].
+//
+// It must hold that n <= len(ipiv), n <= len(jpiv). rhs must have stride ldz and n number of accesible elements.
+// Dlatdf implicitly expects z matrix to be at most an 8×8 matrix. This is fulfilled by it's only caller, Dtgsy2.
+//
+// ijob info:
+// ijob==2: First compute an approximative null-vector e of Z using DGECON,
+// e is normalized and solve for Zx = +-e - f with the sign giving the greater value
+// of 2-norm(x). About 5 times as expensive as Default.
+// ijob!=2: Local look ahead strategy where all entries of the rhs. b is chosen as either +1 or -1 (Default).
+//
+// rdsum info:
+// On entry, the sum of squares of computed contributions to the Dif-estimate
+// under computation by Dtgsyl, where the scaling factor rdscal (see below)
+// has been factored out. On exit, the corresponding sum of squares updated
+// with the contributions from the current sub-system. If trans = 'T' rdsum is not touched.
+// NOTE: rdsum only makes sense when Dtgsy2 is called by STGSYL.
+//
+// rdscal info:
+// On entry, scaling factor used to prevent overflow in rdsum. On exit, rdscal is
+// updated w.r.t. the current contributions in rdsum. If trans = 'T', rdscal is not touched.
+// NOTE: rdscal only makes sense when Dtgsy2 is called by Dtgsyl.
+//
+// Dlatdf is an internal routine. It is exported for testing purposes.
+func (impl Implementation) Dlatdf(ijob, n int, z []float64, ldz int, rhs []float64, rdsum, rdscal float64, ipiv, jpiv []int) (sum, scale float64) {
+	switch {
+	case n < 0:
+		panic(nLT0)
+	case ldz < max(1, n):
+		panic(badLdZ)
+	case len(rhs) < (n-1)*ldz:
+		// rhs is expected to have stride ldz
+		panic(shortRHS)
+	case len(ipiv) < n:
+		panic(badLenIpiv)
+	case len(jpiv) < n:
+		panic(badLenJpiv)
+	case len(z) > (ldz+1)*8:
+		// Dlatdf expects z to be less than 8 in dimension.
+		panic("lapack: Dlatdf expects z to be at most 8×8")
+	}
+
+	bi := blas64.Implementation()
+	var temp float64
+	xp := make([]float64, n)
+	if ijob == 2 {
+		// Compute approximate nullvector xm of Z when ijob == 2.
+		xm := make([]float64, n)
+		work := make([]float64, 4*n)
+		impl.Dgecon(lapack.MaxRowSum, n, z, ldz, 1, work, make([]int, n)) // iwork is unused.
+		bi.Dcopy(n, work[n:], 1, xm, 1)
+
+		// Compute rhs.
+		impl.Dlaswp(1, xm, ldz, 0, n-2, ipiv[:n-1], -1)
+		temp = 1 / math.Sqrt(bi.Ddot(n, xm, 1, xm, 1))
+		bi.Dscal(n, temp, xm, 1)
+		bi.Dcopy(n, xm, 1, xp, 1)
+		bi.Daxpy(n, 1.0, rhs, 1, xp, 1)
+		bi.Daxpy(n, -1.0, xm, 1, rhs, 1)
+		impl.Dgesc2(n, z, ldz, rhs, ipiv, jpiv)
+		impl.Dgesc2(n, z, ldz, xp, ipiv, jpiv)
+		if bi.Dasum(n, xp, 1) > bi.Dasum(n, rhs, 1) {
+			bi.Dcopy(n, xp, 1, rhs, 1)
+		}
+
+		// Compute sum of squares.
+		rdscal, rdsum = impl.Dlassq(n, rhs, 1, rdscal, rdsum)
+		return rdsum, rdscal
+	}
+
+	// Apply permutations IPIV to RHS
+	// If ijob != 2 uses look-ahead strategy.
+	impl.Dlaswp(1, rhs, ldz, 0, n-2, ipiv[:n-1], 1)
+
+	// Solve for L-part choosing rhs either to +1 or -1.
+	pmone := -1.0
+	for j := 0; j < n-2; j++ {
+		bp := rhs[j] + 1
+		bm := rhs[j] - 1
+
+		// Look-ahead for L-part rhs[0:n-2] = + or -1, splus and
+		// smin computed more efficiently than in Bsolve [1].
+		splus := 1 + bi.Ddot(n-j-1, z[(j+1)*ldz+j:], ldz, z[(j+1)*ldz+j:], ldz)
+		sminu := bi.Ddot(n-j-1, z[(j+1)*ldz+j:], ldz, rhs[j+1:], 1)
+		splus *= rhs[j]
+		switch {
+		case splus > sminu:
+			rhs[j] = bp
+		case sminu > splus:
+			rhs[j] = bm
+		default:
+			// In this case the updating sums are equal and we can
+			// choose rsh[j] +1 or -1. The first time this happens
+			// we choose -1, thereafter +1. This is a simple way to
+			// get good estimates of matrices like Byers well-known
+			// example (see [1]). (Not done in Bsolve.)
+			rhs[j] += pmone
+			pmone = 1.0
+		}
+
+		// Compute remaining rhs.
+		temp = -rhs[j]
+		bi.Daxpy(n-j-1, temp, z[(j+1)*ldz+j:], ldz, rhs[j+1:], 1)
+	}
+
+	// Solve for U-part, look-ahead for rhs[n-1] = +-1. This is not done
+	// in Bsolve and will hopefully give us a better estimate because
+	// any ill-conditioning of the original matrix is transferred to U
+	// and not to L. U[n-1,n-1] is an approximation to sigma_min(LU).
+	bi.Dcopy(n-1, rhs, 1, xp, 1)
+	xp[n-1] = rhs[n-1] + 1
+	rhs[n-1] -= 1
+	splus := 0.0
+	sminu := 0.0
+	for i := n - 1; i >= 0; i-- {
+		temp = 1 / z[i*ldz+i]
+		xp[i] *= temp
+		rhs[i] *= temp
+		for k := i + 1; k < n; k++ {
+			xp[i] -= float64(xp[k] * (z[i*ldz+k] * temp))
+			rhs[i] -= float64(rhs[k] * (z[i*ldz+k] * temp))
+		}
+		splus += math.Abs(xp[i])
+		sminu += math.Abs(rhs[i])
+	}
+	if splus > sminu {
+		bi.Dcopy(n, xp, 1, rhs, 1)
+	}
+
+	// Apply the permutations jpiv to the computed solution (rhs).
+	impl.Dlaswp(1, rhs, 1, 0, n-2, jpiv[:n-1], -1)
+	// Compute the sum of squares.
+	rdscal, rdsum = impl.Dlassq(n, rhs, 1, rdscal, rdsum)
+	return rdsum, rdscal
+}

--- a/lapack/gonum/lapack_test.go
+++ b/lapack/gonum/lapack_test.go
@@ -398,6 +398,11 @@ func TestDlatbs(t *testing.T) {
 	testlapack.DlatbsTest(t, impl)
 }
 
+func TestDlatdf(t *testing.T) {
+	t.Parallel()
+	testlapack.DlatdfTest(t, impl)
+}
+
 func TestDlatrd(t *testing.T) {
 	t.Parallel()
 	testlapack.DlatrdTest(t, impl)

--- a/lapack/testlapack/dlatdf.go
+++ b/lapack/testlapack/dlatdf.go
@@ -1,0 +1,97 @@
+// Copyright ©2021 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"golang.org/x/exp/rand"
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/blas64"
+	"gonum.org/v1/gonum/floats"
+	"gonum.org/v1/gonum/lapack"
+)
+
+type Dlatdfer interface {
+	Dlatdf(ijob, n int, z []float64, ldz int, rhs []float64, rdsum, rdscal float64, ipiv, jpiv []int) (sum, scale float64)
+
+	Dgetc2er
+	Dgesc2er
+}
+
+func DlatdfTest(t *testing.T, impl Dlatdfer) {
+	const tol = 1e-12
+	rnd := rand.New(rand.NewSource(1))
+	// The only caller of Dlatdf is Dtgsy2 where we can see that Z is an 8x8 matrix used as either 2x2, 4x4 or 8x8 matrix.
+	for _, n := range []int{2, 4, 8} {
+		for _, ldz := range []int{n, n + 5} {
+			testDlatdf(t, impl, rnd, 0, n, ldz, tol)
+			testDlatdf(t, impl, rnd, 2, n, ldz, tol)
+			break
+		}
+	}
+}
+
+func testDlatdf(t *testing.T, impl Dlatdfer, rnd *rand.Rand, ijob, n int, ldz int, tol float64) {
+	name := fmt.Sprintf("n=%v,ldz=%v,ijob=%v", n, ldz, ijob)
+	// Random general matrix for Z
+	z := randomGeneral(n, n, max(1, ldz), rnd)
+	// Generate a random right hand side vector.
+	b := randomGeneral(n, 1, ldz, rnd)
+
+	// Compute the LU part of the factorization of the n×n
+	// matrix Z with Dgetc2:  Z = P * L * U * Q
+	ipiv := make([]int, n)
+	jpiv := make([]int, n)
+	lu := cloneGeneral(z)
+	k := impl.Dgetc2(n, lu.Data, lu.Stride, ipiv, jpiv)
+	if k > 0 {
+		t.Errorf("%v: %d index of U was perturbed in Dgetc2", name, k)
+	}
+	rhs := cloneGeneral(b)
+	scal := 1.
+	if ijob == 0 {
+		scal = impl.Dgesc2(n, z.Data, z.Stride, rhs.Data, ipiv, jpiv)
+	}
+	// From reference: rdscal (and rdsum) only makes
+	// sense when Dtgsy2 is called by Dtgsyl.
+	rdsum := 0.
+	rdscal := scal
+	// Call Dlatdf to solve Z*x = scale*b.
+	x := cloneGeneral(rhs)
+	luCopy := cloneGeneral(lu)
+	ipivCopy := make([]int, len(ipiv))
+	copy(ipivCopy, ipiv)
+	jpivCopy := make([]int, len(jpiv))
+	copy(jpivCopy, jpiv)
+	sum, _ := impl.Dlatdf(ijob, n, lu.Data, lu.Stride, x.Data, rdsum, rdscal, ipiv, jpiv)
+	if n == 0 {
+		return
+	}
+	_, _ = sum, scal // are these used?
+	// Check that const input to Dlatdf hasn't been modified.
+	if !floats.Same(lu.Data, luCopy.Data) {
+		t.Errorf("%v: unexpected modification in LU decompositon of Z", name)
+	}
+	if !intsEqual(ipiv, ipivCopy) {
+		t.Errorf("%v: unexpected modification in ipiv", name)
+	}
+	if !intsEqual(jpiv, jpivCopy) {
+		t.Errorf("%v: unexpected modification in jpiv", name)
+	}
+
+	blas64.Gemm(blas.NoTrans, blas.NoTrans, 1, z, x, -scal, b)
+	diff := b
+
+	// Compute the residual |Z*x - b| / |x|.
+	xnorm := dlange(lapack.MaxColumnSum, n, 1, x.Data, 1)
+	resid := dlange(lapack.MaxColumnSum, n, 1, diff.Data, 1) / xnorm
+	if resid > tol || math.IsNaN(resid) {
+		t.Errorf("%v: unexpected result;scal=%v, resid=%v, want<=%v", name, scal, resid, tol)
+	}
+
+}


### PR DESCRIPTION
Please take a look.

@vladimir-ch  There is something real fishy here. Like you said:
> This says that the slice rhs given to Dlaswp is too short. Based on the call above, rhs should be an (n-1)x1 matrix (that is, a column vector) with the stride ldz.
Though this is not the case! If rhs has stride ldz then this routine operates on non-acessible data. So rhs probably has stride 1 though I can't for the life of me figure out how those `Dlaswp` calls work.