### PR TITLE
num/quat: add PowReal function

### DIFF
--- a/num/quat/exp.go
+++ b/num/quat/exp.go
@@ -55,10 +55,28 @@ func Pow(q, r Number) Number {
 	return Exp(Mul(Log(q), r))
 }
 
+// PowReal return q**r, the base-q exponential of r.
+// For generalized compatibility with math.Pow:
+//      PowReal(0, ±0) returns 1+0i+0j+0k
+//      PowReal(0, c) for c<0 returns Inf+0i+0j+0k.
+func PowReal(q Number, r float64) Number {
+	if q == zero {
+		switch {
+		case r == 0:
+			return Number{Real: 1}
+		case r < 0:
+			return Inf()
+		case r > 0:
+			return zero
+		}
+	}
+	return Exp(Scale(r, Log(q)))
+}
+
 // Sqrt returns the square root of q.
 func Sqrt(q Number) Number {
 	if q == zero {
 		return zero
 	}
-	return Pow(q, Number{Real: 0.5})
+	return PowReal(q, 0.5)
 }

--- a/num/quat/exp_test.go
+++ b/num/quat/exp_test.go
@@ -190,6 +190,99 @@ func TestPow(t *testing.T) {
 	}
 }
 
+var powRealTests = []struct {
+	q    Number
+	r    float64
+	want Number
+}{
+	{q: Number{}, r: 0, want: Number{Real: 1}},
+	{
+		q: Number{Real: 1, Imag: 1, Jmag: 1, Kmag: 1}, r: 2,
+		want: Number{Real: -2, Imag: 2, Jmag: 2, Kmag: 2},
+	},
+	{
+		q: Number{Real: 1, Imag: 0, Jmag: 1, Kmag: 1}, r: 2,
+		want: Number{Real: -1, Imag: 0, Jmag: 2, Kmag: 2},
+	},
+	{
+		q: Number{Real: 1, Imag: 0, Jmag: 0, Kmag: 1}, r: 2,
+		want: Number{Real: 0, Imag: 0, Jmag: 0, Kmag: 2},
+	},
+	{
+		q: Number{Real: 0, Imag: 1, Jmag: 1, Kmag: 1}, r: 2,
+		want: Number{Real: -3, Imag: 0, Jmag: 0, Kmag: 0},
+	},
+	{
+		q: Number{Real: 0, Imag: 0, Jmag: 1, Kmag: 1}, r: 2,
+		want: Number{Real: -2, Imag: 0, Jmag: 0, Kmag: 0},
+	},
+	{
+		q: Number{Real: 0, Imag: 0, Jmag: 0, Kmag: 1}, r: 2,
+		want: Number{Real: -1, Imag: 0, Jmag: 0, Kmag: 0},
+	},
+
+	{
+		q: Number{Real: 1, Imag: 1, Jmag: 1, Kmag: 1}, r: math.Pi,
+		want: Number{Real: -8.728144138959564, Imag: -0.7527136547040768, Jmag: -0.7527136547040768, Kmag: -0.7527136547040768},
+	},
+	{
+		q: Number{Real: 1, Imag: 0, Jmag: 1, Kmag: 1}, r: math.Pi,
+		want: Number{Real: -5.561182514695044, Imag: 0, Jmag: 0.5556661490713818, Kmag: 0.5556661490713818},
+	},
+	{
+		q: Number{Real: 1, Imag: 0, Jmag: 0, Kmag: 1}, r: math.Pi,
+		want: Number{Real: -2.320735561810013, Imag: 0, Jmag: 0, Kmag: 1.8544983901925216},
+	},
+	{
+		q: Number{Real: 0, Imag: 1, Jmag: 1, Kmag: 1}, r: math.Pi,
+		want: Number{Real: 1.2388947209955585, Imag: -3.162774128856231, Jmag: -3.162774128856231, Kmag: -3.162774128856231},
+	},
+	{
+		q: Number{Real: 0, Imag: 0, Jmag: 1, Kmag: 1}, r: math.Pi,
+		want: Number{Real: 0.6552860151073727, Imag: 0, Jmag: -2.0488506614051922, Kmag: -2.0488506614051922},
+	},
+	{
+		q: Number{Real: 0, Imag: 0, Jmag: 0, Kmag: 1}, r: math.Pi,
+		want: Number{Real: 0.22058404074969779, Imag: 0, Jmag: 0, Kmag: -0.9753679720836315},
+	},
+
+	{
+		q: Number{Real: 1, Imag: 1, Jmag: 1, Kmag: 1}, r: 3,
+		want: Number{Real: -8, Imag: 0, Jmag: 0, Kmag: 0},
+	},
+	{
+		q: Number{Real: 1, Imag: 0, Jmag: 1, Kmag: 1}, r: 3,
+		want: Number{Real: -5, Imag: 0, Jmag: 1, Kmag: 1},
+	},
+	{
+		q: Number{Real: 1, Imag: 0, Jmag: 0, Kmag: 1}, r: 3,
+		want: Number{Real: -2, Imag: 0, Jmag: 0, Kmag: 2},
+	},
+	{
+		q: Number{Real: 0, Imag: 1, Jmag: 1, Kmag: 1}, r: 3,
+		want: Number{Real: 0, Imag: -3, Jmag: -3, Kmag: -3},
+	},
+	{
+		q: Number{Real: 0, Imag: 0, Jmag: 1, Kmag: 1}, r: 3,
+		want: Number{Real: 0, Imag: 0, Jmag: -2, Kmag: -2},
+	},
+	{
+		q: Number{Real: 0, Imag: 0, Jmag: 0, Kmag: 1}, r: 3,
+		want: Number{Real: 0, Imag: 0, Jmag: 0, Kmag: -1},
+	},
+}
+
+func TestRealPow(t *testing.T) {
+	t.Parallel()
+	const tol = 1e-14
+	for _, test := range powRealTests {
+		got := PowReal(test.q, test.r)
+		if !equalApprox(got, test.want, tol) {
+			t.Errorf("unexpected result for Pow(%v, %v): got:%v want:%v", test.q, test.r, got, test.want)
+		}
+	}
+}
+
 var sqrtTests = []struct {
 	q    Number
 	want Number


### PR DESCRIPTION
This brings the quat package into line with the others in num, which already have `PowReal`. See https://github.com/gonum/gonum/pull/1805#discussion_r878771435 for motivation.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
