### PR TITLE
integrate: use more efficient "is sorted" routine

### DIFF
--- a/integrate/simpsons.go
+++ b/integrate/simpsons.go
@@ -4,7 +4,7 @@
 
 package integrate
 
-import "sort"
+import "slices"
 
 // Simpsons returns an approximate value of the integral
 //
@@ -27,7 +27,7 @@ func Simpsons(x, f []float64) float64 {
 		panic("integrate: slice length mismatch")
 	case n < 3:
 		panic("integrate: input data too small")
-	case !sort.Float64sAreSorted(x):
+	case !slices.IsSorted(x):
 		panic("integrate: must be sorted")
 	}
 

--- a/integrate/trapezoidal.go
+++ b/integrate/trapezoidal.go
@@ -4,7 +4,7 @@
 
 package integrate
 
-import "sort"
+import "slices"
 
 // Trapezoidal returns an approximate value of the integral
 //
@@ -36,7 +36,7 @@ func Trapezoidal(x, f []float64) float64 {
 		panic("integrate: slice length mismatch")
 	case n < 2:
 		panic("integrate: input data too small")
-	case !sort.Float64sAreSorted(x):
+	case !slices.IsSorted(x):
 		panic("integrate: input must be sorted")
 	}
 


### PR DESCRIPTION
This PR introduces a modernization change that is not necessarily related to #617 but which was spun out from my attempts at generifying the leaves of `graph`. Benchmarks to follow.

Blocked by https://github.com/gonum/gonum/pull/1940.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
