### PR TITLE
spatial/r3: use array conversion in safe code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # Do not move this line; it is referred to by README.md.
         # Versions of Go that are explicitly supported by Gonum.
-        go-version: [1.17.x, 1.16.x]
+        go-version: [1.17.x]
         platform: [ubuntu-latest, macos-latest]
         force-goarch: ["", "386"]
         tags: 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.merged == true
     strategy:
       matrix:
-        go-version: [1.17.x, 1.16.x]
+        go-version: [1.17.x]
         platform: [ubuntu-latest]
         tags: 
           - ""

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2.3.0
+        uses: golangci/golangci-lint-action@v2.5.2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.34
+          version: v1.44.2
           only-new-issues: true
           args: --timeout=5m

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ build: off
 
 image: Visual Studio 2019
 
-stack: go 1.16
+stack: go 1.17
 
 clone_folder: c:\gopath\src\gonum.org\v1\gonum
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gonum.org/v1/gonum
 
-go 1.14
+go 1.17
 
 require (
 	github.com/google/go-cmp v0.5.7

--- a/spatial/r3/mat_safe.go
+++ b/spatial/r3/mat_safe.go
@@ -127,14 +127,8 @@ func (m *Mat) RawMatrix() blas64.General {
 	return blas64.General{Rows: 3, Cols: 3, Data: m.data[:], Stride: 3}
 }
 
-// BUG(kortschak): Implementing NewMat without unsafe conversion or slice to
-// array pointer conversion leaves it with semantics that do not match the
-// sharing semantics that exist in the mat package.
 func arrayFrom(vals []float64) *array {
-	// TODO(kortschak): Use array conversion when go1.16 is no longer supported.
-	var a array
-	copy(a[:], vals)
-	return &a
+	return (*array)(vals)
 }
 
 // Mat returns a 3×3 rotation matrix corresponding to the receiver. It

--- a/spatial/r3/mat_unsafe.go
+++ b/spatial/r3/mat_unsafe.go
@@ -140,7 +140,6 @@ func (r Rotation) Mat() *Mat {
 }
 
 func arrayFrom(vals []float64) *array {
-	// TODO(kortschak): Use array conversion when go1.16 is no longer supported.
 	return (*array)(unsafe.Pointer(&vals[0]))
 }
 


### PR DESCRIPTION
This is the only Go version dependent change that needs to be made prior to the next release. Sadly, the unsafe conversion needs to remain in the unsafe path, otherwise we could have collapsed it back to a single file.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
