### PR TITLE
spatial: use generic lexical sorting routine

### DIFF
--- a/graph/internal/ordered/doc.go
+++ b/graph/internal/ordered/doc.go
@@ -2,5 +2,5 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package ordered provides common sort ordering types.
+// Package ordered provides common sort ordering types for the graph package.
 package ordered // import "gonum.org/v1/gonum/graph/internal/ordered"

--- a/graph/internal/ordered/sort.go
+++ b/graph/internal/ordered/sort.go
@@ -15,27 +15,6 @@ func ByID(n []graph.Node) {
 	sort.Slice(n, func(i, j int) bool { return n[i].ID() < n[j].ID() })
 }
 
-// BySliceValues sorts a slice of []int64 lexically by the values of the
-// []int64.
-func BySliceValues(c [][]int64) {
-	sort.Slice(c, func(i, j int) bool {
-		a, b := c[i], c[j]
-		l := len(a)
-		if len(b) < l {
-			l = len(b)
-		}
-		for k, v := range a[:l] {
-			if v < b[k] {
-				return true
-			}
-			if v > b[k] {
-				return false
-			}
-		}
-		return len(a) < len(b)
-	})
-}
-
 // BySliceIDs sorts a slice of []graph.Node lexically by the IDs of the
 // []graph.Node.
 func BySliceIDs(c [][]graph.Node) {

--- a/graph/path/bellman_ford_moore_test.go
+++ b/graph/path/bellman_ford_moore_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/path/internal/testgraphs"
 	"gonum.org/v1/gonum/graph/traverse"
+	"gonum.org/v1/gonum/internal/sorted"
 )
 
 func TestBellmanFordFrom(t *testing.T) {
@@ -163,7 +163,7 @@ func TestBellmanFordAllFrom(t *testing.T) {
 						test.Name, tg.typ, gotPaths)
 				}
 			} else {
-				ordered.BySliceValues(gotPaths)
+				sorted.BySliceValues(gotPaths)
 				if !reflect.DeepEqual(gotPaths, test.WantPaths) {
 					t.Errorf("testing %q %s: unexpected shortest paths:\ngot: %v\nwant:%v",
 						test.Name, tg.typ, gotPaths, test.WantPaths)
@@ -194,7 +194,7 @@ func TestBellmanFordAllFrom(t *testing.T) {
 						test.Name, tg.typ, gotPaths)
 				}
 			} else {
-				ordered.BySliceValues(gotPaths)
+				sorted.BySliceValues(gotPaths)
 				if !reflect.DeepEqual(gotPaths, test.WantPaths) {
 					t.Errorf("testing %q %s: unexpected shortest paths:\ngot: %v\nwant:%v",
 						test.Name, tg.typ, gotPaths, test.WantPaths)

--- a/graph/path/dijkstra_test.go
+++ b/graph/path/dijkstra_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/path/internal/testgraphs"
 	"gonum.org/v1/gonum/graph/simple"
 	"gonum.org/v1/gonum/graph/traverse"
+	"gonum.org/v1/gonum/internal/sorted"
 )
 
 func TestDijkstraFrom(t *testing.T) {
@@ -182,7 +182,7 @@ func TestDijkstraAllFrom(t *testing.T) {
 					gotPaths[i] = append(gotPaths[i], v.ID())
 				}
 			}
-			ordered.BySliceValues(gotPaths)
+			sorted.BySliceValues(gotPaths)
 			if !reflect.DeepEqual(gotPaths, test.WantPaths) {
 				t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 					test.Name, gotPaths, test.WantPaths)
@@ -210,7 +210,7 @@ func TestDijkstraAllFrom(t *testing.T) {
 					gotPaths[i] = append(gotPaths[i], v.ID())
 				}
 			}
