### PR TITLE
graph/topo: fix cycle canonicalistion

### DIFF
--- a/graph/topo/paton_cycles_test.go
+++ b/graph/topo/paton_cycles_test.go
@@ -119,9 +119,10 @@ func TestUndirectedCyclesIn(t *testing.T) {
 // c lists each node only once - the final node must not be a
 // reiteration of the first node.
 func canonicalise(c []graph.Node) []graph.Node {
-	if len(c) < 2 {
+	if len(c) < 3 {
 		return c
 	}
+	c = c[:len(c)-1] // Remove the bridge to the first node.
 	idx := 0
 	min := c[0].ID()
 	for i, n := range c[1:] {
@@ -136,5 +137,6 @@ func canonicalise(c []graph.Node) []graph.Node {
 	if c[len(c)-1].ID() < c[1].ID() {
 		slices.Reverse(c[1:])
 	}
+	c = append(c, c[0]) // Add a new bridge.
 	return c
 }


### PR DESCRIPTION
The cycle was being canonicalised retaining the duplicated bridge node at the end of the slice. Fix this by removing the node, performing the cicular permutation as described, and then adding the new final node.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
