### PR TITLE
graph: merge set.Ints and set.Int64s into one generic set

### DIFF
--- a/graph/coloring/coloring.go
+++ b/graph/coloring/coloring.go
@@ -128,13 +128,13 @@ func DsaturExact(term Terminator, g graph.Undirected) (k int, colors map[int64]i
 // dSaturColoring is a partial graph coloring.
 type dSaturColoring struct {
 	colors    map[int64]int
-	uncolored set.Int64s
+	uncolored set.Ints[int64]
 }
 
 // newDsaturColoring returns a dSaturColoring representing a partial coloring
 // of a graph with the given nodes and colors.
 func newDsaturColoring(nodes []graph.Node, colors map[int64]int) dSaturColoring {
-	uncolored := make(set.Int64s)
+	uncolored := make(set.Ints[int64])
 	for _, v := range nodes {
 		vid := v.ID()
 		if _, ok := colors[vid]; !ok {
@@ -193,7 +193,7 @@ func dSaturExact(term Terminator, selector *saturationDegree, cand dSaturColorin
 			if best == nil {
 				return -1, nil, term.Err()
 			}
-			colors := make(set.Ints)
+			colors := make(set.Ints[int])
 			for _, c := range best {
 				colors.Add(c)
 			}
@@ -215,7 +215,7 @@ func dSaturExact(term Terminator, selector *saturationDegree, cand dSaturColorin
 	adjColors := selector.adjColors[selector.indexOf[vid]]
 
 	// Collect all feasible existing colors plus one, remembering it.
-	feasible := make(set.Ints)
+	feasible := make(set.Ints[int])
 	for _, c := range cand.colors {
 		if adjColors.Has(c) {
 			continue
@@ -293,7 +293,7 @@ func bestMaximumClique(g graph.Undirected, cliques [][]graph.Node) (colors map[i
 
 // cliqueDegree returns the degree of the clique to nodes outside the clique.
 func cliqueDegree(g graph.Undirected, clique []graph.Node) int {
-	n := make(set.Int64s)
+	n := make(set.Ints[int64])
 	for _, u := range clique {
 		to := g.From(u.ID())
 		for to.Next() {
@@ -584,7 +584,7 @@ func greedyColoringOf(g graph.Undirected, order graph.Nodes, partial map[int64]i
 	if !constrained {
 		return k + 1, colors
 	}
-	seen := make(set.Ints)
+	seen := make(set.Ints[int])
 	for _, c := range colors {
 		seen.Add(c)
 	}
@@ -593,8 +593,8 @@ func greedyColoringOf(g graph.Undirected, order graph.Nodes, partial map[int64]i
 
 // colorsOf returns all the colors in the coloring that are used by the
 // given nodes.
-func colorsOf(nodes graph.Nodes, coloring map[int64]int) set.Ints {
-	c := make(set.Ints, nodes.Len())
+func colorsOf(nodes graph.Nodes, coloring map[int64]int) set.Ints[int] {
+	c := make(set.Ints[int], nodes.Len())
 	for nodes.Next() {
 		used, ok := coloring[nodes.Node().ID()]
 		if ok {
@@ -692,7 +692,7 @@ type saturationDegree struct {
 	// colors of each node.
 	indexOf   map[int64]int
 	degrees   []int
-	adjColors []set.Ints
+	adjColors []set.Ints[int]
 
 	// g and colors are the graph coloring.
 	// colors is held by both the iterator
@@ -712,13 +712,13 @@ func newSaturationDegree(it graph.Nodes, g graph.Undirected, colors map[int64]in
 		nodes:     nodes,
 		indexOf:   make(map[int64]int, len(nodes)),
 		degrees:   make([]int, len(nodes)),
-		adjColors: make([]set.Ints, len(nodes)),
+		adjColors: make([]set.Ints[int], len(nodes)),
 		g:         g,
 		colors:    colors,
 	}
 	for i, u := range nodes {
 		sd.degrees[i] = g.From(u.ID()).Len()
-		sd.adjColors[i] = make(set.Ints)
+		sd.adjColors[i] = make(set.Ints[int])
 		sd.indexOf[u.ID()] = i
 	}
 	for uid, c := range colors {
@@ -734,7 +734,7 @@ func newSaturationDegree(it graph.Nodes, g graph.Undirected, colors map[int64]in
 func (sd *saturationDegree) reset(colors map[int64]int) {
 	sd.colors = colors
 	for i := range sd.nodes {
-		sd.adjColors[i] = make(set.Ints)
+		sd.adjColors[i] = make(set.Ints[int])
 	}
 	for uid, c := range colors {
 		to := sd.g.From(uid)
@@ -804,8 +804,8 @@ func (sd *saturationDegree) pass() int {
 }
 
 // same implements the same function from San Segundo doi:10.1016/j.cor.2011.10.008.
-func (sd *saturationDegree) same(vi, vj set.Ints) int {
-	valid := make(set.Ints)
+func (sd *saturationDegree) same(vi, vj set.Ints[int]) int {
+	valid := make(set.Ints[int])
 	for _, c := range sd.colors {
 		if !vi.Has(c) {
 			valid.Add(c)
@@ -823,7 +823,7 @@ func saturationDegreeOf(vid int64, g graph.Undirected, colors map[int64]int) int
 	if _, ok := colors[vid]; ok {
 		panic("coloring: saturation degree not defined for colored node")
 	}
-	adjColors := make(set.Ints)
+	adjColors := make(set.Ints[int])
 	to := g.From(vid)
 	for to.Next() {
 		if c, ok := colors[to.Node().ID()]; ok {

--- a/graph/coloring/coloring_test.go
+++ b/graph/coloring/coloring_test.go
@@ -29,11 +29,11 @@ var coloringTests = []struct {
 
 	partial map[int64]int
 
-	dsatur      set.Ints
-	randomized  set.Ints
-	rlf         set.Ints
-	sanSegundo  set.Ints
-	welshPowell set.Ints
+	dsatur      set.Ints[int]
+	randomized  set.Ints[int]
+	rlf         set.Ints[int]
+	sanSegundo  set.Ints[int]
+	welshPowell set.Ints[int]
 }{
 	{
 		name:   "empty",
@@ -411,8 +411,8 @@ var coloringTests = []struct {
 	},
 }
 
-func setOf(vals ...int) set.Ints {
-	s := make(set.Ints)
+func setOf(vals ...int) set.Ints[int] {
+	s := make(set.Ints[int])
 	for _, v := range vals {
 		s.Add(v)
 	}
@@ -767,6 +767,16 @@ func BenchmarkColoring(b *testing.B) {
 					}
 				})
 			}
+			b.Run("Randomized", func(b *testing.B) {
+				rnd := rand.NewSource(1)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					_, _, err := Randomized(bench.g, nil, rnd)
+					if err != nil {
+						b.Fatalf("coloring failed: %v", err)
+					}
+				}
+			})
 			b.Run("RecursiveLargestFirst", func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					RecursiveLargestFirst(bench.g)

--- a/graph/community/louvain_common.go
+++ b/graph/community/louvain_common.go
@@ -342,7 +342,7 @@ type slice struct {
 }
 
 // newSlice returns a new slice of elements from s, sorted ascending.
-func newSlice(s set.Ints) *slice {
+func newSlice(s set.Ints[int]) *slice {
 	elems := make([]int, 0, len(s))
 	for i := range s {
 		elems = append(elems, i)

--- a/graph/community/louvain_directed.go
+++ b/graph/community/louvain_directed.go
@@ -593,7 +593,7 @@ func (l *directedLocalMover) deltaQ(n graph.Node) (deltaQ float64, dst int, src 
 	gamma := l.resolution
 
 	// Find communities connected to n.
-	connected := make(set.Ints)
+	connected := make(set.Ints[int])
 	// The following for loop is equivalent to:
 	//
 	//  for _, v := range l.g.From(n) {

--- a/graph/community/louvain_directed_multiplex.go
+++ b/graph/community/louvain_directed_multiplex.go
@@ -133,18 +133,18 @@ func NewDirectedLayers(layers ...graph.Directed) (DirectedLayers, error) {
 	if len(layers) == 0 {
 		return nil, nil
 	}
-	base := make(set.Int64s)
+	base := make(set.Ints[int64])
 	nodes := layers[0].Nodes()
 	for nodes.Next() {
 		base.Add(nodes.Node().ID())
 	}
 	for i, l := range layers[1:] {
-		next := make(set.Int64s)
+		next := make(set.Ints[int64])
 		nodes := l.Nodes()
 		for nodes.Next() {
 			next.Add(nodes.Node().ID())
 		}
-		if !set.Int64sEqual(base, next) {
+		if !set.IntsEqual(base, next) {
 			return nil, fmt.Errorf("community: layer ID mismatch between layers: %d", i+1)
 		}
 	}
@@ -796,7 +796,7 @@ func (l *directedMultiplexLocalMover) deltaQ(n graph.Node) (deltaQ float64, dst 
 		iterator = &dense{n: len(l.communities)}
 	} else {
 		// Find communities connected to n.
-		connected := make(set.Ints)
+		connected := make(set.Ints[int])
 		// The following for loop is equivalent to:
 		//
 		//  for i := 0; i < l.g.Depth(); i++ {

--- a/graph/community/louvain_directed_multiplex_test.go
+++ b/graph/community/louvain_directed_multiplex_test.go
@@ -5,6 +5,7 @@
 package community
 
 import (
+	"fmt"
 	"math"
 	"reflect"
 	"sort"
@@ -721,4 +722,31 @@ func directedMultiplexFrom(raw []layer) (DirectedLayers, []float64, error) {
 		return nil, nil, err
 	}
 	return g, weights, nil
+}
+
+func BenchmarkNewDirectedLayers(b *testing.B) {
+	for _, graphSize := range []int{1e0, 1e1, 1e3, 1e5} {
+		for _, numGraphs := range []int{1e0, 1e1} {
+			b.Run(
+				fmt.Sprintf("graphSize=%d,numGraphs=%d", graphSize, numGraphs),
+				func(b *testing.B) {
+					g := simple.NewDirectedGraph()
+					for i := 0; i < graphSize; i++ {
+						g.AddNode(g.NewNode())
+					}
+					gs := make([]graph.Directed, numGraphs)
+					for i := 0; i < numGraphs; i++ {
+						gs[i] = g
+					}
+
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						_, err := NewDirectedLayers(gs...)
+						if err != nil {
+							b.Fatalf("NewDirectedLayers failed: %v", err)
+						}
+					}
+				})
+		}
+	}
 }

--- a/graph/community/louvain_undirected.go
+++ b/graph/community/louvain_undirected.go
@@ -536,7 +536,7 @@ func (l *undirectedLocalMover) deltaQ(n graph.Node) (deltaQ float64, dst int, sr
 	gamma := l.resolution
 
 	// Find communities connected to n.
-	connected := make(set.Ints)
+	connected := make(set.Ints[int])
 	// The following for loop is equivalent to:
 	//
 	//  for _, v := range l.g.From(n) {

--- a/graph/community/louvain_undirected_multiplex.go
+++ b/graph/community/louvain_undirected_multiplex.go
@@ -129,18 +129,18 @@ func NewUndirectedLayers(layers ...graph.Undirected) (UndirectedLayers, error) {
 	if len(layers) == 0 {
 		return nil, nil
 	}
-	base := make(set.Int64s)
+	base := make(set.Ints[int64])
 	nodes := layers[0].Nodes()
 	for nodes.Next() {
 		base.Add(nodes.Node().ID())
 	}
 	for i, l := range layers[1:] {
-		next := make(set.Int64s)
+		next := make(set.Ints[int64])
 		nodes := l.Nodes()
 		for nodes.Next() {
 			next.Add(nodes.Node().ID())
 		}
-		if !set.Int64sEqual(next, base) {
+		if !set.IntsEqual(next, base) {
 			return nil, fmt.Errorf("community: layer ID mismatch between layers: %d", i+1)
 		}
 	}
@@ -735,7 +735,7 @@ func (l *undirectedMultiplexLocalMover) deltaQ(n graph.Node) (deltaQ float64, ds
 		iterator = &dense{n: len(l.communities)}
 	} else {
 		// Find communities connected to n.
-		connected := make(set.Ints)
+		connected := make(set.Ints[int])
 		// The following for loop is equivalent to:
 		//
 		//  for i := 0; i < l.g.Depth(); i++ {

--- a/graph/community/louvain_undirected_multiplex_test.go
+++ b/graph/community/louvain_undirected_multiplex_test.go
@@ -5,6 +5,7 @@
 package community
 
 import (
+	"fmt"
 	"math"
 	"reflect"
 	"sort"
@@ -690,4 +691,31 @@ func undirectedMultiplexFrom(raw []layer) (UndirectedLayers, []float64, error) {
 		return nil, nil, err
 	}
 	return g, weights, nil
+}
+
+func BenchmarkNewUndirectedLayers(b *testing.B) {
+	for _, graphSize := range []int{1e0, 1e1, 1e3, 1e5} {
+		for _, numGraphs := range []int{1e0, 1e1} {
+			b.Run(
+				fmt.Sprintf("graphSize=%d,numGraphs=%d", graphSize, numGraphs),
+				func(b *testing.B) {
+					g := simple.NewUndirectedGraph()
+					for i := 0; i < graphSize; i++ {
+						g.AddNode(g.NewNode())
+					}
+					gs := make([]graph.Undirected, numGraphs)
+					for i := 0; i < numGraphs; i++ {
+						gs[i] = g
+					}
+
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						_, err := NewUndirectedLayers(gs...)
+						if err != nil {
+							b.Fatalf("NewUndirectedLayers failed: %v", err)
+						}
+					}
+				})
+		}
+	}
 }

--- a/graph/encoding/dot/bench_test.go
+++ b/graph/encoding/dot/bench_test.go
@@ -1,0 +1,117 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dot
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/exp/rand"
+
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/graphs/gen"
+	"gonum.org/v1/gonum/graph/multi"
+	"gonum.org/v1/gonum/graph/simple"
+)
+
+var (
+	gnpDirected_10_tenth   = gnpDirected(10, 0.1)
+	gnpDirected_100_tenth  = gnpDirected(100, 0.1)
+	gnpDirected_1000_tenth = gnpDirected(1000, 0.1)
+	gnpDirected_10_half    = gnpDirected(10, 0.5)
+	gnpDirected_100_half   = gnpDirected(100, 0.5)
+	gnpDirected_1000_half  = gnpDirected(1000, 0.5)
+
+	powerLawMultiDirected_10_tenth   = powerLawMultiDirected(10, 1)
+	powerLawMultiDirected_100_tenth  = powerLawMultiDirected(100, 10)
+	powerLawMultiDirected_1000_tenth = powerLawMultiDirected(1000, 100)
+	powerLawMultiDirected_10_half    = powerLawMultiDirected(10, 5)
+	powerLawMultiDirected_100_half   = powerLawMultiDirected(100, 50)
+	powerLawMultiDirected_1000_half  = powerLawMultiDirected(1000, 500)
+)
+
+func gnpDirected(n int, p float64) graph.Directed {
+	g := simple.NewDirectedGraph()
+	err := gen.Gnp(g, n, p, rand.NewSource(1))
+	if err != nil {
+		panic(fmt.Sprintf("dot: bad test: %v", err))
+	}
+	return g
+}
+
+func powerLawMultiDirected(n, d int) graph.DirectedMultigraph {
+	g := multi.NewDirectedGraph()
+	err := gen.PowerLaw(g, n, d, rand.NewSource(1))
+	if err != nil {
+		panic(fmt.Sprintf("dot: bad test: %v", err))
+	}
+	return g
+}
+
+func benchmarkUnmarshal(b *testing.B, g graph.Directed) {
+	marshalled, err := Marshal(g, "g", "", "")
+	if err != nil {
+		b.Fatalf("dot: bad Marshal input: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(marshalled, simple.NewDirectedGraph()); err != nil {
+			b.Fatalf("dot: bad Unmarshal input: %v", err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalGnp_10_tenth(b *testing.B) {
+	benchmarkUnmarshal(b, gnpDirected_10_tenth)
+}
+func BenchmarkUnmarshalGnp_100_tenth(b *testing.B) {
+	benchmarkUnmarshal(b, gnpDirected_100_tenth)
+}
+func BenchmarkUnmarshalGnp_1000_tenth(b *testing.B) {
+	benchmarkUnmarshal(b, gnpDirected_1000_tenth)
+}
+func BenchmarkUnmarshalGnp_10_half(b *testing.B) {
+	benchmarkUnmarshal(b, gnpDirected_10_half)
+}
+func BenchmarkUnmarshalGnp_100_half(b *testing.B) {
+	benchmarkUnmarshal(b, gnpDirected_100_half)
+}
+func BenchmarkUnmarshalGnp_1000_half(b *testing.B) {
+	benchmarkUnmarshal(b, gnpDirected_1000_half)
+}
+
+func benchmarkUnmarshalMulti(b *testing.B, g graph.DirectedMultigraph) {
+	marshalled, err := MarshalMulti(g, "g", "", "")
+	if err != nil {
+		b.Fatalf("dot: bad Marshal input: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := UnmarshalMulti(marshalled, multi.NewDirectedGraph()); err != nil {
+			b.Fatalf("dot: bad Unmarshal input: %v", err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalMultiPowerLaw_10_tenth(b *testing.B) {
+	benchmarkUnmarshalMulti(b, powerLawMultiDirected_10_tenth)
+}
+func BenchmarkUnmarshalMultiPowerLaw_100_tenth(b *testing.B) {
+	benchmarkUnmarshalMulti(b, powerLawMultiDirected_100_tenth)
+}
+func BenchmarkUnmarshalMultiPowerLaw_1000_tenth(b *testing.B) {
+	benchmarkUnmarshalMulti(b, powerLawMultiDirected_1000_tenth)
+}
+func BenchmarkUnmarshalMultiPowerLaw_10_half(b *testing.B) {
+	benchmarkUnmarshalMulti(b, powerLawMultiDirected_10_half)
+}
+func BenchmarkUnmarshalMultiPowerLaw_100_half(b *testing.B) {
+	benchmarkUnmarshalMulti(b, powerLawMultiDirected_100_half)
+}
+func BenchmarkUnmarshalMultiPowerLaw_1000_half(b *testing.B) {
+	benchmarkUnmarshalMulti(b, powerLawMultiDirected_1000_half)
+}

--- a/graph/encoding/dot/decode.go
+++ b/graph/encoding/dot/decode.go
@@ -358,7 +358,7 @@ func (gen *generator) popSubgraph() []graph.Node {
 // unique returns the set of unique nodes contained within ns.
 func unique(ns []graph.Node) []graph.Node {
 	var nodes []graph.Node
-	seen := make(set.Int64s)
+	seen := make(set.Ints[int64])
 	for _, n := range ns {
 		id := n.ID()
 		if seen.Has(id) {

--- a/graph/internal/set/same.go
+++ b/graph/internal/set/same.go
@@ -23,15 +23,6 @@ func same(a, b Nodes) bool {
 // hash maps are passed as a pointer to a runtime Hmap struct. A map is
 // not seen by the runtime as a pointer though, so we use unsafe to get
 // the maps' pointer values to compare.
-func intsSame(a, b Ints) bool {
-	return *(*uintptr)(unsafe.Pointer(&a)) == *(*uintptr)(unsafe.Pointer(&b))
-}
-
-// int64sSame determines whether two sets are backed by the same store. In the
-// current implementation using hash maps it makes use of the fact that
-// hash maps are passed as a pointer to a runtime Hmap struct. A map is
-// not seen by the runtime as a pointer though, so we use unsafe to get
-// the maps' pointer values to compare.
-func int64sSame(a, b Int64s) bool {
+func intsSame[T Int](a, b Ints[T]) bool {
 	return *(*uintptr)(unsafe.Pointer(&a)) == *(*uintptr)(unsafe.Pointer(&b))
 }

--- a/graph/internal/set/same_appengine.go
+++ b/graph/internal/set/same_appengine.go
@@ -23,15 +23,6 @@ func same(a, b Nodes) bool {
 // hash maps are passed as a pointer to a runtime Hmap struct. A map is
 // not seen by the runtime as a pointer though, so we use reflect to get
 // the maps' pointer values to compare.
-func intsSame(a, b Ints) bool {
-	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
-}
-
-// int64sSame determines whether two sets are backed by the same store. In the
-// current implementation using hash maps it makes use of the fact that
-// hash maps are passed as a pointer to a runtime Hmap struct. A map is
-// not seen by the runtime as a pointer though, so we use reflect to get
-// the maps' pointer values to compare.
-func int64sSame(a, b Int64s) bool {
+func intsSame[T Int](a, b Ints[T]) bool {
 	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
 }

--- a/graph/internal/set/set.go
+++ b/graph/internal/set/set.go
@@ -6,84 +6,35 @@ package set
 
 import "gonum.org/v1/gonum/graph"
 
-// Ints is a set of int identifiers.
-type Ints map[int]struct{}
+type Int interface{ ~int | ~int64 }
 
-// The simple accessor methods for Ints are provided to allow ease of
-// implementation change should the need arise.
+type Ints[T Int] map[T]struct{}
 
 // Add inserts an element into the set.
-func (s Ints) Add(e int) {
+func (s Ints[T]) Add(e T) {
 	s[e] = struct{}{}
 }
 
 // Has reports the existence of the element in the set.
-func (s Ints) Has(e int) bool {
+func (s Ints[T]) Has(e T) bool {
 	_, ok := s[e]
 	return ok
 }
 
 // Remove deletes the specified element from the set.
-func (s Ints) Remove(e int) {
+func (s Ints[T]) Remove(e T) {
 	delete(s, e)
 }
 
 // Count reports the number of elements stored in the set.
-func (s Ints) Count() int {
+func (s Ints[T]) Count() int {
 	return len(s)
 }
 
 // IntsEqual reports set equality between the parameters. Sets are equal if
 // and only if they have the same elements.
-func IntsEqual(a, b Ints) bool {
+func IntsEqual[T Int](a, b Ints[T]) bool {
 	if intsSame(a, b) {
-		return true
-	}
-
-	if len(a) != len(b) {
-		return false
-	}
-
-	for e := range a {
-		if _, ok := b[e]; !ok {
-			return false
-		}
-	}
-
-	return true
-}
-
-// Int64s is a set of int64 identifiers.
-type Int64s map[int64]struct{}
-
-// The simple accessor methods for Ints are provided to allow ease of
-// implementation change should the need arise.
-
-// Add inserts an element into the set.
-func (s Int64s) Add(e int64) {
-	s[e] = struct{}{}
-}
-
-// Has reports the existence of the element in the set.
-func (s Int64s) Has(e int64) bool {
-	_, ok := s[e]
-	return ok
-}
-
-// Remove deletes the specified element from the set.
-func (s Int64s) Remove(e int64) {
-	delete(s, e)
-}
-
-// Count reports the number of elements stored in the set.
-func (s Int64s) Count() int {
-	return len(s)
-}
-
-// Int64sEqual reports set equality between the parameters. Sets are equal if
-// and only if they have the same elements.
-func Int64sEqual(a, b Int64s) bool {
-	if int64sSame(a, b) {
 		return true
 	}
 

--- a/graph/internal/set/set_test.go
+++ b/graph/internal/set/set_test.go
@@ -13,149 +13,16 @@ type node int64
 
 func (n node) ID() int64 { return int64(n) }
 
-// TestSame tests the assumption that pointer equality via unsafe conversion
+// TestSameInts tests the assumption that pointer equality via unsafe conversion
 // of a map[int]struct{} to uintptr is a valid test for perfect identity between
 // set values. If any of the tests in TestSame fail, the package is broken and same
 // must be reimplemented to conform to the runtime map implementation. The relevant
 // code to look at (at least for gc) is the hmap type in runtime/map.go.
 
-func TestSameInt64s(t *testing.T) {
-	var (
-		a = make(Int64s)
-		b = make(Int64s)
-		c = a
-	)
-
-	if int64sSame(a, b) {
-		t.Error("Independently created sets test as same")
-	}
-	if !int64sSame(a, c) {
-		t.Error("Set copy and original test as not same.")
-	}
-	a.Add(1)
-	if !int64sSame(a, c) {
-		t.Error("Set copy and original test as not same after addition.")
-	}
-	if !int64sSame(nil, nil) {
-		t.Error("nil sets test as not same.")
-	}
-	if int64sSame(b, nil) {
-		t.Error("nil and empty sets test as same.")
-	}
-}
-
-func TestAddInt64s(t *testing.T) {
-	s := make(Int64s)
-	if s.Count() != 0 {
-		t.Error("Set somehow contains new elements upon creation")
-	}
-
-	s.Add(1)
-	s.Add(3)
-	s.Add(5)
-
-	if s.Count() != 3 {
-		t.Error("Incorrect number of set elements after adding")
-	}
-
-	if !s.Has(1) || !s.Has(3) || !s.Has(5) {
-		t.Error("Set doesn't contain element that was added")
-	}
-
-	s.Add(1)
-
-	if s.Count() > 3 {
-		t.Error("Set double-adds element (element not unique)")
-	} else if s.Count() < 3 {
-		t.Error("Set double-add lowered len")
-	}
-
-	if !s.Has(1) {
-		t.Error("Set doesn't contain double-added element")
-	}
-
-	if !s.Has(3) || !s.Has(5) {
-		t.Error("Set removes element on double-add")
-	}
-}
-
-func TestRemoveInt64s(t *testing.T) {
-	s := make(Int64s)
-
-	s.Add(1)
-	s.Add(3)
-	s.Add(5)
-
-	s.Remove(1)
-
-	if s.Count() != 2 {
-		t.Error("Incorrect number of set elements after removing an element")
-	}
-
-	if s.Has(1) {
-		t.Error("Element present after removal")
-	}
-
-	if !s.Has(3) || !s.Has(5) {
-		t.Error("Set remove removed wrong element")
-	}
-
-	s.Remove(1)
-
-	if s.Count() != 2 || s.Has(1) {
-		t.Error("Double set remove does something strange")
-	}
-
-	s.Add(1)
-
-	if s.Count() != 3 || !s.Has(1) {
-		t.Error("Cannot add element after removal")
-	}
-}
-
-func TestSelfEqualInt64s(t *testing.T) {
-	s := make(Int64s)
-
-	if !Int64sEqual(s, s) {
-		t.Error("Set is not equal to itself")
-	}
-
-	s.Add(1)
-
-	if !Int64sEqual(s, s) {
-		t.Error("Set ceases self equality after adding element")
-	}
-}
-
-func TestEqualInt64s(t *testing.T) {
-	a := make(Int64s)
-	b := make(Int64s)
-
-	if !Int64sEqual(a, b) {
-		t.Error("Two different empty sets not equal")
-	}
-
-	a.Add(1)
-	if Int64sEqual(a, b) {
-		t.Error("Two different sets with different sizes equal")
-	}
-
-	b.Add(1)
-	if !Int64sEqual(a, b) {
-		t.Error("Two sets with same element not equal")
-	}
-
-	b.Remove(1)
-	b.Add(2)
-	if Int64sEqual(a, b) {
-		t.Error("Two different sets with different elements equal")
-	}
-}
-
 func TestSameInts(t *testing.T) {
 	var (
-		a = make(Ints)
-		b = make(Ints)
+		a = make(Ints[int64])
+		b = make(Ints[int64])
 		c = a
 	)
 
@@ -163,13 +30,13 @@ func TestSameInts(t *testing.T) {
 		t.Error("Independently created sets test as same")
 	}
 	if !intsSame(a, c) {
-		t.Error("Set copy and original test as not same.")
+		t.Error("Ints copy and original test as not same.")
 	}
 	a.Add(1)
 	if !intsSame(a, c) {
-		t.Error("Set copy and original test as not same after addition.")
+		t.Error("Ints copy and original test as not same after addition.")
 	}
-	if !intsSame(nil, nil) {
+	if !intsSame[int64](nil, nil) {
 		t.Error("nil sets test as not same.")
 	}
 	if intsSame(b, nil) {
@@ -178,9 +45,9 @@ func TestSameInts(t *testing.T) {
 }
 
 func TestAddInts(t *testing.T) {
-	s := make(Ints)
+	s := make(Ints[int64])
 	if s.Count() != 0 {
-		t.Error("Set somehow contains new elements upon creation")
+		t.Error("Ints somehow contains new elements upon creation")
 	}
 
 	s.Add(1)
@@ -192,28 +59,28 @@ func TestAddInts(t *testing.T) {
 	}
 
 	if !s.Has(1) || !s.Has(3) || !s.Has(5) {
-		t.Error("Set doesn't contain element that was added")
+		t.Error("Ints doesn't contain element that was added")
 	}
 
 	s.Add(1)
 
 	if s.Count() > 3 {
-		t.Error("Set double-adds element (element not unique)")
+		t.Error("Ints double-adds element (element not unique)")
 	} else if s.Count() < 3 {
-		t.Error("Set double-add lowered len")
+		t.Error("Ints double-add lowered len")
 	}
 
 	if !s.Has(1) {
-		t.Error("Set doesn't contain double-added element")
+		t.Error("Ints doesn't contain double-added element")
 	}
 
 	if !s.Has(3) || !s.Has(5) {
-		t.Error("Set removes element on double-add")
+		t.Error("Ints removes element on double-add")
 	}
 }
 
 func TestRemoveInts(t *testing.T) {
-	s := make(Ints)
+	s := make(Ints[int64])
 
 	s.Add(1)
 	s.Add(3)
@@ -230,7 +97,7 @@ func TestRemoveInts(t *testing.T) {
 	}
 
 	if !s.Has(3) || !s.Has(5) {
-		t.Error("Set remove removed wrong element")
+		t.Error("Ints remove removed wrong element")
 	}
 
 	s.Remove(1)
@@ -247,22 +114,22 @@ func TestRemoveInts(t *testing.T) {
 }
 
 func TestSelfEqualInts(t *testing.T) {
-	s := make(Ints)
+	s := make(Ints[int64])
 
 	if !IntsEqual(s, s) {
-		t.Error("Set is not equal to itself")
+		t.Error("Ints is not equal to itself")
 	}
 
 	s.Add(1)
 
 	if !IntsEqual(s, s) {
-		t.Error("Set ceases self equality after adding element")
+		t.Error("Ints ceases self equality after adding element")
 	}
 }
 
 func TestEqualInts(t *testing.T) {
-	a := make(Ints)
-	b := make(Ints)
+	a := make(Ints[int64])
+	b := make(Ints[int64])
 
 	if !IntsEqual(a, b) {
 		t.Error("Two different empty sets not equal")
@@ -296,11 +163,11 @@ func TestSameNodes(t *testing.T) {
 		t.Error("Independently created sets test as same")
 	}
 	if !same(a, c) {
-		t.Error("Set copy and original test as not same.")
+		t.Error("Ints copy and original test as not same.")
 	}
 	a.Add(node(1))
 	if !same(a, c) {
-		t.Error("Set copy and original test as not same after addition.")
+		t.Error("Ints copy and original test as not same after addition.")
 	}
 	if !same(nil, nil) {
 		t.Error("nil sets test as not same.")
@@ -313,11 +180,11 @@ func TestSameNodes(t *testing.T) {
 func TestAddNodes(t *testing.T) {
 	s := NewNodes()
 	if s == nil {
-		t.Fatal("Set cannot be created successfully")
+		t.Fatal("Ints cannot be created successfully")
 	}
 
 	if s.Count() != 0 {
-		t.Error("Set somehow contains new elements upon creation")
+		t.Error("Ints somehow contains new elements upon creation")
 	}
 
 	s.Add(node(1))
@@ -329,23 +196,23 @@ func TestAddNodes(t *testing.T) {
 	}
 
 	if !s.Has(node(1)) || !s.Has(node(3)) || !s.Has(node(5)) {
-		t.Error("Set doesn't contain element that was added")
+		t.Error("Ints doesn't contain element that was added")
 	}
 
 	s.Add(node(1))
 
 	if s.Count() > 3 {
-		t.Error("Set double-adds element (element not unique)")
+		t.Error("Ints double-adds element (element not unique)")
 	} else if s.Count() < 3 {
-		t.Error("Set double-add lowered len")
+		t.Error("Ints double-add lowered len")
 	}
 
 	if !s.Has(node(1)) {
-		t.Error("Set doesn't contain double-added element")
+		t.Error("Ints doesn't contain double-added element")
 	}
 
 	if !s.Has(node(3)) || !s.Has(node(5)) {
-		t.Error("Set removes element on double-add")
+		t.Error("Ints removes element on double-add")
 	}
 
 	for e, n := range s {
@@ -373,7 +240,7 @@ func TestRemoveNodes(t *testing.T) {
 	}
 
 	if !s.Has(node(3)) || !s.Has(node(5)) {
-		t.Error("Set remove removed wrong element")
+		t.Error("Ints remove removed wrong element")
 	}
 
 	s.Remove(node(1))
@@ -393,13 +260,13 @@ func TestSelfEqualNodes(t *testing.T) {
 	s := NewNodes()
 
 	if !Equal(s, s) {
-		t.Error("Set is not equal to itself")
+		t.Error("Ints is not equal to itself")
 	}
 
 	s.Add(node(1))
 
 	if !Equal(s, s) {
-		t.Error("Set ceases self equality after adding element")
+		t.Error("Ints ceases self equality after adding element")
 	}
 }
 

--- a/graph/path/a_star.go
+++ b/graph/path/a_star.go
@@ -47,7 +47,7 @@ func AStar(s, t graph.Node, g traverse.Graph, h Heuristic) (path Shortest, expan
 	path = newShortestFrom(s, []graph.Node{s, t})
 	tid := t.ID()
 
-	visited := make(set.Int64s)
+	visited := make(set.Ints[int64])
 	open := &aStarQueue{indexOf: make(map[int64]int)}
 	heap.Push(open, aStarNode{node: s, gscore: 0, fscore: h(s, t)})
 

--- a/graph/path/shortest.go
+++ b/graph/path/shortest.go
@@ -159,7 +159,7 @@ func (p Shortest) To(vid int64) (path []graph.Node, weight float64) {
 	path = []graph.Node{p.nodes[to]}
 	weight = math.Inf(1)
 	if p.hasNegativeCycle {
-		seen := make(set.Ints)
+		seen := make(set.Ints[int])
 		seen.Add(from)
 		for to != from {
 			next := p.next[to]
@@ -348,7 +348,7 @@ func (p ShortestAlts) To(vid int64) (path []graph.Node, weight float64, unique b
 	path = []graph.Node{p.nodes[to]}
 	if p.hasNegativeCycle {
 		weight = math.Inf(1)
-		seen := make(set.Ints)
+		seen := make(set.Ints[int])
 		seen.Add(from)
 		for to != from {
 			c := p.next[to]

--- a/graph/set/uid/uid.go
+++ b/graph/set/uid/uid.go
@@ -17,12 +17,12 @@ const Max = math.MaxInt64
 // Set implements available ID storage.
 type Set struct {
 	maxID      int64
-	used, free set.Int64s
+	used, free set.Ints[int64]
 }
 
 // NewSet returns a new Set.
 func NewSet() *Set {
-	return &Set{maxID: -1, used: make(set.Int64s), free: make(set.Int64s)}
+	return &Set{maxID: -1, used: make(set.Ints[int64]), free: make(set.Ints[int64])}
 }
 
 // NewID returns a new unique ID. The ID returned is not considered used

--- a/graph/testgraph/testgraph.go
+++ b/graph/testgraph/testgraph.go
@@ -2102,7 +2102,7 @@ type RandomNodes struct {
 	curr int64
 
 	state *rand.Rand
-	seen  set.Int64s
+	seen  set.Ints[int64]
 	count int
 }
 
@@ -2118,7 +2118,7 @@ func NewRandomNodes(n int, seed uint64, new func(id int64) graph.Node) *RandomNo
 		newNode: new,
 
 		state: rand.New(rand.NewSource(seed)),
-		seen:  make(set.Int64s),
+		seen:  make(set.Ints[int64]),
 		count: 0,
 	}
 }
@@ -2159,7 +2159,7 @@ func (n *RandomNodes) Node() graph.Node {
 // Reset returns the iterator to its initial state.
 func (n *RandomNodes) Reset() {
 	n.state = rand.New(rand.NewSource(n.seed))
-	n.seen = make(set.Int64s)
+	n.seen = make(set.Ints[int64])
 	n.count = 0
 }
 

--- a/graph/topo/bench_test.go
+++ b/graph/topo/bench_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"testing"
 
+	"golang.org/x/exp/rand"
+
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/graphs/gen"
 	"gonum.org/v1/gonum/graph/simple"
@@ -20,11 +22,25 @@ var (
 	gnpDirected_10_half    = gnpDirected(10, 0.5)
 	gnpDirected_100_half   = gnpDirected(100, 0.5)
 	gnpDirected_1000_half  = gnpDirected(1000, 0.5)
+
+	gnpUndirected_10_tenth  = gnpUndirected(10, 0.1)
+	gnpUndirected_100_tenth = gnpUndirected(100, 0.1)
+	gnpUndirected_10_half   = gnpUndirected(10, 0.5)
+	gnpUndirected_100_half  = gnpUndirected(100, 0.5)
 )
 
 func gnpDirected(n int, p float64) graph.Directed {
 	g := simple.NewDirectedGraph()
-	err := gen.Gnp(g, n, p, nil)
+	err := gen.Gnp(g, n, p, rand.NewSource(1))
+	if err != nil {
+		panic(fmt.Sprintf("topo: bad test: %v", err))
+	}
+	return g
+}
+
+func gnpUndirected(n int, p float64) graph.Undirected {
+	g := simple.NewUndirectedGraph()
+	err := gen.Gnp(g, n, p, rand.NewSource(1))
 	if err != nil {
 		panic(fmt.Sprintf("topo: bad test: %v", err))
 	}
@@ -58,4 +74,36 @@ func BenchmarkTarjanSCCGnp_100_half(b *testing.B) {
 }
 func BenchmarkTarjanSCCGnp_1000_half(b *testing.B) {
 	benchmarkTarjanSCC(b, gnpDirected_1000_half)
+}
+
+func benchmarkDirectedCyclesIn(b *testing.B, g graph.Directed) {
+	for i := 0; i < b.N; i++ {
+		DirectedCyclesIn(g)
+	}
+}
+
+func BenchmarkDirectedCyclesInGnp_10_tenth(b *testing.B) {
+	benchmarkDirectedCyclesIn(b, gnpDirected_10_tenth)
+}
+func BenchmarkDirectedCyclesInGnp_10_half(b *testing.B) {
+	benchmarkDirectedCyclesIn(b, gnpDirected_10_half)
+}
+
+func benchmarkUndirectedCyclesIn(b *testing.B, g graph.Undirected) {
+	for i := 0; i < b.N; i++ {
+		UndirectedCyclesIn(g)
+	}
+}
+
+func BenchmarkUndirectedCyclesInGnp_10_tenth(b *testing.B) {
+	benchmarkUndirectedCyclesIn(b, gnpUndirected_10_tenth)
+}
+func BenchmarkUndirectedCyclesInGnp_100_tenth(b *testing.B) {
+	benchmarkUndirectedCyclesIn(b, gnpUndirected_100_tenth)
+}
+func BenchmarkUndirectedCyclesInGnp_10_half(b *testing.B) {
+	benchmarkUndirectedCyclesIn(b, gnpUndirected_10_half)
+}
+func BenchmarkUndirectedCyclesInGnp_100_half(b *testing.B) {
+	benchmarkUndirectedCyclesIn(b, gnpUndirected_100_half)
 }

--- a/graph/topo/johnson_cycles.go
+++ b/graph/topo/johnson_cycles.go
@@ -17,8 +17,8 @@ import (
 // Comments in the johnson methods are kept in sync with the comments
 // and labels from the paper.
 type johnson struct {
-	adjacent johnsonGraph // SCC adjacency list.
-	b        []set.Ints   // Johnson's "B-list".
+	adjacent johnsonGraph    // SCC adjacency list.
+	b        []set.Ints[int] // Johnson's "B-list".
 	blocked  []bool
 	s        int
 
@@ -32,7 +32,7 @@ func DirectedCyclesIn(g graph.Directed) [][]graph.Node {
 	jg := johnsonGraphFrom(g)
 	j := johnson{
 		adjacent: jg,
-		b:        make([]set.Ints, len(jg.orig)),
+		b:        make([]set.Ints[int], len(jg.orig)),
 		blocked:  make([]bool, len(jg.orig)),
 	}
 
@@ -57,7 +57,7 @@ func DirectedCyclesIn(g graph.Directed) [][]graph.Node {
 			}
 			if len(j.adjacent.succ[v.ID()]) > 0 {
 				j.blocked[i] = false
-				j.b[i] = make(set.Ints)
+				j.b[i] = make(set.Ints[int])
 			}
 		}
 		//L3:
@@ -125,8 +125,8 @@ type johnsonGraph struct {
 	orig  []graph.Node
 	index map[int64]int
 
-	nodes set.Int64s
-	succ  map[int64]set.Int64s
+	nodes set.Ints[int64]
+	succ  map[int64]set.Ints[int64]
 }
 
 // johnsonGraphFrom returns a deep copy of the graph g.
@@ -137,8 +137,8 @@ func johnsonGraphFrom(g graph.Directed) johnsonGraph {
 		orig:  nodes,
 		index: make(map[int64]int, len(nodes)),
 
-		nodes: make(set.Int64s, len(nodes)),
-		succ:  make(map[int64]set.Int64s),
+		nodes: make(set.Ints[int64], len(nodes)),
+		succ:  make(map[int64]set.Ints[int64]),
 	}
 	for i, u := range nodes {
 		uid := u.ID()
@@ -147,7 +147,7 @@ func johnsonGraphFrom(g graph.Directed) johnsonGraph {
 		for to.Next() {
 			v := to.Node()
 			if c.succ[uid] == nil {
-				c.succ[uid] = make(set.Int64s)
+				c.succ[uid] = make(set.Ints[int64])
 				c.nodes.Add(uid)
 			}
 			c.nodes.Add(v.ID())
@@ -207,8 +207,8 @@ func (g johnsonGraph) sccSubGraph(sccs [][]graph.Node, min int) johnsonGraph {
 	sub := johnsonGraph{
 		orig:  g.orig,
 		index: g.index,
-		nodes: make(set.Int64s),
-		succ:  make(map[int64]set.Int64s),
+		nodes: make(set.Ints[int64]),
+		succ:  make(map[int64]set.Ints[int64]),
 	}
 
 	var n int
@@ -221,7 +221,7 @@ func (g johnsonGraph) sccSubGraph(sccs [][]graph.Node, min int) johnsonGraph {
 			for _, v := range scc {
 				if _, ok := g.succ[u.ID()][v.ID()]; ok {
 					if sub.succ[u.ID()] == nil {
-						sub.succ[u.ID()] = make(set.Int64s)
+						sub.succ[u.ID()] = make(set.Ints[int64])
 						sub.nodes.Add(u.ID())
 					}
 					sub.nodes.Add(v.ID())

--- a/graph/topo/paton_cycles.go
+++ b/graph/topo/paton_cycles.go
@@ -17,7 +17,7 @@ func UndirectedCyclesIn(g graph.Undirected) [][]graph.Node {
 	// https://doi.org/10.1145/363219.363232
 
 	var cycles [][]graph.Node
-	done := make(set.Int64s)
+	done := make(set.Ints[int64])
 	var tree linear.NodeStack
 	nodes := g.Nodes()
 	for nodes.Next() {
@@ -30,7 +30,7 @@ func UndirectedCyclesIn(g graph.Undirected) [][]graph.Node {
 
 		tree = tree[:0]
 		tree.Push(n)
-		from := sets{id: set.Int64s{}}
+		from := sets{id: set.Ints[int64]{}}
 		to := map[int64]graph.Node{id: n}
 
 		for tree.Len() != 0 {
@@ -68,12 +68,12 @@ func UndirectedCyclesIn(g graph.Undirected) [][]graph.Node {
 	return cycles
 }
 
-type sets map[int64]set.Int64s
+type sets map[int64]set.Ints[int64]
 
 func (s sets) add(uid, vid int64) {
 	e, ok := s[vid]
 	if !ok {
-		e = make(set.Int64s)
+		e = make(set.Ints[int64])
 		s[vid] = e
 	}
 	e.Add(uid)

--- a/graph/topo/tarjan.go
+++ b/graph/topo/tarjan.go
@@ -115,7 +115,7 @@ func tarjanSCCstabilized(g graph.Directed, order func([]graph.Node)) [][]graph.N
 
 		indexTable: make(map[int64]int, len(nodes)),
 		lowLink:    make(map[int64]int, len(nodes)),
-		onStack:    make(set.Int64s),
+		onStack:    make(set.Ints[int64]),
 	}
 	for _, v := range nodes {
 		if t.indexTable[v.ID()] == 0 {
@@ -135,7 +135,7 @@ type tarjan struct {
 	index      int
 	indexTable map[int64]int
 	lowLink    map[int64]int
-	onStack    set.Int64s
+	onStack    set.Ints[int64]
 
 	stack []graph.Node
 

--- a/graph/traverse/traverse.go
+++ b/graph/traverse/traverse.go
@@ -39,7 +39,7 @@ type BreadthFirst struct {
 	Traverse func(graph.Edge) bool
 
 	queue   linear.NodeQueue
-	visited set.Int64s
+	visited set.Ints[int64]
 }
 
 // Walk performs a breadth-first traversal of the graph g starting from the given node,
@@ -49,7 +49,7 @@ type BreadthFirst struct {
 // non-nil, it is called with each node the first time it is visited.
 func (b *BreadthFirst) Walk(g Graph, from graph.Node, until func(n graph.Node, d int) bool) graph.Node {
 	if b.visited == nil {
-		b.visited = make(set.Int64s)
+		b.visited = make(set.Ints[int64])
 	}
 	b.queue.Enqueue(from)
 	if b.Visit != nil && !b.visited.Has(from.ID()) {
@@ -147,7 +147,7 @@ type DepthFirst struct {
 	Traverse func(graph.Edge) bool
 
 	stack   linear.NodeStack
-	visited set.Int64s
+	visited set.Ints[int64]
 }
 
 // Walk performs a depth-first traversal of the graph g starting from the given node,
@@ -157,7 +157,7 @@ type DepthFirst struct {
 // is called with each node the first time it is visited.
 func (d *DepthFirst) Walk(g Graph, from graph.Node, until func(graph.Node) bool) graph.Node {
 	if d.visited == nil {
-		d.visited = make(set.Int64s)
+		d.visited = make(set.Ints[int64])
 	}
 	d.stack.Push(from)
 	for d.stack.Len() != 0 {


### PR DESCRIPTION
This PR introduces a single modernization change from https://github.com/gonum/gonum/pull/1934. Benchmarks will follow.

Follow-on to https://github.com/gonum/gonum/pull/1934, which was my first attempt at this but was too large to properly benchmark.

Blocked by https://github.com/gonum/gonum/pull/1940.
<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
