### PR TITLE
ci: update to go1.21

### DIFF
--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -6,13 +6,21 @@ on:
 jobs:
   ci:
     name: lint
+    strategy:
+      matrix:
+        go: ["1.21.x"]
     runs-on: ubuntu-latest
     env:
-        GO111MODULE: on
+      GO111MODULE: on
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
-    - uses: dominikh/staticcheck-action@v1
-      with:
-        version: "2022.1"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: WillAbides/setup-go-faster@v1.7.0
+        with:
+          go-version: ${{ matrix.go }}
+      - uses: dominikh/staticcheck-action@v1.3.0
+        with:
+          version: "2023.1.6"
+          install-go: false
+          cache-key: ${{ matrix.go }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gonum.org/v1/gonum
 
-go 1.20
+go 1.21
 
 require (
 	github.com/goccmack/gocc v0.0.0-20230228185258-2292f9e40198


### PR DESCRIPTION
This PR is a prerequisite for a few others I intend to raise that will better prepare `graph` and other packages for generics and other modernization, as described in https://github.com/gonum/gonum/issues/617.

Follow-on to https://github.com/gonum/gonum/pull/1934, which was my first attempt at this but was too large to properly benchmark.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
