### PR TITLE
stat: use more efficient sort routines

### DIFF
--- a/stat/combin/combin.go
+++ b/stat/combin/combin.go
@@ -6,6 +6,7 @@ package combin
 
 import (
 	"math"
+	"slices"
 	"sort"
 )
 
@@ -203,7 +204,7 @@ func CombinationIndex(comb []int, n, k int) int {
 	if len(comb) != k {
 		panic("combin: bad length combination")
 	}
-	if !sort.IntsAreSorted(comb) {
+	if !slices.IsSorted(comb) {
 		panic("combin: input combination is not sorted")
 	}
 	contains := make(map[int]struct{}, k)

--- a/stat/distmv/studentst.go
+++ b/stat/distmv/studentst.go
@@ -6,7 +6,7 @@ package distmv
 
 import (
 	"math"
-	"sort"
+	"slices"
 
 	"golang.org/x/exp/rand"
 	"golang.org/x/tools/container/intsets"
@@ -219,7 +219,7 @@ func findUnob(observed []int, dim int) (unobserved []int) {
 	var setUnob intsets.Sparse
 	setUnob.Difference(&setAll, &setOb)
 	unobserved = setUnob.AppendTo(nil)
-	sort.Ints(unobserved)
+	slices.Sort(unobserved)
 	return unobserved
 }
 

--- a/stat/distuv/alphastable_test.go
+++ b/stat/distuv/alphastable_test.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -179,8 +179,8 @@ func testStability(t *testing.T, i, n int, alpha, beta1, beta2, c1, c2, mu1, mu2
 		sample1[i] = d1.Rand() + d2.Rand()
 		sample2[i] = d.Rand()
 	}
-	sort.Float64s(sample1)
-	sort.Float64s(sample2)
+	slices.Sort(sample1)
+	slices.Sort(sample2)
 	ks := stat.KolmogorovSmirnov(sample1, nil, sample2, nil)
 	if ks > ksTol {
 		t.Errorf("%d: Kolmogorov-Smirnov distance %g exceeding tolerance %g", i, ks, ksTol)

--- a/stat/distuv/bernoulli_test.go
+++ b/stat/distuv/bernoulli_test.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -56,7 +56,7 @@ func testBernoulli(t *testing.T, dist Bernoulli, i int) {
 	)
 	x := make([]float64, n)
 	generateSamples(x, dist)
-	sort.Float64s(x)
+	slices.Sort(x)
 
 	checkMean(t, i, x, dist, tol)
 	checkVarAndStd(t, i, x, dist, tol)

--- a/stat/distuv/beta_test.go
+++ b/stat/distuv/beta_test.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -54,7 +54,7 @@ func testBeta(t *testing.T, b Beta, i int) {
 	)
 	x := make([]float64, n)
 	generateSamples(x, b)
-	sort.Float64s(x)
+	slices.Sort(x)
 
 	testRandLogProbContinuous(t, i, 0, x, b, tol, bins)
 	checkMean(t, i, x, b, tol)

--- a/stat/distuv/binomial_test.go
+++ b/stat/distuv/binomial_test.go
@@ -5,7 +5,7 @@
 package distuv
 
 import (
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -140,7 +140,7 @@ func testBinomial(t *testing.T, b Binomial, i int) {
 	)
 	x := make([]float64, n)
 	generateSamples(x, b)
-	sort.Float64s(x)
+	slices.Sort(x)
 
 	checkMean(t, i, x, b, tol)
 	checkVarAndStd(t, i, x, b, tol)

--- a/stat/distuv/chi_test.go
+++ b/stat/distuv/chi_test.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -74,7 +74,7 @@ func testChi(t *testing.T, c Chi, i int) {
 	)
 	x := make([]float64, n)
 	generateSamples(x, c)
-	sort.Float64s(x)
+	slices.Sort(x)
 
 	testRandLogProbContinuous(t, i, 0, x, c, tol, bins)
 	checkMean(t, i, x, c, tol)

--- a/stat/distuv/chisquared_test.go
+++ b/stat/distuv/chisquared_test.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -74,7 +74,7 @@ func testChiSquared(t *testing.T, c ChiSquared, i int) {
 	)
 	x := make([]float64, n)
 	generateSamples(x, c)
-	sort.Float64s(x)
+	slices.Sort(x)
 
 	testRandLogProbContinuous(t, i, 0, x, c, tol, bins)
 	checkMean(t, i, x, c, tol)

--- a/stat/distuv/exponential_test.go
+++ b/stat/distuv/exponential_test.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -68,7 +68,7 @@ func testExponential(t *testing.T, dist Exponential, i int) {
 	)
 	x := make([]float64, n)
 	generateSamples(x, dist)
-	sort.Float64s(x)
+	slices.Sort(x)
 
 	checkMean(t, i, x, dist, tol)
 	checkVarAndStd(t, i, x, dist, tol)

--- a/stat/distuv/f_test.go
+++ b/stat/distuv/f_test.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -82,7 +82,7 @@ func testF(t *testing.T, f F, i int) {
 	)
 	x := make([]float64, n)
 	generateSamples(x, f)
-	sort.Float64s(x)
+	slices.Sort(x)
 
 	testRandLogProbContinuous(t, i, 0, x, f, tol, bins)
 	checkProbContinuous(t, i, x, 0, math.Inf(1), f, 1e-4)

--- a/stat/distuv/gamma_test.go
+++ b/stat/distuv/gamma_test.go
@@ -7,7 +7,7 @@ package distuv
 import (
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -57,7 +57,7 @@ func testGamma(t *testing.T, f Gamma, i int) {
 	)
 	x := make([]float64, n)
 	generateSamples(x, f)
-	sort.Float64s(x)
+	slices.Sort(x)
 
 	var quadTol float64
 

--- a/stat/distuv/gumbel_test.go
+++ b/stat/distuv/gumbel_test.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -60,7 +60,7 @@ func testGumbelRight(t *testing.T, g GumbelRight, i int) {
 	)
 	x := make([]float64, n)
 	generateSamples(x, g)
-	sort.Float64s(x)
+	slices.Sort(x)
 
 	min := math.Inf(-1)
 	testRandLogProbContinuous(t, i, min, x, g, tol, bins)

--- a/stat/distuv/inversegamma_test.go
+++ b/stat/distuv/inversegamma_test.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -47,7 +47,7 @@ func testInverseGamma(t *testing.T, f InverseGamma, i int) {
 	)
 	x := make([]float64, n)
 	generateSamples(x, f)
-	sort.Float64s(x)
+	slices.Sort(x)
 
 	testRandLogProbContinuous(t, i, 0, x, f, tol, bins)
 	checkMean(t, i, x, f, tol)

--- a/stat/distuv/laplace.go
+++ b/stat/distuv/laplace.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 
 	"golang.org/x/exp/rand"
 	"gonum.org/v1/gonum/stat"
@@ -62,7 +62,7 @@ func (l *Laplace) Fit(samples, weights []float64) {
 		sortedSamples []float64
 		sortedWeights []float64
 	)
-	if sort.Float64sAreSorted(samples) {
+	if slices.IsSorted(samples) {
 		sortedSamples = samples
 		sortedWeights = weights
 	} else {

--- a/stat/distuv/laplace_test.go
+++ b/stat/distuv/laplace_test.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -82,7 +82,7 @@ func testLaplace(t *testing.T, dist Laplace, i int) {
 	)
 	x := make([]float64, n)
 	generateSamples(x, dist)
-	sort.Float64s(x)
+	slices.Sort(x)
 
 	checkMean(t, i, x, dist, tol)
 	checkVarAndStd(t, i, x, dist, tol)

--- a/stat/distuv/lognormal_test.go
+++ b/stat/distuv/lognormal_test.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -26,7 +26,7 @@ func TestLognormal(t *testing.T) {
 		)
 		x := make([]float64, n)
 		generateSamples(x, dist)
-		sort.Float64s(x)
+		slices.Sort(x)
 
 		checkMean(t, i, x, dist, tol)
 		checkVarAndStd(t, i, x, dist, tol)

--- a/stat/distuv/norm_test.go
+++ b/stat/distuv/norm_test.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -107,7 +107,7 @@ func testNormal(t *testing.T, dist Normal, i int) {
 	)
 	x := make([]float64, n)
 	generateSamples(x, dist)
-	sort.Float64s(x)
+	slices.Sort(x)
 
 	checkMean(t, i, x, dist, tol)
 	checkVarAndStd(t, i, x, dist, tol)

--- a/stat/distuv/pareto_test.go
+++ b/stat/distuv/pareto_test.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -159,7 +159,7 @@ func testPareto(t *testing.T, p Pareto, i int) {
 	)
 	x := make([]float64, n)
 	generateSamples(x, p)
-	sort.Float64s(x)
+	slices.Sort(x)
 
 	checkQuantileCDFSurvival(t, i, x, p, 1e-3)
 	testRandLogProbContinuous(t, i, 0, x, p, tol, bins)

--- a/stat/distuv/poisson_test.go
+++ b/stat/distuv/poisson_test.go
@@ -7,7 +7,7 @@ package distuv
 import (
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -125,7 +125,7 @@ func testPoisson(t *testing.T, p Poisson, i int) {
 	)
 	x := make([]float64, n)
 	generateSamples(x, p)
-	sort.Float64s(x)
+	slices.Sort(x)
 
 	checkProbDiscrete(t, i, x, p, 2e-3)
 	checkMean(t, i, x, p, tol)

--- a/stat/distuv/studentst_test.go
+++ b/stat/distuv/studentst_test.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -55,7 +55,7 @@ func testStudentsT(t *testing.T, c StudentsT, i int) {
 	)
 	x := make([]float64, n)
 	generateSamples(x, c)
-	sort.Float64s(x)
+	slices.Sort(x)
 
 	testRandLogProbContinuous(t, i, math.Inf(-1), x, c, tol, bins)
 	checkMean(t, i, x, c, tol)

--- a/stat/distuv/triangle_test.go
+++ b/stat/distuv/triangle_test.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -65,7 +65,7 @@ func TestTriangle(t *testing.T) {
 		)
 		x := make([]float64, n)
 		generateSamples(x, f)
-		sort.Float64s(x)
+		slices.Sort(x)
 
 		checkMean(t, i, x, f, tol)
 		checkVarAndStd(t, i, x, f, tol)

--- a/stat/distuv/uniform_test.go
+++ b/stat/distuv/uniform_test.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -85,7 +85,7 @@ func testUniform(t *testing.T, u Uniform, i int) {
 	)
 	x := make([]float64, n)
 	generateSamples(x, u)
-	sort.Float64s(x)
+	slices.Sort(x)
 
 	testRandLogProbContinuous(t, i, 0, x, u, tol, bins)
 	checkMean(t, i, x, u, tol)

--- a/stat/distuv/weibull_test.go
+++ b/stat/distuv/weibull_test.go
@@ -6,7 +6,7 @@ package distuv
 
 import (
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"golang.org/x/exp/rand"
@@ -249,7 +249,7 @@ func testWeibull(t *testing.T, dist Weibull, i int) {
 	)
 	x := make([]float64, n)
 	generateSamples(x, dist)
-	sort.Float64s(x)
+	slices.Sort(x)
 
 	checkMean(t, i, x, dist, tol)
 	checkVarAndStd(t, i, x, dist, tol)

--- a/stat/roc.go
+++ b/stat/roc.go
@@ -6,7 +6,7 @@ package stat
 
 import (
 	"math"
-	"sort"
+	"slices"
 )
 
 // ROC returns paired false positive rate (FPR) and true positive rate
@@ -44,10 +44,10 @@ func ROC(cutoffs, y []float64, classes []bool, weights []float64) (tpr, fpr, thr
 	if weights != nil && len(y) != len(weights) {
 		panic("stat: slice length mismatch")
 	}
-	if !sort.Float64sAreSorted(y) {
+	if !slices.IsSorted(y) {
 		panic("stat: input must be sorted ascending")
 	}
-	if !sort.Float64sAreSorted(cutoffs) {
+	if !slices.IsSorted(cutoffs) {
 		panic("stat: cutoff values must be sorted ascending")
 	}
 	if len(y) == 0 {

--- a/stat/sampleuv/sample_test.go
+++ b/stat/sampleuv/sample_test.go
@@ -5,7 +5,7 @@
 package sampleuv
 
 import (
-	"sort"
+	"slices"
 	"testing"
 
 	"gonum.org/v1/gonum/floats/scalar"
@@ -29,7 +29,7 @@ func TestLatinHypercube(t *testing.T) {
 			distuv.Normal{Mu: 5, Sigma: 3},
 		} {
 			LatinHypercube{Q: dist}.Sample(samples)
-			sort.Float64s(samples)
+			slices.Sort(samples)
 			for i, v := range samples {
 				p := dist.CDF(v)
 				if p < float64(i)/float64(nSamples) || p > float64(i+1)/float64(nSamples) {

--- a/stat/sampleuv/withoutreplacement.go
+++ b/stat/sampleuv/withoutreplacement.go
@@ -5,7 +5,7 @@
 package sampleuv
 
 import (
-	"sort"
+	"slices"
 
 	"golang.org/x/exp/rand"
 )
@@ -56,6 +56,6 @@ func WithoutReplacement(idxs []int, n int, src rand.Source) {
 		}
 		idxs[i] = r
 		sorted = append(sorted, r)
-		sort.Ints(sorted)
+		slices.Sort(sorted)
 	}
 }

--- a/stat/stat.go
+++ b/stat/stat.go
@@ -6,6 +6,7 @@ package stat
 
 import (
 	"math"
+	"slices"
 	"sort"
 
 	"gonum.org/v1/gonum/floats"
@@ -73,7 +74,7 @@ func CDF(q float64, c CumulantKind, x, weights []float64) float64 {
 	if len(x) == 0 {
 		panic("stat: zero length slice")
 	}
-	if !sort.Float64sAreSorted(x) {
+	if !slices.IsSorted(x) {
 		panic("x data are not sorted")
 	}
 
@@ -512,10 +513,10 @@ func Histogram(count, dividers, x, weights []float64) []float64 {
 	if len(count) != len(dividers)-1 {
 		panic("histogram: bin count mismatch")
 	}
-	if !sort.Float64sAreSorted(dividers) {
+	if !slices.IsSorted(dividers) {
 		panic("histogram: dividers are not sorted")
 	}
-	if !sort.Float64sAreSorted(x) {
+	if !slices.IsSorted(x) {
 		panic("histogram: x data are not sorted")
 	}
 	for i := range count {
@@ -632,10 +633,10 @@ func KolmogorovSmirnov(x, xWeights, y, yWeights []float64) float64 {
 		return math.NaN()
 	}
 
-	if !sort.Float64sAreSorted(x) {
+	if !slices.IsSorted(x) {
 		panic("x data are not sorted")
 	}
-	if !sort.Float64sAreSorted(y) {
+	if !slices.IsSorted(y) {
 		panic("y data are not sorted")
 	}
 
@@ -1091,7 +1092,7 @@ func Quantile(p float64, c CumulantKind, x, weights []float64) float64 {
 	if floats.HasNaN(x) {
 		return math.NaN() // This is needed because the algorithm breaks otherwise.
 	}
-	if !sort.Float64sAreSorted(x) {
+	if !slices.IsSorted(x) {
 		panic("x data are not sorted")
 	}
 
@@ -1188,7 +1189,7 @@ func skewCorrection(n float64) float64 {
 // length as x.
 func SortWeighted(x, weights []float64) {
 	if weights == nil {
-		sort.Float64s(x)
+		slices.Sort(x)
 		return
 	}
 	if len(x) != len(weights) {


### PR DESCRIPTION
This PR introduces a modernization change that is not necessarily related to #617 but which was spun out from my attempts at generifying the leaves of `graph`. Benchmarks to follow.

Blocked by https://github.com/gonum/gonum/pull/1940.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
