### PR TITLE
spatial/r3: fix deprecation syntax so it is recognised by pkgsite

### DIFF
--- a/spatial/r3/mat_safe.go
+++ b/spatial/r3/mat_safe.go
@@ -62,7 +62,7 @@ func Eye() *Mat {
 //	Skew({x,y,z}) = ⎢ z  0 -x⎥
 //	                ⎣-y  x  0⎦
 //
-// DEPRECATED: use Mat.Skew()
+// Deprecated: use Mat.Skew()
 func Skew(v Vec) (M *Mat) {
 	return &Mat{&array{
 		0, -v.Z, v.Y,

--- a/spatial/r3/mat_unsafe.go
+++ b/spatial/r3/mat_unsafe.go
@@ -49,7 +49,7 @@ func Eye() *Mat {
 //	Skew({x,y,z}) = ⎢ z  0 -x⎥
 //	                ⎣-y  x  0⎦
 //
-// DEPRECATED: use Mat.Skew()
+// Deprecated: use Mat.Skew()
 func Skew(v Vec) (M *Mat) {
 	return &Mat{&array{
 		{0, -v.Z, v.Y},


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
