### PR TITLE
spatial: replace custom reverse logic with slices.Reverse

### DIFF
--- a/spatial/kdtree/kdtree_test.go
+++ b/spatial/kdtree/kdtree_test.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -288,9 +289,7 @@ func nearestN(n int, q Point, p Points) []ComparableDist {
 		return nk.Heap
 	}
 	sort.Sort(nk)
-	for i, j := 0, len(nk.Heap)-1; i < j; i, j = i+1, j-1 {
-		nk.Heap[i], nk.Heap[j] = nk.Heap[j], nk.Heap[i]
-	}
+	slices.Reverse(nk.Heap)
 	return nk.Heap
 }
 

--- a/spatial/vptree/vptree_test.go
+++ b/spatial/vptree/vptree_test.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -204,9 +205,7 @@ func nearestN(n int, q Comparable, p []Comparable) []ComparableDist {
 		return nk.Heap
 	}
 	sort.Sort(nk)
-	for i, j := 0, len(nk.Heap)-1; i < j; i, j = i+1, j-1 {
-		nk.Heap[i], nk.Heap[j] = nk.Heap[j], nk.Heap[i]
-	}
+	slices.Reverse(nk.Heap)
 	return nk.Heap
 }
 


### PR DESCRIPTION
This PR introduces a single modernization change from https://github.com/gonum/gonum/pull/1934. Benchmarks will follow.

Follow-on to https://github.com/gonum/gonum/pull/1934, which was my first attempt at this but was too large to properly benchmark.

Blocked by https://github.com/gonum/gonum/pull/1940.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
