### PR TITLE
lapack/testlapack: relax tolerance in Dlapy2 test

### DIFF
--- a/lapack/testlapack/dlapy2.go
+++ b/lapack/testlapack/dlapy2.go
@@ -24,7 +24,7 @@ func Dlapy2Test(t *testing.T, impl Dlapy2er) {
 		y := math.Abs(1e200 * rnd.NormFloat64())
 		got := impl.Dlapy2(x, y)
 		want := math.Hypot(x, y)
-		if !scalar.EqualWithinRel(got, want, 1e-16) {
+		if !scalar.EqualWithinRel(got, want, 1e-15) {
 			t.Errorf("Dlapy2(%g, %g) = %g, want %g", x, y, got, want)
 		}
 	}


### PR DESCRIPTION
This is done to avoid test failure in the netlib repo on remote build infrastructure.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
