### PR TITLE
graph/iterator: allocate reflect map iterator inline

### DIFF
--- a/graph/iterator/lines_map_safe.go
+++ b/graph/iterator/lines_map_safe.go
@@ -17,7 +17,7 @@ import (
 // The iteration order of Lines is randomized.
 type Lines struct {
 	lines reflect.Value
-	iter  *reflect.MapIter
+	iter  reflect.MapIter
 	pos   int
 	curr  graph.Line
 }
@@ -30,7 +30,9 @@ type Lines struct {
 // the call to NewLines.
 func NewLines(lines map[int64]graph.Line) *Lines {
 	rv := reflect.ValueOf(lines)
-	return &Lines{lines: rv, iter: rv.MapRange()}
+	l := &Lines{lines: rv}
+	l.iter.Reset(rv)
+	return l
 }
 
 // Len returns the remaining number of lines to be iterated over.
@@ -61,7 +63,7 @@ func (l *Lines) Line() graph.Line {
 func (l *Lines) Reset() {
 	l.curr = nil
 	l.pos = 0
-	l.iter = l.lines.MapRange()
+	l.iter.Reset(l.lines)
 }
 
 // LineSlice returns all the remaining lines in the iterator and advances
@@ -83,7 +85,7 @@ func (l *Lines) LineSlice() []graph.Line {
 // The iteration order of WeightedLines is randomized.
 type WeightedLines struct {
 	lines reflect.Value
-	iter  *reflect.MapIter
+	iter  reflect.MapIter
 	pos   int
 	curr  graph.WeightedLine
 }
@@ -96,7 +98,9 @@ type WeightedLines struct {
 // the call to NewWeightedLines.
 func NewWeightedLines(lines map[int64]graph.WeightedLine) *WeightedLines {
 	rv := reflect.ValueOf(lines)
-	return &WeightedLines{lines: rv, iter: rv.MapRange()}
+	l := &WeightedLines{lines: rv}
+	l.iter.Reset(rv)
+	return l
 }
 
 // Len returns the remaining number of lines to be iterated over.
@@ -127,7 +131,7 @@ func (l *WeightedLines) WeightedLine() graph.WeightedLine {
 func (l *WeightedLines) Reset() {
 	l.curr = nil
 	l.pos = 0
-	l.iter = l.lines.MapRange()
+	l.iter.Reset(l.lines)
 }
 
 // WeightedLineSlice returns all the remaining lines in the iterator and advances

--- a/graph/iterator/nodes_map_safe.go
+++ b/graph/iterator/nodes_map_safe.go
@@ -17,7 +17,7 @@ import (
 // The iteration order of Nodes is randomized.
 type Nodes struct {
 	nodes reflect.Value
-	iter  *reflect.MapIter
+	iter  reflect.MapIter
 	pos   int
 	curr  graph.Node
 }
@@ -30,7 +30,9 @@ type Nodes struct {
 // the call to NewNodes.
 func NewNodes(nodes map[int64]graph.Node) *Nodes {
 	rv := reflect.ValueOf(nodes)
-	return &Nodes{nodes: rv, iter: rv.MapRange()}
+	n := &Nodes{nodes: rv}
+	n.iter.Reset(rv)
+	return n
 }
 
 // Len returns the remaining number of nodes to be iterated over.
@@ -84,7 +86,7 @@ func (n *Nodes) NodeSlice() []graph.Node {
 type NodesByEdge struct {
 	nodes map[int64]graph.Node
 	edges reflect.Value
-	iter  *reflect.MapIter
+	iter  reflect.MapIter
 	pos   int
 	curr  graph.Node
 }
@@ -100,7 +102,9 @@ type NodesByEdge struct {
 // is mutated after the call to NewNodes.
 func NewNodesByEdge(nodes map[int64]graph.Node, edges map[int64]graph.Edge) *NodesByEdge {
 	rv := reflect.ValueOf(edges)
-	return &NodesByEdge{nodes: nodes, edges: rv, iter: rv.MapRange()}
+	n := &NodesByEdge{nodes: nodes, edges: rv}
+	n.iter.Reset(rv)
+	return n
 }
 
 // NewNodesByWeightedEdge returns a NodesByEdge initialized with the
@@ -114,7 +118,9 @@ func NewNodesByEdge(nodes map[int64]graph.Node, edges map[int64]graph.Edge) *Nod
 // is mutated after the call to NewNodes.
 func NewNodesByWeightedEdge(nodes map[int64]graph.Node, edges map[int64]graph.WeightedEdge) *NodesByEdge {
 	rv := reflect.ValueOf(edges)
-	return &NodesByEdge{nodes: nodes, edges: rv, iter: rv.MapRange()}
+	n := &NodesByEdge{nodes: nodes, edges: rv}
+	n.iter.Reset(rv)
+	return n
 }
 
 // NewNodesByLines returns a NodesByEdge initialized with the
@@ -128,7 +134,9 @@ func NewNodesByWeightedEdge(nodes map[int64]graph.Node, edges map[int64]graph.We
 // is mutated after the call to NewNodes.
 func NewNodesByLines(nodes map[int64]graph.Node, lines map[int64]map[int64]graph.Line) *NodesByEdge {
 	rv := reflect.ValueOf(lines)
-	return &NodesByEdge{nodes: nodes, edges: rv, iter: rv.MapRange()}
+	n := &NodesByEdge{nodes: nodes, edges: rv}
+	n.iter.Reset(rv)
+	return n
 }
 
 // NewNodesByWeightedLines returns a NodesByEdge initialized with the
@@ -142,7 +150,9 @@ func NewNodesByLines(nodes map[int64]graph.Node, lines map[int64]map[int64]graph
 // is mutated after the call to NewNodes.
 func NewNodesByWeightedLines(nodes map[int64]graph.Node, lines map[int64]map[int64]graph.WeightedLine) *NodesByEdge {
 	rv := reflect.ValueOf(lines)
-	return &NodesByEdge{nodes: nodes, edges: rv, iter: rv.MapRange()}
+	n := &NodesByEdge{nodes: nodes, edges: rv}
+	n.iter.Reset(rv)
+	return n
 }
 
 // Len returns the remaining number of nodes to be iterated over.
@@ -173,7 +183,7 @@ func (n *NodesByEdge) Node() graph.Node {
 func (n *NodesByEdge) Reset() {
 	n.curr = nil
 	n.pos = 0
-	n.iter = n.edges.MapRange()
+	n.iter.Reset(n.edges)
 }
 
 // NodeSlice returns all the remaining nodes in the iterator and advances


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: gonum.org/v1/gonum/graph/traverse
cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
                                    │  old.bench  │             new.bench              │
                                    │   sec/op    │   sec/op     vs base               │
WalkAllBreadthFirstGnp_10_tenth-8     3.797µ ± 2%   3.609µ ± 3%  -4.95% (p=0.002 n=10)
WalkAllBreadthFirstGnp_100_tenth-8    149.9µ ± 2%   147.8µ ± 3%       ~ (p=0.579 n=10)
WalkAllBreadthFirstGnp_1000_tenth-8   13.12m ± 4%   12.75m ± 2%  -2.76% (p=0.019 n=10)
WalkAllBreadthFirstGnp_10_half-8      8.758µ ± 2%   8.530µ ± 1%  -2.61% (p=0.000 n=10)
WalkAllBreadthFirstGnp_100_half-8     624.3µ ± 2%   618.2µ ± 2%       ~ (p=0.143 n=10)
WalkAllBreadthFirstGnp_1000_half-8    60.83m ± 3%   58.88m ± 6%       ~ (p=0.052 n=10)
WalkAllDepthFirstGnp_10_tenth-8       3.763µ ± 2%   3.568µ ± 2%  -5.18% (p=0.002 n=10)
WalkAllDepthFirstGnp_100_tenth-8      150.5µ ± 3%   145.0µ ± 1%  -3.66% (p=0.000 n=10)
WalkAllDepthFirstGnp_1000_tenth-8     12.79m ± 2%   12.70m ± 6%       ~ (p=0.579 n=10)
WalkAllDepthFirstGnp_10_half-8        8.662µ ± 2%   8.333µ ± 4%  -3.79% (p=0.015 n=10)
WalkAllDepthFirstGnp_100_half-8       637.1µ ± 1%   629.2µ ± 4%       ~ (p=0.739 n=10)
WalkAllDepthFirstGnp_1000_half-8      59.31m ± 5%   57.91m ± 1%  -2.36% (p=0.001 n=10)
geomean                               366.6µ        356.5µ       -2.75%

                                    │   old.bench   │              new.bench               │
                                    │     B/op      │     B/op       vs base               │
WalkAllBreadthFirstGnp_10_tenth-8      1.627Ki ± 0%    1.533Ki ± 0%  -5.76% (p=0.000 n=10)
WalkAllBreadthFirstGnp_100_tenth-8     31.16Ki ± 0%    29.58Ki ± 0%  -5.07% (p=0.000 n=10)
WalkAllBreadthFirstGnp_1000_tenth-8   1032.0Ki ± 0%   1016.4Ki ± 0%  -1.52% (p=0.000 n=10)
WalkAllBreadthFirstGnp_10_half-8       2.861Ki ± 0%    2.689Ki ± 0%  -6.01% (p=0.000 n=10)
WalkAllBreadthFirstGnp_100_half-8      63.02Ki ± 0%    61.44Ki ± 0%  -2.50% (p=0.000 n=10)
WalkAllBreadthFirstGnp_1000_half-8     4.052Mi ± 0%    4.036Mi ± 0%  -0.38% (p=0.000 n=10)
WalkAllDepthFirstGnp_10_tenth-8        1.627Ki ± 0%    1.533Ki ± 0%  -5.76% (p=0.000 n=10)
WalkAllDepthFirstGnp_100_tenth-8       31.16Ki ± 0%    29.58Ki ± 0%  -5.07% (p=0.000 n=10)
WalkAllDepthFirstGnp_1000_tenth-8      1.108Mi ± 1%    1.092Mi ± 1%  -1.43% (p=0.000 n=10)
WalkAllDepthFirstGnp_10_half-8         2.861Ki ± 0%    2.689Ki ± 0%  -6.01% (p=0.000 n=10)
WalkAllDepthFirstGnp_100_half-8        63.14Ki ± 0%    61.56Ki ± 0%  -2.51% (p=0.000 n=10)
WalkAllDepthFirstGnp_1000_half-8       6.294Mi ± 2%    6.279Mi ± 0%  -0.24% (p=0.000 n=10)
geomean                                60.94Ki         58.78Ki       -3.55%

                                    │  old.bench  │              new.bench              │
                                    │  allocs/op  │  allocs/op   vs base                │
WalkAllBreadthFirstGnp_10_tenth-8      33.00 ± 0%    27.00 ± 0%  -18.18% (p=0.000 n=10)
WalkAllBreadthFirstGnp_100_tenth-8    1.289k ± 0%   1.188k ± 0%   -7.84% (p=0.000 n=10)
WalkAllBreadthFirstGnp_1000_tenth-8   103.1k ± 0%   102.1k ± 0%   -0.97% (p=0.000 n=10)
WalkAllBreadthFirstGnp_10_half-8       81.00 ± 0%    70.00 ± 0%  -13.58% (p=0.000 n=10)
WalkAllBreadthFirstGnp_100_half-8     5.367k ± 0%   5.266k ± 0%   -1.88% (p=0.000 n=10)
WalkAllBreadthFirstGnp_1000_half-8    501.9k ± 0%   500.9k ± 0%   -0.20% (p=0.000 n=10)
WalkAllDepthFirstGnp_10_tenth-8        33.00 ± 0%    27.00 ± 0%  -18.18% (p=0.000 n=10)
WalkAllDepthFirstGnp_100_tenth-8      1.289k ± 0%   1.188k ± 0%   -7.84% (p=0.000 n=10)
WalkAllDepthFirstGnp_1000_tenth-8     103.1k ± 0%   102.1k ± 0%   -0.97% (p=0.000 n=10)
WalkAllDepthFirstGnp_10_half-8         81.00 ± 0%    70.00 ± 0%  -13.58% (p=0.000 n=10)
WalkAllDepthFirstGnp_100_half-8       5.367k ± 0%   5.266k ± 0%   -1.88% (p=0.000 n=10)
WalkAllDepthFirstGnp_1000_half-8      501.9k ± 0%   500.9k ± 0%   -0.20% (p=0.000 n=10)
geomean                               3.139k        2.908k        -7.36%
```

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
