### PR TITLE
graph/path: fix yen k-shortest path with root cycles

### DIFF
--- a/graph/path/yen_ksp.go
+++ b/graph/path/yen_ksp.go
@@ -5,6 +5,7 @@
 package path
 
 import (
+	"math"
 	"sort"
 
 	"gonum.org/v1/gonum/graph"
@@ -41,7 +42,9 @@ func YenKShortestPaths(g graph.Graph, k int, s, t graph.Node) [][]graph.Node {
 	var pot []yenShortest
 	var root []graph.Node
 	for i := int64(1); i < int64(k); i++ {
-		for n := 0; n < len(paths[i-1])-2; n++ {
+		// The spur node ranges from the first node to the next
+		// to last node in the previous k-shortest path.
+		for n := 0; n < len(paths[i-1])-1; n++ {
 			yk.reset()
 
 			spur := paths[i-1][n]
@@ -62,19 +65,24 @@ func YenKShortestPaths(g graph.Graph, k int, s, t graph.Node) [][]graph.Node {
 					yk.removeEdge(path[n].ID(), path[n+1].ID())
 				}
 			}
+			for _, u := range root[:len(root)-1] {
+				yk.removeNode(u.ID())
+			}
 
 			spath, weight := DijkstraFrom(spur, yk).To(t.ID())
+			if math.IsInf(weight, 1) {
+				continue
+			}
 			if len(root) > 1 {
 				var rootWeight float64
 				for x := 1; x < len(root); x++ {
 					w, _ := yk.weight(root[x-1].ID(), root[x].ID())
 					rootWeight += w
 				}
-				root = append(root[:len(root)-1], spath...)
-				pot = append(pot, yenShortest{root, weight + rootWeight})
-			} else {
-				pot = append(pot, yenShortest{spath, weight})
+				spath = append(root[:len(root)-1], spath...)
+				weight += rootWeight
 			}
+			pot = append(pot, yenShortest{spath, weight})
 		}
 
 		if len(pot) == 0 {
@@ -115,12 +123,19 @@ type yenKSPAdjuster struct {
 	// used for shortest path calculation.
 	weight Weighting
 
+	// visitedNodes holds the nodes that have
+	// been removed by Yen's algorithm.
+	visitedNodes map[int64]struct{}
+
 	// visitedEdges holds the edges that have
 	// been removed by Yen's algorithm.
 	visitedEdges map[[2]int64]struct{}
 }
 
 func (g yenKSPAdjuster) From(id int64) graph.Nodes {
+	if _, blocked := g.visitedNodes[id]; blocked {
+		return graph.Empty
+	}
 	nodes := graph.NodesOf(g.Graph.From(id))
 	for i := 0; i < len(nodes); {
 		if g.canWalk(id, nodes[i].ID()) {
@@ -130,22 +145,33 @@ func (g yenKSPAdjuster) From(id int64) graph.Nodes {
 		nodes[i] = nodes[len(nodes)-1]
 		nodes = nodes[:len(nodes)-1]
 	}
+	if len(nodes) == 0 {
+		return graph.Empty
+	}
 	return iterator.NewOrderedNodes(nodes)
 }
 
 func (g yenKSPAdjuster) canWalk(u, v int64) bool {
-	_, ok := g.visitedEdges[[2]int64{u, v}]
-	return !ok
+	if _, blocked := g.visitedNodes[v]; blocked {
+		return false
+	}
+	_, blocked := g.visitedEdges[[2]int64{u, v}]
+	return !blocked
+}
+
+func (g yenKSPAdjuster) removeNode(u int64) {
+	g.visitedNodes[u] = struct{}{}
 }
 
 func (g yenKSPAdjuster) removeEdge(u, v int64) {
 	g.visitedEdges[[2]int64{u, v}] = struct{}{}
-	if g.isDirected {
+	if !g.isDirected {
 		g.visitedEdges[[2]int64{v, u}] = struct{}{}
 	}
 }
 
 func (g *yenKSPAdjuster) reset() {
+	g.visitedNodes = make(map[int64]struct{})
 	g.visitedEdges = make(map[[2]int64]struct{})
 }
 

--- a/graph/path/yen_ksp_test.go
+++ b/graph/path/yen_ksp_test.go
@@ -171,6 +171,21 @@ var yenShortestPathTests = []struct {
 			{0, 1, 2, 5, 6},
 		},
 	},
+	{
+		name:  "clean_root", // This is the failing case in gonum/gonum#1778.
+		graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
+		edges: []simple.WeightedEdge{
+			{F: simple.Node(1), T: simple.Node(2), W: 4},
+			{F: simple.Node(1), T: simple.Node(3), W: 1},
+			{F: simple.Node(2), T: simple.Node(3), W: 4},
+		},
+		query: simple.Edge{F: simple.Node(1), T: simple.Node(2)},
+		k:     3,
+		wantPaths: [][]int64{
+			{1, 2},
+			{1, 3, 2},
+		},
+	},
 }
 
 func bipartite(n int, weight, inc float64) []simple.WeightedEdge {


### PR DESCRIPTION
Previously the code was not removing nodes on the root of the search path, resulting in searches that could re-enter previously searched nodes. In addition to this, the logic for making edges was incorrectly making both directions for digraphs and only one direction for undirected graphs.

Finally, the range of nodes to include in the spur-node set was off-by-one. This is now clarified by including the comment from the wiki article since the pseudo-code is less clear than the English due to choice of range indexing convention.

Please take a look.

Fixes #1778

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
