### PR TITLE
lapack: use more efficient sort routines

### DIFF
--- a/lapack/gonum/dlasrt.go
+++ b/lapack/gonum/dlasrt.go
@@ -5,6 +5,7 @@
 package gonum
 
 import (
+	"slices"
 	"sort"
 
 	"gonum.org/v1/gonum/lapack"
@@ -29,7 +30,7 @@ func (impl Implementation) Dlasrt(s lapack.Sort, n int, d []float64) {
 	default:
 		panic(badSort)
 	case lapack.SortIncreasing:
-		sort.Float64s(d)
+		slices.Sort(d)
 	case lapack.SortDecreasing:
 		sort.Sort(sort.Reverse(sort.Float64Slice(d)))
 	}

--- a/lapack/testlapack/dlasq2.go
+++ b/lapack/testlapack/dlasq2.go
@@ -7,7 +7,7 @@ package testlapack
 import (
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -42,7 +42,7 @@ func Dlasq2Test(t *testing.T, impl Dlasq2er) {
 						z[2*i] = rnd.Float64()
 						want[i] = z[2*i]
 					}
-					sort.Float64s(want)
+					slices.Sort(want)
 				case 2:
 					// Random tridiagonal matrix
 					for i := range z {
@@ -111,7 +111,7 @@ func Dlasq2Test(t *testing.T, impl Dlasq2er) {
 					}
 				}
 
-				sort.Float64s(got)
+				slices.Sort(got)
 				diff := floats.Distance(got, want, math.Inf(1))
 				if diff > tol {
 					t.Errorf("%v: unexpected eigenvalues; diff=%v\n%v\n%v\n\n", name, diff, got, want)

--- a/lapack/testlapack/dsterf.go
+++ b/lapack/testlapack/dsterf.go
@@ -7,7 +7,7 @@ package testlapack
 import (
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -55,7 +55,7 @@ func DsterfTest(t *testing.T, impl Dsterfer) {
 		}
 		want := make([]float64, len(test.want))
 		copy(want, test.want)
-		sort.Float64s(want)
+		slices.Sort(want)
 		diff := floats.Distance(got, want, math.Inf(1))
 		if diff > tol {
 			t.Errorf("Case %d, n=%v: unexpected result, |dGot-dWant|=%v", cas, n, diff)
@@ -162,7 +162,7 @@ func DsterfTest(t *testing.T, impl Dsterfer) {
 			}
 
 			// Test that the eigenvalues are sorted.
-			if !sort.Float64sAreSorted(dGot) {
+			if !slices.IsSorted(dGot) {
 				t.Errorf("%v: eigenvalues are not sorted", name)
 				continue
 			}


### PR DESCRIPTION
This PR introduces a modernization change that is not necessarily related to #617 but which was spun out from my attempts at generifying the leaves of `graph`. Benchmarks to follow.

Blocked by https://github.com/gonum/gonum/pull/1940.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
