### PR TITLE
lapack/{gonum,testlapack}: apply semgrep-go suggestions

### DIFF
--- a/lapack/gonum/dtrexc.go
+++ b/lapack/gonum/dtrexc.go
@@ -174,12 +174,12 @@ func (impl Implementation) Dtrexc(compq lapack.UpdateSchurComp, n int, t []float
 		here := ifst
 		for here > ilst {
 			// Swap block with next one above.
+			nbnext := 1
+			if here >= 2 && t[(here-1)*ldt+here-2] != 0 {
+				nbnext = 2
+			}
 			if nbf == 1 || nbf == 2 {
 				// Current block either 1×1 or 2×2.
-				nbnext := 1
-				if here-2 >= 0 && t[(here-1)*ldt+here-2] != 0 {
-					nbnext = 2
-				}
 				ok = impl.Dlaexc(wantq, n, t, ldt, q, ldq, here-nbnext, nbnext, nbf, work)
 				if !ok {
 					return ifst, here, false
@@ -194,10 +194,6 @@ func (impl Implementation) Dtrexc(compq lapack.UpdateSchurComp, n int, t []float
 
 			// Current block consists of two 1×1 blocks each of
 			// which must be swapped individually.
-			nbnext := 1
-			if here-2 >= 0 && t[(here-1)*ldt+here-2] != 0 {
-				nbnext = 2
-			}
 			ok = impl.Dlaexc(wantq, n, t, ldt, q, ldq, here-nbnext, nbnext, 1, work)
 			if !ok {
 				return ifst, here, false

--- a/lapack/testlapack/dtrexc.go
+++ b/lapack/testlapack/dtrexc.go
@@ -175,7 +175,7 @@ func dtrexcTest(t *testing.T, impl Dtrexcer, rnd *rand.Rand, n, ifst, ilst, extr
 			if modMin <= j && j < modMax {
 				continue
 			}
-			if q.Data[i*q.Stride+j]-qCopy.Data[i*qCopy.Stride+j] != 0 {
+			if q.Data[i*q.Stride+j] != qCopy.Data[i*qCopy.Stride+j] {
 				t.Errorf("%v: unexpected modification of Q[%v,%v]", name, i, j)
 			}
 		}


### PR DESCRIPTION
Please take a look. See https://github.com/dgryski/semgrep-go.

I did not apply many of the other `Odd comparison` semgrep go suggestions because they seemed to detract from readability. Worth looking into some of the `MarshalJSON` suggestions though:

<details><summary>semgrep-go output</summary>

```
/gonum$ semgrep -f ~/src/misc/semgrep-go/ .
Running 45 rules...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|45/45
blas/gonum/level2cmplx128.go
severity:error rule:home.pato.src.misc.semgrep-go.odd-comparison: Odd comparison
2070:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2081:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2129:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2141:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2310:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2322:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2370:					if n-j-1 > 0 {
--------------------------------------------------------------------------------
2381:					if n-j-1 > 0 {
--------------------------------------------------------------------------------
2543:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2553:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2594:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2605:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2755:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2766:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2809:					if n-j-1 > 0 {
--------------------------------------------------------------------------------
2819:					if n-j-1 > 0 {

blas/gonum/level2cmplx64.go
severity:error rule:home.pato.src.misc.semgrep-go.odd-comparison: Odd comparison
2100:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2111:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2159:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2171:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2342:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2354:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2402:					if n-j-1 > 0 {
--------------------------------------------------------------------------------
2413:					if n-j-1 > 0 {
--------------------------------------------------------------------------------
2577:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2587:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2628:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2639:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2791:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2802:					if n-i-1 > 0 {
--------------------------------------------------------------------------------
2845:					if n-j-1 > 0 {
--------------------------------------------------------------------------------
2855:					if n-j-1 > 0 {

blas/gonum/level2float32.go
severity:error rule:home.pato.src.misc.semgrep-go.odd-comparison: Odd comparison
1307:				if i-k < 0 {
--------------------------------------------------------------------------------
1326:			if i-k < 0 {
--------------------------------------------------------------------------------
1351:				if i-k < 0 {
--------------------------------------------------------------------------------
1368:			if i-k < 0 {

blas/gonum/level2float64.go
severity:error rule:home.pato.src.misc.semgrep-go.odd-comparison: Odd comparison
1287:				if i-k < 0 {
--------------------------------------------------------------------------------
1306:			if i-k < 0 {
--------------------------------------------------------------------------------
1331:				if i-k < 0 {
--------------------------------------------------------------------------------
1348:			if i-k < 0 {

blas/testblas/common.go
severity:error rule:home.pato.src.misc.semgrep-go.odd-comparison: Odd comparison
191:		if i-kl < 0 {

graph/flow/control_flow_bench_test.go
severity:error rule:home.pato.src.misc.semgrep-go.os-error-handling-functions: New code should use errors.Is with the appropriate error type
34:		if os.IsNotExist(err) {

graph/formats/cytoscapejs/cytoscapejs.go
severity:error rule:home.pato.src.misc.semgrep-go.marshal-json-pointer-receiver: MarshalJSON with a pointer receiver has surprising results: https://github.com/golang/go/issues/22967
86:func (e *ElemData) MarshalJSON() ([]byte, error) {
--------------------------------------------------------------------------------
193:func (n *NodeData) MarshalJSON() ([]byte, error) {
--------------------------------------------------------------------------------
256:func (e *EdgeData) MarshalJSON() ([]byte, error) {

graph/formats/dot/internal/lexer/lexer.go
severity:error rule:home.pato.src.misc.semgrep-go.deprecated-ioutil-readfile: ioutil.ReadFile is deprecated
autofix: os.ReadFile(fpath)
46:	src, err := ioutil.ReadFile(fpath)

graph/formats/dot/internal/lexer/lexer_test.go
severity:error rule:home.pato.src.misc.semgrep-go.os-error-handling-functions: New code should use errors.Is with the appropriate error type
60:		if os.IsNotExist(err) {

graph/formats/dot/internal/parser/parser_test.go
severity:error rule:home.pato.src.misc.semgrep-go.os-error-handling-functions: New code should use errors.Is with the appropriate error type
93:		if os.IsNotExist(err) {

graph/formats/rdf/urna_test.go
severity:error rule:home.pato.src.misc.semgrep-go.os-error-handling-functions: New code should use errors.Is with the appropriate error type
44:					if !os.IsNotExist(err) {

graph/formats/sigmajs/sigmajs.go
severity:error rule:home.pato.src.misc.semgrep-go.marshal-json-pointer-receiver: MarshalJSON with a pointer receiver has surprising results: https://github.com/golang/go/issues/22967
34:func (n *Node) MarshalJSON() ([]byte, error) {
--------------------------------------------------------------------------------
80:func (e *Edge) MarshalJSON() ([]byte, error) {

graph/path/floydwarshall.go
severity:error rule:home.pato.src.misc.semgrep-go.odd-comparison: Odd comparison
51:				} else if ij-joint == 0 {

lapack/gonum/dlaexc.go
severity:error rule:home.pato.src.misc.semgrep-go.odd-comparison: Odd comparison
91:		if n-j3 > 0 {
--------------------------------------------------------------------------------
241:		if n-j1-2 > 0 {
--------------------------------------------------------------------------------
259:		if n-j3-2 > 0 {

lapack/gonum/dlasq5.go
severity:error rule:home.pato.src.misc.semgrep-go.odd-comparison: Odd comparison
28:	if n0-i0-1 <= 0 {

lapack/gonum/dlasq6.go
severity:error rule:home.pato.src.misc.semgrep-go.odd-comparison: Odd comparison
27:	if n0-i0-1 <= 0 {

lapack/gonum/dlauum.go
severity:error rule:home.pato.src.misc.semgrep-go.odd-comparison: Odd comparison
59:			if n-i-ib > 0 {
--------------------------------------------------------------------------------
73:			if n-i-ib > 0 {

lapack/gonum/dtrevc3.go
severity:error rule:home.pato.src.misc.semgrep-go.odd-comparison: Odd comparison
491:				if ki-1 > 0 {
--------------------------------------------------------------------------------
684:				if n-ki-1 > 0 {
--------------------------------------------------------------------------------
807:				if n-ki-2 > 0 {

lapack/testlapack/dggsvd3.go
severity:error rule:home.pato.src.misc.semgrep-go.odd-comparison: Odd comparison
133:		if m-k-l >= 0 {

lapack/testlapack/dlahqr.go
severity:error rule:home.pato.src.misc.semgrep-go.odd-comparison: Odd comparison
49:						if ilo-1 >= 0 {
--------------------------------------------------------------------------------
140:					if test.ilo-1 >= 0 {

lapack/testlapack/dlaqr04.go
severity:error rule:home.pato.src.misc.semgrep-go.odd-comparison: Odd comparison
52:							if ilo-1 >= 0 {
--------------------------------------------------------------------------------
164:					if test.ilo-1 >= 0 {

lapack/testlapack/dlaqr23.go
severity:error rule:home.pato.src.misc.semgrep-go.odd-comparison: Odd comparison
54:	if ktop-1 >= 0 {

lapack/testlapack/dtgsja.go
severity:error rule:home.pato.src.misc.semgrep-go.odd-comparison: Odd comparison
125:		if m-k-l >= 0 {

stat/card/hll32.go
severity:error rule:home.pato.src.misc.semgrep-go.err-nil-check: superfluous nil err check before return
214:	if err != nil {
215:		return err
216:	}
217:	return nil

stat/card/hll64.go
severity:error rule:home.pato.src.misc.semgrep-go.err-nil-check: superfluous nil err check before return
216:	if err != nil {
217:		return err
218:	}
219:	return nil
ran 45 rules on 1291 files: 71 findings

```

</details>