### PR TITLE
add optional bounds to NelderMead

### DIFF
--- a/optimize/neldermead.go
+++ b/optimize/neldermead.go
@@ -5,7 +5,6 @@
 package optimize
 
 import (
-	"fmt"
 	"math"
 	"sort"
 
@@ -179,7 +178,7 @@ func (n *NelderMead) initLocal(loc *Location) (Operation, error) {
 	}
 
 	if n.Bounds != nil && len(n.Bounds) != dim {
-		return 0, fmt.Errorf("neldermead: incorrect number of bounds, (got %d expected %d)", len(n.Bounds), dim)
+		panic("neldermead: incorrect number of bounds")
 	}
 
 	// No simplex provided. Begin initializing initial simplex. First simplex

--- a/optimize/neldermead.go
+++ b/optimize/neldermead.go
@@ -5,6 +5,7 @@
 package optimize
 
 import (
+	"fmt"
 	"math"
 	"sort"
 
@@ -69,7 +70,7 @@ type NelderMead struct {
 	Contraction     float64 // Contraction parameter (>0, <1)
 	Shrink          float64 // Shrink parameter (>0, <1)
 	SimplexSize     float64 // size of auto-constructed initial simplex
-	Bounds          []Bound // Bounds parameter if not nil, Bounds must have length equal to dim
+	Bounds          []Bound // Bounds parameter if not nil, must have length equal to dim: len(Bounds) == len(Location.X)
 
 	status Status
 	err    error
@@ -177,10 +178,8 @@ func (n *NelderMead) initLocal(loc *Location) (Operation, error) {
 		return n.returnNext(nmMajor, loc)
 	}
 
-	if n.Bounds != nil {
-		if len(n.Bounds) != dim {
-			panic("neldermead: incorrect number of bounds")
-		}
+	if n.Bounds != nil && len(n.Bounds) != dim {
+		return 0, fmt.Errorf("neldermead: incorrect number of bounds, (got %d expected %d)", len(n.Bounds), dim)
 	}
 
 	// No simplex provided. Begin initializing initial simplex. First simplex

--- a/optimize/neldermead_test.go
+++ b/optimize/neldermead_test.go
@@ -1,0 +1,104 @@
+package optimize_test
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+
+	"gonum.org/v1/gonum/optimize"
+)
+
+func ExampleNelderMead() {
+	p := optimize.Problem{
+		Func: func(x []float64) float64 {
+			return math.Pow(x[0]-(4.0/5.0), 2)
+		},
+	}
+
+	withoutBounds := &optimize.NelderMead{}
+	result1, _ := optimize.Minimize(p, []float64{2}, &optimize.Settings{}, withoutBounds)
+	fmt.Printf("without bounds: %.1f\n", result1.X[0])
+
+	withBounds := &optimize.NelderMead{
+		Bounds: []optimize.Bound{
+			{Min: 1, Max: 3},
+		},
+	}
+	result2, _ := optimize.Minimize(p, []float64{2}, &optimize.Settings{}, withBounds)
+	fmt.Printf("with bounds: %.1f\n", result2.X[0])
+
+	// Output:
+	// without bounds: 0.8
+	// with bounds: 1.0
+}
+
+func TestMinimize_NelderMead(t *testing.T) {
+	isBoundsErr := func(t *testing.T, err error) {
+		t.Helper()
+		if err == nil || !strings.Contains(err.Error(), "incorrect number of bounds") {
+			t.Errorf("it should return a bounds length error, got %#v", err)
+		}
+	}
+	doesNotOccur := func(t *testing.T, err error) {
+		t.Helper()
+		if err != nil {
+			t.Errorf("did not expect an error got %#v", err)
+		}
+	}
+
+	tests := []struct {
+		Name      string
+		Bounds    []optimize.Bound
+		X         []float64
+		ExpectErr func(t *testing.T, err error)
+	}{
+		{
+			Name:      "no bounds set",
+			Bounds:    nil,
+			X:         []float64{0},
+			ExpectErr: doesNotOccur,
+		},
+		{
+			Name:      "non nil bounds",
+			Bounds:    []optimize.Bound{},
+			X:         []float64{0},
+			ExpectErr: isBoundsErr,
+		},
+		{
+			Name:      "zero len bounds with non zero len x",
+			Bounds:    []optimize.Bound{},
+			X:         []float64{0, 0},
+			ExpectErr: isBoundsErr,
+		},
+		{
+			Name:      "equal len x and len bounds",
+			Bounds:    []optimize.Bound{{}, {}},
+			X:         []float64{0, 0},
+			ExpectErr: doesNotOccur,
+		},
+		{
+			Name:      "not equal len x and len bounds",
+			Bounds:    []optimize.Bound{{}, {}, {}},
+			X:         []float64{0},
+			ExpectErr: isBoundsErr,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			p := optimize.Problem{
+				Func: func(x []float64) float64 {
+					return math.Pow(x[0]-(4.0/5.0), 2)
+				},
+			}
+
+			withBounds := &optimize.NelderMead{
+				Bounds: test.Bounds,
+			}
+
+			_, err := optimize.Minimize(p, test.X, &optimize.Settings{}, withBounds)
+			test.ExpectErr(t, err)
+		})
+	}
+}

--- a/optimize/neldermead_test.go
+++ b/optimize/neldermead_test.go
@@ -3,8 +3,6 @@ package optimize_test
 import (
 	"fmt"
 	"math"
-	"strings"
-	"testing"
 
 	"gonum.org/v1/gonum/optimize"
 )
@@ -31,74 +29,4 @@ func ExampleNelderMead() {
 	// Output:
 	// without bounds: 0.8
 	// with bounds: 1.0
-}
-
-func TestMinimize_NelderMead(t *testing.T) {
-	isBoundsErr := func(t *testing.T, err error) {
-		t.Helper()
-		if err == nil || !strings.Contains(err.Error(), "incorrect number of bounds") {
-			t.Errorf("it should return a bounds length error, got %#v", err)
-		}
-	}
-	doesNotOccur := func(t *testing.T, err error) {
-		t.Helper()
-		if err != nil {
-			t.Errorf("did not expect an error got %#v", err)
-		}
-	}
-
-	tests := []struct {
-		Name      string
-		Bounds    []optimize.Bound
-		X         []float64
-		ExpectErr func(t *testing.T, err error)
-	}{
-		{
-			Name:      "no bounds set",
-			Bounds:    nil,
-			X:         []float64{0},
-			ExpectErr: doesNotOccur,
-		},
-		{
-			Name:      "non nil bounds",
-			Bounds:    []optimize.Bound{},
-			X:         []float64{0},
-			ExpectErr: isBoundsErr,
-		},
-		{
-			Name:      "zero len bounds with non zero len x",
-			Bounds:    []optimize.Bound{},
-			X:         []float64{0, 0},
-			ExpectErr: isBoundsErr,
-		},
-		{
-			Name:      "equal len x and len bounds",
-			Bounds:    []optimize.Bound{{}, {}},
-			X:         []float64{0, 0},
-			ExpectErr: doesNotOccur,
-		},
-		{
-			Name:      "not equal len x and len bounds",
-			Bounds:    []optimize.Bound{{}, {}, {}},
-			X:         []float64{0},
-			ExpectErr: isBoundsErr,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			p := optimize.Problem{
-				Func: func(x []float64) float64 {
-					return math.Pow(x[0]-(4.0/5.0), 2)
-				},
-			}
-
-			withBounds := &optimize.NelderMead{
-				Bounds: test.Bounds,
-			}
-
-			_, err := optimize.Minimize(p, test.X, &optimize.Settings{}, withBounds)
-			test.ExpectErr(t, err)
-		})
-	}
 }


### PR DESCRIPTION
API changes are backwards compatible. Zero value (nil slice of Bound) behaves exactly as it did before.

I read the Nelder Mead implementation in nlopt and noticed how it handles bounds. Here is what I think it might look like added to the gonum implementation. 

This is a possible fix for: https://github.com/gonum/gonum/issues/1725

I did not add tests or TDD because this is/was an exploration.