### PR TITLE
unit: use more efficient sort routine

### DIFF
--- a/unit/unit_test.go
+++ b/unit/unit_test.go
@@ -472,3 +472,44 @@ func BenchmarkMulMapLargeSame(b *testing.B) {
 		u2.Mul(u1)
 	}
 }
+
+func BenchmarkDimensionsString(b *testing.B) {
+	oneDim := Dimensions{CurrentDim: 1}
+	threeDims := Dimensions{
+		CurrentDim:           1,
+		LengthDim:            2,
+		LuminousIntensityDim: 3,
+	}
+	allDims := Dimensions{
+		CurrentDim:           1,
+		LengthDim:            2,
+		LuminousIntensityDim: 3,
+		MassDim:              4,
+		MoleDim:              5,
+		TemperatureDim:       6,
+		TimeDim:              7,
+		AngleDim:             8,
+	}
+
+	b.Run("oneDim", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if oneDim.String() != "" {
+				b.FailNow()
+			}
+		}
+	})
+	b.Run("threeDims", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if threeDims.String() != "" {
+				b.FailNow()
+			}
+		}
+	})
+	b.Run("allDims", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if allDims.String() != "" {
+				b.FailNow()
+			}
+		}
+	})
+}


### PR DESCRIPTION
This PR introduces a modernization change that is not necessarily related to #617 but which was spun out from my attempts at generifying the leaves of `graph`. Benchmarks to follow.

Blocked by https://github.com/gonum/gonum/pull/1940.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
