### PR TITLE
graph/formats/rdf: add Has{All,Any}{Out,In} and Repeat query methods

### DIFF
--- a/graph/formats/rdf/graph_example_test.go
+++ b/graph/formats/rdf/graph_example_test.go
@@ -154,17 +154,15 @@ func ExampleQuery() {
 	}
 
 	// g.V().has('name', 'heracles').repeat(out('father')).emit().values('name')
-	q := heracles
-	for i := 0; ; i++ {
+	var i int
+	heracles.Repeat(func(q rdf.Query) (rdf.Query, bool) {
 		q = q.Out(father)
-		results := q.Out(name).Result()
-		if len(results) == 0 {
-			break
-		}
-		for _, r := range results {
+		for _, r := range q.Out(name).Result() {
 			fmt.Printf("Heracles' lineage %d: %s\n", i, r.Value)
 		}
-	}
+		i++
+		return q, true
+	})
 
 	// parents and typ are helper filters for queries below.
 	parents := func(s *rdf.Statement) bool {

--- a/graph/formats/rdf/query.go
+++ b/graph/formats/rdf/query.go
@@ -232,6 +232,29 @@ func (q Query) Not(p Query) Query {
 	return r
 }
 
+// Repeat repeatedly calls fn on q until the set of results is empty or
+// ok is false, and then returns the result. If the last non-empty result
+// is wanted, fn should return its input and false when the partial
+// traversal returns an empty result.
+//
+// 	result := start.Repeat(func(q rdf.Query) (rdf.Query, bool) {
+// 		r := q.Out(condition)
+// 		if r.Len() == 0 {
+// 			return q, false
+// 		}
+// 		return r, true
+// 	}).Result()
+//
+func (q Query) Repeat(fn func(Query) (q Query, ok bool)) Query {
+	for {
+		var ok bool
+		q, ok = fn(q)
+		if !ok || len(q.terms) == 0 {
+			return q
+		}
+	}
+}
+
 // Unique returns a copy of the receiver that contains only one instance
 // of each term.
 func (q Query) Unique() Query {
@@ -243,6 +266,11 @@ func (q Query) Unique() Query {
 		}
 	}
 	return r
+}
+
+// Len returns the number of terms held by the query.
+func (q Query) Len() int {
+	return len(q.terms)
 }
 
 // Result returns the terms held by the query.


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
