### PR TITLE
lapack/gonum: implement optimal packing in Dlaqr5 

### DIFF
--- a/lapack/gonum/bench_test.go
+++ b/lapack/gonum/bench_test.go
@@ -13,3 +13,4 @@ import (
 func BenchmarkDgeev(b *testing.B)  { testlapack.DgeevBenchmark(b, impl) }
 func BenchmarkDlangb(b *testing.B) { testlapack.DlangbBenchmark(b, impl) }
 func BenchmarkDlantb(b *testing.B) { testlapack.DlantbBenchmark(b, impl) }
+func BenchmarkDlaqr5(b *testing.B) { testlapack.Dlaqr5Benchmark(b, impl) }

--- a/lapack/gonum/dhseqr.go
+++ b/lapack/gonum/dhseqr.go
@@ -191,7 +191,7 @@ func (impl Implementation) Dhseqr(job lapack.SchurJob, compz lapack.SchurComp, n
 		// Matrices of order ntiny or smaller must be processed by
 		// Dlahqr because of insufficient subdiagonal scratch space.
 		// This is a hard limit.
-		ntiny = 11
+		ntiny = 15
 
 		// nl is the size of a local workspace to help small matrices
 		// through a rare Dlahqr failure. nl > ntiny is required and

--- a/lapack/gonum/dlaqr04.go
+++ b/lapack/gonum/dlaqr04.go
@@ -118,7 +118,7 @@ func (impl Implementation) Dlaqr04(wantt, wantz bool, n, ilo, ihi int, h []float
 		// Matrices of order ntiny or smaller must be processed by
 		// Dlahqr because of insufficient subdiagonal scratch space.
 		// This is a hard limit.
-		ntiny = 11
+		ntiny = 15
 		// Exceptional deflation windows: try to cure rare slow
 		// convergence by varying the size of the deflation window after
 		// kexnw iterations.
@@ -218,20 +218,20 @@ func (impl Implementation) Dlaqr04(wantt, wantz bool, n, ilo, ihi int, h []float
 	} else {
 		fname = "DLAQR4"
 	}
-	// nwr is the recommended deflation window size. n is greater than 11,
+	// nwr is the recommended deflation window size. n is greater than ntiny,
 	// so there is enough subdiagonal workspace for nwr >= 2 as required.
-	// (In fact, there is enough subdiagonal space for nwr >= 3.)
-	// TODO(vladimir-ch): If there is enough space for nwr >= 3, should we
+	// (In fact, there is enough subdiagonal space for nwr >= 4.)
+	// TODO(vladimir-ch): If there is enough space for nwr >= 4, should we
 	// use it?
 	nwr := impl.Ilaenv(13, fname, jbcmpz, n, ilo, ihi, lwork)
 	nwr = max(2, nwr)
 	nwr = min(ihi-ilo+1, min((n-1)/3, nwr))
 
-	// nsr is the recommended number of simultaneous shifts. n is greater
-	// than 11, so there is enough subdiagonal workspace for nsr to be even
-	// and greater than or equal to two as required.
+	// nsr is the recommended number of simultaneous shifts. n is greater than
+	// ntiny, so there is enough subdiagonal workspace for nsr to be even and
+	// greater than or equal to two as required.
 	nsr := impl.Ilaenv(15, fname, jbcmpz, n, ilo, ihi, lwork)
-	nsr = min(nsr, min((n+6)/9, ihi-ilo))
+	nsr = min(nsr, min((n-3)/6, ihi-ilo))
 	nsr = max(2, nsr&^1)
 
 	// Workspace query call to Dlaqr23.
@@ -264,7 +264,7 @@ func (impl Implementation) Dlaqr04(wantt, wantz bool, n, ilo, ihi int, h []float
 
 	// nsmax is the largest number of simultaneous shifts for which there is
 	// sufficient workspace.
-	nsmax := min((n+6)/9, 2*lwork/3) &^ 1
+	nsmax := min((n-3)/6, 2*lwork/3) &^ 1
 
 	ndfl := 1 // Number of iterations since last deflation.
 	ndec := 0 // Deflation window size decrement.
@@ -470,7 +470,7 @@ func (impl Implementation) Dlaqr04(wantt, wantz bool, n, ilo, ihi int, h []float
 		//   (nhv must be at least kdu but more is better),
 		// - an nhv×kdu vertical work array WV along the left-hand-edge
 		//   (nhv must be at least kdu but more is better).
-		kdu := 3*ns - 3
+		kdu := 2 * ns
 		ku := n - kdu
 		kwh := kdu
 		kwv = kdu + 3

--- a/lapack/testlapack/dlaqr5.go
+++ b/lapack/testlapack/dlaqr5.go
@@ -60,11 +60,11 @@ func testDlaqr5(t *testing.T, impl Dlaqr5er, n, extra, kacc22 int, rnd *rand.Ran
 	}
 
 	v := randomGeneral(nshfts/2, 3, 3+extra, rnd)
-	u := randomGeneral(3*nshfts-3, 3*nshfts-3, 3*nshfts-3+extra, rnd)
+	u := randomGeneral(2*nshfts, 2*nshfts, 2*nshfts+extra, rnd)
 	nh := n
-	wh := randomGeneral(3*nshfts-3, n, n+extra, rnd)
+	wh := randomGeneral(2*nshfts, n, n+extra, rnd)
 	nv := n
-	wv := randomGeneral(n, 3*nshfts-3, 3*nshfts-3+extra, rnd)
+	wv := randomGeneral(n, 2*nshfts, 2*nshfts+extra, rnd)
 
 	h := randomHessenberg(n, n+extra, rnd)
 	if ktop > 0 {

--- a/lapack/testlapack/dlaqr5.go
+++ b/lapack/testlapack/dlaqr5.go
@@ -40,11 +40,18 @@ func testDlaqr5(t *testing.T, impl Dlaqr5er, n, extra, kacc22 int, rnd *rand.Ran
 	nshfts := 2 * n
 	sr := make([]float64, nshfts)
 	si := make([]float64, nshfts)
-	for i := 0; i < n; i++ {
+	for i := 0; i < nshfts; {
+		if i == nshfts-1 || rnd.Float64() < 0.5 {
+			re := rnd.NormFloat64()
+			sr[i], si[i] = re, 0
+			i++
+			continue
+		}
 		re := rnd.NormFloat64()
 		im := rnd.NormFloat64()
-		sr[2*i], sr[2*i+1] = re, re
-		si[2*i], si[2*i+1] = im, -im
+		sr[i], sr[i+1] = re, re
+		si[i], si[i+1] = im, -im
+		i += 2
 	}
 	ktop := rnd.Intn(n)
 	kbot := rnd.Intn(n)

--- a/lapack/testlapack/dlaqr5_bench.go
+++ b/lapack/testlapack/dlaqr5_bench.go
@@ -1,0 +1,81 @@
+// Copyright ©2023 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/exp/rand"
+)
+
+func Dlaqr5Benchmark(b *testing.B, impl Dlaqr5er) {
+	const (
+		random = iota
+		iplusj
+		laplacian
+	)
+	rnd := rand.New(rand.NewSource(1))
+	for _, typ := range []int{random, iplusj, laplacian} {
+		for _, n := range []int{100, 200, 500, 1000} {
+			h := zeros(n, n, n)
+			var name string
+			switch typ {
+			case random:
+				name = fmt.Sprintf("HessenbergRandom%d", n)
+				h = randomHessenberg(n, n, rnd)
+			case iplusj:
+				name = fmt.Sprintf("HessenbergIPlusJ%d", n)
+				for i := 0; i < n; i++ {
+					for j := max(0, i-1); j < n; j++ {
+						h.Data[i*h.Stride+j] = float64(i + j + 2)
+					}
+				}
+			case laplacian:
+				name = fmt.Sprintf("Laplacian%d", n)
+				for i := 0; i < n; i++ {
+					if i > 0 {
+						h.Data[i*h.Stride+i-1] = -1
+					}
+					h.Data[i*h.Stride+i] = 2
+					if i < n-1 {
+						h.Data[i*h.Stride+i+1] = -1
+					}
+				}
+			}
+			hCopy := cloneGeneral(h)
+			nshifts := 2 * n
+			sr := make([]float64, nshifts)
+			si := make([]float64, nshifts)
+			for i := 0; i < nshifts; {
+				if i == nshifts-1 || rnd.Float64() < 0.5 {
+					re := rnd.NormFloat64()
+					sr[i], si[i] = re, 0
+					i++
+					continue
+				}
+				re := rnd.NormFloat64()
+				im := rnd.NormFloat64()
+				sr[i], sr[i+1] = re, re
+				si[i], si[i+1] = im, -im
+				i += 2
+			}
+			v := zeros(nshifts/2, 3, 3)
+			u := zeros(3*nshifts-3, 3*nshifts-3, 3*nshifts-3)
+			nh := n
+			wh := zeros(3*nshifts-3, n, n)
+			nv := n
+			wv := zeros(n, 3*nshifts-3, 3*nshifts-3)
+			z := eye(n, n)
+			b.Run(name, func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					copyGeneral(h, hCopy)
+					impl.Dlaqr5(true, true, 1, n, 0, n-1, nshifts, sr, si, h.Data, h.Stride, 0, n-1, z.Data, z.Stride,
+						v.Data, v.Stride, u.Data, u.Stride, nh, wv.Data, wv.Stride, nv, wh.Data, wh.Stride)
+				}
+			})
+		}
+	}
+}

--- a/lapack/testlapack/dlaqr5_bench.go
+++ b/lapack/testlapack/dlaqr5_bench.go
@@ -63,11 +63,11 @@ func Dlaqr5Benchmark(b *testing.B, impl Dlaqr5er) {
 				i += 2
 			}
 			v := zeros(nshifts/2, 3, 3)
-			u := zeros(3*nshifts-3, 3*nshifts-3, 3*nshifts-3)
+			u := zeros(2*nshifts, 2*nshifts, 2*nshifts)
 			nh := n
-			wh := zeros(3*nshifts-3, n, n)
+			wh := zeros(2*nshifts, n, n)
 			nv := n
-			wv := zeros(n, 3*nshifts-3, 3*nshifts-3)
+			wv := zeros(n, 2*nshifts, 2*nshifts)
 			z := eye(n, n)
 			b.Run(name, func(b *testing.B) {
 				for i := 0; i < b.N; i++ {


### PR DESCRIPTION
...and update workspace sizes in Dhseqr and Dlaqr04.

See https://github.com/Reference-LAPACK/lapack/pull/480 for the same change in the Reference.

This is another item from my unattended backlog accumulated over the past couple of years. The diff here is useless, it's practically a rewrite. The test coverage of Dlaqr5 is almost complete, which gives me some confidence the indices are correct. The result is a quite nice runtime improvement for non-tiny matrices:

```
goos: linux
goarch: amd64
pkg: gonum.org/v1/gonum/lapack/gonum
cpu: 12th Gen Intel(R) Core(TM) i7-12800H
                               │    old.txt    │               new.txt               │
                               │    sec/op     │    sec/op     vs base               │
Dgeev/AntisymRandom3-20           2.187µ ± ∞ ¹   2.219µ ± ∞ ¹        ~ (p=0.421 n=5)
Dgeev/AntisymRandom4-20           3.216µ ± ∞ ¹   3.276µ ± ∞ ¹        ~ (p=0.151 n=5)
Dgeev/AntisymRandom5-20           5.083µ ± ∞ ¹   5.087µ ± ∞ ¹        ~ (p=0.548 n=5)
Dgeev/AntisymRandom10-20          17.17µ ± ∞ ¹   17.34µ ± ∞ ¹        ~ (p=1.000 n=5)
Dgeev/AntisymRandom50-20          698.2µ ± ∞ ¹   700.2µ ± ∞ ¹        ~ (p=0.421 n=5)
Dgeev/AntisymRandom100-20         5.478m ± ∞ ¹   4.420m ± ∞ ¹  -19.31% (p=0.008 n=5)
Dgeev/AntisymRandom200-20         37.09m ± ∞ ¹   28.98m ± ∞ ¹  -21.88% (p=0.008 n=5)
Dgeev/AntisymRandom500-20         542.5m ± ∞ ¹   411.6m ± ∞ ¹  -24.12% (p=0.008 n=5)
Dgeev/Circulant3-20               2.021µ ± ∞ ¹   2.054µ ± ∞ ¹        ~ (p=0.310 n=5)
Dgeev/Circulant4-20               3.488µ ± ∞ ¹   3.526µ ± ∞ ¹        ~ (p=0.421 n=5)
Dgeev/Circulant5-20               4.493µ ± ∞ ¹   4.465µ ± ∞ ¹        ~ (p=0.548 n=5)
Dgeev/Circulant10-20              15.65µ ± ∞ ¹   15.71µ ± ∞ ¹        ~ (p=0.841 n=5)
Dgeev/Circulant50-20              536.2µ ± ∞ ¹   537.7µ ± ∞ ¹        ~ (p=0.222 n=5)
Dgeev/Circulant100-20             4.723m ± ∞ ¹   4.000m ± ∞ ¹  -15.31% (p=0.008 n=5)
Dgeev/Circulant200-20             32.40m ± ∞ ¹   26.61m ± ∞ ¹  -17.89% (p=0.008 n=5)
Dgeev/Circulant500-20             494.8m ± ∞ ¹   402.6m ± ∞ ¹  -18.63% (p=0.008 n=5)
Dlaqr5/HessenbergRandom100-20    12.372m ± ∞ ¹   4.564m ± ∞ ¹  -63.11% (p=0.008 n=5)
Dlaqr5/HessenbergRandom200-20    127.24m ± ∞ ¹   38.78m ± ∞ ¹  -69.52% (p=0.008 n=5)
Dlaqr5/HessenbergRandom500-20    2371.9m ± ∞ ¹   808.4m ± ∞ ¹  -65.92% (p=0.008 n=5)
Dlaqr5/HessenbergRandom1000-20    42.673 ± ∞ ¹    7.406 ± ∞ ¹  -82.64% (p=0.008 n=5)
Dlaqr5/HessenbergIPlusJ100-20    13.286m ± ∞ ¹   4.664m ± ∞ ¹  -64.89% (p=0.008 n=5)
Dlaqr5/HessenbergIPlusJ200-20    131.48m ± ∞ ¹   42.95m ± ∞ ¹  -67.33% (p=0.008 n=5)
Dlaqr5/HessenbergIPlusJ500-20    2433.3m ± ∞ ¹   824.9m ± ∞ ¹  -66.10% (p=0.008 n=5)
Dlaqr5/HessenbergIPlusJ1000-20    38.965 ± ∞ ¹    7.059 ± ∞ ¹  -81.88% (p=0.008 n=5)
Dlaqr5/Laplacian100-20           11.443m ± ∞ ¹   4.529m ± ∞ ¹  -60.43% (p=0.008 n=5)
Dlaqr5/Laplacian200-20           124.76m ± ∞ ¹   37.67m ± ∞ ¹  -69.81% (p=0.008 n=5)
Dlaqr5/Laplacian500-20           2507.1m ± ∞ ¹   842.1m ± ∞ ¹  -66.41% (p=0.008 n=5)
Dlaqr5/Laplacian1000-20           41.991 ± ∞ ¹    7.088 ± ∞ ¹  -83.12% (p=0.008 n=5)
geomean                           7.546m         4.232m        -43.92%
¹ need >= 6 samples for confidence interval at level 0.95
```

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
