### PR TITLE
graph: replace custom reverse logic with slices.Reverse

### DIFF
--- a/graph/community/louvain_directed_multiplex_test.go
+++ b/graph/community/louvain_directed_multiplex_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"slices"
 	"sort"
 	"testing"
 
@@ -608,7 +609,7 @@ func TestLouvainDirectedMultiplex(t *testing.T) {
 			}
 
 			// Recovery of Q values is reversed.
-			if reverse(qs); !sort.Float64sAreSorted(qs) {
+			if slices.Reverse(qs); !sort.Float64sAreSorted(qs) {
 				t.Errorf("Q values not monotonically increasing: %.5v", qs)
 			}
 		}

--- a/graph/community/louvain_directed_test.go
+++ b/graph/community/louvain_directed_test.go
@@ -7,6 +7,7 @@ package community
 import (
 	"math"
 	"reflect"
+	"slices"
 	"sort"
 	"testing"
 
@@ -631,7 +632,7 @@ func testModularizeDirected(t *testing.T, test communityDirectedQTest, g graph.D
 		}
 
 		// Recovery of Q values is reversed.
-		if reverse(qs); !sort.Float64sAreSorted(qs) {
+		if slices.Reverse(qs); !sort.Float64sAreSorted(qs) {
 			t.Errorf("Q values not monotonically increasing: %.5v", qs)
 		}
 	}

--- a/graph/community/louvain_test.go
+++ b/graph/community/louvain_test.go
@@ -214,12 +214,6 @@ type moveStructures struct {
 	tol        float64
 }
 
-func reverse(f []float64) {
-	for i, j := 0, len(f)-1; i < j; i, j = i+1, j-1 {
-		f[i], f[j] = f[j], f[i]
-	}
-}
-
 func hasNegative(f []float64) bool {
 	for _, v := range f {
 		if v < 0 {

--- a/graph/community/louvain_undirected_multiplex_test.go
+++ b/graph/community/louvain_undirected_multiplex_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"slices"
 	"sort"
 	"testing"
 
@@ -577,7 +578,7 @@ func TestLouvainMultiplex(t *testing.T) {
 			}
 
 			// Recovery of Q values is reversed.
-			if reverse(qs); !sort.Float64sAreSorted(qs) {
+			if slices.Reverse(qs); !sort.Float64sAreSorted(qs) {
 				t.Errorf("Q values not monotonically increasing: %.5v", qs)
 			}
 		}

--- a/graph/community/louvain_undirected_test.go
+++ b/graph/community/louvain_undirected_test.go
@@ -7,6 +7,7 @@ package community
 import (
 	"math"
 	"reflect"
+	"slices"
 	"sort"
 	"testing"
 
@@ -694,7 +695,7 @@ func testModularizeUndirected(t *testing.T, test communityUndirectedQTest, g gra
 		}
 
 		// Recovery of Q values is reversed.
-		if reverse(qs); !sort.Float64sAreSorted(qs) {
+		if slices.Reverse(qs); !sort.Float64sAreSorted(qs) {
 			t.Errorf("Q values not monotonically increasing: %.5v", qs)
 		}
 	}

--- a/graph/internal/ordered/sort.go
+++ b/graph/internal/ordered/sort.go
@@ -71,10 +71,3 @@ func LinesByIDs(n []graph.Line) {
 		return n[i].ID() < n[j].ID()
 	})
 }
-
-// Reverse reverses the order of nodes.
-func Reverse(nodes []graph.Node) {
-	for i, j := 0, len(nodes)-1; i < j; i, j = i+1, j-1 {
-		nodes[i], nodes[j] = nodes[j], nodes[i]
-	}
-}

--- a/graph/path/shortest.go
+++ b/graph/path/shortest.go
@@ -6,12 +6,12 @@ package path
 
 import (
 	"math"
+	"slices"
 
 	"golang.org/x/exp/rand"
 
 	"gonum.org/v1/gonum/floats/scalar"
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/internal/set"
 	"gonum.org/v1/gonum/mat"
 )
@@ -184,7 +184,7 @@ func (p Shortest) To(vid int64) (path []graph.Node, weight float64) {
 			n--
 		}
 	}
-	ordered.Reverse(path)
+	slices.Reverse(path)
 	return path, math.Min(weight, p.dist[p.indexOf[vid]])
 }
 
@@ -397,7 +397,7 @@ func (p ShortestAlts) To(vid int64) (path []graph.Node, weight float64, unique b
 		weight = p.dist[p.indexOf[vid]]
 	}
 
-	ordered.Reverse(path)
+	slices.Reverse(path)
 	return path, weight, unique
 }
 
@@ -460,9 +460,9 @@ func (p ShortestAlts) allTo(from, to int, seen []bool, path []graph.Node, fn fun
 		if path == nil {
 			return
 		}
-		ordered.Reverse(path)
+		slices.Reverse(path)
 		fn(path)
-		ordered.Reverse(path)
+		slices.Reverse(path)
 		return
 	}
 	first := true