-			ordered.BySliceValues(gotPaths)
+			sorted.BySliceValues(gotPaths)
 			if !reflect.DeepEqual(gotPaths, test.WantPaths) {
 				t.Errorf("testing %q %s: unexpected shortest paths:\ngot: %v\nwant:%v",
 					test.Name, tg.typ, gotPaths, test.WantPaths)
@@ -318,7 +318,7 @@ func TestDijkstraAllPaths(t *testing.T) {
 				got[i] = append(got[i], v.ID())
 			}
 		}
-		ordered.BySliceValues(got)
+		sorted.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.WantPaths) {
 			t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 				test.Name, got, test.WantPaths)
@@ -337,7 +337,7 @@ func TestDijkstraAllPaths(t *testing.T) {
 				got[i] = append(got[i], v.ID())
 			}
 		}
-		ordered.BySliceValues(got)
+		sorted.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.WantPaths) {
 			t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 				test.Name, got, test.WantPaths)

--- a/graph/path/floydwarshall_test.go
+++ b/graph/path/floydwarshall_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/path/internal/testgraphs"
+	"gonum.org/v1/gonum/internal/sorted"
 )
 
 func TestFloydWarshall(t *testing.T) {
@@ -87,7 +87,7 @@ func TestFloydWarshall(t *testing.T) {
 				got[i] = append(got[i], v.ID())
 			}
 		}
-		ordered.BySliceValues(got)
+		sorted.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.WantPaths) {
 			t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 				test.Name, got, test.WantPaths)
@@ -106,7 +106,7 @@ func TestFloydWarshall(t *testing.T) {
 				got[i] = append(got[i], v.ID())
 			}
 		}
-		ordered.BySliceValues(got)
+		sorted.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.WantPaths) {
 			t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 				test.Name, got, test.WantPaths)

--- a/graph/path/johnson_apsp_test.go
+++ b/graph/path/johnson_apsp_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/path/internal/testgraphs"
+	"gonum.org/v1/gonum/internal/sorted"
 )
 
 func TestJohnsonAllPaths(t *testing.T) {
@@ -87,7 +87,7 @@ func TestJohnsonAllPaths(t *testing.T) {
 				got[i] = append(got[i], v.ID())
 			}
 		}
-		ordered.BySliceValues(got)
+		sorted.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.WantPaths) {
 			t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 				test.Name, got, test.WantPaths)
@@ -106,7 +106,7 @@ func TestJohnsonAllPaths(t *testing.T) {
 				got[i] = append(got[i], v.ID())
 			}
 		}
