### PR TITLE
all: replace min/max helpers with min/max builtins

### DIFF
--- a/blas/blas32/conv.go
+++ b/blas/blas32/conv.go
@@ -263,17 +263,3 @@ func (t TriangularBand) From(a TriangularBandCols) {
 	}
 	dst.From(src)
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}

--- a/blas/blas64/conv.go
+++ b/blas/blas64/conv.go
@@ -261,17 +261,3 @@ func (t TriangularBand) From(a TriangularBandCols) {
 	}
 	dst.From(src)
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}

--- a/blas/cblas128/conv.go
+++ b/blas/cblas128/conv.go
@@ -263,17 +263,3 @@ func (t TriangularBand) From(a TriangularBandCols) {
 	}
 	dst.From(src)
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}

--- a/blas/cblas64/conv.go
+++ b/blas/cblas64/conv.go
@@ -263,17 +263,3 @@ func (t TriangularBand) From(a TriangularBandCols) {
 	}
 	dst.From(src)
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}

--- a/blas/gonum/gonum.go
+++ b/blas/gonum/gonum.go
@@ -21,20 +21,6 @@ const (
 	minParBlock = 4  // minimum number of blocks needed to go parallel
 )
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func min(a, b int) int {
-	if a > b {
-		return b
-	}
-	return a
-}
-
 // blocks returns the number of divisions of the dimension length with the given
 // block size.
 func blocks(dim, bsize int) int {

--- a/blas/testblas/common.go
+++ b/blas/testblas/common.go
@@ -402,20 +402,6 @@ func makeZGeneral(data []complex128, m, n int, ld int) []complex128 {
 	return a
 }
 
-func max(a, b int) int {
-	if a < b {
-		return b
-	}
-	return a
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // zPack returns the uplo triangle of an n×n matrix A in packed format.
 func zPack(uplo blas.Uplo, n int, a []complex128, lda int) []complex128 {
 	if n == 0 {

--- a/graph/formats/rdf/iso_canonical.go
+++ b/graph/formats/rdf/iso_canonical.go
@@ -868,13 +868,6 @@ func sub(a, b lexicalStatements, max int) []*Statement {
 	return d
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func (s lexicalStatements) Len() int { return len(s.statements) }
 func (s lexicalStatements) Less(i, j int) bool {
 	return relabeledStatement{s.statements[i], s.hashes}.less(relabeledStatement{s.statements[j], s.hashes})

--- a/graph/topo/tarjan.go
+++ b/graph/topo/tarjan.go
@@ -187,10 +187,3 @@ func (t *tarjan) strongconnect(v graph.Node) {
 		t.sccs = append(t.sccs, scc)
 	}
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/lapack/gonum/lapack.go
+++ b/lapack/gonum/lapack.go
@@ -13,20 +13,6 @@ type Implementation struct{}
 
 var _ lapack.Float64 = Implementation{}
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func abs(a int) int {
 	if a < 0 {
 		return -a

--- a/lapack/lapack64/lapack64.go
+++ b/lapack/lapack64/lapack64.go
@@ -27,13 +27,6 @@ type Tridiagonal struct {
 	DU []float64
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 // Potrf computes the Cholesky factorization of a.
 // The factorization has the form
 //

--- a/lapack/testlapack/general.go
+++ b/lapack/testlapack/general.go
@@ -32,20 +32,6 @@ const (
 	bignum = safmax * ulp
 )
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // worklen describes how much workspace a test should use.
 type worklen int
 

--- a/mat/matrix.go
+++ b/mat/matrix.go
@@ -962,20 +962,6 @@ func Trace(a Matrix) float64 {
 	return v
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 // use returns a float64 slice with l elements, using f if it
 // has the necessary capacity, otherwise creating a new slice.
 func use(f []float64, l int) []float64 {

--- a/mathext/internal/amos/amos.go
+++ b/mathext/internal/amos/amos.go
@@ -28,20 +28,6 @@ func abs(a int) int {
 	return -a
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func Zairy(ZR, ZI float64, ID, KODE int) (AIR, AII float64, NZ, IERR int) {
 	// zairy is adapted from the original Netlib code by Donald Amos.
 	// http://www.netlib.no/netlib/amos/zairy.f

--- a/mathext/internal/amos/origcode_test.go
+++ b/mathext/internal/amos/origcode_test.go
@@ -20,19 +20,6 @@ func iabs(a int) int {
 	return -a
 }
 
-func min0(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max0(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
 
 func zairyOrig(ZR, ZI float64, ID, KODE int) (AIR, AII float64, NZ, IERR int) {
 	// zairy is adapted from the original Netlib code by Donald Amos.
@@ -337,7 +324,7 @@ Seventy:
 	K2 = imach[16]
 	R1M5 = dmach[5]
 
-	K = min0(iabs(K1), iabs(K2))
+	K = min(iabs(K1), iabs(K2))
 	ELIM = 2.303e0 * (float64(K)*R1M5 - 3.0e0)
 	K1 = imach[14] - 1
 	AA = R1M5 * float64(K1)
@@ -1227,7 +1214,7 @@ func zksclOrig(ZRR, ZRI, FNU float64, N int, YR, YI []float64, NZ int, RZR, RZI,
 	ZEROI = 0
 	NZ = 0
 	IC = 0
-	NN = min0(2, N)
+	NN = min(2, N)
 	for I = 1; I <= NN; I++ {
 		S1R = YR[I]
 		S1I = YI[I]
@@ -1508,7 +1495,7 @@ func zasyiOrig(ZR, ZI, FNU float64, KODE, N int, YR, YI []float64, NZ int, RL, T
 	AZ = zabs(complex(ZR, ZI))
 	ARM = 1.0e3 * dmach[1]
 	RTR1 = dsqrt(ARM)
-	IL = min0(2, N)
+	IL = min(2, N)
 	DFNU = FNU + float64(float32(N-IL))
 
 	// OVERFLOW TEST
@@ -1788,7 +1775,7 @@ Twenty:
 Forty:
 	// BACKWARD RECURRENCE AND SUM NORMALIZING RELATION.
 	K = K + 1
-	KK = max0(I+IAZ, K+INU)
+	KK = max(I+IAZ, K+INU)
 	FKK = float64(float32(KK))
 	P1R = ZEROR
 	P1I = ZEROI
@@ -1994,7 +1981,7 @@ Fifty:
 	COEFR = AA * dcos(AK1I)
 	COEFI = AA * dsin(AK1I)
 	ATOL = TOL * ACZ / FNUP
-	IL = min0(2, NN)
+	IL = min(2, NN)
 	for I = 1; I <= IL; I++ {
 		DFNU = FNU + float64(float32(NN-I))
 		FNUP = DFNU + 1.0e0

--- a/optimize/minimize.go
+++ b/optimize/minimize.go
@@ -18,13 +18,6 @@ const (
 	negativeTasks        string = "optimize: negative input number of tasks"
 )
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // Task is a type to communicate between the Method and the outer
 // calling script.
 type Task struct {

--- a/spatial/kdtree/medians.go
+++ b/spatial/kdtree/medians.go
@@ -72,13 +72,6 @@ func Select(list SortSlicer, k int) int {
 	}
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // MedianOfMedians returns the index to the median value of the medians
 // of groups of 5 consecutive elements.
 func MedianOfMedians(list SortSlicer) int {

--- a/stat/card/card.go
+++ b/stat/card/card.go
@@ -36,20 +36,6 @@ func linearCounting(m, v float64) float64 {
 	return m * (math.Log(m) - math.Log(v))
 }
 
-func max(a, b uint8) uint8 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func min(a, b uint8) uint8 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func typeNameOf(v interface{}) string {
 	t := reflect.TypeOf(v)
 	var prefix string

--- a/stat/pca_cca.go
+++ b/stat/pca_cca.go
@@ -94,13 +94,6 @@ func (c *PC) VarsTo(dst []float64) []float64 {
 	return dst
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // CC is a type for computing the canonical correlations of a pair of matrices.
 // The results of the canonical correlation analysis are only valid
 // if the call to CanonicalCorrelations was successful.

--- a/stat/samplemv/samplemv.go
+++ b/stat/samplemv/samplemv.go
@@ -25,13 +25,6 @@ var (
 	_ WeightedSampler = Importance{}
 )
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // Sampler generates a batch of samples according to the rule specified by the
 // implementing type. The number of samples generated is equal to rows(batch),
 // and the samples are stored in-place into the input.

--- a/stat/sampleuv/sample.go
+++ b/stat/sampleuv/sample.go
@@ -25,13 +25,6 @@ var (
 	_ WeightedSampler = Importance{}
 )
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // Sampler generates a batch of samples according to the rule specified by the
 // implementing type. The number of samples generated is equal to len(batch),
 // and the samples are stored in-place into the input.


### PR DESCRIPTION
Closes https://github.com/gonum/gonum/issues/1904.

We support minimum Go 1.21 since v0.15.0 (https://github.com/gonum/gonum/pull/1935).

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
