### PR TITLE
internal/asm/*: use correct test len

### DIFF
--- a/internal/asm/f32/bench_test.go
+++ b/internal/asm/f32/bench_test.go
@@ -7,7 +7,7 @@ package f32
 import "testing"
 
 const (
-	benchLen = 1e5
+	benchLen = 10e5
 	a        = 2
 )
 

--- a/internal/asm/f64/benchAxpy_test.go
+++ b/internal/asm/f64/benchAxpy_test.go
@@ -11,7 +11,7 @@ import (
 	. "gonum.org/v1/gonum/internal/asm/f64"
 )
 
-const testLen = 1e5
+const testLen = 50e5
 
 var (
 	a = 2.0


### PR DESCRIPTION
f64 contains larger benchmarks than f32 and other packages. Make the test data large enough to pass benchmarks.

Please take a look.