### PR TITLE
graph: update API to use type parameters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gonum.org/v1/gonum
 
-go 1.14
+go 1.18
 
 require (
 	golang.org/x/exp v0.0.0-20191002040644-a1355ae1e2c3

--- a/graph/path/a_star.go
+++ b/graph/path/a_star.go
@@ -126,8 +126,7 @@ func (q *aStarQueue) Len() int {
 	return len(q.nodes)
 }
 
-func (q *aStarQueue) Push(x aStarNode) {
-	n := x
+func (q *aStarQueue) Push(n aStarNode) {
 	q.indexOf[n.node.ID()] = len(q.nodes)
 	q.nodes = append(q.nodes, n)
 }

--- a/graph/path/dijkstra.go
+++ b/graph/path/dijkstra.go
@@ -5,10 +5,9 @@
 package path
 
 import (
-	"container/heap"
-
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/traverse"
+	"gonum.org/v1/gonum/internal/heap"
 )
 
 // DijkstraFrom returns a shortest-path tree for a shortest path from u to all nodes in
@@ -52,7 +51,7 @@ func DijkstraFrom(u graph.Node, g traverse.Graph) Shortest {
 	// http://www.cs.utexas.edu/ftp/techreports/tr07-54.pdf
 	Q := priorityQueue{{node: u, dist: 0}}
 	for Q.Len() != 0 {
-		mid := heap.Pop(&Q).(distanceNode)
+		mid := heap.Pop[distanceNode](&Q)
 		k := path.indexOf[mid.node.ID()]
 		if mid.dist > path.dist[k] {
 			continue
@@ -75,7 +74,7 @@ func DijkstraFrom(u graph.Node, g traverse.Graph) Shortest {
 			}
 			joint := path.dist[k] + w
 			if joint < path.dist[j] {
-				heap.Push(&Q, distanceNode{node: v, dist: joint})
+				heap.Push[distanceNode](&Q, distanceNode{node: v, dist: joint})
 				path.set(j, joint, k)
 			}
 		}
@@ -125,7 +124,7 @@ func DijkstraAllFrom(u graph.Node, g traverse.Graph) ShortestAlts {
 	// http://www.cs.utexas.edu/ftp/techreports/tr07-54.pdf
 	Q := priorityQueue{{node: u, dist: 0}}
 	for Q.Len() != 0 {
-		mid := heap.Pop(&Q).(distanceNode)
+		mid := heap.Pop[distanceNode](&Q)
 		k := path.indexOf[mid.node.ID()]
 		if mid.dist > path.dist[k] {
 			continue
@@ -146,7 +145,7 @@ func DijkstraAllFrom(u graph.Node, g traverse.Graph) ShortestAlts {
 			}
 			joint := path.dist[k] + w
 			if joint < path.dist[j] {
-				heap.Push(&Q, distanceNode{node: v, dist: joint})
+				heap.Push[distanceNode](&Q, distanceNode{node: v, dist: joint})
 				path.set(j, joint, k)
 			} else if joint == path.dist[j] {
 				path.addPath(j, k)
@@ -190,9 +189,9 @@ func dijkstraAllPaths(g graph.Graph, paths AllShortest) {
 		// http://www.cs.utexas.edu/ftp/techreports/tr07-54.pdf
 
 		// Q must be empty at this point.
-		heap.Push(&Q, distanceNode{node: u, dist: 0})
+		heap.Push[distanceNode](&Q, distanceNode{node: u, dist: 0})
 		for Q.Len() != 0 {
-			mid := heap.Pop(&Q).(distanceNode)
+			mid := heap.Pop[distanceNode](&Q)
 			k := paths.indexOf[mid.node.ID()]
 			if mid.dist < paths.dist.At(i, k) {
 				paths.dist.Set(i, k, mid.dist)
@@ -212,7 +211,7 @@ func dijkstraAllPaths(g graph.Graph, paths AllShortest) {
 				}
 				joint := paths.dist.At(i, k) + w
 				if joint < paths.dist.At(i, j) {
-					heap.Push(&Q, distanceNode{node: v, dist: joint})
+					heap.Push[distanceNode](&Q, distanceNode{node: v, dist: joint})
 					paths.set(i, j, joint, k)
 				} else if joint == paths.dist.At(i, j) {
 					paths.add(i, j, k)
@@ -233,10 +232,10 @@ type priorityQueue []distanceNode
 func (q priorityQueue) Len() int            { return len(q) }
 func (q priorityQueue) Less(i, j int) bool  { return q[i].dist < q[j].dist }
 func (q priorityQueue) Swap(i, j int)       { q[i], q[j] = q[j], q[i] }
-func (q *priorityQueue) Push(n interface{}) { *q = append(*q, n.(distanceNode)) }
-func (q *priorityQueue) Pop() interface{} {
+func (q *priorityQueue) Push(n distanceNode) { *q = append(*q, n) }
+func (q *priorityQueue) Pop() distanceNode {
 	t := *q
-	var n interface{}
+	var n distanceNode
 	n, *q = t[len(t)-1], t[:len(t)-1]
 	return n
 }

--- a/graph/path/dynamic/dstarlite.go
+++ b/graph/path/dynamic/dstarlite.go
@@ -5,13 +5,13 @@
 package dynamic
 
 import (
-	"container/heap"
 	"fmt"
 	"math"
 
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/path"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/heap"
 )
 
 // DStarLite implements the D* Lite dynamic re-planning path search algorithm.
@@ -478,13 +478,13 @@ func (q dStarLiteQueue) Len() int {
 	return len(q)
 }
 
-func (q *dStarLiteQueue) Push(x interface{}) {
-	n := x.(*dStarLiteNode)
+func (q *dStarLiteQueue) Push(x *dStarLiteNode) {
+	n := x
 	n.idx = len(*q)
 	*q = append(*q, n)
 }
 
-func (q *dStarLiteQueue) Pop() interface{} {
+func (q *dStarLiteQueue) Pop() *dStarLiteNode {
 	n := (*q)[len(*q)-1]
 	n.idx = -1
 	*q = (*q)[:len(*q)-1]
@@ -501,18 +501,18 @@ func (q dStarLiteQueue) top() *dStarLiteNode {
 // insert puts the node u into the queue with the key k.
 func (q *dStarLiteQueue) insert(u *dStarLiteNode, k key) {
 	u.key = k
-	heap.Push(q, u)
+	heap.Push[*dStarLiteNode](q, u)
 }
 
 // update updates the node in the queue identified by id with the key k.
 func (q *dStarLiteQueue) update(n *dStarLiteNode, k key) {
 	n.key = k
-	heap.Fix(q, n.idx)
+	heap.Fix[*dStarLiteNode](q, n.idx)
 }
 
 // remove removes the node identified by id from the queue.
 func (q *dStarLiteQueue) remove(n *dStarLiteNode) {
-	heap.Remove(q, n.idx)
+	heap.Remove[*dStarLiteNode](q, n.idx)
 	n.key = badKey
 	n.idx = -1
 }

--- a/graph/path/dynamic/dstarlite.go
+++ b/graph/path/dynamic/dstarlite.go
@@ -478,8 +478,7 @@ func (q dStarLiteQueue) Len() int {
 	return len(q)
 }
 
-func (q *dStarLiteQueue) Push(x *dStarLiteNode) {
-	n := x
+func (q *dStarLiteQueue) Push(n *dStarLiteNode) {
 	n.idx = len(*q)
 	*q = append(*q, n)
 }

--- a/graph/path/spanning_tree.go
+++ b/graph/path/spanning_tree.go
@@ -105,8 +105,7 @@ func (q *primQueue) Len() int {
 	return len(q.nodes)
 }
 
-func (q *primQueue) Push(x simple.WeightedEdge) {
-	n := x
+func (q *primQueue) Push(n simple.WeightedEdge) {
 	q.indexOf[n.From().ID()] = len(q.nodes)
 	q.nodes = append(q.nodes, n)
 }

--- a/graph/path/spanning_tree.go
+++ b/graph/path/spanning_tree.go
@@ -5,12 +5,12 @@
 package path
 
 import (
-	"container/heap"
 	"math"
 	"sort"
 
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/heap"
 )
 
 // WeightedBuilder is a type that can add nodes and weighted edges.
@@ -44,7 +44,7 @@ func Prim(dst WeightedBuilder, g graph.WeightedUndirected) float64 {
 	dst.AddNode(nodes[0])
 	for _, u := range nodes[1:] {
 		dst.AddNode(u)
-		heap.Push(q, simple.WeightedEdge{F: u, W: math.Inf(1)})
+		heap.Push[simple.WeightedEdge](q, simple.WeightedEdge{F: u, W: math.Inf(1)})
 	}
 
 	u := nodes[0]
@@ -59,7 +59,7 @@ func Prim(dst WeightedBuilder, g graph.WeightedUndirected) float64 {
 
 	var w float64
 	for q.Len() > 0 {
-		e := heap.Pop(q).(simple.WeightedEdge)
+		e := heap.Pop[simple.WeightedEdge](q)
 		if e.To() != nil && g.HasEdgeBetween(e.From().ID(), e.To().ID()) {
 			dst.SetWeightedEdge(g.WeightedEdge(e.From().ID(), e.To().ID()))
 			w += e.Weight()
@@ -105,13 +105,13 @@ func (q *primQueue) Len() int {
 	return len(q.nodes)
 }
 
-func (q *primQueue) Push(x interface{}) {
-	n := x.(simple.WeightedEdge)
+func (q *primQueue) Push(x simple.WeightedEdge) {
+	n := x
 	q.indexOf[n.From().ID()] = len(q.nodes)
 	q.nodes = append(q.nodes, n)
 }
 
-func (q *primQueue) Pop() interface{} {
+func (q *primQueue) Pop() simple.WeightedEdge {
 	n := q.nodes[len(q.nodes)-1]
 	q.nodes = q.nodes[:len(q.nodes)-1]
 	delete(q.indexOf, n.From().ID())
@@ -139,7 +139,7 @@ func (q *primQueue) update(u, v graph.Node, key float64) {
 	}
 	q.nodes[i].T = v
 	q.nodes[i].W = key
-	heap.Fix(q, i)
+	heap.Fix[simple.WeightedEdge](q, i)
 }
 
 // UndirectedWeightLister is an undirected graph that returns edge weights and

--- a/internal/heap/example_intheap_test.go
+++ b/internal/heap/example_intheap_test.go
@@ -1,0 +1,47 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This example demonstrates an integer heap built using the heap interface.
+package heap_test
+
+import (
+	"container/heap"
+	"fmt"
+)
+
+// An IntHeap is a min-heap of ints.
+type IntHeap []int
+
+func (h IntHeap) Len() int           { return len(h) }
+func (h IntHeap) Less(i, j int) bool { return h[i] < h[j] }
+func (h IntHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+
+func (h *IntHeap) Push(x interface{}) {
+	// Push and Pop use pointer receivers because they modify the slice's length,
+	// not just its contents.
+	*h = append(*h, x.(int))
+}
+
+func (h *IntHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+// This example inserts several ints into an IntHeap, checks the minimum,
+// and removes them in order of priority.
+func Example_intHeap() {
+	h := &IntHeap{2, 1, 5}
+	heap.Init(h)
+	heap.Push(h, 3)
+	fmt.Printf("minimum: %d\n", (*h)[0])
+	for h.Len() > 0 {
+		fmt.Printf("%d ", heap.Pop(h))
+	}
+	// Output:
+	// minimum: 1
+	// 1 2 3 5
+}

--- a/internal/heap/example_pq_test.go
+++ b/internal/heap/example_pq_test.go
@@ -1,0 +1,98 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This example demonstrates a priority queue built using the heap interface.
+package heap_test
+
+import (
+	"container/heap"
+	"fmt"
+)
+
+// An Item is something we manage in a priority queue.
+type Item struct {
+	value    string // The value of the item; arbitrary.
+	priority int    // The priority of the item in the queue.
+	// The index is needed by update and is maintained by the heap.Interface methods.
+	index int // The index of the item in the heap.
+}
+
+// A PriorityQueue implements heap.Interface and holds Items.
+type PriorityQueue []*Item
+
+func (pq PriorityQueue) Len() int { return len(pq) }
+
+func (pq PriorityQueue) Less(i, j int) bool {
+	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
+	return pq[i].priority > pq[j].priority
+}
+
+func (pq PriorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *PriorityQueue) Push(x interface{}) {
+	n := len(*pq)
+	item := x.(*Item)
+	item.index = n
+	*pq = append(*pq, item)
+}
+
+func (pq *PriorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil  // avoid memory leak
+	item.index = -1 // for safety
+	*pq = old[0 : n-1]
+	return item
+}
+
+// update modifies the priority and value of an Item in the queue.
+func (pq *PriorityQueue) update(item *Item, value string, priority int) {
+	item.value = value
+	item.priority = priority
+	heap.Fix(pq, item.index)
+}
+
+// This example creates a PriorityQueue with some items, adds and manipulates an item,
+// and then removes the items in priority order.
+func Example_priorityQueue() {
+	// Some items and their priorities.
+	items := map[string]int{
+		"banana": 3, "apple": 2, "pear": 4,
+	}
+
+	// Create a priority queue, put the items in it, and
+	// establish the priority queue (heap) invariants.
+	pq := make(PriorityQueue, len(items))
+	i := 0
+	for value, priority := range items {
+		pq[i] = &Item{
+			value:    value,
+			priority: priority,
+			index:    i,
+		}
+		i++
+	}
+	heap.Init(&pq)
+
+	// Insert a new item and then modify its priority.
+	item := &Item{
+		value:    "orange",
+		priority: 1,
+	}
+	heap.Push(&pq, item)
+	pq.update(item, item.value, 5)
+
+	// Take the items out; they arrive in decreasing priority order.
+	for pq.Len() > 0 {
+		item := heap.Pop(&pq).(*Item)
+		fmt.Printf("%.2d:%s ", item.priority, item.value)
+	}
+	// Output:
+	// 05:orange 04:pear 03:banana 02:apple
+}

--- a/internal/heap/heap.go
+++ b/internal/heap/heap.go
@@ -1,0 +1,119 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package heap provides heap operations for any type that implements
+// heap.Interface. A heap is a tree with the property that each node is the
+// minimum-valued node in its subtree.
+//
+// The minimum element in the tree is the root, at index 0.
+//
+// A heap is a common way to implement a priority queue. To build a priority
+// queue, implement the Heap interface with the (negative) priority as the
+// ordering for the Less method, so Push adds items while Pop removes the
+// highest-priority item from the queue. The Examples include such an
+// implementation; the file example_pq_test.go has the complete source.
+//
+package heap
+
+import "sort"
+
+// The Interface type describes the requirements
+// for a type using the routines in this package.
+// Any type that implements it may be used as a
+// min-heap with the following invariants (established after
+// Init has been called or if the data is empty or sorted):
+//
+//	!h.Less(j, i) for 0 <= i < h.Len() and 2*i+1 <= j <= 2*i+2 and j < h.Len()
+//
+// Note that Push and Pop in this interface are for package heap's
+// implementation to call. To add and remove things from the heap,
+// use heap.Push and heap.Pop.
+type Interface interface {
+	sort.Interface
+	Push(x interface{}) // add x as element Len()
+	Pop() interface{}   // remove and return element Len() - 1.
+}
+
+// Init establishes the heap invariants required by the other routines in this package.
+// Init is idempotent with respect to the heap invariants
+// and may be called whenever the heap invariants may have been invalidated.
+// The complexity is O(n) where n = h.Len().
+func Init(h Interface) {
+	// heapify
+	n := h.Len()
+	for i := n/2 - 1; i >= 0; i-- {
+		down(h, i, n)
+	}
+}
+
+// Push pushes the element x onto the heap.
+// The complexity is O(log n) where n = h.Len().
+func Push(h Interface, x interface{}) {
+	h.Push(x)
+	up(h, h.Len()-1)
+}
+
+// Pop removes and returns the minimum element (according to Less) from the heap.
+// The complexity is O(log n) where n = h.Len().
+// Pop is equivalent to Remove(h, 0).
+func Pop(h Interface) interface{} {
+	n := h.Len() - 1
+	h.Swap(0, n)
+	down(h, 0, n)
+	return h.Pop()
+}
+
+// Remove removes and returns the element at index i from the heap.
+// The complexity is O(log n) where n = h.Len().
+func Remove(h Interface, i int) interface{} {
+	n := h.Len() - 1
+	if n != i {
+		h.Swap(i, n)
+		if !down(h, i, n) {
+			up(h, i)
+		}
+	}
+	return h.Pop()
+}
+
+// Fix re-establishes the heap ordering after the element at index i has changed its value.
+// Changing the value of the element at index i and then calling Fix is equivalent to,
+// but less expensive than, calling Remove(h, i) followed by a Push of the new value.
+// The complexity is O(log n) where n = h.Len().
+func Fix(h Interface, i int) {
+	if !down(h, i, h.Len()) {
+		up(h, i)
+	}
+}
+
+func up(h Interface, j int) {
+	for {
+		i := (j - 1) / 2 // parent
+		if i == j || !h.Less(j, i) {
+			break
+		}
+		h.Swap(i, j)
+		j = i
+	}
+}
+
+func down(h Interface, i0, n int) bool {
+	i := i0
+	for {
+		j1 := 2*i + 1
+		if j1 >= n || j1 < 0 { // j1 < 0 after int overflow
+			break
+		}
+		j := j1 // left child
+		if j2 := j1 + 1; j2 < n && h.Less(j2, j1) {
+			j = j2 // = 2*i + 2  // right child
+		}
+		if !h.Less(j, i) {
+			break
+		}
+		h.Swap(i, j)
+		i = j
+	}
+	return i > i0
+}

--- a/internal/heap/heap.go
+++ b/internal/heap/heap.go
@@ -29,17 +29,17 @@ import "sort"
 // Note that Push and Pop in this interface are for package heap's
 // implementation to call. To add and remove things from the heap,
 // use heap.Push and heap.Pop.
-type Interface interface {
+type Interface[T any] interface {
 	sort.Interface
-	Push(x interface{}) // add x as element Len()
-	Pop() interface{}   // remove and return element Len() - 1.
+	Push(x T) // add x as element Len()
+	Pop() T   // remove and return element Len() - 1.
 }
 
 // Init establishes the heap invariants required by the other routines in this package.
 // Init is idempotent with respect to the heap invariants
 // and may be called whenever the heap invariants may have been invalidated.
 // The complexity is O(n) where n = h.Len().
-func Init(h Interface) {
+func Init[T any](h Interface[T]) {
 	// heapify
 	n := h.Len()
 	for i := n/2 - 1; i >= 0; i-- {
@@ -49,7 +49,7 @@ func Init(h Interface) {
 
 // Push pushes the element x onto the heap.
 // The complexity is O(log n) where n = h.Len().
-func Push(h Interface, x interface{}) {
+func Push[T any](h Interface[T], x T) {
 	h.Push(x)
 	up(h, h.Len()-1)
 }
@@ -57,7 +57,7 @@ func Push(h Interface, x interface{}) {
 // Pop removes and returns the minimum element (according to Less) from the heap.
 // The complexity is O(log n) where n = h.Len().
 // Pop is equivalent to Remove(h, 0).
-func Pop(h Interface) interface{} {
+func Pop[T any](h Interface[T]) T {
 	n := h.Len() - 1
 	h.Swap(0, n)
 	down(h, 0, n)
@@ -66,7 +66,7 @@ func Pop(h Interface) interface{} {
 
 // Remove removes and returns the element at index i from the heap.
 // The complexity is O(log n) where n = h.Len().
-func Remove(h Interface, i int) interface{} {
+func Remove[T any](h Interface[T], i int) T {
 	n := h.Len() - 1
 	if n != i {
 		h.Swap(i, n)
@@ -81,13 +81,13 @@ func Remove(h Interface, i int) interface{} {
 // Changing the value of the element at index i and then calling Fix is equivalent to,
 // but less expensive than, calling Remove(h, i) followed by a Push of the new value.
 // The complexity is O(log n) where n = h.Len().
-func Fix(h Interface, i int) {
+func Fix[T any](h Interface[T], i int) {
 	if !down(h, i, h.Len()) {
 		up(h, i)
 	}
 }
 
-func up(h Interface, j int) {
+func up[T any](h Interface[T], j int) {
 	for {
 		i := (j - 1) / 2 // parent
 		if i == j || !h.Less(j, i) {
@@ -98,7 +98,7 @@ func up(h Interface, j int) {
 	}
 }
 
-func down(h Interface, i0, n int) bool {
+func down[T any](h Interface[T], i0, n int) bool {
 	i := i0
 	for {
 		j1 := 2*i + 1

--- a/internal/heap/heap_test.go
+++ b/internal/heap/heap_test.go
@@ -1,0 +1,214 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package heap
+
+import (
+	"math/rand"
+	"testing"
+)
+
+type myHeap []int
+
+func (h *myHeap) Less(i, j int) bool {
+	return (*h)[i] < (*h)[j]
+}
+
+func (h *myHeap) Swap(i, j int) {
+	(*h)[i], (*h)[j] = (*h)[j], (*h)[i]
+}
+
+func (h *myHeap) Len() int {
+	return len(*h)
+}
+
+func (h *myHeap) Pop() (v interface{}) {
+	*h, v = (*h)[:h.Len()-1], (*h)[h.Len()-1]
+	return
+}
+
+func (h *myHeap) Push(v interface{}) {
+	*h = append(*h, v.(int))
+}
+
+func (h myHeap) verify(t *testing.T, i int) {
+	t.Helper()
+	n := h.Len()
+	j1 := 2*i + 1
+	j2 := 2*i + 2
+	if j1 < n {
+		if h.Less(j1, i) {
+			t.Errorf("heap invariant invalidated [%d] = %d > [%d] = %d", i, h[i], j1, h[j1])
+			return
+		}
+		h.verify(t, j1)
+	}
+	if j2 < n {
+		if h.Less(j2, i) {
+			t.Errorf("heap invariant invalidated [%d] = %d > [%d] = %d", i, h[i], j1, h[j2])
+			return
+		}
+		h.verify(t, j2)
+	}
+}
+
+func TestInit0(t *testing.T) {
+	h := new(myHeap)
+	for i := 20; i > 0; i-- {
+		h.Push(0) // all elements are the same
+	}
+	Init(h)
+	h.verify(t, 0)
+
+	for i := 1; h.Len() > 0; i++ {
+		x := Pop(h).(int)
+		h.verify(t, 0)
+		if x != 0 {
+			t.Errorf("%d.th pop got %d; want %d", i, x, 0)
+		}
+	}
+}
+
+func TestInit1(t *testing.T) {
+	h := new(myHeap)
+	for i := 20; i > 0; i-- {
+		h.Push(i) // all elements are different
+	}
+	Init(h)
+	h.verify(t, 0)
+
+	for i := 1; h.Len() > 0; i++ {
+		x := Pop(h).(int)
+		h.verify(t, 0)
+		if x != i {
+			t.Errorf("%d.th pop got %d; want %d", i, x, i)
+		}
+	}
+}
+
+func Test(t *testing.T) {
+	h := new(myHeap)
+	h.verify(t, 0)
+
+	for i := 20; i > 10; i-- {
+		h.Push(i)
+	}
+	Init(h)
+	h.verify(t, 0)
+
+	for i := 10; i > 0; i-- {
+		Push(h, i)
+		h.verify(t, 0)
+	}
+
+	for i := 1; h.Len() > 0; i++ {
+		x := Pop(h).(int)
+		if i < 20 {
+			Push(h, 20+i)
+		}
+		h.verify(t, 0)
+		if x != i {
+			t.Errorf("%d.th pop got %d; want %d", i, x, i)
+		}
+	}
+}
+
+func TestRemove0(t *testing.T) {
+	h := new(myHeap)
+	for i := 0; i < 10; i++ {
+		h.Push(i)
+	}
+	h.verify(t, 0)
+
+	for h.Len() > 0 {
+		i := h.Len() - 1
+		x := Remove(h, i).(int)
+		if x != i {
+			t.Errorf("Remove(%d) got %d; want %d", i, x, i)
+		}
+		h.verify(t, 0)
+	}
+}
+
+func TestRemove1(t *testing.T) {
+	h := new(myHeap)
+	for i := 0; i < 10; i++ {
+		h.Push(i)
+	}
+	h.verify(t, 0)
+
+	for i := 0; h.Len() > 0; i++ {
+		x := Remove(h, 0).(int)
+		if x != i {
+			t.Errorf("Remove(0) got %d; want %d", x, i)
+		}
+		h.verify(t, 0)
+	}
+}
+
+func TestRemove2(t *testing.T) {
+	N := 10
+
+	h := new(myHeap)
+	for i := 0; i < N; i++ {
+		h.Push(i)
+	}
+	h.verify(t, 0)
+
+	m := make(map[int]bool)
+	for h.Len() > 0 {
+		m[Remove(h, (h.Len()-1)/2).(int)] = true
+		h.verify(t, 0)
+	}
+
+	if len(m) != N {
+		t.Errorf("len(m) = %d; want %d", len(m), N)
+	}
+	for i := 0; i < len(m); i++ {
+		if !m[i] {
+			t.Errorf("m[%d] doesn't exist", i)
+		}
+	}
+}
+
+func BenchmarkDup(b *testing.B) {
+	const n = 10000
+	h := make(myHeap, 0, n)
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < n; j++ {
+			Push(&h, 0) // all elements are the same
+		}
+		for h.Len() > 0 {
+			Pop(&h)
+		}
+	}
+}
+
+func TestFix(t *testing.T) {
+	h := new(myHeap)
+	h.verify(t, 0)
+
+	for i := 200; i > 0; i -= 10 {
+		Push(h, i)
+	}
+	h.verify(t, 0)
+
+	if (*h)[0] != 10 {
+		t.Fatalf("Expected head to be 10, was %d", (*h)[0])
+	}
+	(*h)[0] = 210
+	Fix(h, 0)
+	h.verify(t, 0)
+
+	for i := 100; i > 0; i-- {
+		elem := rand.Intn(h.Len())
+		if i&1 == 0 {
+			(*h)[elem] *= 2
+		} else {
+			(*h)[elem] /= 2
+		}
+		Fix(h, elem)
+		h.verify(t, 0)
+	}
+}

--- a/internal/heap/heap_test.go
+++ b/internal/heap/heap_test.go
@@ -23,13 +23,13 @@ func (h *myHeap) Len() int {
 	return len(*h)
 }
 
-func (h *myHeap) Pop() (v interface{}) {
+func (h *myHeap) Pop() (v int) {
 	*h, v = (*h)[:h.Len()-1], (*h)[h.Len()-1]
 	return
 }
 
-func (h *myHeap) Push(v interface{}) {
-	*h = append(*h, v.(int))
+func (h *myHeap) Push(v int) {
+	*h = append(*h, v)
 }
 
 func (h myHeap) verify(t *testing.T, i int) {
@@ -58,11 +58,11 @@ func TestInit0(t *testing.T) {
 	for i := 20; i > 0; i-- {
 		h.Push(0) // all elements are the same
 	}
-	Init(h)
+	Init[int](h)
 	h.verify(t, 0)
 
 	for i := 1; h.Len() > 0; i++ {
-		x := Pop(h).(int)
+		x := Pop[int](h)
 		h.verify(t, 0)
 		if x != 0 {
 			t.Errorf("%d.th pop got %d; want %d", i, x, 0)
@@ -75,11 +75,11 @@ func TestInit1(t *testing.T) {
 	for i := 20; i > 0; i-- {
 		h.Push(i) // all elements are different
 	}
-	Init(h)
+	Init[int](h)
 	h.verify(t, 0)
 
 	for i := 1; h.Len() > 0; i++ {
-		x := Pop(h).(int)
+		x := Pop[int](h)
 		h.verify(t, 0)
 		if x != i {
 			t.Errorf("%d.th pop got %d; want %d", i, x, i)
@@ -94,18 +94,18 @@ func Test(t *testing.T) {
 	for i := 20; i > 10; i-- {
 		h.Push(i)
 	}
-	Init(h)
+	Init[int](h)
 	h.verify(t, 0)
 
 	for i := 10; i > 0; i-- {
-		Push(h, i)
+		Push[int](h, i)
 		h.verify(t, 0)
 	}
 
 	for i := 1; h.Len() > 0; i++ {
-		x := Pop(h).(int)
+		x := Pop[int](h)
 		if i < 20 {
-			Push(h, 20+i)
+			Push[int](h, 20+i)
 		}
 		h.verify(t, 0)
 		if x != i {
@@ -123,7 +123,7 @@ func TestRemove0(t *testing.T) {
 
 	for h.Len() > 0 {
 		i := h.Len() - 1
-		x := Remove(h, i).(int)
+		x := Remove[int](h, i)
 		if x != i {
 			t.Errorf("Remove(%d) got %d; want %d", i, x, i)
 		}
@@ -139,7 +139,7 @@ func TestRemove1(t *testing.T) {
 	h.verify(t, 0)
 
 	for i := 0; h.Len() > 0; i++ {
-		x := Remove(h, 0).(int)
+		x := Remove[int](h, 0)
 		if x != i {
 			t.Errorf("Remove(0) got %d; want %d", x, i)
 		}
@@ -158,7 +158,7 @@ func TestRemove2(t *testing.T) {
 
 	m := make(map[int]bool)
 	for h.Len() > 0 {
-		m[Remove(h, (h.Len()-1)/2).(int)] = true
+		m[Remove[int](h, (h.Len()-1)/2)] = true
 		h.verify(t, 0)
 	}
 
@@ -177,10 +177,10 @@ func BenchmarkDup(b *testing.B) {
 	h := make(myHeap, 0, n)
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < n; j++ {
-			Push(&h, 0) // all elements are the same
+			Push[int](&h, 0) // all elements are the same
 		}
 		for h.Len() > 0 {
-			Pop(&h)
+			Pop[int](&h)
 		}
 	}
 }
@@ -190,7 +190,7 @@ func TestFix(t *testing.T) {
 	h.verify(t, 0)
 
 	for i := 200; i > 0; i -= 10 {
-		Push(h, i)
+		Push[int](h, i)
 	}
 	h.verify(t, 0)
 
@@ -198,7 +198,7 @@ func TestFix(t *testing.T) {
 		t.Fatalf("Expected head to be 10, was %d", (*h)[0])
 	}
 	(*h)[0] = 210
-	Fix(h, 0)
+	Fix[int](h, 0)
 	h.verify(t, 0)
 
 	for i := 100; i > 0; i-- {
@@ -208,7 +208,7 @@ func TestFix(t *testing.T) {
 		} else {
 			(*h)[elem] /= 2
 		}
-		Fix(h, elem)
+		Fix[int](h, elem)
 		h.verify(t, 0)
 	}
 }


### PR DESCRIPTION
This *draft* PR is meant to get the ball rolling on *evaluating* what the graph API may look like if using (Go 1.18) type parameters. The intention of #617 is to to make the Gonum graph API safer (and easier) to use, hopefully reducing the need for run-time type assertions.

Note, thus far, no user-facing API has been changed in any significant way.

Updates #617.

**Edit:** note, 91c920cccff3d96d33eafb212096b92c11e0bd92 adds a copy of `container/heap` from golang/go@4a37a1d. This code is not meant to be submitted to Gonum in the final PR. As Go 1.18 (or Go 1.19) is released, there should be a type parameterized standard library `heap` package. The code is included for now to make `go test` pass.