### PR TITLE
Fixed a grammatical error in Unit docs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@
 Alexander Egurnov <alexander.egurnov@gmail.com>
 Andrei Blinnikov <goofinator@mail.ru>
 antichris <chris@u-d13.com>
+Bailey Lissington <lissington4@gmail.com>
 Bill Gray <wgray@gogray.com>
 Bill Noon <noon.bill@gmail.com>
 Brendan Tracey <tracey.brendan@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -19,6 +19,7 @@ Alexander Egurnov <alexander.egurnov@gmail.com>
 Andrei Blinnikov <goofinator@mail.ru>
 Andrew Brampton <brampton@gmail.com>
 antichris <chris@u-d13.com>
+Bailey Lissington <lissington4@gmail.com>
 Bill Gray <wgray@gogray.com>
 Bill Noon <noon.bill@gmail.com>
 Brendan Tracey <tracey.brendan@gmail.com>

--- a/unit/doc.go
+++ b/unit/doc.go
@@ -66,7 +66,7 @@
 //
 // The unit package also provides the Unit type, a representation of a general
 // dimensional value. Unit can be used to help prevent errors of dimensionality
-// when multiplying or dividing dimensional numbers defined a run time. New
+// when multiplying or dividing dimensional numbers defined at run time. New
 // variables of type Unit can be created with the New function and the
 // Dimensions map. For example, the code
 //


### PR DESCRIPTION
Fixed a grammatical from "a run time" to "at run time"

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
