### PR TITLE
internal: generify and move ordered.BySliceValues to top-level place

### DIFF
--- a/graph/community/bisect_example_test.go
+++ b/graph/community/bisect_example_test.go
@@ -11,8 +11,8 @@ import (
 	"golang.org/x/exp/rand"
 
 	"gonum.org/v1/gonum/graph/community"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 func ExampleProfile_simple() {
@@ -51,9 +51,9 @@ func ExampleProfile_simple() {
 	for _, d := range p {
 		comm := d.Communities()
 		for _, c := range comm {
-			ordered.ByID(c)
+			order.ByID(c)
 		}
-		ordered.BySliceIDs(comm)
+		order.BySliceIDs(comm)
 		fmt.Printf("Low:%.2v High:%.2v Score:%v Communities:%v Q=%.3v\n",
 			d.Low, d.High, d.Score, comm, community.Q(g, comm, d.Low))
 	}
@@ -199,9 +199,9 @@ func ExampleProfile_multiplex() {
 	for _, d := range p {
 		comm := d.Communities()
 		for _, c := range comm {
-			ordered.ByID(c)
+			order.ByID(c)
 		}
-		ordered.BySliceIDs(comm)
+		order.BySliceIDs(comm)
 		fmt.Printf("Low:%.2v High:%.2v Score:%v Communities:%v Q=%.3v\n",
 			d.Low, d.High, d.Score, comm, community.QMultiplex(g, comm, weights, []float64{d.Low}))
 	}

--- a/graph/community/k_communities_test.go
+++ b/graph/community/k_communities_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 // batageljZaversnikGraph is the example graph from
@@ -125,9 +125,9 @@ func TestKCliqueCommunities(t *testing.T) {
 		got := KCliqueCommunities(test.k, g)
 
 		for _, c := range got {
-			ordered.ByID(c)
+			order.ByID(c)
 		}
-		ordered.BySliceIDs(got)
+		order.BySliceIDs(got)
 
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexpected k-connected components for %q k=%d:\ngot: %v\nwant:%v", test.name, test.k, got, test.want)

--- a/graph/community/louvain_directed.go
+++ b/graph/community/louvain_directed.go
@@ -11,9 +11,9 @@ import (
 	"golang.org/x/exp/rand"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/internal/set"
 	"gonum.org/v1/gonum/graph/iterator"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 // qDirected returns the modularity Q score of the graph g subdivided into the
@@ -185,7 +185,7 @@ func reduceDirected(g graph.Directed, communities [][]graph.Node) *ReducedDirect
 		// community provided by the user for a Q calculation.
 		// Probably we should use a function to map the
 		// communities in the test sets to the remapped order.
-		ordered.ByID(nodes)
+		order.ByID(nodes)
 		communities = make([][]graph.Node, len(nodes))
 		for i := range nodes {
 			communities[i] = []graph.Node{node(i)}

--- a/graph/community/louvain_directed_multiplex.go
+++ b/graph/community/louvain_directed_multiplex.go
@@ -11,9 +11,9 @@ import (
 	"golang.org/x/exp/rand"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/internal/set"
 	"gonum.org/v1/gonum/graph/iterator"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 // DirectedMultiplex is a directed multiplex graph.
@@ -298,7 +298,7 @@ func reduceDirectedMultiplex(g DirectedMultiplex, communities [][]graph.Node, we
 		// community provided by the user for a Q calculation.
 		// Probably we should use a function to map the
 		// communities in the test sets to the remapped order.
-		ordered.ByID(nodes)
+		order.ByID(nodes)
 		communities = make([][]graph.Node, len(nodes))
 		for i := range nodes {
 			communities[i] = []graph.Node{node(i)}

--- a/graph/community/louvain_directed_multiplex_test.go
+++ b/graph/community/louvain_directed_multiplex_test.go
@@ -17,8 +17,8 @@ import (
 	"gonum.org/v1/gonum/floats"
 	"gonum.org/v1/gonum/floats/scalar"
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 var communityDirectedMultiplexQTests = []struct {
@@ -310,7 +310,7 @@ func TestCommunityQDirectedMultiplex(t *testing.T) {
 			got := floats.Sum(q)
 			if !scalar.EqualWithinAbsOrRel(got, structure.want, structure.tol, structure.tol) && !math.IsNaN(structure.want) {
 				for _, c := range communities {
-					ordered.ByID(c)
+					order.ByID(c)
 				}
 				t.Errorf("unexpected Q value for %q %v: got: %v %.3v want: %v",
 					test.name, communities, got, q, structure.want)
@@ -338,7 +338,7 @@ tests:
 					communityOf[n] = i
 					communities[i] = append(communities[i], simple.Node(n))
 				}
-				ordered.ByID(communities[i])
+				order.ByID(communities[i])
 			}
 			resolution := []float64{structure.resolution}
 
@@ -359,7 +359,7 @@ tests:
 
 			// This is done to avoid run-to-run
 			// variation due to map iteration order.
-			ordered.ByID(l.nodes)
+			order.ByID(l.nodes)
 
 			l.shuffle(rnd)
 
@@ -376,7 +376,7 @@ tests:
 						}
 						migrated[i] = append(migrated[i], simple.Node(n))
 					}
-					ordered.ByID(migrated[i])
+					order.ByID(migrated[i])
 				}
 
 				for i, c := range structure.memberships {
@@ -454,7 +454,7 @@ tests:
 				for n := range c {
 					communities[i] = append(communities[i], simple.Node(n))
 				}
-				ordered.ByID(communities[i])
+				order.ByID(communities[i])
 			}
 
 			gQ := QMultiplex(g, communities, weights, []float64{structure.resolution})
@@ -540,7 +540,7 @@ func TestMoveLocalDirectedMultiplex(t *testing.T) {
 				for n := range c {
 					communities[i] = append(communities[i], simple.Node(n))
 				}
-				ordered.ByID(communities[i])
+				order.ByID(communities[i])
 			}
 
 			r := reduceDirectedMultiplex(reduceDirectedMultiplex(g, nil, weights), communities, weights)
@@ -580,9 +580,9 @@ func TestLouvainDirectedMultiplex(t *testing.T) {
 			for n := range c {
 				want[i] = append(want[i], simple.Node(n))
 			}
-			ordered.ByID(want[i])
+			order.ByID(want[i])
 		}
-		ordered.BySliceIDs(want)
+		order.BySliceIDs(want)
 
 		var (
 			got   *ReducedDirectedMultiplex
@@ -616,9 +616,9 @@ func TestLouvainDirectedMultiplex(t *testing.T) {
 
 		gotCommunities := got.Communities()
 		for _, c := range gotCommunities {
-			ordered.ByID(c)
+			order.ByID(c)
 		}
-		ordered.BySliceIDs(gotCommunities)
+		order.BySliceIDs(gotCommunities)
 		if !reflect.DeepEqual(gotCommunities, want) {
 			t.Errorf("unexpected community membership for %s Q=%.4v:\n\tgot: %v\n\twant:%v",
 				test.name, bestQ, gotCommunities, want)
@@ -631,9 +631,9 @@ func TestLouvainDirectedMultiplex(t *testing.T) {
 			if p.parent != nil {
 				communities = p.parent.Communities()
 				for _, c := range communities {
-					ordered.ByID(c)
+					order.ByID(c)
 				}
-				ordered.BySliceIDs(communities)
+				order.BySliceIDs(communities)
 			} else {
 				communities = reduceDirectedMultiplex(g, nil, weights).Communities()
 			}

--- a/graph/community/louvain_directed_test.go
+++ b/graph/community/louvain_directed_test.go
@@ -15,8 +15,8 @@ import (
 
 	"gonum.org/v1/gonum/floats/scalar"
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 type communityDirectedQTest struct {
@@ -245,7 +245,7 @@ func testCommunityQDirected(t *testing.T, test communityDirectedQTest, g graph.D
 		got := Q(g, communities, structure.resolution)
 		if !scalar.EqualWithinAbsOrRel(got, structure.want, structure.tol, structure.tol) && !math.IsNaN(structure.want) {
 			for _, c := range communities {
-				ordered.ByID(c)
+				order.ByID(c)
 			}
 			t.Errorf("unexpected Q value for %q %v: got: %v want: %v",
 				test.name, communities, got, structure.want)
@@ -298,7 +298,7 @@ func testCommunityDeltaQDirected(t *testing.T, test communityDirectedQTest, g gr
 				communityOf[n] = i
 				communities[i] = append(communities[i], simple.Node(n))
 			}
-			ordered.ByID(communities[i])
+			order.ByID(communities[i])
 		}
 
 		before := Q(g, communities, structure.resolution)
@@ -313,7 +313,7 @@ func testCommunityDeltaQDirected(t *testing.T, test communityDirectedQTest, g gr
 
 		// This is done to avoid run-to-run
 		// variation due to map iteration order.
-		ordered.ByID(l.nodes)
+		order.ByID(l.nodes)
 
 		l.shuffle(rnd)
 
@@ -330,7 +330,7 @@ func testCommunityDeltaQDirected(t *testing.T, test communityDirectedQTest, g gr
 					}
 					migrated[i] = append(migrated[i], simple.Node(n))
 				}
-				ordered.ByID(migrated[i])
+				order.ByID(migrated[i])
 			}
 
 			for i, c := range structure.memberships {
@@ -423,7 +423,7 @@ func testReduceQConsistencyDirected(t *testing.T, test communityDirectedQTest, g
 			for n := range c {
 				communities[i] = append(communities[i], simple.Node(n))
 			}
-			ordered.ByID(communities[i])
+			order.ByID(communities[i])
 		}
 
 		gQ := Q(g, communities, structure.resolution)
@@ -537,7 +537,7 @@ func testMoveLocalDirected(t *testing.T, test localDirectedMoveTest, g graph.Dir
 			for n := range c {
 				communities[i] = append(communities[i], simple.Node(n))
 			}
-			ordered.ByID(communities[i])
+			order.ByID(communities[i])
 		}
 
 		r := reduceDirected(reduceDirected(g, nil), communities)
@@ -603,9 +603,9 @@ func testModularizeDirected(t *testing.T, test communityDirectedQTest, g graph.D
 		for n := range c {
 			want[i] = append(want[i], simple.Node(n))
 		}
-		ordered.ByID(want[i])
+		order.ByID(want[i])
 	}
-	ordered.BySliceIDs(want)
+	order.BySliceIDs(want)
 
 	var (
 		got   *ReducedDirected
@@ -639,9 +639,9 @@ func testModularizeDirected(t *testing.T, test communityDirectedQTest, g graph.D
 
 	gotCommunities := got.Communities()
 	for _, c := range gotCommunities {
-		ordered.ByID(c)
+		order.ByID(c)
 	}
-	ordered.BySliceIDs(gotCommunities)
+	order.BySliceIDs(gotCommunities)
 	if !reflect.DeepEqual(gotCommunities, want) {
 		t.Errorf("unexpected community membership for %s Q=%.4v:\n\tgot: %v\n\twant:%v",
 			test.name, bestQ, gotCommunities, want)
@@ -654,9 +654,9 @@ func testModularizeDirected(t *testing.T, test communityDirectedQTest, g graph.D
 		if p.parent != nil {
 			communities = p.parent.Communities()
 			for _, c := range communities {
-				ordered.ByID(c)
+				order.ByID(c)
 			}
-			ordered.BySliceIDs(communities)
+			order.BySliceIDs(communities)
 		} else {
 			communities = reduceDirected(g, nil).Communities()
 		}

--- a/graph/community/louvain_undirected.go
+++ b/graph/community/louvain_undirected.go
@@ -11,9 +11,9 @@ import (
 	"golang.org/x/exp/rand"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/internal/set"
 	"gonum.org/v1/gonum/graph/iterator"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 // qUndirected returns the modularity Q score of the graph g subdivided into the
@@ -183,7 +183,7 @@ func reduceUndirected(g graph.Undirected, communities [][]graph.Node) *ReducedUn
 		// community provided by the user for a Q calculation.
 		// Probably we should use a function to map the
 		// communities in the test sets to the remapped order.
-		ordered.ByID(nodes)
+		order.ByID(nodes)
 		communities = make([][]graph.Node, len(nodes))
 		for i := range nodes {
 			communities[i] = []graph.Node{node(i)}

--- a/graph/community/louvain_undirected_multiplex.go
+++ b/graph/community/louvain_undirected_multiplex.go
@@ -11,9 +11,9 @@ import (
 	"golang.org/x/exp/rand"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/internal/set"
 	"gonum.org/v1/gonum/graph/iterator"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 // UndirectedMultiplex is an undirected multiplex graph.
@@ -294,7 +294,7 @@ func reduceUndirectedMultiplex(g UndirectedMultiplex, communities [][]graph.Node
 		// community provided by the user for a Q calculation.
 		// Probably we should use a function to map the
 		// communities in the test sets to the remapped order.
-		ordered.ByID(nodes)
+		order.ByID(nodes)
 		communities = make([][]graph.Node, len(nodes))
 		for i := range nodes {
 			communities[i] = []graph.Node{node(i)}

--- a/graph/community/louvain_undirected_multiplex_test.go
+++ b/graph/community/louvain_undirected_multiplex_test.go
@@ -17,8 +17,8 @@ import (
 	"gonum.org/v1/gonum/floats"
 	"gonum.org/v1/gonum/floats/scalar"
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 var communityUndirectedMultiplexQTests = []struct {
@@ -279,7 +279,7 @@ func TestCommunityQUndirectedMultiplex(t *testing.T) {
 			got := floats.Sum(q)
 			if !scalar.EqualWithinAbsOrRel(got, structure.want, structure.tol, structure.tol) && !math.IsNaN(structure.want) {
 				for _, c := range communities {
-					ordered.ByID(c)
+					order.ByID(c)
 				}
 				t.Errorf("unexpected Q value for %q %v: got: %v %.3v want: %v",
 					test.name, communities, got, q, structure.want)
@@ -307,7 +307,7 @@ tests:
 					communityOf[n] = i
 					communities[i] = append(communities[i], simple.Node(n))
 				}
-				ordered.ByID(communities[i])
+				order.ByID(communities[i])
 			}
 			resolution := []float64{structure.resolution}
 
@@ -328,7 +328,7 @@ tests:
 
 			// This is done to avoid run-to-run
 			// variation due to map iteration order.
-			ordered.ByID(l.nodes)
+			order.ByID(l.nodes)
 
 			l.shuffle(rnd)
 
@@ -345,7 +345,7 @@ tests:
 						}
 						migrated[i] = append(migrated[i], simple.Node(n))
 					}
-					ordered.ByID(migrated[i])
+					order.ByID(migrated[i])
 				}
 
 				for i, c := range structure.memberships {
@@ -423,7 +423,7 @@ tests:
 				for n := range c {
 					communities[i] = append(communities[i], simple.Node(n))
 				}
-				ordered.ByID(communities[i])
+				order.ByID(communities[i])
 			}
 
 			gQ := QMultiplex(g, communities, weights, []float64{structure.resolution})
@@ -509,7 +509,7 @@ func TestMoveLocalUndirectedMultiplex(t *testing.T) {
 				for n := range c {
 					communities[i] = append(communities[i], simple.Node(n))
 				}
-				ordered.ByID(communities[i])
+				order.ByID(communities[i])
 			}
 
 			r := reduceUndirectedMultiplex(reduceUndirectedMultiplex(g, nil, weights), communities, weights)
@@ -549,9 +549,9 @@ func TestLouvainMultiplex(t *testing.T) {
 			for n := range c {
 				want[i] = append(want[i], simple.Node(n))
 			}
-			ordered.ByID(want[i])
+			order.ByID(want[i])
 		}
-		ordered.BySliceIDs(want)
+		order.BySliceIDs(want)
 
 		var (
 			got   *ReducedUndirectedMultiplex
@@ -585,9 +585,9 @@ func TestLouvainMultiplex(t *testing.T) {
 
 		gotCommunities := got.Communities()
 		for _, c := range gotCommunities {
-			ordered.ByID(c)
+			order.ByID(c)
 		}
-		ordered.BySliceIDs(gotCommunities)
+		order.BySliceIDs(gotCommunities)
 		if !reflect.DeepEqual(gotCommunities, want) {
 			t.Errorf("unexpected community membership for %s Q=%.4v:\n\tgot: %v\n\twant:%v",
 				test.name, bestQ, gotCommunities, want)
@@ -600,9 +600,9 @@ func TestLouvainMultiplex(t *testing.T) {
 			if p.parent != nil {
 				communities = p.parent.Communities()
 				for _, c := range communities {
-					ordered.ByID(c)
+					order.ByID(c)
 				}
-				ordered.BySliceIDs(communities)
+				order.BySliceIDs(communities)
 			} else {
 				communities = reduceUndirectedMultiplex(g, nil, weights).Communities()
 			}

--- a/graph/community/louvain_undirected_test.go
+++ b/graph/community/louvain_undirected_test.go
@@ -15,8 +15,8 @@ import (
 
 	"gonum.org/v1/gonum/floats/scalar"
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 type communityUndirectedQTest struct {
@@ -308,7 +308,7 @@ func testCommunityQUndirected(t *testing.T, test communityUndirectedQTest, g gra
 		got := Q(g, communities, structure.resolution)
 		if !scalar.EqualWithinAbsOrRel(got, structure.want, structure.tol, structure.tol) && !math.IsNaN(structure.want) {
 			for _, c := range communities {
-				ordered.ByID(c)
+				order.ByID(c)
 			}
 			t.Errorf("unexpected Q value for %q %v: got: %v want: %v",
 				test.name, communities, got, structure.want)
@@ -361,7 +361,7 @@ func testCommunityDeltaQUndirected(t *testing.T, test communityUndirectedQTest, 
 				communityOf[n] = i
 				communities[i] = append(communities[i], simple.Node(n))
 			}
-			ordered.ByID(communities[i])
+			order.ByID(communities[i])
 		}
 
 		before := Q(g, communities, structure.resolution)
@@ -376,7 +376,7 @@ func testCommunityDeltaQUndirected(t *testing.T, test communityUndirectedQTest, 
 
 		// This is done to avoid run-to-run
 		// variation due to map iteration order.
-		ordered.ByID(l.nodes)
+		order.ByID(l.nodes)
 
 		l.shuffle(rnd)
 
@@ -393,7 +393,7 @@ func testCommunityDeltaQUndirected(t *testing.T, test communityUndirectedQTest, 
 					}
 					migrated[i] = append(migrated[i], simple.Node(n))
 				}
-				ordered.ByID(migrated[i])
+				order.ByID(migrated[i])
 			}
 
 			for i, c := range structure.memberships {
@@ -486,7 +486,7 @@ func testReduceQConsistencyUndirected(t *testing.T, test communityUndirectedQTes
 			for n := range c {
 				communities[i] = append(communities[i], simple.Node(n))
 			}
-			ordered.ByID(communities[i])
+			order.ByID(communities[i])
 		}
 
 		gQ := Q(g, communities, structure.resolution)
@@ -600,7 +600,7 @@ func testMoveLocalUndirected(t *testing.T, test localUndirectedMoveTest, g graph
 			for n := range c {
 				communities[i] = append(communities[i], simple.Node(n))
 			}
-			ordered.ByID(communities[i])
+			order.ByID(communities[i])
 		}
 
 		r := reduceUndirected(reduceUndirected(g, nil), communities)
@@ -666,9 +666,9 @@ func testModularizeUndirected(t *testing.T, test communityUndirectedQTest, g gra
 		for n := range c {
 			want[i] = append(want[i], simple.Node(n))
 		}
-		ordered.ByID(want[i])
+		order.ByID(want[i])
 	}
-	ordered.BySliceIDs(want)
+	order.BySliceIDs(want)
 
 	var (
 		got   *ReducedUndirected
@@ -702,9 +702,9 @@ func testModularizeUndirected(t *testing.T, test communityUndirectedQTest, g gra
 
 	gotCommunities := got.Communities()
 	for _, c := range gotCommunities {
-		ordered.ByID(c)
+		order.ByID(c)
 	}
-	ordered.BySliceIDs(gotCommunities)
+	order.BySliceIDs(gotCommunities)
 	if !reflect.DeepEqual(gotCommunities, want) {
 		t.Errorf("unexpected community membership for %s Q=%.4v:\n\tgot: %v\n\twant:%v",
 			test.name, bestQ, gotCommunities, want)
@@ -717,9 +717,9 @@ func testModularizeUndirected(t *testing.T, test communityUndirectedQTest, g gra
 		if p.parent != nil {
 			communities = p.parent.Communities()
 			for _, c := range communities {
-				ordered.ByID(c)
+				order.ByID(c)
 			}
-			ordered.BySliceIDs(communities)
+			order.BySliceIDs(communities)
 		} else {
 			communities = reduceUndirected(g, nil).Communities()
 		}

--- a/graph/encoding/digraph6/digraph6.go
+++ b/graph/encoding/digraph6/digraph6.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/iterator"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 // Graph is a digraph6-represented directed graph.
@@ -37,7 +37,7 @@ var (
 func Encode(g graph.Graph) Graph {
 	nodes := graph.NodesOf(g.Nodes())
 	n := len(nodes)
-	ordered.ByID(nodes)
+	order.ByID(nodes)
 	indexOf := make(map[int64]int, n)
 	for i, n := range nodes {
 		indexOf[n.ID()] = i

--- a/graph/encoding/dot/encode.go
+++ b/graph/encoding/dot/encode.go
@@ -14,7 +14,7 @@ import (
 
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/encoding"
-	"gonum.org/v1/gonum/graph/internal/ordered"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 // Node is a DOT graph node.
@@ -166,7 +166,7 @@ func (p *simpleGraphPrinter) print(g graph.Graph, name string, needsIndent, isSu
 	}
 
 	nodes := graph.NodesOf(g.Nodes())
-	ordered.ByID(nodes)
+	order.ByID(nodes)
 
 	havePrintedNodeHeader := false
 	for _, n := range nodes {
@@ -206,7 +206,7 @@ func (p *simpleGraphPrinter) print(g graph.Graph, name string, needsIndent, isSu
 	for _, n := range nodes {
 		nid := n.ID()
 		to := graph.NodesOf(g.From(nid))
-		ordered.ByID(to)
+		order.ByID(to)
 		for _, t := range to {
 			tid := t.ID()
 			f := edge{inGraph: name, from: nid, to: tid}
@@ -465,7 +465,7 @@ func (p *multiGraphPrinter) print(g graph.Multigraph, name string, needsIndent, 
 	}
 
 	nodes := graph.NodesOf(g.Nodes())
-	ordered.ByID(nodes)
+	order.ByID(nodes)
 
 	havePrintedNodeHeader := false
 	for _, n := range nodes {
@@ -505,13 +505,13 @@ func (p *multiGraphPrinter) print(g graph.Multigraph, name string, needsIndent, 
 	for _, n := range nodes {
 		nid := n.ID()
 		to := graph.NodesOf(g.From(nid))
-		ordered.ByID(to)
+		order.ByID(to)
 
 		for _, t := range to {
 			tid := t.ID()
 
 			lines := graph.LinesOf(g.Lines(nid, tid))
-			ordered.LinesByIDs(lines)
+			order.LinesByIDs(lines)
 
 			for _, l := range lines {
 				lid := l.ID()

--- a/graph/encoding/graph6/graph6.go
+++ b/graph/encoding/graph6/graph6.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/iterator"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 // Graph is a graph6-represented undirected graph.
@@ -35,7 +35,7 @@ var (
 func Encode(g graph.Graph) Graph {
 	nodes := graph.NodesOf(g.Nodes())
 	n := len(nodes)
-	ordered.ByID(nodes)
+	order.ByID(nodes)
 	indexOf := make(map[int64]int, n)
 	for i, n := range nodes {
 		indexOf[n.ID()] = i

--- a/graph/flow/control_flow_test.go
+++ b/graph/flow/control_flow_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 var dominatorsTests = []struct {
@@ -171,7 +171,7 @@ func TestDominators(t *testing.T) {
 				}
 
 				for _, nodes := range got.dominatedBy {
-					ordered.ByID(nodes)
+					order.ByID(nodes)
 				}
 
 				if !reflect.DeepEqual(got.dominatedBy, test.want.dominatedBy) {

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 type graphBuilder interface {
@@ -263,8 +263,8 @@ func TestCopyWeighted(t *testing.T) {
 func same(a, b graph.Graph) bool {
 	aNodes := graph.NodesOf(a.Nodes())
 	bNodes := graph.NodesOf(b.Nodes())
-	ordered.ByID(aNodes)
-	ordered.ByID(bNodes)
+	order.ByID(aNodes)
+	order.ByID(bNodes)
 	for i, na := range aNodes {
 		nb := bNodes[i]
 		if na != nb {
@@ -277,8 +277,8 @@ func same(a, b graph.Graph) bool {
 		if len(aFromU) != len(bFromU) {
 			return false
 		}
-		ordered.ByID(aFromU)
-		ordered.ByID(bFromU)
+		order.ByID(aFromU)
+		order.ByID(bFromU)
 		for i, va := range aFromU {
 			vb := bFromU[i]
 			if va != vb {

--- a/graph/graphs/gen/duplication.go
+++ b/graph/graphs/gen/duplication.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/exp/rand"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 // UndirectedMutator is an undirected graph builder that can remove edges.
@@ -56,7 +56,7 @@ func Duplication(dst UndirectedMutator, n int, delta, alpha, sigma float64, src 
 	}
 
 	nodes := graph.NodesOf(dst.Nodes())
-	ordered.ByID(nodes)
+	order.ByID(nodes)
 	if len(nodes) == 0 {
 		n--
 		u := dst.NewNode()
@@ -76,7 +76,7 @@ func Duplication(dst UndirectedMutator, n int, delta, alpha, sigma float64, src 
 		for {
 			// Add edges to parent's neighbours.
 			to := graph.NodesOf(dst.From(u.ID()))
-			ordered.ByID(to)
+			order.ByID(to)
 			for _, v := range to {
 				vid := v.ID()
 				if rnd() < delta || dst.HasEdgeBetween(vid, did) {

--- a/graph/internal/ordered/doc.go
+++ b/graph/internal/ordered/doc.go
@@ -1,6 +1,0 @@
-// Copyright ©2017 The Gonum Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
-// Package ordered provides common sort ordering types.
-package ordered // import "gonum.org/v1/gonum/graph/internal/ordered"

--- a/graph/iterator/nodes_test.go
+++ b/graph/iterator/nodes_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/iterator"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 var orderedNodesTests = []struct {
@@ -740,7 +740,7 @@ func TestNodeSlicers(t *testing.T) {
 				t.Errorf("test %d: unexpected total node count: got:%d want:%d", k, gotLen, wantLen)
 			}
 			got := append(gotIter, gotSlice...)
-			ordered.ByID(got)
+			order.ByID(got)
 			if !reflect.DeepEqual(got, test.want) {
 				t.Errorf("test %d: unexpected node slice:\ngot: %v\nwant:%v", k, got, test.want)
 			}

--- a/graph/layout/layout_test.go
+++ b/graph/layout/layout_test.go
@@ -15,8 +15,8 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/iterator"
+	"gonum.org/v1/gonum/internal/order"
 	"gonum.org/v1/plot/cmpimg"
 )
 
@@ -29,13 +29,13 @@ type orderedGraph struct {
 
 func (g orderedGraph) Nodes() graph.Nodes {
 	n := graph.NodesOf(g.Graph.Nodes())
-	ordered.ByID(n)
+	order.ByID(n)
 	return iterator.NewOrderedNodes(n)
 }
 
 func (g orderedGraph) From(id int64) graph.Nodes {
 	n := graph.NodesOf(g.Graph.From(id))
-	ordered.ByID(n)
+	order.ByID(n)
 	return iterator.NewOrderedNodes(n)
 }
 

--- a/graph/path/bellman_ford_moore_test.go
+++ b/graph/path/bellman_ford_moore_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/path/internal/testgraphs"
 	"gonum.org/v1/gonum/graph/traverse"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 func TestBellmanFordFrom(t *testing.T) {
@@ -163,7 +163,7 @@ func TestBellmanFordAllFrom(t *testing.T) {
 						test.Name, tg.typ, gotPaths)
 				}
 			} else {
-				ordered.BySliceValues(gotPaths)
+				order.BySliceValues(gotPaths)
 				if !reflect.DeepEqual(gotPaths, test.WantPaths) {
 					t.Errorf("testing %q %s: unexpected shortest paths:\ngot: %v\nwant:%v",
 						test.Name, tg.typ, gotPaths, test.WantPaths)
@@ -194,7 +194,7 @@ func TestBellmanFordAllFrom(t *testing.T) {
 						test.Name, tg.typ, gotPaths)
 				}
 			} else {
-				ordered.BySliceValues(gotPaths)
+				order.BySliceValues(gotPaths)
 				if !reflect.DeepEqual(gotPaths, test.WantPaths) {
 					t.Errorf("testing %q %s: unexpected shortest paths:\ngot: %v\nwant:%v",
 						test.Name, tg.typ, gotPaths, test.WantPaths)

--- a/graph/path/dijkstra_test.go
+++ b/graph/path/dijkstra_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/path/internal/testgraphs"
 	"gonum.org/v1/gonum/graph/simple"
 	"gonum.org/v1/gonum/graph/traverse"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 func TestDijkstraFrom(t *testing.T) {
@@ -182,7 +182,7 @@ func TestDijkstraAllFrom(t *testing.T) {
 					gotPaths[i] = append(gotPaths[i], v.ID())
 				}
 			}
-			ordered.BySliceValues(gotPaths)
+			order.BySliceValues(gotPaths)
 			if !reflect.DeepEqual(gotPaths, test.WantPaths) {
 				t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 					test.Name, gotPaths, test.WantPaths)
@@ -210,7 +210,7 @@ func TestDijkstraAllFrom(t *testing.T) {
 					gotPaths[i] = append(gotPaths[i], v.ID())
 				}
 			}
-			ordered.BySliceValues(gotPaths)
+			order.BySliceValues(gotPaths)
 			if !reflect.DeepEqual(gotPaths, test.WantPaths) {
 				t.Errorf("testing %q %s: unexpected shortest paths:\ngot: %v\nwant:%v",
 					test.Name, tg.typ, gotPaths, test.WantPaths)
@@ -318,7 +318,7 @@ func TestDijkstraAllPaths(t *testing.T) {
 				got[i] = append(got[i], v.ID())
 			}
 		}
-		ordered.BySliceValues(got)
+		order.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.WantPaths) {
 			t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 				test.Name, got, test.WantPaths)
@@ -337,7 +337,7 @@ func TestDijkstraAllPaths(t *testing.T) {
 				got[i] = append(got[i], v.ID())
 			}
 		}
-		ordered.BySliceValues(got)
+		order.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.WantPaths) {
 			t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 				test.Name, got, test.WantPaths)

--- a/graph/path/floydwarshall_test.go
+++ b/graph/path/floydwarshall_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/path/internal/testgraphs"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 func TestFloydWarshall(t *testing.T) {
@@ -87,7 +87,7 @@ func TestFloydWarshall(t *testing.T) {
 				got[i] = append(got[i], v.ID())
 			}
 		}
-		ordered.BySliceValues(got)
+		order.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.WantPaths) {
 			t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 				test.Name, got, test.WantPaths)
@@ -106,7 +106,7 @@ func TestFloydWarshall(t *testing.T) {
 				got[i] = append(got[i], v.ID())
 			}
 		}
-		ordered.BySliceValues(got)
+		order.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.WantPaths) {
 			t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 				test.Name, got, test.WantPaths)

--- a/graph/path/johnson_apsp_test.go
+++ b/graph/path/johnson_apsp_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/path/internal/testgraphs"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 func TestJohnsonAllPaths(t *testing.T) {
@@ -87,7 +87,7 @@ func TestJohnsonAllPaths(t *testing.T) {
 				got[i] = append(got[i], v.ID())
 			}
 		}
-		ordered.BySliceValues(got)
+		order.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.WantPaths) {
 			t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 				test.Name, got, test.WantPaths)
@@ -106,7 +106,7 @@ func TestJohnsonAllPaths(t *testing.T) {
 				got[i] = append(got[i], v.ID())
 			}
 		}
-		ordered.BySliceValues(got)
+		order.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.WantPaths) {
 			t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 				test.Name, got, test.WantPaths)

--- a/graph/path/shortest_test.go
+++ b/graph/path/shortest_test.go
@@ -15,8 +15,8 @@ import (
 
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/graphs/gen"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 var shortestTests = []struct {
@@ -58,7 +58,7 @@ func TestShortestAlts(t *testing.T) {
 							gotPaths[i] = append(gotPaths[i], v.ID())
 						}
 					}
-					ordered.BySliceValues(gotPaths)
+					order.BySliceValues(gotPaths)
 					var wantPaths [][]int64
 					if len(want) != 0 {
 						wantPaths = make([][]int64, len(want))
@@ -68,7 +68,7 @@ func TestShortestAlts(t *testing.T) {
 							wantPaths[i] = append(wantPaths[i], v.ID())
 						}
 					}
-					ordered.BySliceValues(wantPaths)
+					order.BySliceValues(wantPaths)
 					if !reflect.DeepEqual(gotPaths, wantPaths) {
 						t.Errorf("unexpected shortest paths %d --> %d:\ngot: %v\nwant:%v",
 							uid, vid, gotPaths, wantPaths)
@@ -104,7 +104,7 @@ func TestAllShortest(t *testing.T) {
 							gotPaths[i] = append(gotPaths[i], v.ID())
 						}
 					}
-					ordered.BySliceValues(gotPaths)
+					order.BySliceValues(gotPaths)
 					var wantPaths [][]int64
 					if len(want) != 0 {
 						wantPaths = make([][]int64, len(want))
@@ -114,7 +114,7 @@ func TestAllShortest(t *testing.T) {
 							wantPaths[i] = append(wantPaths[i], v.ID())
 						}
 					}
-					ordered.BySliceValues(wantPaths)
+					order.BySliceValues(wantPaths)
 					if !reflect.DeepEqual(gotPaths, wantPaths) {
 						t.Errorf("unexpected shortest paths %d --> %d:\ngot: %v\nwant:%v",
 							uid, vid, gotPaths, wantPaths)

--- a/graph/path/yen_ksp_test.go
+++ b/graph/path/yen_ksp_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 var yenShortestPathTests = []struct {
@@ -389,11 +389,11 @@ func TestYenKSP(t *testing.T) {
 				if w == last {
 					continue
 				}
-				ordered.BySliceValues(gotIDs[first:i])
+				order.BySliceValues(gotIDs[first:i])
 				first = i
 				last = w
 			}
-			ordered.BySliceValues(gotIDs[first:])
+			order.BySliceValues(gotIDs[first:])
 		}
 
 		if !reflect.DeepEqual(test.wantPaths, gotIDs) {

--- a/graph/product/product.go
+++ b/graph/product/product.go
@@ -6,7 +6,7 @@ package product
 
 import (
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
+	"gonum.org/v1/gonum/internal/order"
 	"gonum.org/v1/gonum/stat/combin"
 )
 
@@ -367,7 +367,7 @@ func cartesianNodes(a, b graph.Graph) (aNodes, bNodes []graph.Node, product []No
 // lexicalNodes returns the nodes in g sorted lexically by node ID.
 func lexicalNodes(g graph.Graph) []graph.Node {
 	nodes := graph.NodesOf(g.Nodes())
-	ordered.ByID(nodes)
+	order.ByID(nodes)
 	return nodes
 }
 

--- a/graph/simple/dense_directed_matrix.go
+++ b/graph/simple/dense_directed_matrix.go
@@ -6,8 +6,8 @@ package simple
 
 import (
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/iterator"
+	"gonum.org/v1/gonum/internal/order"
 	"gonum.org/v1/gonum/mat"
 )
 
@@ -60,7 +60,7 @@ func NewDirectedMatrix(n int, init, self, absent float64) *DirectedMatrix {
 // specifies the cost of self connection, and absent specifies the weight
 // returned for absent edges.
 func NewDirectedMatrixFrom(nodes []graph.Node, init, self, absent float64) *DirectedMatrix {
-	ordered.ByID(nodes)
+	order.ByID(nodes)
 	for i, n := range nodes {
 		if int64(i) != n.ID() {
 			panic("simple: non-contiguous node IDs")

--- a/graph/simple/dense_undirected_matrix.go
+++ b/graph/simple/dense_undirected_matrix.go
@@ -6,8 +6,8 @@ package simple
 
 import (
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/iterator"
+	"gonum.org/v1/gonum/internal/order"
 	"gonum.org/v1/gonum/mat"
 )
 
@@ -60,7 +60,7 @@ func NewUndirectedMatrix(n int, init, self, absent float64) *UndirectedMatrix {
 // specifies the cost of self connection, and absent specifies the weight
 // returned for absent edges.
 func NewUndirectedMatrixFrom(nodes []graph.Node, init, self, absent float64) *UndirectedMatrix {
-	ordered.ByID(nodes)
+	order.ByID(nodes)
 	for i, n := range nodes {
 		if int64(i) != n.ID() {
 			panic("simple: non-contiguous node IDs")

--- a/graph/simple/densegraph_test.go
+++ b/graph/simple/densegraph_test.go
@@ -11,17 +11,17 @@ import (
 	"golang.org/x/exp/rand"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/internal/set"
 	"gonum.org/v1/gonum/graph/simple"
 	"gonum.org/v1/gonum/graph/testgraph"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 func isZeroContiguousSet(nodes []graph.Node) bool {
 	t := make([]graph.Node, len(nodes))
 	copy(t, nodes)
 	nodes = t
-	ordered.ByID(nodes)
+	order.ByID(nodes)
 	for i, n := range nodes {
 		if int64(i) != n.ID() {
 			return false
@@ -641,7 +641,7 @@ func TestDenseLists(t *testing.T) {
 		t.Fatalf("Wrong number of nodes: got:%v want:%v", len(nodes), 15)
 	}
 
-	ordered.ByID(nodes)
+	order.ByID(nodes)
 
 	for i, node := range graph.NodesOf(dg.Nodes()) {
 		if int64(i) != node.ID() {

--- a/graph/spectral/laplacian_test.go
+++ b/graph/spectral/laplacian_test.go
@@ -9,9 +9,9 @@ import (
 
 	"gonum.org/v1/gonum/floats/scalar"
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/iterator"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 	"gonum.org/v1/gonum/mat"
 )
 
@@ -128,7 +128,7 @@ type sortedNodeGraph struct {
 
 func (g sortedNodeGraph) Nodes() graph.Nodes {
 	n := graph.NodesOf(g.Graph.Nodes())
-	ordered.ByID(n)
+	order.ByID(n)
 	return iterator.NewOrderedNodes(n)
 }
 

--- a/graph/testgraph/testgraph.go
+++ b/graph/testgraph/testgraph.go
@@ -16,8 +16,8 @@ import (
 
 	"gonum.org/v1/gonum/floats/scalar"
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/internal/set"
+	"gonum.org/v1/gonum/internal/order"
 	"gonum.org/v1/gonum/mat"
 )
 
@@ -126,8 +126,8 @@ func ReturnAllNodes(t *testing.T, b Builder, useEmpty bool) {
 			got = append(got, it.Node())
 		}
 
-		ordered.ByID(got)
-		ordered.ByID(want)
+		order.ByID(got)
+		order.ByID(want)
 
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("unexpected nodes result for test %q:\ngot: %v\nwant:%v", test.name, got, want)
@@ -165,8 +165,8 @@ func ReturnNodeSlice(t *testing.T, b Builder, useEmpty bool) {
 		}
 		got := s.NodeSlice()
 
-		ordered.ByID(got)
-		ordered.ByID(want)
+		order.ByID(got)
+		order.ByID(want)
 
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("unexpected nodes result for test %q:\ngot: %v\nwant:%v", test.name, got, want)
@@ -1409,9 +1409,9 @@ func AddNodes(t *testing.T, g NodeAdder, n int) {
 		}
 	}
 
-	ordered.ByID(addedNodes)
+	order.ByID(addedNodes)
 	graphNodes := graph.NodesOf(g.Nodes())
-	ordered.ByID(graphNodes)
+	order.ByID(graphNodes)
 	if !reflect.DeepEqual(addedNodes, graphNodes) {
 		if n > 20 {
 			t.Errorf("unexpected node set after node addition: got len:%v want len:%v", len(graphNodes), len(addedNodes))
@@ -1486,9 +1486,9 @@ func AddArbitraryNodes(t *testing.T, g NodeAdder, add graph.Nodes) {
 
 	add.Reset()
 	addedNodes := graph.NodesOf(add)
-	ordered.ByID(addedNodes)
+	order.ByID(addedNodes)
 	graphNodes := graph.NodesOf(g.Nodes())
-	ordered.ByID(graphNodes)
+	order.ByID(graphNodes)
 	if !reflect.DeepEqual(addedNodes, graphNodes) {
 		t.Errorf("unexpected node set after node addition: got:\n %v\nwant:\n%v", graphNodes, addedNodes)
 	}

--- a/graph/topo/bron_kerbosch_test.go
+++ b/graph/topo/bron_kerbosch_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 var vOrderTests = []struct {
@@ -196,7 +196,7 @@ func TestBronKerbosch(t *testing.T) {
 			slices.Sort(ids)
 			got[j] = ids
 		}
-		ordered.BySliceValues(got)
+		order.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexpected cliques for test %q:\ngot: %v\nwant:%v", test.name, got, test.want)
 		}

--- a/graph/topo/clique_graph.go
+++ b/graph/topo/clique_graph.go
@@ -6,8 +6,8 @@ package topo
 
 import (
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/internal/set"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 // Builder is a pure topological graph construction type.
@@ -26,9 +26,9 @@ func CliqueGraph(dst Builder, g graph.Undirected) {
 	// Construct a consistent view of cliques in g. Sorting costs
 	// us a little, but not as much as the cliques themselves.
 	for _, c := range cliques {
-		ordered.ByID(c)
+		order.ByID(c)
 	}
-	ordered.BySliceIDs(cliques)
+	order.BySliceIDs(cliques)
 
 	cliqueNodes := make(cliqueNodeSets, len(cliques))
 	for id, c := range cliques {
@@ -59,7 +59,7 @@ func CliqueGraph(dst Builder, g graph.Undirected) {
 					for _, n := range set.IntersectionOfNodes(uc.nodes, vc.nodes) {
 						edgeNodes = append(edgeNodes, n)
 					}
-					ordered.ByID(edgeNodes)
+					order.ByID(edgeNodes)
 				}
 
 				dst.SetEdge(CliqueGraphEdge{from: uc.Clique, to: vc.Clique, nodes: edgeNodes})

--- a/graph/topo/johnson_cycles.go
+++ b/graph/topo/johnson_cycles.go
@@ -6,9 +6,9 @@ package topo
 
 import (
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/internal/set"
 	"gonum.org/v1/gonum/graph/iterator"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 // johnson implements Johnson's "Finding all the elementary
@@ -132,7 +132,7 @@ type johnsonGraph struct {
 // johnsonGraphFrom returns a deep copy of the graph g.
 func johnsonGraphFrom(g graph.Directed) johnsonGraph {
 	nodes := graph.NodesOf(g.Nodes())
-	ordered.ByID(nodes)
+	order.ByID(nodes)
 	c := johnsonGraph{
 		orig:  nodes,
 		index: make(map[int64]int, len(nodes)),

--- a/graph/topo/johnson_cycles_test.go
+++ b/graph/topo/johnson_cycles_test.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"testing"
 
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 var cyclesInTests = []struct {
@@ -108,7 +108,7 @@ func TestDirectedCyclesIn(t *testing.T) {
 			}
 			got[j] = ids
 		}
-		ordered.BySliceValues(got)
+		order.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexpected johnson result for %d:\n\tgot:%#v\n\twant:%#v", i, got, test.want)
 		}

--- a/graph/topo/paton_cycles_test.go
+++ b/graph/topo/paton_cycles_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 var undirectedCyclesInTests = []struct {
@@ -98,7 +98,7 @@ func TestUndirectedCyclesIn(t *testing.T) {
 			ids[len(ids)-1] = ids[0]
 			got[j] = ids
 		}
-		ordered.BySliceValues(got)
+		order.BySliceValues(got)
 		var matched bool
 		for _, want := range test.want {
 			if reflect.DeepEqual(got, want) {

--- a/graph/topo/tarjan.go
+++ b/graph/topo/tarjan.go
@@ -9,8 +9,8 @@ import (
 	"slices"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/internal/set"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 // Unorderable is an error containing sets of unorderable graph.Nodes.
@@ -30,7 +30,7 @@ func (e Unorderable) Error() string {
 	return fmt.Sprintf("topo: no topological ordering: cyclic components: %v", [][]graph.Node(e))
 }
 
-func lexical(nodes []graph.Node) { ordered.ByID(nodes) }
+func lexical(nodes []graph.Node) { order.ByID(nodes) }
 
 // Sort performs a topological sort of the directed graph g returning the 'from' to 'to'
 // sort order. If a topological ordering is not possible, an Unorderable error is returned

--- a/graph/topo/tarjan_test.go
+++ b/graph/topo/tarjan_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 type interval struct{ start, end int }
@@ -182,8 +182,8 @@ func TestTarjanSCC(t *testing.T) {
 			slices.Sort(gotIDs[i])
 		}
 		for _, iv := range test.ambiguousOrder {
-			ordered.BySliceValues(test.want[iv.start:iv.end])
-			ordered.BySliceValues(gotIDs[iv.start:iv.end])
+			order.BySliceValues(test.want[iv.start:iv.end])
+			order.BySliceValues(gotIDs[iv.start:iv.end])
 		}
 		if !reflect.DeepEqual(gotIDs, test.want) {
 			t.Errorf("unexpected Tarjan scc result for %d:\n\tgot:%v\n\twant:%v", i, gotIDs, test.want)

--- a/graph/topo/topo.go
+++ b/graph/topo/topo.go
@@ -6,8 +6,8 @@ package topo
 
 import (
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/traverse"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 // IsPathIn returns whether path is a path in g.
@@ -80,8 +80,8 @@ func Equal(a, b graph.Graph) bool {
 
 	aNodeSlice := graph.NodesOf(aNodes)
 	bNodeSlice := graph.NodesOf(bNodes)
-	ordered.ByID(aNodeSlice)
-	ordered.ByID(bNodeSlice)
+	order.ByID(aNodeSlice)
+	order.ByID(bNodeSlice)
 	for i, aU := range aNodeSlice {
 		id := aU.ID()
 		if id != bNodeSlice[i].ID() {
@@ -96,8 +96,8 @@ func Equal(a, b graph.Graph) bool {
 
 		aAdjacent := graph.NodesOf(toA)
 		bAdjacent := graph.NodesOf(toB)
-		ordered.ByID(aAdjacent)
-		ordered.ByID(bAdjacent)
+		order.ByID(aAdjacent)
+		order.ByID(bAdjacent)
 		for i, aV := range aAdjacent {
 			id := aV.ID()
 			if id != bAdjacent[i].ID() {

--- a/graph/topo/topo_test.go
+++ b/graph/topo/topo_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 func TestIsPath(t *testing.T) {
@@ -167,7 +167,7 @@ func TestConnectedComponents(t *testing.T) {
 			slices.Sort(ids)
 			got[j] = ids
 		}
-		ordered.BySliceValues(got)
+		order.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexpected connected components for test %d %T:\ngot: %v\nwant:%v", i, g, got, test.want)
 		}

--- a/graph/traverse/traverse_test.go
+++ b/graph/traverse/traverse_test.go
@@ -13,8 +13,8 @@ import (
 
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/graphs/gen"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/order"
 )
 
 var (
@@ -375,7 +375,7 @@ func TestWalkAll(t *testing.T) {
 				slices.Sort(ids)
 				got[j] = ids
 			}
-			ordered.BySliceValues(got)
+			order.BySliceValues(got)
 			if !reflect.DeepEqual(got, test.want) {
 				t.Errorf("unexpected connected components for test %d using %T:\ngot: %v\nwant:%v", i, w, got, test.want)
 			}

--- a/internal/order/doc.go
+++ b/internal/order/doc.go
@@ -1,0 +1,6 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package order provides common sorting functions.
+package order // import "gonum.org/v1/gonum/internal/order"

--- a/internal/order/order.go
+++ b/internal/order/order.go
@@ -1,10 +1,12 @@
-// Copyright ©2015 The Gonum Authors. All rights reserved.
+// Copyright ©2024 The Gonum Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package ordered
+package order
 
 import (
+	"cmp"
+	"slices"
 	"sort"
 
 	"gonum.org/v1/gonum/graph"
@@ -15,24 +17,17 @@ func ByID(n []graph.Node) {
 	sort.Slice(n, func(i, j int) bool { return n[i].ID() < n[j].ID() })
 }
 
-// BySliceValues sorts a slice of []int64 lexically by the values of the
-// []int64.
-func BySliceValues(c [][]int64) {
-	sort.Slice(c, func(i, j int) bool {
-		a, b := c[i], c[j]
-		l := len(a)
-		if len(b) < l {
-			l = len(b)
-		}
+// BySliceValues sorts a slice of []cmp.Ordered lexically by the values of
+// the []cmp.Ordered.
+func BySliceValues[S interface{ ~[]E }, E cmp.Ordered](c []S) {
+	slices.SortFunc(c, func(a, b S) int {
+		l := min(len(a), len(b))
 		for k, v := range a[:l] {
-			if v < b[k] {
-				return true
-			}
-			if v > b[k] {
-				return false
+			if n := cmp.Compare(v, b[k]); n != 0 {
+				return n
 			}
 		}
-		return len(a) < len(b)
+		return cmp.Compare(len(a), len(b))
 	})
 }
 

--- a/spatial/vptree/vptree_test.go
+++ b/spatial/vptree/vptree_test.go
@@ -17,6 +17,8 @@ import (
 	"unsafe"
 
 	"golang.org/x/exp/rand"
+
+	"gonum.org/v1/gonum/internal/order"
 )
 
 var (
@@ -344,8 +346,8 @@ func TestDo(t *testing.T) {
 	for i, p := range wpData {
 		want[i] = p.(Point)
 	}
-	sort.Sort(lexical(got))
-	sort.Sort(lexical(want))
+	order.BySliceValues(got)
+	order.BySliceValues(want)
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("unexpected result from tree iteration: got:%v want:%v", got, want)
@@ -354,27 +356,6 @@ func TestDo(t *testing.T) {
 		t.Error("tree iteration unexpectedly killed")
 	}
 }
-
-type lexical []Point
-
-func (c lexical) Len() int { return len(c) }
-func (c lexical) Less(i, j int) bool {
-	a, b := c[i], c[j]
-	l := len(a)
-	if len(b) < l {
-		l = len(b)
-	}
-	for k, v := range a[:l] {
-		if v < b[k] {
-			return true
-		}
-		if v > b[k] {
-			return false
-		}
-	}
-	return len(a) < len(b)
-}
-func (c lexical) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
 
 func BenchmarkNew(b *testing.B) {
 	for _, effort := range []int{0, 10, 100} {


### PR DESCRIPTION
This PR introduces a modernization change that is not necessarily related to #617 but which was spun out from my attempts at generifying the leaves of `graph`.

Although it may not provide any value in of itself, it will be used by forthcoming PRs to remove duplicate code.

Benchmarks to follow.

Blocked by https://github.com/gonum/gonum/pull/1940.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
