### PR TITLE
mat: make QR satisfy Matrix

### DIFF
--- a/lapack/lapack.go
+++ b/lapack/lapack.go
@@ -27,6 +27,7 @@ type Float64 interface {
 	Dlansy(norm MatrixNorm, uplo blas.Uplo, n int, a []float64, lda int, work []float64) float64
 	Dlapmr(forward bool, m, n int, x []float64, ldx int, k []int)
 	Dlapmt(forward bool, m, n int, x []float64, ldx int, k []int)
+	Dorgqr(m, n, k int, a []float64, lda int, tau, work []float64, lwork int)
 	Dormqr(side blas.Side, trans blas.Transpose, m, n, k int, a []float64, lda int, tau, c []float64, ldc int, work []float64, lwork int)
 	Dormlq(side blas.Side, trans blas.Transpose, m, n, k int, a []float64, lda int, tau, c []float64, ldc int, work []float64, lwork int)
 	Dpbcon(uplo blas.Uplo, n, kd int, ab []float64, ldab int, anorm float64, work []float64, iwork []int) float64

--- a/lapack/lapack64/lapack64.go
+++ b/lapack/lapack64/lapack64.go
@@ -694,6 +694,28 @@ func Ormlq(side blas.Side, trans blas.Transpose, a blas64.General, tau []float64
 	lapack64.Dormlq(side, trans, c.Rows, c.Cols, a.Rows, a.Data, max(1, a.Stride), tau, c.Data, max(1, c.Stride), work, lwork)
 }
 
+// Orgqr generates an m×n matrix Q with orthonormal columns defined by the
+// product of elementary reflectors
+//
+//	Q = H_0 * H_1 * ... * H_{k-1}
+//
+// as computed by Geqrf.
+//
+// k is determined by the length of tau.
+//
+// The length of work must be at least n and it also must be that 0 <= k <= n
+// and 0 <= n <= m.
+//
+// work is temporary storage, and lwork specifies the usable memory length. At
+// minimum, lwork >= n, and the amount of blocking is limited by the usable
+// length. If lwork == -1, instead of computing Orgqr the optimal work length
+// is stored into work[0].
+//
+// Orgqr will panic if the conditions on input values are not met.
+func Orgqr(a blas64.General, tau []float64, work []float64, lwork int) {
+	lapack64.Dorgqr(a.Rows, a.Cols, len(tau), a.Data, a.Stride, tau, work, lwork)
+}
+
 // Ormqr multiplies an m×n matrix C by an orthogonal matrix Q as
 //
 //	C = Q * C   if side == blas.Left  and trans == blas.NoTrans,
@@ -705,12 +727,13 @@ func Ormlq(side blas.Side, trans blas.Transpose, a blas64.General, tau []float64
 //
 //	Q = H_0 * H_1 * ... * H_{k-1}.
 //
+// k is determined by the length of tau.
+//
 // If side == blas.Left, A is an m×k matrix and 0 <= k <= m.
 // If side == blas.Right, A is an n×k matrix and 0 <= k <= n.
 // The ith column of A contains the vector which defines the elementary
-// reflector H_i and tau[i] contains its scalar factor. tau must have length k
-// and Ormqr will panic otherwise. Geqrf returns A and tau in the required
-// form.
+// reflector H_i and tau[i] contains its scalar factor. Geqrf returns A and tau
+// in the required form.
 //
 // work must have length at least max(1,lwork), and lwork must be at least n if
 // side == blas.Left and at least m if side == blas.Right, otherwise Ormqr will
@@ -725,7 +748,7 @@ func Ormlq(side blas.Side, trans blas.Transpose, a blas64.General, tau []float64
 // If lwork is -1, instead of performing Ormqr, the optimal workspace size will
 // be stored into work[0].
 func Ormqr(side blas.Side, trans blas.Transpose, a blas64.General, tau []float64, c blas64.General, work []float64, lwork int) {
-	lapack64.Dormqr(side, trans, c.Rows, c.Cols, a.Cols, a.Data, max(1, a.Stride), tau, c.Data, max(1, c.Stride), work, lwork)
+	lapack64.Dormqr(side, trans, c.Rows, c.Cols, len(tau), a.Data, max(1, a.Stride), tau, c.Data, max(1, c.Stride), work, lwork)
 }
 
 // Pocon estimates the reciprocal of the condition number of a positive-definite

--- a/mat/qr_test.go
+++ b/mat/qr_test.go
@@ -42,6 +42,13 @@ func TestQR(t *testing.T) {
 			t.Errorf("Q is not orthonormal: m = %v, n = %v", m, n)
 		}
 
+		if !EqualApprox(a, &qr, 1e-14) {
+			t.Errorf("m=%d,n=%d: A and QR are not equal", m, n)
+		}
+		if !EqualApprox(a.T(), qr.T(), 1e-14) {
+			t.Errorf("m=%d,n=%d: Aᵀ and (QR)ᵀ are not equal", m, n)
+		}
+
 		qr.RTo(&r)
 
 		var got Dense


### PR DESCRIPTION
Making QR satisfy Matrix is more difficult compared to the other factorization types because the matrix Q is represented only implicitly and recovering it is expensive. I opted for computing it explicitly together with the factorization at the expense of memory.

I also switched from Dormqr (prepare the identity matrix and multiply Q into it) to Dorgqr which exists for exactly this purpose.

Please take a look.

Updates #926 

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
