### PR TITLE
ci: add go1.18 go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # Do not move this line; it is referred to by README.md.
         # Versions of Go that are explicitly supported by Gonum.
-        go-version: [1.17.x]
+        go-version: [1.18.x, 1.17.x]
         platform: [ubuntu-latest, macos-latest]
         force-goarch: ["", "386"]
         tags: 

--- a/.github/workflows/script.d/deps.sh
+++ b/.github/workflows/script.d/deps.sh
@@ -2,25 +2,15 @@
 
 set -ex
 
-# Avoid contaminating the go.mod/go.sum files.
-# TODO(kortschak): Remove when golang/go#30515 is resolved
-WORK=$(mktemp -d)
-pushd $WORK
-
 # Required for format check.
-go get golang.org/x/tools/cmd/goimports
+go install golang.org/x/tools/cmd/goimports@latest
 # Required for imports check.
-go get gonum.org/v1/tools/cmd/check-imports
+go install gonum.org/v1/tools/cmd/check-imports@latest
 # Required for copyright header check.
-go get gonum.org/v1/tools/cmd/check-copyright
+go install gonum.org/v1/tools/cmd/check-copyright@latest
 # Required for coverage.
-go get golang.org/x/tools/cmd/cover
+go install golang.org/x/tools/cmd/cover@latest
 # Required for dot parser checks.
-go get github.com/goccmack/gocc@66c61e9
+go install github.com/goccmack/gocc@66c61e9
 # Required for rdf parser checks.
-go get golang.org/x/tools/cmd/stringer
-
-# Clean up.
-# TODO(kortschak): Remove when golang/go#30515 is resolved.
-popd
-rm -rf $WORK
+go install golang.org/x/tools/cmd/stringer@latest


### PR DESCRIPTION
This will be v0.11.0 when it is merged, with the release text posted at [gonum-dev](https://groups.google.com/g/gonum-dev/c/hdYiSkcH9Q8/m/H9p1Y1sjAgAJ); make suggestions for change to that text at gonum-dev.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
