### PR TITLE
stat: Variance should work if the input length equals 1

### DIFF
--- a/stat/stat.go
+++ b/stat/stat.go
@@ -1319,6 +1319,11 @@ func MeanVariance(x, weights []float64) (mean, variance float64) {
 		unnormalisedVariance float64
 		sumWeights           float64
 	)
+
+	if len(x) == 1 {
+		return x[0], 0
+	}
+
 	mean, unnormalisedVariance, sumWeights = meanUnnormalisedVarianceSumWeights(x, weights)
 	return mean, unnormalisedVariance / (sumWeights - 1)
 }

--- a/stat/stat_test.go
+++ b/stat/stat_test.go
@@ -1773,6 +1773,11 @@ func TestVariance(t *testing.T) {
 			weights: []float64{1, 1.5, 1},
 			ans:     .8,
 		},
+		{
+			x:       []float64{2},
+			weights: nil,
+			ans:     0,
+		},
 	} {
 		variance := Variance(test.x, test.weights)
 		if math.Abs(variance-test.ans) > 1e-14 {
@@ -1781,6 +1786,36 @@ func TestVariance(t *testing.T) {
 	}
 	if !panics(func() { Variance(make([]float64, 3), make([]float64, 2)) }) {
 		t.Errorf("Variance did not panic with x, weights length mismatch")
+	}
+}
+
+func TestMeanVariance(t *testing.T) {
+	m, v := MeanVariance([]float64{0.0}, nil)
+	if math.IsNaN(m) {
+		t.Errorf("MeanVariance mismatch case 0: Expected %v, Found %v", 0.0, m)
+	}
+	if math.IsNaN(v) {
+		t.Errorf("MeanVariance mismatch case 0: Expected %v, Found %v", 0.0, v)
+	}
+	if math.Abs(m-0.0) > 1e-14 {
+		t.Errorf("MeanVariance mismatch case 0: Expected %v, Found %v", 0.0, m)
+	}
+	if math.Abs(v-0.0) > 1e-14 {
+		t.Errorf("MeanVariance mismatch case 0: Expected %v, Found %v", 0.0, v)
+	}
+
+	m, v = MeanVariance([]float64{0.0, 1.0}, nil)
+	if math.IsNaN(m) {
+		t.Errorf("MeanVariance mismatch case 0: Expected %v, Found %v", 0.5, m)
+	}
+	if math.IsNaN(v) {
+		t.Errorf("MeanVariance mismatch case 0: Expected %v, Found %v", 0.5, v)
+	}
+	if math.Abs(m-0.5) > 1e-14 {
+		t.Errorf("MeanVariance mismatch case 0: Expected %v, Found %v", 0.5, m)
+	}
+	if math.Abs(v-0.5) > 1e-14 {
+		t.Errorf("MeanVariance mismatch case 0: Expected %v, Found %v", 0.5, v)
 	}
 }
 


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->

same to the NumPy, if the input length is `1`, the current function will return `NaN`

```py
>>> np.var([1])
0.0
```
