### PR TITLE
mat: fixed typo in mat.Solve/mat.SolveVec

### DIFF
--- a/mat/solve.go
+++ b/mat/solve.go
@@ -14,7 +14,7 @@ import (
 //
 //	minimize over x |b - A*x|_2
 //
-// where A is an m×n matrix A, b is a given m element vector and x is n element
+// where A is an m×n matrix, b is a given m element vector and x is n element
 // solution vector. Solve assumes that A has full rank, that is
 //
 //	rank(A) = min(m,n)
@@ -121,7 +121,7 @@ func (m *Dense) Solve(a, b Matrix) error {
 //
 //	minimize over x |b - A*x|_2
 //
-// where A is an m×n matrix A, b is a given m element vector and x is n element
+// where A is an m×n matrix, b is a given m element vector and x is n element
 // solution vector. Solve assumes that A has full rank, that is
 //
 //	rank(A) = min(m,n)


### PR DESCRIPTION
It seems the extra `A` here is unintended.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
