### PR TITLE
graph: replace ordered.Int64s with slices.Sort

### DIFF
--- a/graph/internal/ordered/sort.go
+++ b/graph/internal/ordered/sort.go
@@ -57,11 +57,6 @@ func BySliceIDs(c [][]graph.Node) {
 	})
 }
 
-// Int64s sorts a slice of int64.
-func Int64s(s []int64) {
-	sort.Slice(s, func(i, j int) bool { return s[i] < s[j] })
-}
-
 // LinesByIDs sort a slice of graph.LinesByIDs lexically by the From IDs,
 // then by the To IDs, finally by the Line IDs.
 func LinesByIDs(n []graph.Line) {

--- a/graph/topo/bron_kerbosch_test.go
+++ b/graph/topo/bron_kerbosch_test.go
@@ -6,6 +6,7 @@ package topo
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -66,12 +67,12 @@ func TestDegeneracyOrdering(t *testing.T) {
 		}
 		var offset int
 		for k, want := range test.wantCore {
-			ordered.Int64s(want)
+			slices.Sort(want)
 			got := make([]int64, len(want))
 			for j, n := range order[len(order)-len(want)-offset : len(order)-offset] {
 				got[j] = n.ID()
 			}
-			ordered.Int64s(got)
+			slices.Sort(got)
 			if !reflect.DeepEqual(got, want) {
 				t.Errorf("unexpected %d-core for test %d:\ngot: %v\nwant:%v", k, i, got, want)
 			}
@@ -79,7 +80,7 @@ func TestDegeneracyOrdering(t *testing.T) {
 			for j, n := range core[k] {
 				got[j] = n.ID()
 			}
-			ordered.Int64s(got)
+			slices.Sort(got)
 			if !reflect.DeepEqual(got, want) {
 				t.Errorf("unexpected %d-core for test %d:\ngot: %v\nwant:%v", k, i, got, want)
 			}
@@ -116,8 +117,8 @@ func TestKCore(t *testing.T) {
 			for _, n := range core {
 				got = append(got, n.ID())
 			}
-			ordered.Int64s(got)
-			ordered.Int64s(want)
+			slices.Sort(got)
+			slices.Sort(want)
 			if !reflect.DeepEqual(got, want) {
 				t.Errorf("unexpected %d-core for test %d:\ngot: %v\nwant:%v", k, i, got, want)
 			}
@@ -192,7 +193,7 @@ func TestBronKerbosch(t *testing.T) {
 			for k, n := range c {
 				ids[k] = n.ID()
 			}
-			ordered.Int64s(ids)
+			slices.Sort(ids)
 			got[j] = ids
 		}
 		ordered.BySliceValues(got)

--- a/graph/topo/tarjan_test.go
+++ b/graph/topo/tarjan_test.go
@@ -6,6 +6,7 @@ package topo
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -178,7 +179,7 @@ func TestTarjanSCC(t *testing.T) {
 			for j, id := range scc {
 				gotIDs[i][j] = id.ID()
 			}
-			ordered.Int64s(gotIDs[i])
+			slices.Sort(gotIDs[i])
 		}
 		for _, iv := range test.ambiguousOrder {
 			ordered.BySliceValues(test.want[iv.start:iv.end])

--- a/graph/topo/topo_test.go
+++ b/graph/topo/topo_test.go
@@ -6,6 +6,7 @@ package topo
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -163,7 +164,7 @@ func TestConnectedComponents(t *testing.T) {
 			for k, n := range c {
 				ids[k] = n.ID()
 			}
-			ordered.Int64s(ids)
+			slices.Sort(ids)
 			got[j] = ids
 		}
 		ordered.BySliceValues(got)

--- a/graph/traverse/traverse_test.go
+++ b/graph/traverse/traverse_test.go
@@ -7,6 +7,7 @@ package traverse
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -171,7 +172,7 @@ func TestBreadthFirst(t *testing.T) {
 			t.Errorf("unexpected final node for test %d:\ngot:  %v\nwant: %v", i, final, test.final)
 		}
 		for _, l := range got {
-			ordered.Int64s(l)
+			slices.Sort(l)
 		}
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexpected BFS level structure for test %d:\ngot:  %v\nwant: %v", i, got, test.want)
@@ -371,7 +372,7 @@ func TestWalkAll(t *testing.T) {
 				for k, n := range c {
 					ids[k] = n.ID()
 				}
-				ordered.Int64s(ids)
+				slices.Sort(ids)
 				got[j] = ids
 			}
 			ordered.BySliceValues(got)


### PR DESCRIPTION
This PR introduces a single modernization change from https://github.com/gonum/gonum/pull/1934. Benchmarks will follow.

Follow-on to https://github.com/gonum/gonum/pull/1934, which was my first attempt at this but was too large to properly benchmark.

Blocked by https://github.com/gonum/gonum/pull/1940.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
