### PR TITLE
cmplxs: replace custom reverse logic with slices.Reverse

### DIFF
--- a/cmplxs/cmplxs.go
+++ b/cmplxs/cmplxs.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"math"
 	"math/cmplx"
+	"slices"
 
 	"gonum.org/v1/gonum/cmplxs/cscalar"
 	"gonum.org/v1/gonum/internal/asm/c128"
@@ -563,10 +564,10 @@ func Real(dst []float64, src []complex128) []float64 {
 }
 
 // Reverse reverses the order of elements in the slice.
+//
+// Deprecated: This function simply calls [slices.Reverse].
 func Reverse(s []complex128) {
-	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
-		s[i], s[j] = s[j], s[i]
-	}
+	slices.Reverse(s)
 }
 
 // Same returns true when the input slices have the same length and all

--- a/cmplxs/cmplxs_test.go
+++ b/cmplxs/cmplxs_test.go
@@ -1371,3 +1371,16 @@ func BenchmarkNorm2Small(b *testing.B)  { benchmarkNorm2(b, Small) }
 func BenchmarkNorm2Medium(b *testing.B) { benchmarkNorm2(b, Medium) }
 func BenchmarkNorm2Large(b *testing.B)  { benchmarkNorm2(b, Large) }
 func BenchmarkNorm2Huge(b *testing.B)   { benchmarkNorm2(b, Huge) }
+
+func benchmarkReverse(b *testing.B, size int) {
+	src := rand.NewSource(1)
+	s := randomSlice(size, src)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Reverse(s)
+	}
+}
+func BenchmarkReverseSmall(b *testing.B)  { benchmarkReverse(b, Small) }
+func BenchmarkReverseMedium(b *testing.B) { benchmarkReverse(b, Medium) }
+func BenchmarkReverseLarge(b *testing.B)  { benchmarkReverse(b, Large) }
+func BenchmarkReverseHuge(b *testing.B)   { benchmarkReverse(b, Huge) }


### PR DESCRIPTION
This PR introduces a single modernization change from https://github.com/gonum/gonum/pull/1934. Benchmarks will follow.

Follow-on to https://github.com/gonum/gonum/pull/1934, which was my first attempt at this but was too large to properly benchmark.

Blocked by https://github.com/gonum/gonum/pull/1940.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
