### PR TITLE
graph/internal/ordered: replace slice sort types with sort.Slice calls

### DIFF
--- a/graph/community/bisect_example_test.go
+++ b/graph/community/bisect_example_test.go
@@ -7,7 +7,6 @@ package community_test
 import (
 	"fmt"
 	"log"
-	"sort"
 
 	"golang.org/x/exp/rand"
 
@@ -52,9 +51,9 @@ func ExampleProfile_simple() {
 	for _, d := range p {
 		comm := d.Communities()
 		for _, c := range comm {
-			sort.Sort(ordered.ByID(c))
+			ordered.ByID(c)
 		}
-		sort.Sort(ordered.BySliceIDs(comm))
+		ordered.BySliceIDs(comm)
 		fmt.Printf("Low:%.2v High:%.2v Score:%v Communities:%v Q=%.3v\n",
 			d.Low, d.High, d.Score, comm, community.Q(g, comm, d.Low))
 	}
@@ -200,9 +199,9 @@ func ExampleProfile_multiplex() {
 	for _, d := range p {
 		comm := d.Communities()
 		for _, c := range comm {
-			sort.Sort(ordered.ByID(c))
+			ordered.ByID(c)
 		}
-		sort.Sort(ordered.BySliceIDs(comm))
+		ordered.BySliceIDs(comm)
 		fmt.Printf("Low:%.2v High:%.2v Score:%v Communities:%v Q=%.3v\n",
 			d.Low, d.High, d.Score, comm, community.QMultiplex(g, comm, weights, []float64{d.Low}))
 	}

--- a/graph/community/k_communities_test.go
+++ b/graph/community/k_communities_test.go
@@ -7,7 +7,6 @@ package community
 import (
 	"fmt"
 	"reflect"
-	"sort"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -126,9 +125,9 @@ func TestKCliqueCommunities(t *testing.T) {
 		got := KCliqueCommunities(test.k, g)
 
 		for _, c := range got {
-			sort.Sort(ordered.ByID(c))
+			ordered.ByID(c)
 		}
-		sort.Sort(ordered.BySliceIDs(got))
+		ordered.BySliceIDs(got)
 
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexpected k-connected components for %q k=%d:\ngot: %v\nwant:%v", test.name, test.k, got, test.want)

--- a/graph/community/louvain_directed.go
+++ b/graph/community/louvain_directed.go
@@ -186,7 +186,7 @@ func reduceDirected(g graph.Directed, communities [][]graph.Node) *ReducedDirect
 		// community provided by the user for a Q calculation.
 		// Probably we should use a function to map the
 		// communities in the test sets to the remapped order.
-		sort.Sort(ordered.ByID(nodes))
+		ordered.ByID(nodes)
 		communities = make([][]graph.Node, len(nodes))
 		for i := range nodes {
 			communities[i] = []graph.Node{node(i)}

--- a/graph/community/louvain_directed_multiplex.go
+++ b/graph/community/louvain_directed_multiplex.go
@@ -7,7 +7,6 @@ package community
 import (
 	"fmt"
 	"math"
-	"sort"
 
 	"golang.org/x/exp/rand"
 
@@ -299,7 +298,7 @@ func reduceDirectedMultiplex(g DirectedMultiplex, communities [][]graph.Node, we
 		// community provided by the user for a Q calculation.
 		// Probably we should use a function to map the
 		// communities in the test sets to the remapped order.
-		sort.Sort(ordered.ByID(nodes))
+		ordered.ByID(nodes)
 		communities = make([][]graph.Node, len(nodes))
 		for i := range nodes {
 			communities[i] = []graph.Node{node(i)}

--- a/graph/community/louvain_directed_multiplex_test.go
+++ b/graph/community/louvain_directed_multiplex_test.go
@@ -308,7 +308,7 @@ func TestCommunityQDirectedMultiplex(t *testing.T) {
 			got := floats.Sum(q)
 			if !scalar.EqualWithinAbsOrRel(got, structure.want, structure.tol, structure.tol) && !math.IsNaN(structure.want) {
 				for _, c := range communities {
-					sort.Sort(ordered.ByID(c))
+					ordered.ByID(c)
 				}
 				t.Errorf("unexpected Q value for %q %v: got: %v %.3v want: %v",
 					test.name, communities, got, q, structure.want)
@@ -336,7 +336,7 @@ tests:
 					communityOf[n] = i
 					communities[i] = append(communities[i], simple.Node(n))
 				}
-				sort.Sort(ordered.ByID(communities[i]))
+				ordered.ByID(communities[i])
 			}
 			resolution := []float64{structure.resolution}
 
@@ -357,7 +357,7 @@ tests:
 
 			// This is done to avoid run-to-run
 			// variation due to map iteration order.
-			sort.Sort(ordered.ByID(l.nodes))
+			ordered.ByID(l.nodes)
 
 			l.shuffle(rnd)
 
@@ -374,7 +374,7 @@ tests:
 						}
 						migrated[i] = append(migrated[i], simple.Node(n))
 					}
-					sort.Sort(ordered.ByID(migrated[i]))
+					ordered.ByID(migrated[i])
 				}
 
 				for i, c := range structure.memberships {
@@ -452,7 +452,7 @@ tests:
 				for n := range c {
 					communities[i] = append(communities[i], simple.Node(n))
 				}
-				sort.Sort(ordered.ByID(communities[i]))
+				ordered.ByID(communities[i])
 			}
 
 			gQ := QMultiplex(g, communities, weights, []float64{structure.resolution})
@@ -538,7 +538,7 @@ func TestMoveLocalDirectedMultiplex(t *testing.T) {
 				for n := range c {
 					communities[i] = append(communities[i], simple.Node(n))
 				}
-				sort.Sort(ordered.ByID(communities[i]))
+				ordered.ByID(communities[i])
 			}
 
 			r := reduceDirectedMultiplex(reduceDirectedMultiplex(g, nil, weights), communities, weights)
@@ -578,9 +578,9 @@ func TestLouvainDirectedMultiplex(t *testing.T) {
 			for n := range c {
 				want[i] = append(want[i], simple.Node(n))
 			}
-			sort.Sort(ordered.ByID(want[i]))
+			ordered.ByID(want[i])
 		}
-		sort.Sort(ordered.BySliceIDs(want))
+		ordered.BySliceIDs(want)
 
 		var (
 			got   *ReducedDirectedMultiplex
@@ -614,9 +614,9 @@ func TestLouvainDirectedMultiplex(t *testing.T) {
 
 		gotCommunities := got.Communities()
 		for _, c := range gotCommunities {
-			sort.Sort(ordered.ByID(c))
+			ordered.ByID(c)
 		}
-		sort.Sort(ordered.BySliceIDs(gotCommunities))
+		ordered.BySliceIDs(gotCommunities)
 		if !reflect.DeepEqual(gotCommunities, want) {
 			t.Errorf("unexpected community membership for %s Q=%.4v:\n\tgot: %v\n\twant:%v",
 				test.name, bestQ, gotCommunities, want)
@@ -629,9 +629,9 @@ func TestLouvainDirectedMultiplex(t *testing.T) {
 			if p.parent != nil {
 				communities = p.parent.Communities()
 				for _, c := range communities {
-					sort.Sort(ordered.ByID(c))
+					ordered.ByID(c)
 				}
-				sort.Sort(ordered.BySliceIDs(communities))
+				ordered.BySliceIDs(communities)
 			} else {
 				communities = reduceDirectedMultiplex(g, nil, weights).Communities()
 			}

--- a/graph/community/louvain_directed_test.go
+++ b/graph/community/louvain_directed_test.go
@@ -244,7 +244,7 @@ func testCommunityQDirected(t *testing.T, test communityDirectedQTest, g graph.D
 		got := Q(g, communities, structure.resolution)
 		if !scalar.EqualWithinAbsOrRel(got, structure.want, structure.tol, structure.tol) && !math.IsNaN(structure.want) {
 			for _, c := range communities {
-				sort.Sort(ordered.ByID(c))
+				ordered.ByID(c)
 			}
 			t.Errorf("unexpected Q value for %q %v: got: %v want: %v",
 				test.name, communities, got, structure.want)
@@ -297,7 +297,7 @@ func testCommunityDeltaQDirected(t *testing.T, test communityDirectedQTest, g gr
 				communityOf[n] = i
 				communities[i] = append(communities[i], simple.Node(n))
 			}
-			sort.Sort(ordered.ByID(communities[i]))
+			ordered.ByID(communities[i])
 		}
 
 		before := Q(g, communities, structure.resolution)
@@ -312,7 +312,7 @@ func testCommunityDeltaQDirected(t *testing.T, test communityDirectedQTest, g gr
 
 		// This is done to avoid run-to-run
 		// variation due to map iteration order.
-		sort.Sort(ordered.ByID(l.nodes))
+		ordered.ByID(l.nodes)
 
 		l.shuffle(rnd)
 
@@ -329,7 +329,7 @@ func testCommunityDeltaQDirected(t *testing.T, test communityDirectedQTest, g gr
 					}
 					migrated[i] = append(migrated[i], simple.Node(n))
 				}
-				sort.Sort(ordered.ByID(migrated[i]))
+				ordered.ByID(migrated[i])
 			}
 
 			for i, c := range structure.memberships {
@@ -422,7 +422,7 @@ func testReduceQConsistencyDirected(t *testing.T, test communityDirectedQTest, g
 			for n := range c {
 				communities[i] = append(communities[i], simple.Node(n))
 			}
-			sort.Sort(ordered.ByID(communities[i]))
+			ordered.ByID(communities[i])
 		}
 
 		gQ := Q(g, communities, structure.resolution)
@@ -536,7 +536,7 @@ func testMoveLocalDirected(t *testing.T, test localDirectedMoveTest, g graph.Dir
 			for n := range c {
 				communities[i] = append(communities[i], simple.Node(n))
 			}
-			sort.Sort(ordered.ByID(communities[i]))
+			ordered.ByID(communities[i])
 		}
 
 		r := reduceDirected(reduceDirected(g, nil), communities)
@@ -602,9 +602,9 @@ func testModularizeDirected(t *testing.T, test communityDirectedQTest, g graph.D
 		for n := range c {
 			want[i] = append(want[i], simple.Node(n))
 		}
-		sort.Sort(ordered.ByID(want[i]))
+		ordered.ByID(want[i])
 	}
-	sort.Sort(ordered.BySliceIDs(want))
+	ordered.BySliceIDs(want)
 
 	var (
 		got   *ReducedDirected
@@ -638,9 +638,9 @@ func testModularizeDirected(t *testing.T, test communityDirectedQTest, g graph.D
 
 	gotCommunities := got.Communities()
 	for _, c := range gotCommunities {
-		sort.Sort(ordered.ByID(c))
+		ordered.ByID(c)
 	}
-	sort.Sort(ordered.BySliceIDs(gotCommunities))
+	ordered.BySliceIDs(gotCommunities)
 	if !reflect.DeepEqual(gotCommunities, want) {
 		t.Errorf("unexpected community membership for %s Q=%.4v:\n\tgot: %v\n\twant:%v",
 			test.name, bestQ, gotCommunities, want)
@@ -653,9 +653,9 @@ func testModularizeDirected(t *testing.T, test communityDirectedQTest, g graph.D
 		if p.parent != nil {
 			communities = p.parent.Communities()
 			for _, c := range communities {
-				sort.Sort(ordered.ByID(c))
+				ordered.ByID(c)
 			}
-			sort.Sort(ordered.BySliceIDs(communities))
+			ordered.BySliceIDs(communities)
 		} else {
 			communities = reduceDirected(g, nil).Communities()
 		}

--- a/graph/community/louvain_undirected.go
+++ b/graph/community/louvain_undirected.go
@@ -183,7 +183,7 @@ func reduceUndirected(g graph.Undirected, communities [][]graph.Node) *ReducedUn
 		// community provided by the user for a Q calculation.
 		// Probably we should use a function to map the
 		// communities in the test sets to the remapped order.
-		sort.Sort(ordered.ByID(nodes))
+		ordered.ByID(nodes)
 		communities = make([][]graph.Node, len(nodes))
 		for i := range nodes {
 			communities[i] = []graph.Node{node(i)}

--- a/graph/community/louvain_undirected_multiplex.go
+++ b/graph/community/louvain_undirected_multiplex.go
@@ -7,7 +7,6 @@ package community
 import (
 	"fmt"
 	"math"
-	"sort"
 
 	"golang.org/x/exp/rand"
 
@@ -295,7 +294,7 @@ func reduceUndirectedMultiplex(g UndirectedMultiplex, communities [][]graph.Node
 		// community provided by the user for a Q calculation.
 		// Probably we should use a function to map the
 		// communities in the test sets to the remapped order.
-		sort.Sort(ordered.ByID(nodes))
+		ordered.ByID(nodes)
 		communities = make([][]graph.Node, len(nodes))
 		for i := range nodes {
 			communities[i] = []graph.Node{node(i)}

--- a/graph/community/louvain_undirected_multiplex_test.go
+++ b/graph/community/louvain_undirected_multiplex_test.go
@@ -277,7 +277,7 @@ func TestCommunityQUndirectedMultiplex(t *testing.T) {
 			got := floats.Sum(q)
 			if !scalar.EqualWithinAbsOrRel(got, structure.want, structure.tol, structure.tol) && !math.IsNaN(structure.want) {
 				for _, c := range communities {
-					sort.Sort(ordered.ByID(c))
+					ordered.ByID(c)
 				}
 				t.Errorf("unexpected Q value for %q %v: got: %v %.3v want: %v",
 					test.name, communities, got, q, structure.want)
@@ -305,7 +305,7 @@ tests:
 					communityOf[n] = i
 					communities[i] = append(communities[i], simple.Node(n))
 				}
-				sort.Sort(ordered.ByID(communities[i]))
+				ordered.ByID(communities[i])
 			}
 			resolution := []float64{structure.resolution}
 
@@ -326,7 +326,7 @@ tests:
 
 			// This is done to avoid run-to-run
 			// variation due to map iteration order.
-			sort.Sort(ordered.ByID(l.nodes))
+			ordered.ByID(l.nodes)
 
 			l.shuffle(rnd)
 
@@ -343,7 +343,7 @@ tests:
 						}
 						migrated[i] = append(migrated[i], simple.Node(n))
 					}
-					sort.Sort(ordered.ByID(migrated[i]))
+					ordered.ByID(migrated[i])
 				}
 
 				for i, c := range structure.memberships {
@@ -421,7 +421,7 @@ tests:
 				for n := range c {
 					communities[i] = append(communities[i], simple.Node(n))
 				}
-				sort.Sort(ordered.ByID(communities[i]))
+				ordered.ByID(communities[i])
 			}
 
 			gQ := QMultiplex(g, communities, weights, []float64{structure.resolution})
@@ -507,7 +507,7 @@ func TestMoveLocalUndirectedMultiplex(t *testing.T) {
 				for n := range c {
 					communities[i] = append(communities[i], simple.Node(n))
 				}
-				sort.Sort(ordered.ByID(communities[i]))
+				ordered.ByID(communities[i])
 			}
 
 			r := reduceUndirectedMultiplex(reduceUndirectedMultiplex(g, nil, weights), communities, weights)
@@ -547,9 +547,9 @@ func TestLouvainMultiplex(t *testing.T) {
 			for n := range c {
 				want[i] = append(want[i], simple.Node(n))
 			}
-			sort.Sort(ordered.ByID(want[i]))
+			ordered.ByID(want[i])
 		}
-		sort.Sort(ordered.BySliceIDs(want))
+		ordered.BySliceIDs(want)
 
 		var (
 			got   *ReducedUndirectedMultiplex
@@ -583,9 +583,9 @@ func TestLouvainMultiplex(t *testing.T) {
 
 		gotCommunities := got.Communities()
 		for _, c := range gotCommunities {
-			sort.Sort(ordered.ByID(c))
+			ordered.ByID(c)
 		}
-		sort.Sort(ordered.BySliceIDs(gotCommunities))
+		ordered.BySliceIDs(gotCommunities)
 		if !reflect.DeepEqual(gotCommunities, want) {
 			t.Errorf("unexpected community membership for %s Q=%.4v:\n\tgot: %v\n\twant:%v",
 				test.name, bestQ, gotCommunities, want)
@@ -598,9 +598,9 @@ func TestLouvainMultiplex(t *testing.T) {
 			if p.parent != nil {
 				communities = p.parent.Communities()
 				for _, c := range communities {
-					sort.Sort(ordered.ByID(c))
+					ordered.ByID(c)
 				}
-				sort.Sort(ordered.BySliceIDs(communities))
+				ordered.BySliceIDs(communities)
 			} else {
 				communities = reduceUndirectedMultiplex(g, nil, weights).Communities()
 			}

--- a/graph/community/louvain_undirected_test.go
+++ b/graph/community/louvain_undirected_test.go
@@ -307,7 +307,7 @@ func testCommunityQUndirected(t *testing.T, test communityUndirectedQTest, g gra
 		got := Q(g, communities, structure.resolution)
 		if !scalar.EqualWithinAbsOrRel(got, structure.want, structure.tol, structure.tol) && !math.IsNaN(structure.want) {
 			for _, c := range communities {
-				sort.Sort(ordered.ByID(c))
+				ordered.ByID(c)
 			}
 			t.Errorf("unexpected Q value for %q %v: got: %v want: %v",
 				test.name, communities, got, structure.want)
@@ -360,7 +360,7 @@ func testCommunityDeltaQUndirected(t *testing.T, test communityUndirectedQTest, 
 				communityOf[n] = i
 				communities[i] = append(communities[i], simple.Node(n))
 			}
-			sort.Sort(ordered.ByID(communities[i]))
+			ordered.ByID(communities[i])
 		}
 
 		before := Q(g, communities, structure.resolution)
@@ -375,7 +375,7 @@ func testCommunityDeltaQUndirected(t *testing.T, test communityUndirectedQTest, 
 
 		// This is done to avoid run-to-run
 		// variation due to map iteration order.
-		sort.Sort(ordered.ByID(l.nodes))
+		ordered.ByID(l.nodes)
 
 		l.shuffle(rnd)
 
@@ -392,7 +392,7 @@ func testCommunityDeltaQUndirected(t *testing.T, test communityUndirectedQTest, 
 					}
 					migrated[i] = append(migrated[i], simple.Node(n))
 				}
-				sort.Sort(ordered.ByID(migrated[i]))
+				ordered.ByID(migrated[i])
 			}
 
 			for i, c := range structure.memberships {
@@ -485,7 +485,7 @@ func testReduceQConsistencyUndirected(t *testing.T, test communityUndirectedQTes
 			for n := range c {
 				communities[i] = append(communities[i], simple.Node(n))
 			}
-			sort.Sort(ordered.ByID(communities[i]))
+			ordered.ByID(communities[i])
 		}
 
 		gQ := Q(g, communities, structure.resolution)
@@ -599,7 +599,7 @@ func testMoveLocalUndirected(t *testing.T, test localUndirectedMoveTest, g graph
 			for n := range c {
 				communities[i] = append(communities[i], simple.Node(n))
 			}
-			sort.Sort(ordered.ByID(communities[i]))
+			ordered.ByID(communities[i])
 		}
 
 		r := reduceUndirected(reduceUndirected(g, nil), communities)
@@ -665,9 +665,9 @@ func testModularizeUndirected(t *testing.T, test communityUndirectedQTest, g gra
 		for n := range c {
 			want[i] = append(want[i], simple.Node(n))
 		}
-		sort.Sort(ordered.ByID(want[i]))
+		ordered.ByID(want[i])
 	}
-	sort.Sort(ordered.BySliceIDs(want))
+	ordered.BySliceIDs(want)
 
 	var (
 		got   *ReducedUndirected
@@ -701,9 +701,9 @@ func testModularizeUndirected(t *testing.T, test communityUndirectedQTest, g gra
 
 	gotCommunities := got.Communities()
 	for _, c := range gotCommunities {
-		sort.Sort(ordered.ByID(c))
+		ordered.ByID(c)
 	}
-	sort.Sort(ordered.BySliceIDs(gotCommunities))
+	ordered.BySliceIDs(gotCommunities)
 	if !reflect.DeepEqual(gotCommunities, want) {
 		t.Errorf("unexpected community membership for %s Q=%.4v:\n\tgot: %v\n\twant:%v",
 			test.name, bestQ, gotCommunities, want)
@@ -716,9 +716,9 @@ func testModularizeUndirected(t *testing.T, test communityUndirectedQTest, g gra
 		if p.parent != nil {
 			communities = p.parent.Communities()
 			for _, c := range communities {
-				sort.Sort(ordered.ByID(c))
+				ordered.ByID(c)
 			}
-			sort.Sort(ordered.BySliceIDs(communities))
+			ordered.BySliceIDs(communities)
 		} else {
 			communities = reduceUndirected(g, nil).Communities()
 		}

--- a/graph/encoding/digraph6/digraph6.go
+++ b/graph/encoding/digraph6/digraph6.go
@@ -8,7 +8,6 @@ package digraph6 // import "gonum.org/v1/gonum/graph/encoding/digraph6"
 import (
 	"fmt"
 	"math/big"
-	"sort"
 	"strings"
 
 	"gonum.org/v1/gonum/graph"
@@ -38,7 +37,7 @@ var (
 func Encode(g graph.Graph) Graph {
 	nodes := graph.NodesOf(g.Nodes())
 	n := len(nodes)
-	sort.Sort(ordered.ByID(nodes))
+	ordered.ByID(nodes)
 	indexOf := make(map[int64]int, n)
 	for i, n := range nodes {
 		indexOf[n.ID()] = i

--- a/graph/encoding/dot/encode.go
+++ b/graph/encoding/dot/encode.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -167,7 +166,7 @@ func (p *simpleGraphPrinter) print(g graph.Graph, name string, needsIndent, isSu
 	}
 
 	nodes := graph.NodesOf(g.Nodes())
-	sort.Sort(ordered.ByID(nodes))
+	ordered.ByID(nodes)
 
 	havePrintedNodeHeader := false
 	for _, n := range nodes {
@@ -207,7 +206,7 @@ func (p *simpleGraphPrinter) print(g graph.Graph, name string, needsIndent, isSu
 	for _, n := range nodes {
 		nid := n.ID()
 		to := graph.NodesOf(g.From(nid))
-		sort.Sort(ordered.ByID(to))
+		ordered.ByID(to)
 		for _, t := range to {
 			tid := t.ID()
 			f := edge{inGraph: name, from: nid, to: tid}
@@ -466,7 +465,7 @@ func (p *multiGraphPrinter) print(g graph.Multigraph, name string, needsIndent, 
 	}
 
 	nodes := graph.NodesOf(g.Nodes())
-	sort.Sort(ordered.ByID(nodes))
+	ordered.ByID(nodes)
 
 	havePrintedNodeHeader := false
 	for _, n := range nodes {
@@ -506,13 +505,13 @@ func (p *multiGraphPrinter) print(g graph.Multigraph, name string, needsIndent, 
 	for _, n := range nodes {
 		nid := n.ID()
 		to := graph.NodesOf(g.From(nid))
-		sort.Sort(ordered.ByID(to))
+		ordered.ByID(to)
 
 		for _, t := range to {
 			tid := t.ID()
 
 			lines := graph.LinesOf(g.Lines(nid, tid))
-			sort.Sort(ordered.LinesByIDs(lines))
+			ordered.LinesByIDs(lines)
 
 			for _, l := range lines {
 				lid := l.ID()

--- a/graph/encoding/graph6/graph6.go
+++ b/graph/encoding/graph6/graph6.go
@@ -8,7 +8,6 @@ package graph6 // import "gonum.org/v1/gonum/graph/encoding/graph6"
 import (
 	"fmt"
 	"math/big"
-	"sort"
 	"strings"
 
 	"gonum.org/v1/gonum/graph"
@@ -36,7 +35,7 @@ var (
 func Encode(g graph.Graph) Graph {
 	nodes := graph.NodesOf(g.Nodes())
 	n := len(nodes)
-	sort.Sort(ordered.ByID(nodes))
+	ordered.ByID(nodes)
 	indexOf := make(map[int64]int, n)
 	for i, n := range nodes {
 		indexOf[n.ID()] = i

--- a/graph/flow/control_flow_test.go
+++ b/graph/flow/control_flow_test.go
@@ -6,7 +6,6 @@ package flow
 
 import (
 	"reflect"
-	"sort"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -172,7 +171,7 @@ func TestDominators(t *testing.T) {
 				}
 
 				for _, nodes := range got.dominatedBy {
-					sort.Sort(ordered.ByID(nodes))
+					ordered.ByID(nodes)
 				}
 
 				if !reflect.DeepEqual(got.dominatedBy, test.want.dominatedBy) {

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -5,7 +5,6 @@
 package graph_test
 
 import (
-	"sort"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -264,8 +263,8 @@ func TestCopyWeighted(t *testing.T) {
 func same(a, b graph.Graph) bool {
 	aNodes := graph.NodesOf(a.Nodes())
 	bNodes := graph.NodesOf(b.Nodes())
-	sort.Sort(ordered.ByID(aNodes))
-	sort.Sort(ordered.ByID(bNodes))
+	ordered.ByID(aNodes)
+	ordered.ByID(bNodes)
 	for i, na := range aNodes {
 		nb := bNodes[i]
 		if na != nb {
@@ -278,8 +277,8 @@ func same(a, b graph.Graph) bool {
 		if len(aFromU) != len(bFromU) {
 			return false
 		}
-		sort.Sort(ordered.ByID(aFromU))
-		sort.Sort(ordered.ByID(bFromU))
+		ordered.ByID(aFromU)
+		ordered.ByID(bFromU)
 		for i, va := range aFromU {
 			vb := bFromU[i]
 			if va != vb {

--- a/graph/graphs/gen/duplication.go
+++ b/graph/graphs/gen/duplication.go
@@ -7,7 +7,6 @@ package gen
 import (
 	"fmt"
 	"math"
-	"sort"
 
 	"golang.org/x/exp/rand"
 
@@ -57,7 +56,7 @@ func Duplication(dst UndirectedMutator, n int, delta, alpha, sigma float64, src 
 	}
 
 	nodes := graph.NodesOf(dst.Nodes())
-	sort.Sort(ordered.ByID(nodes))
+	ordered.ByID(nodes)
 	if len(nodes) == 0 {
 		n--
 		u := dst.NewNode()
@@ -77,7 +76,7 @@ func Duplication(dst UndirectedMutator, n int, delta, alpha, sigma float64, src 
 		for {
 			// Add edges to parent's neighbours.
 			to := graph.NodesOf(dst.From(u.ID()))
-			sort.Sort(ordered.ByID(to))
+			ordered.ByID(to)
 			for _, v := range to {
 				vid := v.ID()
 				if rnd() < delta || dst.HasEdgeBetween(vid, did) {

--- a/graph/internal/ordered/sort.go
+++ b/graph/internal/ordered/sort.go
@@ -4,69 +4,78 @@
 
 package ordered
 
-import "gonum.org/v1/gonum/graph"
+import (
+	"sort"
 
-// ByID implements the sort.Interface sorting a slice of graph.Node
-// by ID.
-type ByID []graph.Node
+	"gonum.org/v1/gonum/graph"
+)
 
-func (n ByID) Len() int           { return len(n) }
-func (n ByID) Less(i, j int) bool { return n[i].ID() < n[j].ID() }
-func (n ByID) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
-
-// BySliceValues implements the sort.Interface sorting a slice of
-// []int64 lexically by the values of the []int64.
-type BySliceValues [][]int64
-
-func (c BySliceValues) Len() int { return len(c) }
-func (c BySliceValues) Less(i, j int) bool {
-	a, b := c[i], c[j]
-	l := len(a)
-	if len(b) < l {
-		l = len(b)
-	}
-	for k, v := range a[:l] {
-		if v < b[k] {
-			return true
-		}
-		if v > b[k] {
-			return false
-		}
-	}
-	return len(a) < len(b)
+// ByID sorts a slice of graph.Node by ID.
+func ByID(n []graph.Node) {
+	sort.Slice(n, func(i, j int) bool { return n[i].ID() < n[j].ID() })
 }
-func (c BySliceValues) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
 
-// BySliceIDs implements the sort.Interface sorting a slice of
-// []graph.Node lexically by the IDs of the []graph.Node.
-type BySliceIDs [][]graph.Node
-
-func (c BySliceIDs) Len() int { return len(c) }
-func (c BySliceIDs) Less(i, j int) bool {
-	a, b := c[i], c[j]
-	l := len(a)
-	if len(b) < l {
-		l = len(b)
-	}
-	for k, v := range a[:l] {
-		if v.ID() < b[k].ID() {
-			return true
+// BySliceValues sorts a slice of []int64 lexically by the values of the
+// []int64.
+func BySliceValues(c [][]int64) {
+	sort.Slice(c, func(i, j int) bool {
+		a, b := c[i], c[j]
+		l := len(a)
+		if len(b) < l {
+			l = len(b)
 		}
-		if v.ID() > b[k].ID() {
-			return false
+		for k, v := range a[:l] {
+			if v < b[k] {
+				return true
+			}
+			if v > b[k] {
+				return false
+			}
 		}
-	}
-	return len(a) < len(b)
+		return len(a) < len(b)
+	})
 }
-func (c BySliceIDs) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
 
-// Int64s implements the sort.Interface sorting a slice of
-// int64.
-type Int64s []int64
+// BySliceIDs sorts a slice of []graph.Node lexically by the IDs of the
+// []graph.Node.
+func BySliceIDs(c [][]graph.Node) {
+	sort.Slice(c, func(i, j int) bool {
+		a, b := c[i], c[j]
+		l := len(a)
+		if len(b) < l {
+			l = len(b)
+		}
+		for k, v := range a[:l] {
+			if v.ID() < b[k].ID() {
+				return true
+			}
+			if v.ID() > b[k].ID() {
+				return false
+			}
+		}
+		return len(a) < len(b)
+	})
+}
 
-func (s Int64s) Len() int           { return len(s) }
-func (s Int64s) Less(i, j int) bool { return s[i] < s[j] }
-func (s Int64s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+// Int64s sorts a slice of int64.
+func Int64s(s []int64) {
+	sort.Slice(s, func(i, j int) bool { return s[i] < s[j] })
+}
+
+// LinesByIDs sort a slice of graph.LinesByIDs lexically by the From IDs,
+// then by the To IDs, finally by the Line IDs.
+func LinesByIDs(n []graph.Line) {
+	sort.Slice(n, func(i, j int) bool {
+		a, b := n[i], n[j]
+		if a.From().ID() != b.From().ID() {
+			return a.From().ID() < b.From().ID()
+		}
+		if a.To().ID() != b.To().ID() {
+			return a.To().ID() < b.To().ID()
+		}
+		return n[i].ID() < n[j].ID()
+	})
+}
 
 // Reverse reverses the order of nodes.
 func Reverse(nodes []graph.Node) {
@@ -74,20 +83,3 @@ func Reverse(nodes []graph.Node) {
 		nodes[i], nodes[j] = nodes[j], nodes[i]
 	}
 }
-
-// LinesByIDs implements the sort.Interface sorting a slice of graph.LinesByIDs
-// lexically by the From IDs, then by the To IDs, finally by the Line IDs.
-type LinesByIDs []graph.Line
-
-func (n LinesByIDs) Len() int { return len(n) }
-func (n LinesByIDs) Less(i, j int) bool {
-	a, b := n[i], n[j]
-	if a.From().ID() != b.From().ID() {
-		return a.From().ID() < b.From().ID()
-	}
-	if a.To().ID() != b.To().ID() {
-		return a.To().ID() < b.To().ID()
-	}
-	return n[i].ID() < n[j].ID()
-}
-func (n LinesByIDs) Swap(i, j int) { n[i], n[j] = n[j], n[i] }

--- a/graph/iterator/nodes_test.go
+++ b/graph/iterator/nodes_test.go
@@ -6,7 +6,6 @@ package iterator_test
 
 import (
 	"reflect"
-	"sort"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -741,7 +740,7 @@ func TestNodeSlicers(t *testing.T) {
 				t.Errorf("test %d: unexpected total node count: got:%d want:%d", k, gotLen, wantLen)
 			}
 			got := append(gotIter, gotSlice...)
-			sort.Sort(ordered.ByID(got))
+			ordered.ByID(got)
 			if !reflect.DeepEqual(got, test.want) {
 				t.Errorf("test %d: unexpected node slice:\ngot: %v\nwant:%v", k, got, test.want)
 			}

--- a/graph/layout/layout_test.go
+++ b/graph/layout/layout_test.go
@@ -11,7 +11,6 @@ import (
 	"image/png"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 
@@ -30,13 +29,13 @@ type orderedGraph struct {
 
 func (g orderedGraph) Nodes() graph.Nodes {
 	n := graph.NodesOf(g.Graph.Nodes())
-	sort.Sort(ordered.ByID(n))
+	ordered.ByID(n)
 	return iterator.NewOrderedNodes(n)
 }
 
 func (g orderedGraph) From(id int64) graph.Nodes {
 	n := graph.NodesOf(g.Graph.From(id))
-	sort.Sort(ordered.ByID(n))
+	ordered.ByID(n)
 	return iterator.NewOrderedNodes(n)
 }
 

--- a/graph/path/bellman_ford_moore_test.go
+++ b/graph/path/bellman_ford_moore_test.go
@@ -7,7 +7,6 @@ package path
 import (
 	"math"
 	"reflect"
-	"sort"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -164,7 +163,7 @@ func TestBellmanFordAllFrom(t *testing.T) {
 						test.Name, tg.typ, gotPaths)
 				}
 			} else {
-				sort.Sort(ordered.BySliceValues(gotPaths))
+				ordered.BySliceValues(gotPaths)
 				if !reflect.DeepEqual(gotPaths, test.WantPaths) {
 					t.Errorf("testing %q %s: unexpected shortest paths:\ngot: %v\nwant:%v",
 						test.Name, tg.typ, gotPaths, test.WantPaths)

--- a/graph/path/dijkstra_test.go
+++ b/graph/path/dijkstra_test.go
@@ -7,7 +7,6 @@ package path
 import (
 	"math"
 	"reflect"
-	"sort"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -183,7 +182,7 @@ func TestDijkstraAllFrom(t *testing.T) {
 					gotPaths[i] = append(gotPaths[i], v.ID())
 				}
 			}
-			sort.Sort(ordered.BySliceValues(gotPaths))
+			ordered.BySliceValues(gotPaths)
 			if !reflect.DeepEqual(gotPaths, test.WantPaths) {
 				t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 					test.Name, gotPaths, test.WantPaths)
@@ -291,7 +290,7 @@ func TestDijkstraAllPaths(t *testing.T) {
 				got[i] = append(got[i], v.ID())
 			}
 		}
-		sort.Sort(ordered.BySliceValues(got))
+		ordered.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.WantPaths) {
 			t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 				test.Name, got, test.WantPaths)

--- a/graph/path/floydwarshall_test.go
+++ b/graph/path/floydwarshall_test.go
@@ -7,7 +7,6 @@ package path
 import (
 	"math"
 	"reflect"
-	"sort"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -88,7 +87,7 @@ func TestFloydWarshall(t *testing.T) {
 				got[i] = append(got[i], v.ID())
 			}
 		}
-		sort.Sort(ordered.BySliceValues(got))
+		ordered.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.WantPaths) {
 			t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 				test.Name, got, test.WantPaths)

--- a/graph/path/johnson_apsp_test.go
+++ b/graph/path/johnson_apsp_test.go
@@ -7,7 +7,6 @@ package path
 import (
 	"math"
 	"reflect"
-	"sort"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -88,7 +87,7 @@ func TestJohnsonAllPaths(t *testing.T) {
 				got[i] = append(got[i], v.ID())
 			}
 		}
-		sort.Sort(ordered.BySliceValues(got))
+		ordered.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.WantPaths) {
 			t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 				test.Name, got, test.WantPaths)

--- a/graph/path/yen_ksp_test.go
+++ b/graph/path/yen_ksp_test.go
@@ -232,11 +232,11 @@ func TestYenKSP(t *testing.T) {
 				if w == last {
 					continue
 				}
-				sort.Sort(ordered.BySliceValues(gotIDs[first:i]))
+				ordered.BySliceValues(gotIDs[first:i])
 				first = i
 				last = w
 			}
-			sort.Sort(ordered.BySliceValues(gotIDs[first:]))
+			ordered.BySliceValues(gotIDs[first:])
 		}
 
 		if !reflect.DeepEqual(test.wantPaths, gotIDs) {

--- a/graph/product/product.go
+++ b/graph/product/product.go
@@ -5,8 +5,6 @@
 package product
 
 import (
-	"sort"
-
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/stat/combin"
@@ -369,7 +367,7 @@ func cartesianNodes(a, b graph.Graph) (aNodes, bNodes []graph.Node, product []No
 // lexicalNodes returns the nodes in g sorted lexically by node ID.
 func lexicalNodes(g graph.Graph) []graph.Node {
 	nodes := graph.NodesOf(g.Nodes())
-	sort.Sort(ordered.ByID(nodes))
+	ordered.ByID(nodes)
 	return nodes
 }
 

--- a/graph/simple/dense_directed_matrix.go
+++ b/graph/simple/dense_directed_matrix.go
@@ -5,8 +5,6 @@
 package simple
 
 import (
-	"sort"
-
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/iterator"
@@ -62,7 +60,7 @@ func NewDirectedMatrix(n int, init, self, absent float64) *DirectedMatrix {
 // specifies the cost of self connection, and absent specifies the weight
 // returned for absent edges.
 func NewDirectedMatrixFrom(nodes []graph.Node, init, self, absent float64) *DirectedMatrix {
-	sort.Sort(ordered.ByID(nodes))
+	ordered.ByID(nodes)
 	for i, n := range nodes {
 		if int64(i) != n.ID() {
 			panic("simple: non-contiguous node IDs")

--- a/graph/simple/dense_undirected_matrix.go
+++ b/graph/simple/dense_undirected_matrix.go
@@ -5,8 +5,6 @@
 package simple
 
 import (
-	"sort"
-
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/iterator"
@@ -62,7 +60,7 @@ func NewUndirectedMatrix(n int, init, self, absent float64) *UndirectedMatrix {
 // specifies the cost of self connection, and absent specifies the weight
 // returned for absent edges.
 func NewUndirectedMatrixFrom(nodes []graph.Node, init, self, absent float64) *UndirectedMatrix {
-	sort.Sort(ordered.ByID(nodes))
+	ordered.ByID(nodes)
 	for i, n := range nodes {
 		if int64(i) != n.ID() {
 			panic("simple: non-contiguous node IDs")

--- a/graph/simple/densegraph_test.go
+++ b/graph/simple/densegraph_test.go
@@ -6,7 +6,6 @@ package simple_test
 
 import (
 	"math"
-	"sort"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -22,7 +21,7 @@ func isZeroContiguousSet(nodes []graph.Node) bool {
 	t := make([]graph.Node, len(nodes))
 	copy(t, nodes)
 	nodes = t
-	sort.Sort(ordered.ByID(nodes))
+	ordered.ByID(nodes)
 	for i, n := range nodes {
 		if int64(i) != n.ID() {
 			return false
@@ -642,7 +641,7 @@ func TestDenseLists(t *testing.T) {
 		t.Fatalf("Wrong number of nodes: got:%v want:%v", len(nodes), 15)
 	}
 
-	sort.Sort(ordered.ByID(nodes))
+	ordered.ByID(nodes)
 
 	for i, node := range graph.NodesOf(dg.Nodes()) {
 		if int64(i) != node.ID() {

--- a/graph/spectral/laplacian_test.go
+++ b/graph/spectral/laplacian_test.go
@@ -5,7 +5,6 @@
 package spectral
 
 import (
-	"sort"
 	"testing"
 
 	"gonum.org/v1/gonum/floats/scalar"
@@ -129,7 +128,7 @@ type sortedNodeGraph struct {
 
 func (g sortedNodeGraph) Nodes() graph.Nodes {
 	n := graph.NodesOf(g.Graph.Nodes())
-	sort.Sort(ordered.ByID(n))
+	ordered.ByID(n)
 	return iterator.NewOrderedNodes(n)
 }
 

--- a/graph/testgraph/testgraph.go
+++ b/graph/testgraph/testgraph.go
@@ -126,8 +126,8 @@ func ReturnAllNodes(t *testing.T, b Builder, useEmpty bool) {
 			got = append(got, it.Node())
 		}
 
-		sort.Sort(ordered.ByID(got))
-		sort.Sort(ordered.ByID(want))
+		ordered.ByID(got)
+		ordered.ByID(want)
 
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("unexpected nodes result for test %q:\ngot: %v\nwant:%v", test.name, got, want)
@@ -165,8 +165,8 @@ func ReturnNodeSlice(t *testing.T, b Builder, useEmpty bool) {
 		}
 		got := s.NodeSlice()
 
-		sort.Sort(ordered.ByID(got))
-		sort.Sort(ordered.ByID(want))
+		ordered.ByID(got)
+		ordered.ByID(want)
 
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("unexpected nodes result for test %q:\ngot: %v\nwant:%v", test.name, got, want)
@@ -1409,9 +1409,9 @@ func AddNodes(t *testing.T, g NodeAdder, n int) {
 		}
 	}
 
-	sort.Sort(ordered.ByID(addedNodes))
+	ordered.ByID(addedNodes)
 	graphNodes := graph.NodesOf(g.Nodes())
-	sort.Sort(ordered.ByID(graphNodes))
+	ordered.ByID(graphNodes)
 	if !reflect.DeepEqual(addedNodes, graphNodes) {
 		if n > 20 {
 			t.Errorf("unexpected node set after node addition: got len:%v want len:%v", len(graphNodes), len(addedNodes))
@@ -1486,9 +1486,9 @@ func AddArbitraryNodes(t *testing.T, g NodeAdder, add graph.Nodes) {
 
 	add.Reset()
 	addedNodes := graph.NodesOf(add)
-	sort.Sort(ordered.ByID(addedNodes))
+	ordered.ByID(addedNodes)
 	graphNodes := graph.NodesOf(g.Nodes())
-	sort.Sort(ordered.ByID(graphNodes))
+	ordered.ByID(graphNodes)
 	if !reflect.DeepEqual(addedNodes, graphNodes) {
 		t.Errorf("unexpected node set after node addition: got:\n %v\nwant:\n%v", graphNodes, addedNodes)
 	}

--- a/graph/topo/bron_kerbosch_test.go
+++ b/graph/topo/bron_kerbosch_test.go
@@ -6,7 +6,6 @@ package topo
 
 import (
 	"reflect"
-	"sort"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -67,12 +66,12 @@ func TestDegeneracyOrdering(t *testing.T) {
 		}
 		var offset int
 		for k, want := range test.wantCore {
-			sort.Sort(ordered.Int64s(want))
+			ordered.Int64s(want)
 			got := make([]int64, len(want))
 			for j, n := range order[len(order)-len(want)-offset : len(order)-offset] {
 				got[j] = n.ID()
 			}
-			sort.Sort(ordered.Int64s(got))
+			ordered.Int64s(got)
 			if !reflect.DeepEqual(got, want) {
 				t.Errorf("unexpected %d-core for test %d:\ngot: %v\nwant:%v", k, i, got, want)
 			}
@@ -80,7 +79,7 @@ func TestDegeneracyOrdering(t *testing.T) {
 			for j, n := range core[k] {
 				got[j] = n.ID()
 			}
-			sort.Sort(ordered.Int64s(got))
+			ordered.Int64s(got)
 			if !reflect.DeepEqual(got, want) {
 				t.Errorf("unexpected %d-core for test %d:\ngot: %v\nwant:%v", k, i, got, want)
 			}
@@ -117,8 +116,8 @@ func TestKCore(t *testing.T) {
 			for _, n := range core {
 				got = append(got, n.ID())
 			}
-			sort.Sort(ordered.Int64s(got))
-			sort.Sort(ordered.Int64s(want))
+			ordered.Int64s(got)
+			ordered.Int64s(want)
 			if !reflect.DeepEqual(got, want) {
 				t.Errorf("unexpected %d-core for test %d:\ngot: %v\nwant:%v", k, i, got, want)
 			}
@@ -193,10 +192,10 @@ func TestBronKerbosch(t *testing.T) {
 			for k, n := range c {
 				ids[k] = n.ID()
 			}
-			sort.Sort(ordered.Int64s(ids))
+			ordered.Int64s(ids)
 			got[j] = ids
 		}
-		sort.Sort(ordered.BySliceValues(got))
+		ordered.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexpected cliques for test %q:\ngot: %v\nwant:%v", test.name, got, test.want)
 		}

--- a/graph/topo/clique_graph.go
+++ b/graph/topo/clique_graph.go
@@ -5,8 +5,6 @@
 package topo
 
 import (
-	"sort"
-
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/internal/set"
@@ -28,9 +26,9 @@ func CliqueGraph(dst Builder, g graph.Undirected) {
 	// Construct a consistent view of cliques in g. Sorting costs
 	// us a little, but not as much as the cliques themselves.
 	for _, c := range cliques {
-		sort.Sort(ordered.ByID(c))
+		ordered.ByID(c)
 	}
-	sort.Sort(ordered.BySliceIDs(cliques))
+	ordered.BySliceIDs(cliques)
 
 	cliqueNodes := make(cliqueNodeSets, len(cliques))
 	for id, c := range cliques {
@@ -61,7 +59,7 @@ func CliqueGraph(dst Builder, g graph.Undirected) {
 					for _, n := range set.IntersectionOfNodes(uc.nodes, vc.nodes) {
 						edgeNodes = append(edgeNodes, n)
 					}
-					sort.Sort(ordered.ByID(edgeNodes))
+					ordered.ByID(edgeNodes)
 				}
 
 				dst.SetEdge(CliqueGraphEdge{from: uc.Clique, to: vc.Clique, nodes: edgeNodes})

--- a/graph/topo/johnson_cycles.go
+++ b/graph/topo/johnson_cycles.go
@@ -5,8 +5,6 @@
 package topo
 
 import (
-	"sort"
-
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/internal/set"
@@ -134,7 +132,7 @@ type johnsonGraph struct {
 // johnsonGraphFrom returns a deep copy of the graph g.
 func johnsonGraphFrom(g graph.Directed) johnsonGraph {
 	nodes := graph.NodesOf(g.Nodes())
-	sort.Sort(ordered.ByID(nodes))
+	ordered.ByID(nodes)
 	c := johnsonGraph{
 		orig:  nodes,
 		index: make(map[int64]int, len(nodes)),

--- a/graph/topo/johnson_cycles_test.go
+++ b/graph/topo/johnson_cycles_test.go
@@ -6,7 +6,6 @@ package topo
 
 import (
 	"reflect"
-	"sort"
 	"testing"
 
 	"gonum.org/v1/gonum/graph/internal/ordered"
@@ -109,7 +108,7 @@ func TestDirectedCyclesIn(t *testing.T) {
 			}
 			got[j] = ids
 		}
-		sort.Sort(ordered.BySliceValues(got))
+		ordered.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexpected johnson result for %d:\n\tgot:%#v\n\twant:%#v", i, got, test.want)
 		}

--- a/graph/topo/paton_cycles_test.go
+++ b/graph/topo/paton_cycles_test.go
@@ -6,7 +6,6 @@ package topo
 
 import (
 	"reflect"
-	"sort"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -98,7 +97,7 @@ func TestUndirectedCyclesIn(t *testing.T) {
 			ids[len(ids)-1] = ids[0]
 			got[j] = ids
 		}
-		sort.Sort(ordered.BySliceValues(got))
+		ordered.BySliceValues(got)
 		var matched bool
 		for _, want := range test.want {
 			if reflect.DeepEqual(got, want) {

--- a/graph/topo/tarjan.go
+++ b/graph/topo/tarjan.go
@@ -6,7 +6,6 @@ package topo
 
 import (
 	"fmt"
-	"sort"
 
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
@@ -30,7 +29,7 @@ func (e Unorderable) Error() string {
 	return fmt.Sprintf("topo: no topological ordering: cyclic components: %v", [][]graph.Node(e))
 }
 
-func lexical(nodes []graph.Node) { sort.Sort(ordered.ByID(nodes)) }
+func lexical(nodes []graph.Node) { ordered.ByID(nodes) }
 
 // Sort performs a topological sort of the directed graph g returning the 'from' to 'to'
 // sort order. If a topological ordering is not possible, an Unorderable error is returned

--- a/graph/topo/tarjan_test.go
+++ b/graph/topo/tarjan_test.go
@@ -6,7 +6,6 @@ package topo
 
 import (
 	"reflect"
-	"sort"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -179,11 +178,11 @@ func TestTarjanSCC(t *testing.T) {
 			for j, id := range scc {
 				gotIDs[i][j] = id.ID()
 			}
-			sort.Sort(ordered.Int64s(gotIDs[i]))
+			ordered.Int64s(gotIDs[i])
 		}
 		for _, iv := range test.ambiguousOrder {
-			sort.Sort(ordered.BySliceValues(test.want[iv.start:iv.end]))
-			sort.Sort(ordered.BySliceValues(gotIDs[iv.start:iv.end]))
+			ordered.BySliceValues(test.want[iv.start:iv.end])
+			ordered.BySliceValues(gotIDs[iv.start:iv.end])
 		}
 		if !reflect.DeepEqual(gotIDs, test.want) {
 			t.Errorf("unexpected Tarjan scc result for %d:\n\tgot:%v\n\twant:%v", i, gotIDs, test.want)

--- a/graph/topo/topo.go
+++ b/graph/topo/topo.go
@@ -5,8 +5,6 @@
 package topo
 
 import (
-	"sort"
-
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/traverse"
@@ -82,8 +80,8 @@ func Equal(a, b graph.Graph) bool {
 
 	aNodeSlice := graph.NodesOf(aNodes)
 	bNodeSlice := graph.NodesOf(bNodes)
-	sort.Sort(ordered.ByID(aNodeSlice))
-	sort.Sort(ordered.ByID(bNodeSlice))
+	ordered.ByID(aNodeSlice)
+	ordered.ByID(bNodeSlice)
 	for i, aU := range aNodeSlice {
 		id := aU.ID()
 		if id != bNodeSlice[i].ID() {
@@ -98,8 +96,8 @@ func Equal(a, b graph.Graph) bool {
 
 		aAdjacent := graph.NodesOf(toA)
 		bAdjacent := graph.NodesOf(toB)
-		sort.Sort(ordered.ByID(aAdjacent))
-		sort.Sort(ordered.ByID(bAdjacent))
+		ordered.ByID(aAdjacent)
+		ordered.ByID(bAdjacent)
 		for i, aV := range aAdjacent {
 			id := aV.ID()
 			if id != bAdjacent[i].ID() {

--- a/graph/topo/topo_test.go
+++ b/graph/topo/topo_test.go
@@ -6,7 +6,6 @@ package topo
 
 import (
 	"reflect"
-	"sort"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -164,10 +163,10 @@ func TestConnectedComponents(t *testing.T) {
 			for k, n := range c {
 				ids[k] = n.ID()
 			}
-			sort.Sort(ordered.Int64s(ids))
+			ordered.Int64s(ids)
 			got[j] = ids
 		}
-		sort.Sort(ordered.BySliceValues(got))
+		ordered.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexpected connected components for test %d %T:\ngot: %v\nwant:%v", i, g, got, test.want)
 		}

--- a/graph/traverse/traverse_test.go
+++ b/graph/traverse/traverse_test.go
@@ -7,7 +7,6 @@ package traverse
 import (
 	"fmt"
 	"reflect"
-	"sort"
 	"strings"
 	"testing"
 
@@ -172,7 +171,7 @@ func TestBreadthFirst(t *testing.T) {
 			t.Errorf("unexpected final node for test %d:\ngot:  %v\nwant: %v", i, final, test.final)
 		}
 		for _, l := range got {
-			sort.Sort(ordered.Int64s(l))
+			ordered.Int64s(l)
 		}
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexpected BFS level structure for test %d:\ngot:  %v\nwant: %v", i, got, test.want)
@@ -372,10 +371,10 @@ func TestWalkAll(t *testing.T) {
 				for k, n := range c {
 					ids[k] = n.ID()
 				}
-				sort.Sort(ordered.Int64s(ids))
+				ordered.Int64s(ids)
 				got[j] = ids
 			}
-			sort.Sort(ordered.BySliceValues(got))
+			ordered.BySliceValues(got)
 			if !reflect.DeepEqual(got, test.want) {
 				t.Errorf("unexpected connected components for test %d using %T:\ngot: %v\nwant:%v", i, w, got, test.want)
 			}


### PR DESCRIPTION
Largely mechanical changes, but some manual replacements in graph/internal/ordered — all obvious.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
