### PR TITLE
graph: fix comment of exported elements

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,6 +38,7 @@ Dong-hee Na <donghee.na92@gmail.com>
 Dustin Spicuzza <dustin@virtualroadside.com>
 Egon Elbre <egonelbre@gmail.com>
 Ekaterina Efimova <katerina.efimova@gmail.com>
+Eng Zer Jun <engzerjun@gmail.com>
 Ethan Burns <burns.ethan@gmail.com>
 Evert Lammerts <evert.lammerts@gmail.com>
 Evgeny Savinov <notime.sea@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -46,6 +46,7 @@ Dong-hee Na <donghee.na92@gmail.com>
 Dustin Spicuzza <dustin@virtualroadside.com>
 Egon Elbre <egonelbre@gmail.com>
 Ekaterina Efimova <katerina.efimova@gmail.com>
+Eng Zer Jun <engzerjun@gmail.com>
 Ethan Burns <burns.ethan@gmail.com>
 Evert Lammerts <evert.lammerts@gmail.com>
 Evgeny Savinov <notime.sea@gmail.com>

--- a/graph/formats/gexf12/gexf.go
+++ b/graph/formats/gexf12/gexf.go
@@ -187,7 +187,7 @@ type AttValues struct {
 	AttValues []AttValue `xml:"attvalue,omitempty"`
 }
 
