### PR TITLE
mat: use more efficient "is sorted" routine

### DIFF
--- a/mat/eigen_test.go
+++ b/mat/eigen_test.go
@@ -6,7 +6,7 @@ package mat
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -227,7 +227,7 @@ func TestEigenSym(t *testing.T) {
 			}
 
 			// Check that the eigenvalues are in ascending order.
-			if !sort.Float64sAreSorted(es.values) {
+			if !slices.IsSorted(es.values) {
 				t.Errorf("n=%d,cas=%d: eigenvalues not ascending", n, cas)
 			}
 		}


### PR DESCRIPTION
This PR introduces a modernization change that is not necessarily related to #617 but which was spun out from my attempts at generifying the leaves of `graph`. Benchmarks to follow.

Blocked by https://github.com/gonum/gonum/pull/1940.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
