### PR TITLE
lapack/gonum: avoid using square of sqrt in Dlassq

### DIFF
--- a/lapack/gonum/dlassq.go
+++ b/lapack/gonum/dlassq.go
@@ -91,7 +91,7 @@ func (impl Implementation) Dlassq(n int, x []float64, incx int, scale float64, s
 				asml += (v * v) * sumsq
 			}
 		default:
-			amed += ax * ax
+			amed += scale * scale * sumsq
 		}
 	}
 	// Combine abig and amed or amed and asml if more than one accumulator was


### PR DESCRIPTION
A small change that makes our implementation identical with the Reference. It avoids using the result of squaring a square root which could lead to a loss of precision.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