-		ordered.BySliceValues(got)
+		sorted.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.WantPaths) {
 			t.Errorf("testing %q: unexpected shortest paths:\ngot: %v\nwant:%v",
 				test.Name, got, test.WantPaths)

--- a/graph/path/shortest_test.go
+++ b/graph/path/shortest_test.go
@@ -16,6 +16,7 @@ import (
 	"gonum.org/v1/gonum/graph/graphs/gen"
 	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/sorted"
 )
 
 var shortestTests = []struct {
@@ -57,7 +58,7 @@ func TestShortestAlts(t *testing.T) {
 							gotPaths[i] = append(gotPaths[i], v.ID())
 						}
 					}
-					ordered.BySliceValues(gotPaths)
+					sorted.BySliceValues(gotPaths)
 					var wantPaths [][]int64
 					if len(want) != 0 {
 						wantPaths = make([][]int64, len(want))
@@ -67,7 +68,7 @@ func TestShortestAlts(t *testing.T) {
 							wantPaths[i] = append(wantPaths[i], v.ID())
 						}
 					}
-					ordered.BySliceValues(wantPaths)
+					sorted.BySliceValues(wantPaths)
 					if !reflect.DeepEqual(gotPaths, wantPaths) {
 						t.Errorf("unexpected shortest paths %d --> %d:\ngot: %v\nwant:%v",
 							uid, vid, gotPaths, wantPaths)
@@ -103,7 +104,7 @@ func TestAllShortest(t *testing.T) {
 							gotPaths[i] = append(gotPaths[i], v.ID())
 						}
 					}
-					ordered.BySliceValues(gotPaths)
+					sorted.BySliceValues(gotPaths)
 					var wantPaths [][]int64
 					if len(want) != 0 {
 						wantPaths = make([][]int64, len(want))
@@ -113,7 +114,7 @@ func TestAllShortest(t *testing.T) {
 							wantPaths[i] = append(wantPaths[i], v.ID())
 						}
 					}
-					ordered.BySliceValues(wantPaths)
+					sorted.BySliceValues(wantPaths)
 					if !reflect.DeepEqual(gotPaths, wantPaths) {
 						t.Errorf("unexpected shortest paths %d --> %d:\ngot: %v\nwant:%v",
 							uid, vid, gotPaths, wantPaths)

--- a/graph/path/yen_ksp_test.go
+++ b/graph/path/yen_ksp_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 
 	"gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/sorted"
 )
 
 var yenShortestPathTests = []struct {
@@ -389,11 +389,11 @@ func TestYenKSP(t *testing.T) {
 				if w == last {
 					continue
 				}
-				ordered.BySliceValues(gotIDs[first:i])
+				sorted.BySliceValues(gotIDs[first:i])
 				first = i
 				last = w
 			}
-			ordered.BySliceValues(gotIDs[first:])
+			sorted.BySliceValues(gotIDs[first:])
 		}
 
 		if !reflect.DeepEqual(test.wantPaths, gotIDs) {

--- a/graph/topo/bron_kerbosch_test.go
+++ b/graph/topo/bron_kerbosch_test.go
@@ -11,6 +11,7 @@ import (
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/sorted"
 )
 
 var vOrderTests = []struct {
@@ -195,7 +196,7 @@ func TestBronKerbosch(t *testing.T) {
 			ordered.Int64s(ids)
 			got[j] = ids
 		}
-		ordered.BySliceValues(got)
+		sorted.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexpected cliques for test %q:\ngot: %v\nwant:%v", test.name, got, test.want)
 		}

--- a/graph/topo/johnson_cycles_test.go
+++ b/graph/topo/johnson_cycles_test.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"testing"
 
-	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/sorted"
 )
 
 var cyclesInTests = []struct {
@@ -108,7 +108,7 @@ func TestDirectedCyclesIn(t *testing.T) {
 			}
 			got[j] = ids
 		}
-		ordered.BySliceValues(got)
+		sorted.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexpected johnson result for %d:\n\tgot:%#v\n\twant:%#v", i, got, test.want)
 		}

