### PR TITLE
mat: add VecDense.Permute

### DIFF
--- a/mat/vector.go
+++ b/mat/vector.go
@@ -837,3 +837,19 @@ func (v *VecDense) RowViewOf(m RawMatrixer, i int) {
 	v.mat.Data = rm.Data[i*rm.Stride : i*rm.Stride+rm.Cols]
 	v.mat.N = rm.Cols
 }
+
+// Permute rearranges the elements of the n-vector v in the receiver as
+// specified by the permutation p[0],p[1],...,p[n-1] of the integers 0,...,n-1.
+//
+// If inverse is false, the given permutation is applied:
+//
+//	v[p[i]] is moved to v[i] for i=0,1,...,n-1.
+//
+// If inverse is true, the inverse permutation is applied:
+//
+//	v[i] is moved to v[p[i]] for i=0,1,...,n-1.
+//
+// p must have length n, otherwise Permute will panic.
+func (v *VecDense) Permute(p []int, inverse bool) {
+	v.asDense().PermuteRows(p, inverse)
+}


### PR DESCRIPTION
I'm wondering whether it wouldn't be more `mat`-like to have signatures
```
// v = P*x or v = P^T*x
func (v *VecDense) Permute(p []int, trans bool, x Vector)

// M = P*A or M = P^T*A
func (m *Dense) PermuteRows(p []int, trans bool, a Matrix)

// M = A*P or M = A*P^T
func (m *Dense) PermuteCols(a Matrix, p []int, trans bool)
```
It complicates the implementation (special-casing on the type of A and whether it's transposed; do we care about orientation of x?) and I'm not sure if the greater flexibility is a benefit for the user. What do you think?