### PR TITLE
graph/path: do not keep duplicate paths in YenKShortestPaths

### DIFF
--- a/graph/path/yen_ksp.go
+++ b/graph/path/yen_ksp.go
@@ -85,7 +85,18 @@ func YenKShortestPaths(g graph.Graph, k int, cost float64, s, t graph.Node) [][]
 				spath = append(root[:len(root)-1], spath...)
 				weight += rootWeight
 			}
-			pot = append(pot, yenShortest{spath, weight})
+
+			// Add the potential k-shortest path if it is new.
+			isNewPot := true
+			for x := range pot {
+				if isSamePath(pot[x].path, spath) {
+					isNewPot = false
+					break
+				}
+			}
+			if isNewPot {
+				pot = append(pot, yenShortest{spath, weight})
+			}
 		}
 
 		if len(pot) == 0 {
@@ -102,6 +113,19 @@ func YenKShortestPaths(g graph.Graph, k int, cost float64, s, t graph.Node) [][]
 	}
 
 	return paths
+}
+
+func isSamePath(pathA, pathB []graph.Node) bool {
+	if len(pathA) != len(pathB) {
+		return false
+	}
+
+	for i := range pathA {
+		if pathA[i].ID() != pathB[i].ID() {
+			return false
+		}
+	}
+	return true
 }
 
 // yenShortest holds a path and its weight for sorting.

--- a/graph/path/yen_ksp.go
+++ b/graph/path/yen_ksp.go
@@ -115,13 +115,13 @@ func YenKShortestPaths(g graph.Graph, k int, cost float64, s, t graph.Node) [][]
 	return paths
 }
 
-func isSamePath(pathA, pathB []graph.Node) bool {
-	if len(pathA) != len(pathB) {
+func isSamePath(a, b []graph.Node) bool {
+	if len(a) != len(b) {
 		return false
 	}
 
-	for i := range pathA {
-		if pathA[i].ID() != pathB[i].ID() {
+	for i, x := range a {
+		if x.ID() != b[i].ID() {
 			return false
 		}
 	}

--- a/graph/path/yen_ksp_test.go
+++ b/graph/path/yen_ksp_test.go
@@ -306,6 +306,28 @@ var yenShortestPathTests = []struct {
 			{8, 2, 4, 3, 7, 5},
 		},
 	},
+	{
+		name:  "grid", // This is the failing case in gonum/gonum#1920.
+		graph: func() graph.WeightedEdgeAdder { return simple.NewWeightedUndirectedGraph(0, math.Inf(1)) },
+		edges: []simple.WeightedEdge{
+			{F: simple.Node(1), T: simple.Node(2), W: 1},
+			{F: simple.Node(2), T: simple.Node(3), W: 2},
+			{F: simple.Node(3), T: simple.Node(6), W: 5},
+			{F: simple.Node(1), T: simple.Node(4), W: 5},
+			{F: simple.Node(2), T: simple.Node(5), W: 4},
+			{F: simple.Node(4), T: simple.Node(5), W: 6},
+			{F: simple.Node(5), T: simple.Node(6), W: 7},
+		},
+		query: simple.Edge{F: simple.Node(1), T: simple.Node(6)},
+		k:     -1,
+		cost:  math.Inf(1),
+		wantPaths: [][]int64{
+			{1, 2, 3, 6},
+			{1, 2, 5, 6},
+			{1, 4, 5, 6},
+			{1, 4, 5, 2, 3, 6},
+		},
+	},
 }
 
 func bipartite(n int, weight, inc float64) []simple.WeightedEdge {


### PR DESCRIPTION
Fixes #1920.

Previously the code is not ignoring spur path that has already been added into the list of potential paths. This can cause the search to return duplicate paths for certain graphs.

/cc @kortschak @vladimir-ch This is an urgent bug fix.

--- 

`YenKShortestPaths` was implemented in PR https://github.com/gonum/gonum/pull/565 and merged on 22 August 2018. On 13 February 2020, the Wikipedia page for Yen's algorithm was updated [^1] to include the conditional to check if the spur path has already been added into the potential paths.

[^1]: https://en.wikipedia.org/w/index.php?title=Yen%27s_algorithm&diff=prev&oldid=940584176