--- a/graph/topo/paton_cycles_test.go
+++ b/graph/topo/paton_cycles_test.go
@@ -11,6 +11,7 @@ import (
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/sorted"
 )
 
 var undirectedCyclesInTests = []struct {
@@ -97,7 +98,7 @@ func TestUndirectedCyclesIn(t *testing.T) {
 			ids[len(ids)-1] = ids[0]
 			got[j] = ids
 		}
-		ordered.BySliceValues(got)
+		sorted.BySliceValues(got)
 		var matched bool
 		for _, want := range test.want {
 			if reflect.DeepEqual(got, want) {

--- a/graph/topo/tarjan_test.go
+++ b/graph/topo/tarjan_test.go
@@ -11,6 +11,7 @@ import (
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/sorted"
 )
 
 type interval struct{ start, end int }
@@ -181,8 +182,8 @@ func TestTarjanSCC(t *testing.T) {
 			ordered.Int64s(gotIDs[i])
 		}
 		for _, iv := range test.ambiguousOrder {
-			ordered.BySliceValues(test.want[iv.start:iv.end])
-			ordered.BySliceValues(gotIDs[iv.start:iv.end])
+			sorted.BySliceValues(test.want[iv.start:iv.end])
+			sorted.BySliceValues(gotIDs[iv.start:iv.end])
 		}
 		if !reflect.DeepEqual(gotIDs, test.want) {
 			t.Errorf("unexpected Tarjan scc result for %d:\n\tgot:%v\n\twant:%v", i, gotIDs, test.want)

--- a/graph/topo/topo_test.go
+++ b/graph/topo/topo_test.go
@@ -11,6 +11,7 @@ import (
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/sorted"
 )
 
 func TestIsPath(t *testing.T) {
@@ -166,7 +167,7 @@ func TestConnectedComponents(t *testing.T) {
 			ordered.Int64s(ids)
 			got[j] = ids
 		}
-		ordered.BySliceValues(got)
+		sorted.BySliceValues(got)
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("unexpected connected components for test %d %T:\ngot: %v\nwant:%v", i, g, got, test.want)
 		}

--- a/graph/traverse/traverse_test.go
+++ b/graph/traverse/traverse_test.go
@@ -14,6 +14,7 @@ import (
 	"gonum.org/v1/gonum/graph/graphs/gen"
 	"gonum.org/v1/gonum/graph/internal/ordered"
 	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/internal/sorted"
 )
 
 var (
@@ -374,7 +375,7 @@ func TestWalkAll(t *testing.T) {
 				ordered.Int64s(ids)
 				got[j] = ids
 			}
-			ordered.BySliceValues(got)
+			sorted.BySliceValues(got)
 			if !reflect.DeepEqual(got, test.want) {
 				t.Errorf("unexpected connected components for test %d using %T:\ngot: %v\nwant:%v", i, w, got, test.want)
 			}

--- a/internal/sorted/doc.go
+++ b/internal/sorted/doc.go
@@ -1,0 +1,6 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package sorted provides common sorting functions.
+package sorted // import "gonum.org/v1/gonum/internal/ordered"

--- a/internal/sorted/sort.go
+++ b/internal/sorted/sort.go
@@ -1,0 +1,27 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sorted
+
+import (
+	"cmp"
+	"slices"
+)
+
+// BySliceValues sorts a slice of []cmp.Ordered (such as []int64)
+// lexically by the values of the []cmp.Ordered.
+func BySliceValues[S interface{ ~[]E }, E cmp.Ordered](c []S) {
+	slices.SortFunc(c, func(a, b S) int {
+		l := len(a)
+		if len(b) < l {
+			l = len(b)
+		}
+		for k, v := range a[:l] {
+			if n := cmp.Compare(v, b[k]); n != 0 {
+				return n
+			}
+		}
+		return cmp.Compare(len(a), len(b))
+	})
+}

--- a/spatial/vptree/vptree_test.go
+++ b/spatial/vptree/vptree_test.go
@@ -16,6 +16,8 @@ import (
 	"unsafe"
 
 	"golang.org/x/exp/rand"
+
+	"gonum.org/v1/gonum/internal/sorted"
 )
 
 var (
@@ -345,8 +347,8 @@ func TestDo(t *testing.T) {
 	for i, p := range wpData {
 		want[i] = p.(Point)
 	}
-	sort.Sort(lexical(got))
-	sort.Sort(lexical(want))
+	sortLexical(got)
+	sortLexical(want)
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("unexpected result from tree iteration: got:%v want:%v", got, want)
@@ -356,26 +358,9 @@ func TestDo(t *testing.T) {
 	}
 }
 
-type lexical []Point
-
-func (c lexical) Len() int { return len(c) }
-func (c lexical) Less(i, j int) bool {
-	a, b := c[i], c[j]
-	l := len(a)
-	if len(b) < l {
-		l = len(b)
-	}
-	for k, v := range a[:l] {
-		if v < b[k] {
-			return true
-		}
-		if v > b[k] {
-			return false
-		}
-	}
-	return len(a) < len(b)
+func sortLexical(p []Point) {
+	sorted.BySliceValues(p)
 }
-func (c lexical) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
 
 func BenchmarkNew(b *testing.B) {
 	for _, effort := range []int{0, 10, 100} {


### PR DESCRIPTION
This PR introduces a modernization change that is not necessarily related to #617 but which was spun out from my attempts at generifying the leaves of `graph`. Benchmarks to follow.

Blocked by https://github.com/gonum/gonum/pull/1940 and https://github.com/gonum/gonum/pull/1953.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
