### PR TITLE
all: replace godoc.org with pkg.go.dev in badges and links

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@
 
 Alexander Egurnov <alexander.egurnov@gmail.com>
 Andrei Blinnikov <goofinator@mail.ru>
+antichris <chris@u-d13.com>
 Bill Gray <wgray@gogray.com>
 Bill Noon <noon.bill@gmail.com>
 Brendan Tracey <tracey.brendan@gmail.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Where possible, the source of algorithms should be referenced in the comments.
 
 Here are the current repositories for the Gonum project.
 If code you want to contribute doesn't quite fit in any of them, then please start a discussion on the [mailing list](https://groups.google.com/forum/#!forum/gonum-dev).
-Code can be found at [github.com/gonum/](https://github.com/gonum/)\<repo\>, and documentation at godoc.org/github.com/gonum/\<repo\>.
+Code can be found at [github.com/gonum/](https://github.com/gonum/)\<repo\>, and documentation at gonum.org/v1/\<repo\>.
 
 * [gonum](https://github.com/gonum/gonum) — The gonum repository contains the majority of Gonum packages
 * [plot](https://github.com/gonum/plot) — A repository for plotting and visualizing data
@@ -80,7 +80,7 @@ Pull requests should include tests for any new code before merging.
 It is ok to start a pull request on partially implemented code to get feedback, and see if your approach to a problem is sound.
 You don't need to have tests, or even have code that compiles to open a pull request, although both will be needed before merge.
 When tests use magic numbers, please include a comment explaining the source of the number.
-Benchmarks are optional for new features, but if you are submitting a pull request justified by performance improvement, you will need benchmarks to measure the impact of your change, and the pull request should include a report from [benchcmp](https://godoc.org/golang.org/x/tools/cmd/benchcmp) or, preferably, [benchstat](https://github.com/rsc/benchstat).
+Benchmarks are optional for new features, but if you are submitting a pull request justified by performance improvement, you will need benchmarks to measure the impact of your change, and the pull request should include a report from [benchcmp](https://pkg.go.dev/golang.org/x/tools/cmd/benchcmp) or, preferably, [benchstat](https://github.com/rsc/benchstat).
 
 ### Code Review
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -18,6 +18,7 @@
 Alexander Egurnov <alexander.egurnov@gmail.com>
 Andrei Blinnikov <goofinator@mail.ru>
 Andrew Brampton <brampton@gmail.com>
+antichris <chris@u-d13.com>
 Bill Gray <wgray@gogray.com>
 Bill Noon <noon.bill@gmail.com>
 Brendan Tracey <tracey.brendan@gmail.com>

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The current list of non-internal tags is as follows:
 - safe — do not use assembly or unsafe
 - bounds — use bounds checks even in internal calls
 - noasm — do not use assembly implementations
-- tomita — use [Tomita, Tanaka, Takahashi pivot choice](https://doi.org/10.1016%2Fj.tcs.2006.06.015) for maximimal clique calculation, otherwise use random pivot (only in [topo package](https://godoc.org/gonum.org/v1/gonum/graph/topo))
+- tomita — use [Tomita, Tanaka, Takahashi pivot choice](https://doi.org/10.1016%2Fj.tcs.2006.06.015) for maximimal clique calculation, otherwise use random pivot (only in [topo package](https://pkg.go.dev/gonum.org/v1/gonum/graph/topo))
 
 
 ## Issues [![TODOs](https://badgen.net/https/api.tickgit.com/badgen/github.com/gonum/gonum)](https://www.tickgit.com/browse?repo=github.com/gonum/gonum)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/valslkp8sr50eepn/branch/master?svg=true)](https://ci.appveyor.com/project/Gonum/gonum/branch/master)
 [![codecov.io](https://codecov.io/gh/gonum/gonum/branch/master/graph/badge.svg)](https://codecov.io/gh/gonum/gonum)
 [![go.dev reference](https://pkg.go.dev/badge/gonum.org/v1/gonum)](https://pkg.go.dev/gonum.org/v1/gonum)
-[![GoDoc](https://godoc.org/gonum.org/v1/gonum?status.svg)](https://godoc.org/gonum.org/v1/gonum)
+[![GoDoc](https://godocs.io/gonum.org/v1/gonum?status.svg)](https://godocs.io/gonum.org/v1/gonum)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gonum/gonum)](https://goreportcard.com/report/github.com/gonum/gonum)
 [![stability-unstable](https://img.shields.io/badge/stability-unstable-yellow.svg)](https://github.com/emersion/stability-badges#unstable)
 

--- a/blas/README.md
+++ b/blas/README.md
@@ -1,4 +1,7 @@
-# Gonum BLAS [![GoDoc](https://godocs.io/gonum.org/v1/gonum/blas?status.svg)](https://godocs.io/gonum.org/v1/gonum/blas)
+# Gonum BLAS
+
+[![go.dev reference](https://pkg.go.dev/badge/gonum.org/v1/gonum/blas)](https://pkg.go.dev/gonum.org/v1/gonum/blas)
+[![GoDoc](https://godocs.io/gonum.org/v1/gonum/blas?status.svg)](https://godocs.io/gonum.org/v1/gonum/blas)
 
 A collection of packages to provide BLAS functionality for the [Go programming
 language](http://golang.org)

--- a/blas/README.md
+++ b/blas/README.md
@@ -1,4 +1,4 @@
-# Gonum BLAS [![GoDoc](https://godoc.org/gonum.org/v1/gonum/blas?status.svg)](https://godoc.org/gonum.org/v1/gonum/blas)
+# Gonum BLAS [![GoDoc](https://godocs.io/gonum.org/v1/gonum/blas?status.svg)](https://godocs.io/gonum.org/v1/gonum/blas)
 
 A collection of packages to provide BLAS functionality for the [Go programming
 language](http://golang.org)

--- a/cmplxs/README.md
+++ b/cmplxs/README.md
@@ -1,4 +1,7 @@
-# Gonum cmplxs [![GoDoc](https://godocs.io/gonum.org/v1/gonum/cmplxs?status.svg)](https://godocs.io/gonum.org/v1/gonum/cmplxs)
+# Gonum cmplxs
+
+[![go.dev reference](https://pkg.go.dev/badge/gonum.org/v1/gonum/cmplxs)](https://pkg.go.dev/gonum.org/v1/gonum/cmplxs)
+[![GoDoc](https://godocs.io/gonum.org/v1/gonum/cmplxs?status.svg)](https://godocs.io/gonum.org/v1/gonum/cmplxs)
 
 Package cmplxs provides a set of helper routines for dealing with slices of complex128.
 The functions avoid allocations to allow for use within tight loops without garbage collection overhead.

--- a/cmplxs/README.md
+++ b/cmplxs/README.md
@@ -1,4 +1,4 @@
-# Gonum cmplxs [![GoDoc](https://godoc.org/gonum.org/v1/gonum/cmplxs?status.svg)](https://godoc.org/gonum.org/v1/gonum/cmplxs)
+# Gonum cmplxs [![GoDoc](https://godocs.io/gonum.org/v1/gonum/cmplxs?status.svg)](https://godocs.io/gonum.org/v1/gonum/cmplxs)
 
 Package cmplxs provides a set of helper routines for dealing with slices of complex128.
 The functions avoid allocations to allow for use within tight loops without garbage collection overhead.

--- a/diff/README.md
+++ b/diff/README.md
@@ -1,3 +1,6 @@
-# Gonum diff [![GoDoc](https://godocs.io/gonum.org/v1/gonum/diff?status.svg)](https://godocs.io/gonum.org/v1/gonum/diff)
+# Gonum diff
+
+[![go.dev reference](https://pkg.go.dev/badge/gonum.org/v1/gonum/diff)](https://pkg.go.dev/gonum.org/v1/gonum/diff)
+[![GoDoc](https://godocs.io/gonum.org/v1/gonum/diff?status.svg)](https://godocs.io/gonum.org/v1/gonum/diff)
 
 Package diff is a package for computing derivatives of functions for the Go language.

--- a/diff/README.md
+++ b/diff/README.md
@@ -1,3 +1,3 @@
-# Gonum diff [![GoDoc](https://godoc.org/gonum.org/v1/gonum/diff?status.svg)](https://godoc.org/gonum.org/v1/gonum/diff)
+# Gonum diff [![GoDoc](https://godocs.io/gonum.org/v1/gonum/diff?status.svg)](https://godocs.io/gonum.org/v1/gonum/diff)
 
 Package diff is a package for computing derivatives of functions for the Go language.

--- a/floats/README.md
+++ b/floats/README.md
@@ -1,4 +1,4 @@
-# Gonum floats [![GoDoc](https://godoc.org/gonum.org/v1/gonum/floats?status.svg)](https://godoc.org/gonum.org/v1/gonum/floats)
+# Gonum floats [![GoDoc](https://godocs.io/gonum.org/v1/gonum/floats?status.svg)](https://godocs.io/gonum.org/v1/gonum/floats)
 
 Package floats provides a set of helper routines for dealing with slices of float64.
 The functions avoid allocations to allow for use within tight loops without garbage collection overhead.

--- a/floats/README.md
+++ b/floats/README.md
@@ -1,4 +1,7 @@
-# Gonum floats [![GoDoc](https://godocs.io/gonum.org/v1/gonum/floats?status.svg)](https://godocs.io/gonum.org/v1/gonum/floats)
+# Gonum floats
+
+[![go.dev reference](https://pkg.go.dev/badge/gonum.org/v1/gonum/floats)](https://pkg.go.dev/gonum.org/v1/gonum/floats)
+[![GoDoc](https://godocs.io/gonum.org/v1/gonum/floats?status.svg)](https://godocs.io/gonum.org/v1/gonum/floats)
 
 Package floats provides a set of helper routines for dealing with slices of float64.
 The functions avoid allocations to allow for use within tight loops without garbage collection overhead.

--- a/graph/README.md
+++ b/graph/README.md
@@ -1,3 +1,6 @@
-# Gonum graph [![GoDoc](https://godocs.io/gonum.org/v1/gonum/graph?status.svg)](https://godocs.io/gonum.org/v1/gonum/graph)
+# Gonum graph
+
+[![go.dev reference](https://pkg.go.dev/badge/gonum.org/v1/gonum/graph)](https://pkg.go.dev/gonum.org/v1/gonum/graph)
+[![GoDoc](https://godocs.io/gonum.org/v1/gonum/graph?status.svg)](https://godocs.io/gonum.org/v1/gonum/graph)
 
 This is a generalized graph package for the Go language.

--- a/graph/README.md
+++ b/graph/README.md
@@ -1,3 +1,3 @@
-# Gonum graph [![GoDoc](https://godoc.org/gonum.org/v1/gonum/graph?status.svg)](https://godoc.org/gonum.org/v1/gonum/graph)
+# Gonum graph [![GoDoc](https://godocs.io/gonum.org/v1/gonum/graph?status.svg)](https://godocs.io/gonum.org/v1/gonum/graph)
 
 This is a generalized graph package for the Go language.

--- a/integrate/README.md
+++ b/integrate/README.md
@@ -1,3 +1,6 @@
-# Gonum integrate [![GoDoc](https://godocs.io/gonum.org/v1/gonum/integrate?status.svg)](https://godocs.io/gonum.org/v1/gonum/integrate)
+# Gonum integrate
+
+[![go.dev reference](https://pkg.go.dev/badge/gonum.org/v1/gonum/integrate)](https://pkg.go.dev/gonum.org/v1/gonum/integrate)
+[![GoDoc](https://godocs.io/gonum.org/v1/gonum/integrate?status.svg)](https://godocs.io/gonum.org/v1/gonum/integrate)
 
 Package integrate provides numerical evaluation of definite integrals of single-variable functions for the Go programming language.

--- a/integrate/README.md
+++ b/integrate/README.md
@@ -1,3 +1,3 @@
-# Gonum integrate [![GoDoc](https://godoc.org/gonum.org/v1/gonum/integrate?status.svg)](https://godoc.org/gonum.org/v1/gonum/integrate)
+# Gonum integrate [![GoDoc](https://godocs.io/gonum.org/v1/gonum/integrate?status.svg)](https://godocs.io/gonum.org/v1/gonum/integrate)
 
 Package integrate provides numerical evaluation of definite integrals of single-variable functions for the Go programming language.

--- a/internal/README.md
+++ b/internal/README.md
@@ -1,3 +1,6 @@
-# Gonum internal [![GoDoc](https://godocs.io/gonum.org/v1/gonum/internal?status.svg)](https://godocs.io/gonum.org/v1/gonum/internal)
+# Gonum internal
+
+[![go.dev reference](https://pkg.go.dev/badge/gonum.org/v1/gonum/internal)](https://pkg.go.dev/gonum.org/v1/gonum/internal)
+[![GoDoc](https://godocs.io/gonum.org/v1/gonum/internal?status.svg)](https://godocs.io/gonum.org/v1/gonum/internal)
 
 This is the set of internal packages for the Gonum project.

--- a/internal/README.md
+++ b/internal/README.md
@@ -1,3 +1,3 @@
-# Gonum internal [![GoDoc](https://godoc.org/gonum.org/v1/gonum/internal?status.svg)](https://godoc.org/gonum.org/v1/gonum/internal)
+# Gonum internal [![GoDoc](https://godocs.io/gonum.org/v1/gonum/internal?status.svg)](https://godocs.io/gonum.org/v1/gonum/internal)
 
 This is the set of internal packages for the Gonum project.

--- a/interp/README.md
+++ b/interp/README.md
@@ -1,3 +1,3 @@
-# Gonum interp [![GoDoc](https://godoc.org/gonum.org/v1/gonum/interp?status.svg)](https://godoc.org/gonum.org/v1/gonum/interp)
+# Gonum interp [![GoDoc](https://godocs.io/gonum.org/v1/gonum/interp?status.svg)](https://godocs.io/gonum.org/v1/gonum/interp)
 
 Package interp is an interpolation package for the Go language.

--- a/interp/README.md
+++ b/interp/README.md
@@ -1,3 +1,6 @@
-# Gonum interp [![GoDoc](https://godocs.io/gonum.org/v1/gonum/interp?status.svg)](https://godocs.io/gonum.org/v1/gonum/interp)
+# Gonum interp
+
+[![go.dev reference](https://pkg.go.dev/badge/gonum.org/v1/gonum/interp)](https://pkg.go.dev/gonum.org/v1/gonum/interp)
+[![GoDoc](https://godocs.io/gonum.org/v1/gonum/interp?status.svg)](https://godocs.io/gonum.org/v1/gonum/interp)
 
 Package interp is an interpolation package for the Go language.

--- a/lapack/README.md
+++ b/lapack/README.md
@@ -1,5 +1,7 @@
-Gonum LAPACK [![GoDoc](https://godocs.io/gonum.org/v1/gonum/lapack?status.svg)](https://godocs.io/gonum.org/v1/gonum/lapack)
+Gonum LAPACK
 ======
+[![go.dev reference](https://pkg.go.dev/badge/gonum.org/v1/gonum/lapack)](https://pkg.go.dev/gonum.org/v1/gonum/lapack)
+[![GoDoc](https://godocs.io/gonum.org/v1/gonum/lapack?status.svg)](https://godocs.io/gonum.org/v1/gonum/lapack)
 
 A collection of packages to provide LAPACK functionality for the Go programming
 language (http://golang.org). This provides a partial implementation in native go
@@ -25,4 +27,3 @@ Go implementation of the LAPACK API (incomplete, implements the `float64` API).
 
 Wrappers for an implementation of the double (i.e., `float64`) precision real parts of
 the LAPACK API.
-

--- a/lapack/README.md
+++ b/lapack/README.md
@@ -1,4 +1,4 @@
-Gonum LAPACK [![GoDoc](https://godoc.org/gonum.org/v1/gonum/lapack?status.svg)](https://godoc.org/gonum.org/v1/gonum/lapack)
+Gonum LAPACK [![GoDoc](https://godocs.io/gonum.org/v1/gonum/lapack?status.svg)](https://godocs.io/gonum.org/v1/gonum/lapack)
 ======
 
 A collection of packages to provide LAPACK functionality for the Go programming

--- a/lapack/gonum/doc.go
+++ b/lapack/gonum/doc.go
@@ -11,18 +11,18 @@
 // for more license information.
 //
 // Slice function arguments frequently represent vectors and matrices. The data
-// layout is identical to that found in https://godoc.org/gonum.org/v1/gonum/blas/gonum.
+// layout is identical to that found in https://pkg.go.dev/gonum.org/v1/gonum/blas/gonum.
 //
 // Most LAPACK functions are built on top the routines defined in the BLAS API,
 // and as such the computation time for many LAPACK functions is
 // dominated by BLAS calls. Here, BLAS is accessed through the
-// blas64 package (https://godoc.org/gonum.org/v1/gonum/blas/blas64). In particular,
+// blas64 package (https://pkg.go.dev/gonum.org/v1/gonum/blas/blas64). In particular,
 // this implies that an external BLAS library will be used if it is
 // registered in blas64.
 //
 // The full LAPACK capability has not been implemented at present. The full
 // API is very large, containing approximately 200 functions for double precision
 // alone. Future additions will be focused on supporting the Gonum matrix
-// package (https://godoc.org/gonum.org/v1/gonum/mat), though pull requests
+// package (https://pkg.go.dev/gonum.org/v1/gonum/mat), though pull requests
 // with implementations and tests for LAPACK function are encouraged.
 package gonum // import "gonum.org/v1/gonum/lapack/gonum"

--- a/lapack/gonum/doc.go
+++ b/lapack/gonum/doc.go
@@ -16,7 +16,7 @@
 // Most LAPACK functions are built on top the routines defined in the BLAS API,
 // and as such the computation time for many LAPACK functions is
 // dominated by BLAS calls. Here, BLAS is accessed through the
-// blas64 package (https://godoc.org/golang.org/v1/gonum/blas/blas64). In particular,
+// blas64 package (https://godoc.org/gonum.org/v1/gonum/blas/blas64). In particular,
 // this implies that an external BLAS library will be used if it is
 // registered in blas64.
 //

--- a/mat/README.md
+++ b/mat/README.md
@@ -1,3 +1,6 @@
-# Gonum matrix [![GoDoc](https://godocs.io/gonum.org/v1/gonum/mat?status.svg)](https://godocs.io/gonum.org/v1/gonum/mat)
+# Gonum matrix
+
+[![go.dev reference](https://pkg.go.dev/badge/gonum.org/v1/gonum/mat)](https://pkg.go.dev/gonum.org/v1/gonum/mat)
+[![GoDoc](https://godocs.io/gonum.org/v1/gonum/mat?status.svg)](https://godocs.io/gonum.org/v1/gonum/mat)
 
 Package mat is a matrix package for the Go language.

--- a/mat/README.md
+++ b/mat/README.md
@@ -1,3 +1,3 @@
-# Gonum matrix [![GoDoc](https://godoc.org/gonum.org/v1/gonum/mat?status.svg)](https://godoc.org/gonum.org/v1/gonum/mat)
+# Gonum matrix [![GoDoc](https://godocs.io/gonum.org/v1/gonum/mat?status.svg)](https://godocs.io/gonum.org/v1/gonum/mat)
 
 Package mat is a matrix package for the Go language.

--- a/mathext/README.md
+++ b/mathext/README.md
@@ -1,3 +1,6 @@
-# mathext [![GoDoc](https://godocs.io/gonum.org/v1/gonum/mathext?status.svg)](https://godocs.io/gonum.org/v1/gonum/mathext)
+# mathext
+
+[![go.dev reference](https://pkg.go.dev/badge/gonum.org/v1/gonum/mathext)](https://pkg.go.dev/gonum.org/v1/gonum/mathext)
+[![GoDoc](https://godocs.io/gonum.org/v1/gonum/mathext?status.svg)](https://godocs.io/gonum.org/v1/gonum/mathext)
 
 Package mathext implements basic elementary functions not included in the Go standard library.

--- a/mathext/README.md
+++ b/mathext/README.md
@@ -1,3 +1,3 @@
-# mathext [![GoDoc](https://godoc.org/gonum.org/v1/gonum/mathext?status.svg)](https://godoc.org/gonum.org/v1/gonum/mathext)
+# mathext [![GoDoc](https://godocs.io/gonum.org/v1/gonum/mathext?status.svg)](https://godocs.io/gonum.org/v1/gonum/mathext)
 
 Package mathext implements basic elementary functions not included in the Go standard library.

--- a/optimize/README.md
+++ b/optimize/README.md
@@ -1,3 +1,3 @@
-# Gonum optimize [![GoDoc](https://godoc.org/gonum.org/v1/gonum/optimize?status.svg)](https://godoc.org/gonum.org/v1/gonum/optimize)
+# Gonum optimize [![GoDoc](https://godocs.io/gonum.org/v1/gonum/optimize?status.svg)](https://godocs.io/gonum.org/v1/gonum/optimize)
 
 Package optimize is an optimization package for the Go language.

--- a/optimize/README.md
+++ b/optimize/README.md
@@ -1,3 +1,6 @@
-# Gonum optimize [![GoDoc](https://godocs.io/gonum.org/v1/gonum/optimize?status.svg)](https://godocs.io/gonum.org/v1/gonum/optimize)
+# Gonum optimize
+
+[![go.dev reference](https://pkg.go.dev/badge/gonum.org/v1/gonum/optimize)](https://pkg.go.dev/gonum.org/v1/gonum/optimize)
+[![GoDoc](https://godocs.io/gonum.org/v1/gonum/optimize?status.svg)](https://godocs.io/gonum.org/v1/gonum/optimize)
 
 Package optimize is an optimization package for the Go language.

--- a/stat/README.md
+++ b/stat/README.md
@@ -1,3 +1,6 @@
-# Gonum stat [![GoDoc](https://godocs.io/gonum.org/v1/gonum/stat?status.svg)](https://godocs.io/gonum.org/v1/gonum/stat)
+# Gonum stat
+
+[![go.dev reference](https://pkg.go.dev/badge/gonum.org/v1/gonum/stat)](https://pkg.go.dev/gonum.org/v1/gonum/stat)
+[![GoDoc](https://godocs.io/gonum.org/v1/gonum/stat?status.svg)](https://godocs.io/gonum.org/v1/gonum/stat)
 
 Package stat is a statistics package for the Go language.

--- a/stat/README.md
+++ b/stat/README.md
@@ -1,3 +1,3 @@
-# Gonum stat [![GoDoc](https://godoc.org/gonum.org/v1/gonum/stat?status.svg)](https://godoc.org/gonum.org/v1/gonum/stat)
+# Gonum stat [![GoDoc](https://godocs.io/gonum.org/v1/gonum/stat?status.svg)](https://godocs.io/gonum.org/v1/gonum/stat)
 
 Package stat is a statistics package for the Go language.


### PR DESCRIPTION
This pull request does the following:

- replace all godoc.org README badges godocs.io ones
- replace remaining (non-badge) godoc.org links with pkg.go.dev ones
- fix a link to the `blas64` docs in the `doc.go` of `lapack/gonum`, that had "golang.org" instead of "gonum.org" in the package path
- add pkg.go.dev reference README badges to all packages that have the godocs.io ones

## Bakground

What caught my eye initially was that the main README had two seemingly identical "go reference" badges. It turned out that one of them was the legacy godoc.org reference which has been redirecting to pkg.go.dev since early 2021 (see https://github.com/golang/go/issues/43178)