### PR TITLE
graph/encoding/graphql: note requirement of dst parameter

### DIFF
--- a/graph/encoding/graphql/decode.go
+++ b/graph/encoding/graphql/decode.go
@@ -17,7 +17,8 @@ import (
 // Unmarshal parses the JSON-encoded data and stores the result in dst.
 // Node IDs are obtained from the JSON fields identified by the uid parameter.
 // UIDs obtained from the JSON encoding must map to unique node ID values
-// consistently across the JSON-encoded spanning tree.
+// consistently across the JSON-encoded spanning tree. graph.Node values
+// returned by dst.NewNode must satisfy StringIDSetter.
 func Unmarshal(data []byte, uid string, dst encoding.Builder) error {
 	if uid == "" {
 		return errors.New("graphql: invalid UID field name")


### PR DESCRIPTION
The spanning tree walk sets nodes' IDs using the SetIDFromString method so note that nodes returned by the destination's NewNode method must satisfy StringIDSetter.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
