### PR TITLE
stat: replace custom reverse logic with slices.Reverse 

### DIFF
--- a/stat/moments_bench_test.go
+++ b/stat/moments_bench_test.go
@@ -18,10 +18,11 @@ import (
 )
 
 const (
-	small  = 10
-	medium = 1000
-	large  = 100000
-	huge   = 10000000
+	empty  = 0
+	small  = 1e1
+	medium = 1e3
+	large  = 1e5
+	huge   = 1e7
 )
 
 // tests for unweighted versions

--- a/stat/roc.go
+++ b/stat/roc.go
@@ -6,6 +6,7 @@ package stat
 
 import (
 	"math"
+	"slices"
 	"sort"
 )
 
@@ -117,13 +118,9 @@ func ROC(cutoffs, y []float64, classes []bool, weights []float64) (tpr, fpr, thr
 		tpr[i] = 1 - float64(tpr[i]*invPos)
 		fpr[i] = 1 - float64(fpr[i]*invNeg)
 	}
-	for i, j := 0, len(tpr)-1; i < j; i, j = i+1, j-1 {
-		tpr[i], tpr[j] = tpr[j], tpr[i]
-		fpr[i], fpr[j] = fpr[j], fpr[i]
-	}
-	for i, j := 0, len(cutoffs)-1; i < j; i, j = i+1, j-1 {
-		cutoffs[i], cutoffs[j] = cutoffs[j], cutoffs[i]
-	}
+	slices.Reverse(tpr)
+	slices.Reverse(fpr)
+	slices.Reverse(cutoffs)
 
 	return tpr, fpr, cutoffs
 }


### PR DESCRIPTION
This PR introduces a single modernization change from https://github.com/gonum/gonum/pull/1934. Benchmarks will follow.

Follow-on to https://github.com/gonum/gonum/pull/1934, which was my first attempt at this but was too large to properly benchmark.

Blocked by https://github.com/gonum/gonum/pull/1940.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
