### PR TITLE
lapack: add Dlagv2 and its tests

### DIFF
--- a/lapack/gonum/dlagv2.go
+++ b/lapack/gonum/dlagv2.go
@@ -56,6 +56,8 @@ func (impl Implementation) Dlagv2(a []float64, lda int, b []float64, ldb int, al
 		panic(badLenAlpha)
 	case len(beta) < 2:
 		panic(badLenBeta)
+	case b[0] <= 0 || b[ldb+1] <= 0 || b[0] < b[ldb+1]:
+		panic(badDiag)
 	}
 
 	const (

--- a/lapack/gonum/dlagv2.go
+++ b/lapack/gonum/dlagv2.go
@@ -57,7 +57,7 @@ func (impl Implementation) Dlagv2(a []float64, lda int, b []float64, ldb int, al
 	case len(beta) < 2:
 		panic(badLenBeta)
 	case b[0] <= 0 || b[ldb+1] <= 0 || b[0] < b[ldb+1]:
-		panic(badDiag)
+		panic(badBDiag)
 	}
 
 	const (

--- a/lapack/gonum/dlagv2.go
+++ b/lapack/gonum/dlagv2.go
@@ -1,0 +1,210 @@
+// Copyright ©2021 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+import (
+	"math"
+
+	"gonum.org/v1/gonum/blas/blas64"
+)
+
+// Dlagv2 computes the Generalized Schur factorization of a real 2×2
+// matrix pencil (A,B) where B is upper triangular. This routine
+// computes orthogonal (rotation) matrices given by CSL, SNL and CSR,
+// SNR such that
+//
+//  1. if the pencil (A,B) has two real eigenvalues (include 0/0 or 1/0 types), then
+//     [ a11 a12 ] = [  CSL  SNL ] [ a11 a12 ] [  CSR -SNR ]
+//     [  0  a22 ]    [ -SNL  CSL ] [ a21 a22 ] [  SNR  CSR ]
+//
+//     [ b11 b12 ] = [  CSL  SNL ] [ b11 b12 ] [  CSR -SNR ]
+//     [  0  b22 ]    [ -SNL  CSL ] [  0  b22 ] [  SNR  CSR ],
+//
+//  2. if the pencil (A,B) has a pair of complex conjugate eigenvalues, then
+//     [ a11 a12 ] = [  CSL  SNL ] [ a11 a12 ] [  CSR -SNR ]
+//     [ a21 a22 ]    [ -SNL  CSL ] [ a21 a22 ] [  SNR  CSR ]
+//
+//     [ b11  0  ] = [  CSL  SNL ] [ b11 b12 ] [  CSR -SNR ]
+//     [  0  b22 ]    [ -SNL  CSL ] [  0  b22 ] [  SNR  CSR ]
+//
+// where b11 >= b22 > 0.
+//
+// On exit, A is overwritten by the A-part of the generalized Schur form
+// and B is overwritten by the B-part of the generalized Schur form.
+//
+// (alphar(k)+imag*alphai(k))/beta(k) are the eigenvalues of the
+// pencil (A,B), k=0,1 where imag = sqrt(-1). Note that beta(k) may
+// be zero. They are solely outputs and will be overwritten.
+//
+// Returned floats are cosines (cs) and sines (sn) of left (l) and right (r)
+// rotation matrices.
+//
+// Dlagv2 is an internal routine. It is exported for testing purposes.
+func (impl Implementation) Dlagv2(a []float64, lda int, b []float64, ldb int, alphar, alphai, beta []float64) (csl, snl, csr, snr float64) {
+	switch {
+	case lda < 2:
+		panic(badLdA)
+	case ldb < 2:
+		panic(badLdB)
+	case len(a) < 4:
+		panic(shortA)
+	case len(b) < 4:
+		panic(shortB)
+	case len(alphar) < 2 || len(alphai) < 2:
+		panic(badLenAlpha)
+	case len(beta) < 2:
+		panic(badLenBeta)
+	}
+
+	const (
+		safmin = dlamchS
+		ulp    = dlamchP
+	)
+
+	// Scale A.
+	anorm := math.Max(math.Abs(a[0])+math.Abs(a[lda]),
+		math.Abs(a[1])+math.Abs(a[lda+1]))
+	anorm = math.Max(anorm, safmin)
+	ascale := 1 / anorm
+	a[0] *= ascale
+	a[1] *= ascale
+	a[lda] *= ascale
+	a[lda+1] *= ascale
+
+	// Scale B.
+	bnorm := math.Max(math.Abs(b[0]),
+		math.Abs(b[1])+math.Abs(b[ldb+1]))
+	bnorm = math.Max(bnorm, safmin)
+	bscale := 1 / bnorm
+	b[0] *= bscale
+	b[1] *= bscale
+	b[ldb+1] *= bscale
+
+	bi := blas64.Implementation()
+	var wi, wr1, scale1 float64
+	switch {
+	// Check if A can be deflated.
+	case math.Abs(a[lda]) <= ulp:
+		csl, csr = 1, 1
+		a[lda] = 0
+		b[ldb] = 0
+
+	// Check if B is singular.
+	case math.Abs(b[0]) <= ulp:
+		csl, snl, _ = impl.Dlartg(a[0], a[lda])
+		csr = 1
+		bi.Drot(2, a, 1, a[lda:], 1, csl, snl)
+		bi.Drot(2, b, 1, b[ldb:], 1, csl, snl)
+		a[lda] = 0
+		b[0] = 0
+		b[ldb] = 0
+
+	case math.Abs(b[ldb+1]) <= ulp:
+		csr, snr, _ = impl.Dlartg(a[lda+1], a[lda+0])
+		snr *= -1
+		bi.Drot(2, a, lda, a[1:], lda, csr, snr)
+		bi.Drot(2, b, ldb, b[1:], ldb, csr, snr)
+		csl = 1
+		a[lda] = 0
+		b[ldb] = 0
+		b[ldb+1] = 0
+
+	// B is nonsingular, first compute the eigenvalues of (A,B).
+	default:
+		scale1, _, wr1, _, wi = impl.Dlag2(a, lda, b, ldb)
+
+		// Ensure upper triangular form before rotations
+		// as Drot will access this element and may propagate NaNs.
+		// Reference does not contain this zeroing.
+		b[ldb] = 0
+
+		if wi != 0 {
+			// A pair of complex conjugate eigenvalues:
+			// first compute the SVD of the matrix B.
+			_, _, snr, csr, snl, csl = impl.Dlasv2(b[0], b[1], b[ldb+1])
+
+			// Form (A,B) := Q(A,B)Zᵀ where Q is left rotation matrix and
+			// Z is right rotation matrix computed from Dlasv2
+			bi.Drot(2, a, 1, a[lda:], 1, csl, snl)
+			bi.Drot(2, b, 1, b[ldb:], 1, csl, snl)
+
+			bi.Drot(2, a, lda, a[1:], lda, csr, snr)
+			bi.Drot(2, b, ldb, b[1:], ldb, csr, snr)
+
+			b[ldb] = 0
+			b[1] = 0
+			break // Exit from switch.
+		}
+
+		// Got real eigenvalues from Dlag2, compute s*A-w*B.
+		h1 := scale1*a[0] - wr1*b[0]
+		h2 := scale1*a[1] - wr1*b[1]
+		h3 := scale1*a[lda+1] - wr1*b[ldb+1]
+
+		rr := impl.Dlapy2(h1, h2)
+		qq := impl.Dlapy2(scale1*a[lda], h3)
+		if rr > qq {
+			// Find right rotation matrix to zero 0,0 element of (sA - wB).
+			csr, snr, _ = impl.Dlartg(h2, h1)
+		} else {
+			// Find right rotation matrix to zero 1,0 element of (sA - wB).
+			csr, snr, _ = impl.Dlartg(h3, scale1*a[lda])
+		}
+		snr *= -1
+		bi.Drot(2, a, lda, a[1:], lda, csr, snr)
+		bi.Drot(2, b, ldb, b[1:], ldb, csr, snr)
+
+		// Compute inf. norms of A and B.
+		h1 = math.Max(math.Abs(a[0])+math.Abs(a[1]),
+			math.Abs(a[lda])+math.Abs(a[lda+1]))
+
+		h2 = math.Max(math.Abs(b[0])+math.Abs(b[1]),
+			math.Abs(b[ldb])+math.Abs(b[ldb+1])) // b[ldb] may be non-zero after rotations.
+
+		if scale1*h1 >= math.Abs(wr1)*h2 {
+			// Find left rotation matrix Q to zero out B[1,0].
+			csl, snl, _ = impl.Dlartg(b[0], b[ldb])
+		} else {
+			// Find left rotation matrix Q to zero out A[1,0]
+			csl, snl, _ = impl.Dlartg(a[0], a[lda])
+		}
+
+		bi.Drot(2, a, 1, a[lda:], 1, csl, snl)
+		bi.Drot(2, b, 1, b[ldb:], 1, csl, snl)
+
+		a[lda] = 0
+		b[ldb] = 0
+	}
+
+	// Unscaling.
+
+	a[0] *= anorm
+	a[1] *= anorm
+	a[lda] *= anorm
+	a[lda+1] *= anorm
+
+	b[0] *= bnorm
+	b[1] *= bnorm
+	b[ldb] *= bnorm
+	b[ldb+1] *= bnorm
+
+	if wi == 0 {
+		alphar[0] = a[0]
+		alphar[1] = a[lda+1]
+		alphai[0] = 0
+		alphai[1] = 0
+		beta[0] = b[0]
+		beta[1] = b[ldb+1]
+	} else {
+		alphar[0] = anorm * wr1 / scale1 / bnorm
+		alphai[0] = anorm * wi / scale1 / bnorm
+		alphar[1] = alphar[0]
+		alphai[1] = -alphai[0]
+		beta[0] = 1
+		beta[1] = 1
+	}
+
+	return csl, snl, csr, snr
+}

--- a/lapack/gonum/errors.go
+++ b/lapack/gonum/errors.go
@@ -35,6 +35,7 @@ const (
 	bothSVDOver         = "lapack: both jobU and jobVT are lapack.SVDOverwrite"
 
 	// Panic strings for bad numerical and string values.
+	badBDiag    = "lapack: bad diagonal elements of B for Dlagv2"
 	badIfst     = "lapack: ifst out of range"
 	badIhi      = "lapack: ihi out of range"
 	badIhiz     = "lapack: ihiz out of range"

--- a/lapack/gonum/lapack_test.go
+++ b/lapack/gonum/lapack_test.go
@@ -203,6 +203,11 @@ func TestDlags2(t *testing.T) {
 	testlapack.Dlags2Test(t, impl)
 }
 
+func TestDlagv2(t *testing.T) {
+	t.Parallel()
+	testlapack.Dlagv2Test(t, impl)
+}
+
 func TestDlagtm(t *testing.T) {
 	t.Parallel()
 	testlapack.DlagtmTest(t, impl)

--- a/lapack/testlapack/dlaexc.go
+++ b/lapack/testlapack/dlaexc.go
@@ -154,7 +154,7 @@ func testDlaexc(t *testing.T, impl Dlaexcer, rnd *rand.Rand, n, extra int) {
 		}
 	}
 
-	if !isSchurCanonicalGeneral(tmat) {
+	if !isSchurCanonicalGeneral(tmat, 0) {
 		t.Errorf("%v: T is not in Schur canonical form", name)
 	}
 

--- a/lapack/testlapack/dlagv2.go
+++ b/lapack/testlapack/dlagv2.go
@@ -1,0 +1,148 @@
+// Copyright ©2021 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"golang.org/x/exp/rand"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/blas64"
+)
+
+type Dlagv2er interface {
+	Dlagv2(a []float64, lda int, b []float64, ldb int, alphar, alphai, beta []float64) (csl, snl, csr, snr float64)
+}
+
+func Dlagv2Test(t *testing.T, impl Dlagv2er) {
+	rnd := rand.New(rand.NewSource(1))
+	for _, lda := range []int{2, 5} {
+		for _, ldb := range []int{2, 5} {
+			for aKind := 20; aKind <= 20; aKind++ {
+				for bKind := 20; bKind <= 20; bKind++ {
+					dlagv2Test(t, impl, rnd, lda, ldb, aKind, bKind)
+				}
+			}
+		}
+	}
+}
+
+func dlagv2Test(t *testing.T, impl Dlagv2er, rnd *rand.Rand, lda, ldb int, aKind, bKind int) {
+	const tol = 1e-14
+
+	a := makeDlag2TestMatrix(rnd, lda, aKind)
+	b := makeDlag2TestMatrix(rnd, ldb, bKind)
+	b.Data[b.Stride] = math.NaN() // b is lower triangular.
+
+	aCopy := cloneGeneral(a)
+	bCopy := cloneGeneral(b)
+	var alphar, alphai, beta [2]float64
+	csl, snl, csr, snr := impl.Dlagv2(a.Data, a.Stride, b.Data, b.Stride, alphar[:], alphai[:], beta[:])
+	beta1, beta2 := beta[0], beta[1]
+	wi1, wi2 := alphai[0], alphai[1]
+	wr1, wr2 := alphar[0], alphar[1]
+	if beta1 == 0 {
+		beta1 = 1
+		// wi1, wr1 = wi1/beta1, wr1/beta1
+	}
+	if beta2 == 0 {
+		beta2 = 1
+		// wi2, wr2 = wi2/beta2, wr2/beta2
+	}
+	// Generate r1, r2 rotation matrices.
+	// r1 = [ CSL  SNL; -SNL CSL]
+	r1 := blas64.General{
+		Data: []float64{csl, snl, -snl, csl},
+		Rows: 2, Cols: 2, Stride: 2,
+	}
+	// r2 = [ CSR -SNR; SNR CSR]
+	r2 := blas64.General{
+		Data: []float64{csr, -snr, snr, csr},
+		Rows: 2, Cols: 2, Stride: 2,
+	}
+	name := fmt.Sprintf("lda=%d,ldb=%d,aKind=%d,bKind=%d", lda, ldb, aKind, bKind)
+	aStr := fmt.Sprintf("A = [%g,%g]\n    [%g,%g]", a.Data[0], a.Data[1], a.Data[a.Stride], a.Data[a.Stride+1])
+	bStr := fmt.Sprintf("B = [%g,%g]\n    [%g,%g]", b.Data[0], b.Data[1], b.Data[b.Stride], b.Data[b.Stride+1])
+
+	if wi1 < 0 {
+		t.Fatalf("%s: negative wi; wi1=%g,wi2=%g,\n%s\n%s", name, wi1, wi2, aStr, bStr)
+		return
+	}
+	if math.Abs(b.Data[b.Stride]) > tol {
+		t.Fatalf("%s: expected b to remain upper triangular:\n%s", name, bStr)
+		return
+	}
+	if b.Data[0] < b.Data[b.Stride+1] {
+		t.Errorf("%s: expected b diagonal elements to be in descending order:\n%s", name, bStr)
+	}
+
+	if !isSchurCanonicalGeneral(b, tol) {
+		t.Fatalf("%s: b is not Schur canonical:\n%s", name, bStr)
+		return
+	}
+	if !isSchurCanonicalGeneral(a, tol) {
+		t.Fatalf("%s: a is not Schur canonical:\n%s", name, aStr)
+		return
+	}
+	switch {
+	case wi1 > 0 || wi2 > 0:
+		// Complex eigenvalue pair.
+		if wr1 != wr2 {
+			t.Fatalf("%s: complex eigenvalue but wr1 != wr2; wr1=%g, wr2=%g,\n%s\n%s", name, wr1, wr2, aStr, bStr)
+			return
+		}
+		if beta1 != beta2 {
+			t.Fatalf("%s: complex eigenvalue but scale1 != scale2; scale1=%g, scale2=%g,\n%s\n%s", name, beta1, beta2, aStr, bStr)
+			return
+		}
+		if b.Data[1] != 0 {
+			t.Errorf("%s: expected b to be diagonal on complex pair:\n%s", name, bStr)
+		}
+	default:
+		// Real eigenvalue pair.
+		if wi1 != 0 || wi2 != 0 {
+			t.Fatalf("%s: real eigenvalue but wi1 != 0 or wi2 != 0; wi1=%g, wi2=%g,\n%s\n%s", name, wi1, wi2, aStr, bStr)
+			return
+		}
+		if a.Data[a.Stride] != 0 {
+			t.Errorf("%s: expected a to be upper triangular on real pair:\n%s", name, aStr)
+		}
+	}
+	return
+	res, err := residualDlag2(aCopy, bCopy, beta1, complex(wr1, wi1))
+	if err != nil {
+		t.Logf("%s: invalid input data: %v\n%s\n%s", name, err, aStr, bStr)
+	}
+	if res > tol || math.IsNaN(res) {
+		t.Errorf("%s: unexpected first eigenvalue %g with s=%g; resid=%g, want<=%g\n%s\n%s", name, complex(wr1, wi1), beta1, res, tol, aStr, bStr)
+	}
+	return
+	res, err = residualDlag2(a, b, beta2, complex(wr2, wi2))
+	if err != nil {
+		t.Logf("%s: invalid input data: %v\n%s\n%s", name, err, aStr, bStr)
+	}
+	if res > tol || math.IsNaN(res) {
+		t.Errorf("%s: unexpected second eigenvalue %g with s=%g; resid=%g, want<=%g\n%s\n%s", name, complex(wr2, wi2), beta2, res, tol, aStr, bStr)
+	}
+	return
+	aux := nanGeneral(2, 2, 2)
+	result := nanGeneral(2, 2, 2)
+	// Aschur = r1 * A * r2
+	// Bschur = r1 * B * r2
+	blas64.Gemm(blas.NoTrans, blas.NoTrans, 1, r1, aCopy, 0, aux)
+	blas64.Gemm(blas.NoTrans, blas.NoTrans, 1, aux, r2, 0, result)
+	if !equalApproxGeneral(result, a, tol) {
+		t.Errorf("%s: unexpected result for A:\nwant=%v\ngot= %v", name, a, result)
+	}
+
+	blas64.Gemm(blas.NoTrans, blas.NoTrans, 1, r1, bCopy, 0, aux)
+	blas64.Gemm(blas.NoTrans, blas.NoTrans, 1, aux, r2, 0, result)
+	if !equalApproxGeneral(result, b, tol) {
+		t.Errorf("%s: unexpected result for B:\nwant=%v\ngot= %v", name, b, result)
+	}
+}

--- a/lapack/testlapack/dlagv2.go
+++ b/lapack/testlapack/dlagv2.go
@@ -1,4 +1,4 @@
-// Copyright ©2021 The Gonum Authors. All rights reserved.
+// Copyright ©2023 The Gonum Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/lapack/testlapack/dtrexc.go
+++ b/lapack/testlapack/dtrexc.go
@@ -140,7 +140,7 @@ func dtrexcTest(t *testing.T, impl Dtrexcer, rnd *rand.Rand, n, ifst, ilst, extr
 		return
 	}
 
-	if !isSchurCanonicalGeneral(tmat) {
+	if !isSchurCanonicalGeneral(tmat, 0) {
 		t.Errorf("%v: T is not in Schur canonical form", name)
 	}
 

--- a/lapack/testlapack/general.go
+++ b/lapack/testlapack/general.go
@@ -1068,15 +1068,15 @@ func extract2x2Block(t []float64, ldt int) (a, b, c, d float64) {
 
 // isSchurCanonical returns whether the 2×2 matrix [a b; c d] is in Schur
 // canonical form.
-func isSchurCanonical(a, b, c, d float64) bool {
-	return c == 0 || (b != 0 && a == d && math.Signbit(b) != math.Signbit(c))
+func isSchurCanonical(a, b, c, d, tol float64) bool {
+	return math.Abs(c) <= tol || (b != 0 && math.Abs(a-d) <= tol && math.Signbit(b) != math.Signbit(c))
 }
 
 // isSchurCanonicalGeneral returns whether T is block upper triangular with 1×1
 // and 2×2 diagonal blocks, each 2×2 block in Schur canonical form. The function
 // checks only along the diagonal and the first subdiagonal, otherwise the lower
 // triangle is not accessed.
-func isSchurCanonicalGeneral(t blas64.General) bool {
+func isSchurCanonicalGeneral(t blas64.General, tol float64) bool {
 	n := t.Cols
 	if t.Rows != n {
 		panic("invalid matrix")
@@ -1094,7 +1094,7 @@ func isSchurCanonicalGeneral(t blas64.General) bool {
 		}
 		// 2×2 block.
 		a, b, c, d := extract2x2Block(t.Data[j*t.Stride+j:], t.Stride)
-		if !isSchurCanonical(a, b, c, d) {
+		if !isSchurCanonical(a, b, c, d, tol) {
 			return false
 		}
 		for i := j + 2; i < n; i++ {
@@ -1117,7 +1117,7 @@ func isSchurCanonicalGeneral(t blas64.General) bool {
 //
 //lint:ignore U1000 This is useful for debugging.
 func schurBlockEigenvalues(a, b, c, d float64) (ev1, ev2 complex128) {
-	if !isSchurCanonical(a, b, c, d) {
+	if !isSchurCanonical(a, b, c, d, 0) {
 		panic("block not in Schur canonical form")
 	}
 	if c == 0 {


### PR DESCRIPTION
Part of #1651. 

Additional notes:
- Rewrote some of the `isSchurCanonical*` functions to take in a tolerance and left existing call sites as taking 0 tolerance.
- Added `badBDiag`