### PR TITLE
graph/tests: fix implicit_example_test

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -94,6 +94,7 @@ Nathan Edwards <etaoinshrdluwho@gmail.com>
 Nick Potts <nick@the-potts.com>
 Nils Wogatzky <odog@netcologne.de>
 Olivier Wulveryck <olivier.wulveryck@gmail.com>
+Omeid Matten <public@omeid.net>
 Or Rikon <rikonor@gmail.com>
 Patricio Whittingslow <graded.sp@gmail.com>
 Patrick DeVivo <patrick@tickgit.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -101,6 +101,7 @@ Nathan Edwards <etaoinshrdluwho@gmail.com>
 Nick Potts <nick@the-potts.com>
 Nils Wogatzky <odog@netcologne.de>
 Olivier Wulveryck <olivier.wulveryck@gmail.com>
+Omeid Matten <public@omeid.net>
 Or Rikon <rikonor@gmail.com>
 Patricio Whittingslow <graded.sp@gmail.com>
 Patrick DeVivo <patrick@tickgit.com>

--- a/graph/implicit_example_test.go
+++ b/graph/implicit_example_test.go
@@ -134,6 +134,7 @@ func (g *GraphNode) nodes(dst []graph.Node, seen map[int64]struct{}) []graph.Nod
 			continue
 		}
 
+		seen[n.ID()] = struct{}{}
 		dst = append(dst, n)
 		if gn, ok := n.(*GraphNode); ok {
 			dst = gn.nodes(dst, seen)


### PR DESCRIPTION
Correctly mark seen neighbours when traversing the example GraphNode.