### PR TITLE
mat: add LU.RowPivots and deprecate LU.Pivot

### DIFF
--- a/mat/lu.go
+++ b/mat/lu.go
@@ -144,16 +144,16 @@ func (lu *LU) LogDet() (det float64, sign float64) {
 	return floats.Sum(logDiag), sign
 }
 
-// Pivot returns the row permutation that represents the permutation matrix P
-// from the LU factorization
+// RowPivots returns the row permutation that represents the permutation matrix
+// P from the LU factorization
 //
 //	A = P * L * U.
 //
 // If dst is nil, a new slice is allocated and returned. If dst is not nil and
-// the length of dst does not equal the size of the factorized matrix, Pivot
-// will panic. Pivot will panic if the receiver does not contain a
+// the length of dst does not equal the size of the factorized matrix, RowPivots
+// will panic. RowPivots will panic if the receiver does not contain a
 // factorization.
-func (lu *LU) Pivot(dst []int) []int {
+func (lu *LU) RowPivots(dst []int) []int {
 	if !lu.isValid() {
 		panic(badLU)
 	}
@@ -175,6 +175,11 @@ func (lu *LU) Pivot(dst []int) []int {
 		dst[i], dst[v] = dst[v], dst[i]
 	}
 	return dst
+}
+
+// Deprecated: Use RowPivots instead.
+func (lu *LU) Pivot(dst []int) []int {
+	return lu.RowPivots(dst)
 }
 
 // RankOne updates an LU factorization as if a rank-one update had been applied to

--- a/mat/lu_test.go
+++ b/mat/lu_test.go
@@ -30,7 +30,7 @@ func TestLUD(t *testing.T) {
 		lu.LTo(&l)
 		lu.UTo(&u)
 		var p Dense
-		pivot := lu.Pivot(nil)
+		pivot := lu.RowPivots(nil)
 		p.Permutation(n, pivot)
 		var got Dense
 		got.Product(&p, &l, &u)
@@ -100,7 +100,7 @@ func luReconstruct(lu *LU) *Dense {
 	lu.LTo(&L)
 	lu.UTo(&U)
 	var P Dense
-	pivot := lu.Pivot(nil)
+	pivot := lu.RowPivots(nil)
 	P.Permutation(len(pivot), pivot)
 
 	var a Dense


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