-// AttValues holds a single attribute value and its associated dynamics.
+// AttValue holds a single attribute value and its associated dynamics.
 type AttValue struct {
 	For       string `xml:"for,attr"`
 	Value     string `xml:"value,attr"`
@@ -197,7 +197,7 @@ type AttValue struct {
 	EndOpen   string `xml:"endopen,attr,omitempty"`
 }
 
-// EdgeShape holds the visual representation of an edge with associated
+// Edgeshape holds the visual representation of an edge with associated
 // dynamics.
 type Edgeshape struct {
 	// Shape be one of solid, dotted, dashed, double

--- a/graph/graphs/gen/gen.go
+++ b/graph/graphs/gen/gen.go
@@ -23,7 +23,7 @@ func abs(a int) int {
 	return a
 }
 
-// NodeIDGraphBuild is a graph that can create new nodes with
+// NodeIDGraphBuilder is a graph that can create new nodes with
 // specified IDs.
 type NodeIDGraphBuilder interface {
 	graph.Builder

--- a/graph/internal/set/set.go
+++ b/graph/internal/set/set.go
@@ -108,7 +108,7 @@ func NewNodes() Nodes {
 	return make(Nodes)
 }
 
-// NewNodes returns a new Nodes with the given size hint, n.
+// NewNodesSize returns a new Nodes with the given size hint, n.
 func NewNodesSize(n int) Nodes {
 	return make(Nodes, n)
 }

--- a/graph/iterator/lines.go
+++ b/graph/iterator/lines.go
@@ -76,7 +76,7 @@ type OrderedWeightedLines struct {
 	lines []graph.WeightedLine
 }
 
-// NewWeightedLineIterator returns an OrderedWeightedLines initialized with the provided lines.
+// NewOrderedWeightedLines returns an OrderedWeightedLines initialized with the provided lines.
 func NewOrderedWeightedLines(lines []graph.WeightedLine) *OrderedWeightedLines {
 	return &OrderedWeightedLines{idx: -1, lines: lines}
 }

--- a/graph/iterator/nodes.go
+++ b/graph/iterator/nodes.go
@@ -254,7 +254,7 @@ type LazyOrderedNodesByLines struct {
 	edges map[int64]map[int64]graph.Line
 }
 
-// NewLazyOrderedNodesByLine returns a LazyOrderedNodesByLines initialized with the
+// NewLazyOrderedNodesByLines returns a LazyOrderedNodesByLines initialized with the
 // provided nodes.
 func NewLazyOrderedNodesByLines(nodes map[int64]graph.Node, edges map[int64]map[int64]graph.Line) *LazyOrderedNodesByLines {
 	return &LazyOrderedNodesByLines{nodes: nodes, edges: edges}

--- a/graph/nodes_edges.go
+++ b/graph/nodes_edges.go
@@ -131,13 +131,13 @@ func EdgesOf(it Edges) []Edge {
 type WeightedEdges interface {
 	Iterator
 
-	// Edge returns the current Edge from the iterator.
+	// WeightedEdge returns the current Edge from the iterator.
 	WeightedEdge() WeightedEdge
 }
 
 // WeightedEdgeSlicer wraps the WeightedEdgeSlice method.
 type WeightedEdgeSlicer interface {
-	// EdgeSlice returns the set of edges remaining
+	// WeightedEdgeSlice returns the set of edges remaining
 	// to be iterated by an Edges iterator.
 	// The holder of the iterator may arbitrarily
 	// change elements in the returned slice, but
@@ -224,14 +224,14 @@ func LinesOf(it Lines) []Line {
 type WeightedLines interface {
 	Iterator
 
-	// Line returns the current Line from the iterator.
+	// WeightedLine returns the current WeightedLine from the iterator.
 	WeightedLine() WeightedLine
 }
 
 // WeightedLineSlicer wraps the WeightedLineSlice method.
 type WeightedLineSlicer interface {
-	// LineSlice returns the set of lines remaining
-	// to be iterated by an Lines iterator.
+	// WeightedLineSlice returns the set of lines remaining
+	// to be iterated by a WeightedLines iterator.
 	// The holder of the iterator may arbitrarily
 	// change elements in the returned slice, but
 	// those changes may be reflected to other

--- a/graph/path/internal/testgraphs/limited.go
+++ b/graph/path/internal/testgraphs/limited.go
@@ -233,12 +233,12 @@ func (l *LimitedVisionGrid) Edge(uid, vid int64) graph.Edge {
 	return l.WeightedEdgeBetween(uid, vid)
 }
 
-// Edge optimistically returns the weighted edge from u to v.
+// WeightedEdge optimistically returns the weighted edge from u to v.
 func (l *LimitedVisionGrid) WeightedEdge(uid, vid int64) graph.WeightedEdge {
 	return l.WeightedEdgeBetween(uid, vid)
 }
 
-// WeightedEdgeBetween optimistically returns the edge between u and v.
+// EdgeBetween optimistically returns the edge between u and v.
 func (l *LimitedVisionGrid) EdgeBetween(uid, vid int64) graph.Edge {
 	return l.WeightedEdgeBetween(uid, vid)
 }

--- a/graph/simple/simple.go
+++ b/graph/simple/simple.go
@@ -33,7 +33,7 @@ func (e Edge) From() graph.Node { return e.F }
 // To returns the to-node of the edge.
 func (e Edge) To() graph.Node { return e.T }
 
-// ReversedLine returns a new Edge with the F and T fields
+// ReversedEdge returns a new Edge with the F and T fields
 // swapped.
 func (e Edge) ReversedEdge() graph.Edge { return Edge{F: e.T, T: e.F} }
 
@@ -49,7 +49,7 @@ func (e WeightedEdge) From() graph.Node { return e.F }
 // To returns the to-node of the edge.
 func (e WeightedEdge) To() graph.Node { return e.T }
 
-// ReversedLine returns a new Edge with the F and T fields
+// ReversedEdge returns a new Edge with the F and T fields
 // swapped. The weight of the new Edge is the same as
 // the weight of the receiver.
 func (e WeightedEdge) ReversedEdge() graph.Edge { return WeightedEdge{F: e.T, T: e.F, W: e.W} }

--- a/graph/topo/johnson_cycles.go
+++ b/graph/topo/johnson_cycles.go
@@ -248,7 +248,7 @@ func (g johnsonGraph) Nodes() graph.Nodes {
 	return iterator.NewOrderedNodes(n)
 }
 
-// Successors is required to satisfy Tarjan.
+// From is required to satisfy Tarjan.
 func (g johnsonGraph) From(id int64) graph.Nodes {
 	adj := g.succ[id]
 	if len(adj) == 0 {


### PR DESCRIPTION
According to [Comment Sentences at github.com/golang](https://github.com/golang/go/wiki/CodeReviewComments#comment-sentences), it is a convention to begin a comment with the name of the exported element.
