### PR TITLE
floats: use more efficient "is sorted" routine

### DIFF
--- a/floats/floats.go
+++ b/floats/floats.go
@@ -7,6 +7,7 @@ package floats
 import (
 	"errors"
 	"math"
+	"slices"
 	"sort"
 
 	"gonum.org/v1/gonum/floats/scalar"
@@ -771,7 +772,7 @@ func Within(s []float64, v float64) int {
 	if len(s) < 2 {
 		panic(shortSpan)
 	}
-	if !sort.Float64sAreSorted(s) {
+	if !slices.IsSorted(s) {
 		panic("floats: input slice not sorted")
 	}
 	if v < s[0] || v >= s[len(s)-1] || math.IsNaN(v) {

--- a/floats/floats_test.go
+++ b/floats/floats_test.go
@@ -7,7 +7,7 @@ package floats
 import (
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 	"strconv"
 	"testing"
 
@@ -191,10 +191,10 @@ func TestArgsortStable(t *testing.T) {
 		}
 		idx := make([]int, len(data))
 		ArgsortStable(data, idx)
-		if !sort.Float64sAreSorted(data) {
+		if !slices.IsSorted(data) {
 			t.Errorf("unexpected data sort order for case %d", i)
 		}
-		if !sort.IntsAreSorted(idx[:i]) {
+		if !slices.IsSorted(idx[:i]) {
 			t.Errorf("unexpected index sort order for case %d", i)
 		}
 	}


### PR DESCRIPTION
This PR introduces a modernization change that is not necessarily related to #617 but which was spun out from my attempts at generifying the leaves of `graph`. Benchmarks to follow.

Blocked by https://github.com/gonum/gonum/pull/1940.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
