### PR TITLE
unit/constant: use log.Fatalf when there are verbs

### DIFF
--- a/unit/constant/generate_defined_types.go
+++ b/unit/constant/generate_defined_types.go
@@ -70,7 +70,7 @@ func main() {
 		}
 		f, err := parser.ParseFile(fset, fn, nil, 0)
 		if err != nil {
-			log.Fatal("failed to parse %q: %v", fn, err) // parse error
+			log.Fatalf("failed to parse %q: %v", fn, err) // parse error
 		}
 		if f.Name.Name != "unit" {
 			log.Fatalf("not parsing unit package: %q", f.Name.Name)


### PR DESCRIPTION
Maybe it's not worth an issue.