@@ -676,7 +676,7 @@ func (p AllShortest) Between(uid, vid int64) (path []graph.Node, weight float64,
 		}
 	}
 	if !p.forward {
-		ordered.Reverse(path)
+		slices.Reverse(path)
 	}
 
 	return path, weight, unique
@@ -765,11 +765,11 @@ func (p AllShortest) allBetween(from, to int, seen []bool, path []graph.Node, fn
 			return
 		}
 		if !p.forward {
-			ordered.Reverse(path)
+			slices.Reverse(path)
 		}
 		fn(path)
 		if !p.forward {
-			ordered.Reverse(path)
+			slices.Reverse(path)
 		}
 		return
 	}

--- a/graph/path/shortest_test.go
+++ b/graph/path/shortest_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -181,7 +182,7 @@ func (p allShortest) allBetween(from, to int, seen []bool, path []graph.Node, pa
 			return paths
 		}
 		if !p.forward {
-			ordered.Reverse(path)
+			slices.Reverse(path)
 		}
 		return append(paths, path)
 	}

--- a/graph/topo/bench_test.go
+++ b/graph/topo/bench_test.go
@@ -27,6 +27,10 @@ var (
 	gnpUndirected_100_tenth = gnpUndirected(100, 0.1)
 	gnpUndirected_10_half   = gnpUndirected(10, 0.5)
 	gnpUndirected_100_half  = gnpUndirected(100, 0.5)
+
+	pathDirected_10     = pathDirected(10)
+	pathDirected_1000   = pathDirected(1e3)
+	pathDirected_100000 = pathDirected(1e5)
 )
 
 func gnpDirected(n int, p float64) graph.Directed {
@@ -44,6 +48,16 @@ func gnpUndirected(n int, p float64) graph.Undirected {
 	if err != nil {
 		panic(fmt.Sprintf("topo: bad test: %v", err))
 	}
+	return g
+}
+
+func pathDirected(n int) graph.Directed {
+	g := simple.NewDirectedGraph()
+	var idSet gen.IDSet
+	for i := 0; i < n; i++ {
+		idSet = append(idSet, int64(i))
+	}
+	gen.Path(g, idSet)
 	return g
 }
 
@@ -78,7 +92,9 @@ func BenchmarkTarjanSCCGnp_1000_half(b *testing.B) {
 
 func benchmarkDirectedCyclesIn(b *testing.B, g graph.Directed) {
 	for i := 0; i < b.N; i++ {
-		DirectedCyclesIn(g)
+		if len(DirectedCyclesIn(g)) == 0 {
+			b.Fatal("unexpected zero-sized cycles set")
+		}
 	}
 }
 
@@ -91,7 +107,9 @@ func BenchmarkDirectedCyclesInGnp_10_half(b *testing.B) {
 
 func benchmarkUndirectedCyclesIn(b *testing.B, g graph.Undirected) {
 	for i := 0; i < b.N; i++ {
-		UndirectedCyclesIn(g)
+		if len(UndirectedCyclesIn(g)) == 0 {
+			b.Fatal("unexpected zero-sized cycles set")
+		}
 	}
 }
 
@@ -106,4 +124,76 @@ func BenchmarkUndirectedCyclesInGnp_10_half(b *testing.B) {
 }
 func BenchmarkUndirectedCyclesInGnp_100_half(b *testing.B) {
 	benchmarkUndirectedCyclesIn(b, gnpUndirected_100_half)
+}
+
+func benchmarkSort(b *testing.B, g graph.Directed) {
+	for i := 0; i < b.N; i++ {
+		if _, err := Sort(g); err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkSortGnp_10_tenth(b *testing.B) {
+	benchmarkSort(b, gnpDirected_10_tenth)
+}
+func BenchmarkSortGnp_100_tenth(b *testing.B) {
+	benchmarkSort(b, gnpDirected_100_tenth)
+}
+func BenchmarkSortGnp_1000_tenth(b *testing.B) {
+	benchmarkSort(b, gnpDirected_1000_tenth)
+}
+func BenchmarkSortGnp_10_half(b *testing.B) {
+	benchmarkSort(b, gnpDirected_10_half)
+}
+func BenchmarkSortGnp_100_half(b *testing.B) {
+	benchmarkSort(b, gnpDirected_100_half)
+}
+func BenchmarkSortGnp_1000_half(b *testing.B) {
+	benchmarkSort(b, gnpDirected_1000_half)
+}
+func BenchmarkSortPath_10(b *testing.B) {
+	benchmarkSort(b, pathDirected_10)
+}
+func BenchmarkSortPath_1000(b *testing.B) {
+	benchmarkSort(b, pathDirected_1000)
+}
+func BenchmarkSortPath_100000(b *testing.B) {
+	benchmarkSort(b, pathDirected_100000)
+}
+
+func benchmarkSortStabilized(b *testing.B, g graph.Directed) {
+	for i := 0; i < b.N; i++ {
+		if _, err := SortStabilized(g, nil); err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkSortStabilizedGnp_10_tenth(b *testing.B) {
+	benchmarkSortStabilized(b, gnpDirected_10_tenth)
+}
+func BenchmarkSortStabilizedGnp_100_tenth(b *testing.B) {
+	benchmarkSortStabilized(b, gnpDirected_100_tenth)
+}
+func BenchmarkSortStabilizedGnp_1000_tenth(b *testing.B) {
+	benchmarkSortStabilized(b, gnpDirected_1000_tenth)
+}
+func BenchmarkSortStabilizedGnp_10_half(b *testing.B) {
+	benchmarkSortStabilized(b, gnpDirected_10_half)
+}
+func BenchmarkSortStabilizedGnp_100_half(b *testing.B) {
+	benchmarkSortStabilized(b, gnpDirected_100_half)
+}
+func BenchmarkSortStabilizedGnp_1000_half(b *testing.B) {
+	benchmarkSortStabilized(b, gnpDirected_1000_half)
+}
+func BenchmarkSortStabilizedPath_10(b *testing.B) {
+	benchmarkSortStabilized(b, pathDirected_10)
+}
+func BenchmarkSortStabilizedPath_1000(b *testing.B) {
+	benchmarkSortStabilized(b, pathDirected_1000)
+}
+func BenchmarkSortStabilizedPath_100000(b *testing.B) {
+	benchmarkSortStabilized(b, pathDirected_100000)
 }

--- a/graph/topo/bench_test.go
+++ b/graph/topo/bench_test.go
@@ -128,7 +128,8 @@ func BenchmarkUndirectedCyclesInGnp_100_half(b *testing.B) {
 
 func benchmarkSort(b *testing.B, g graph.Directed) {
 	for i := 0; i < b.N; i++ {
-		if _, err := Sort(g); err != nil {
+		_, err := Sort(g)
+		if err != nil {
 			b.FailNow()
 		}
 	}
@@ -164,7 +165,8 @@ func BenchmarkSortPath_100000(b *testing.B) {
 
 func benchmarkSortStabilized(b *testing.B, g graph.Directed) {
 	for i := 0; i < b.N; i++ {
-		if _, err := SortStabilized(g, nil); err != nil {
+		_, err := SortStabilized(g, nil)
+		if err != nil {
 			b.FailNow()
 		}
 	}

--- a/graph/topo/bron_kerbosch.go
+++ b/graph/topo/bron_kerbosch.go
@@ -5,8 +5,9 @@
 package topo
 
 import (
+	"slices"
+
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/internal/set"
 )
 
@@ -15,7 +16,7 @@ import (
 func DegeneracyOrdering(g graph.Undirected) (order []graph.Node, cores [][]graph.Node) {
 	order, offsets := degeneracyOrdering(g)
 
-	ordered.Reverse(order)
+	slices.Reverse(order)
 	cores = make([][]graph.Node, len(offsets))
 	offset := len(order)
 	for i, n := range offsets {
@@ -145,7 +146,7 @@ func BronKerbosch(g graph.Undirected) [][]graph.Node {
 	x := set.NewNodes()
 	var bk bronKerbosch
 	order, _ := degeneracyOrdering(g)
-	ordered.Reverse(order)
+	slices.Reverse(order)
 	for _, v := range order {
 		neighbours := graph.NodesOf(g.From(v.ID()))
 		nv := set.NewNodesSize(len(neighbours))

--- a/graph/topo/paton_cycles_test.go
+++ b/graph/topo/paton_cycles_test.go
@@ -6,6 +6,7 @@ package topo
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
@@ -133,7 +134,7 @@ func canonicalise(c []graph.Node) []graph.Node {
 		c = append(c[idx:], c[:idx]...)
 	}
 	if c[len(c)-1].ID() < c[1].ID() {
-		ordered.Reverse(c[1:])
+		slices.Reverse(c[1:])
 	}
 	return c
 }

--- a/graph/topo/tarjan.go
+++ b/graph/topo/tarjan.go
@@ -6,6 +6,7 @@ package topo
 
 import (
 	"fmt"
+	"slices"
 
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
@@ -70,12 +71,10 @@ func sortedFrom(sccs [][]graph.Node, order func([]graph.Node)) ([]graph.Node, er
 	}
 	var err error
 	if sc != nil {
-		for i, j := 0, len(sc)-1; i < j; i, j = i+1, j-1 {
-			sc[i], sc[j] = sc[j], sc[i]
-		}
+		slices.Reverse(sc)
 		err = sc
 	}
-	ordered.Reverse(sorted)
+	slices.Reverse(sorted)
 	return sorted, err
 }
 
@@ -100,12 +99,12 @@ func tarjanSCCstabilized(g graph.Directed, order func([]graph.Node)) [][]graph.N
 		}
 	} else {
 		order(nodes)
-		ordered.Reverse(nodes)
+		slices.Reverse(nodes)
 
 		succ = func(id int64) []graph.Node {
 			to := graph.NodesOf(g.From(id))
 			order(to)
-			ordered.Reverse(to)
+			slices.Reverse(to)
 			return to
 		}
 	}


### PR DESCRIPTION
This PR introduces a single modernization change from https://github.com/gonum/gonum/pull/1934. Benchmarks will follow.

Follow-on to https://github.com/gonum/gonum/pull/1934, which was my first attempt at this but was too large to properly benchmark.

Blocked by https://github.com/gonum/gonum/pull/1940.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
