### PR TITLE
spatial/r3: Skew is now method

### DIFF
--- a/spatial/r3/mat.go
+++ b/spatial/r3/mat.go
@@ -197,3 +197,20 @@ func (m *Mat) Det() float64 {
 	detc := m.At(1, 0)*m.At(2, 1) - m.At(1, 1)*m.At(2, 0)
 	return a*deta - b*detb + c*detc
 }
+
+// Skew sets the receiver to the 3×3 skew symmetric matrix
+// (right hand system) of v.
+//                  ⎡ 0 -z  y⎤
+//  Skew({x,y,z}) = ⎢ z  0 -x⎥
+//                  ⎣-y  x  0⎦
+func (m *Mat) Skew(v Vec) {
+	m.Set(0, 0, 0)
+	m.Set(0, 1, -v.Z)
+	m.Set(0, 2, v.Y)
+	m.Set(1, 0, v.Z)
+	m.Set(1, 1, 0)
+	m.Set(1, 2, -v.X)
+	m.Set(2, 0, -v.Y)
+	m.Set(2, 1, v.X)
+	m.Set(2, 2, 0)
+}

--- a/spatial/r3/mat_safe.go
+++ b/spatial/r3/mat_safe.go
@@ -60,6 +60,8 @@ func Eye() *Mat {
 //                  ⎡ 0 -z  y⎤
 //  Skew({x,y,z}) = ⎢ z  0 -x⎥
 //                  ⎣-y  x  0⎦
+//
+// DEPRECATED: use Mat.Skew()
 func Skew(v Vec) (M *Mat) {
 	return &Mat{&array{
 		0, -v.Z, v.Y,

--- a/spatial/r3/mat_test.go
+++ b/spatial/r3/mat_test.go
@@ -103,9 +103,10 @@ func TestSkew(t *testing.T) {
 	const tol = 1e-16
 	rnd := rand.New(rand.NewSource(1))
 	for tc := 0; tc < 20; tc++ {
+		sk := NewMat(nil)
 		v1 := randomVec(rnd)
 		v2 := randomVec(rnd)
-		sk := Skew(v1)
+		sk.Skew(v1)
 		want := Cross(v1, v2)
 		got := sk.MulVec(v2)
 		if d := want.Sub(got); d.Dot(d) > tol {

--- a/spatial/r3/mat_unsafe.go
+++ b/spatial/r3/mat_unsafe.go
@@ -47,6 +47,8 @@ func Eye() *Mat {
 //                  ⎡ 0 -z  y⎤
 //  Skew({x,y,z}) = ⎢ z  0 -x⎥
 //                  ⎣-y  x  0⎦
+//
+// DEPRECATED: use Mat.Skew()
 func Skew(v Vec) (M *Mat) {
 	return &Mat{&array{
 		{0, -v.Z, v.Y},


### PR DESCRIPTION
I understand this has not been talked about, but it's clearly bad API design in my eyes. What do y'all think?

Changes:
* deprecate Skew package level function in favor of method to prevent heap allocations
