### PR TITLE
mat: calculate Q elements lazily when calling QR.At

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -125,6 +125,7 @@ The University of Washington
 Thomas Berg <tomfuture@gmail.com>
 Tobin Harding <me@tobin.cc>
 Tom Payne <twpayne@gmail.com>
+Tristan Nicholls <tvk.nicholls@gmail.com>
 Valentin Deleplace <deleplace2015@gmail.com>
 Vincent Thiery <vjmthiery@gmail.com>
 Vladimír Chalupecký <vladimir.chalupecky@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -128,6 +128,7 @@ Tamir Hyman <hyman.tamir@gmail.com>
 Thomas Berg <tomfuture@gmail.com>
 Tobin Harding <me@tobin.cc>
 Tom Payne <twpayne@gmail.com>
+Tristan Nicholls <tvk.nicholls@gmail.com>
 Valentin Deleplace <deleplace2015@gmail.com>
 Vincent Thiery <vjmthiery@gmail.com>
 Vladimír Chalupecký <vladimir.chalupecky@gmail.com>

--- a/mat/qr.go
+++ b/mat/qr.go
@@ -149,7 +149,7 @@ func (qr *QR) RTo(dst *Dense) {
 		dst.ReuseAs(r, c)
 	} else {
 		r2, c2 := dst.Dims()
-		if c != r2 || c != c2 {
+		if r != r2 || c != c2 {
 			panic(ErrShape)
 		}
 	}


### PR DESCRIPTION
Fixes #1968.
Builds upon #1970 initial proposal.
- mat: fix dst matrix shape check in QR.RTo
> When a matrix is very tall, calculating Q will currently allocate a large Q at the end of the factorisation, even if it is not going to be used, and a large Q matrix can lead to out of memory issues.
> 
> For this reason, Q is never eagerly computed unless explicitly required to by the user, with QR.ToQ.
To keep fulfilling the Matrix interface, the QR.At method will compute the requested element only, which only require computing a single row of Q.


Small typo found and fixed:
- mat: calculate Q elements lazily when calling QR.At
> Fixed a typo in row/column size check, the expected row size was incorrectly checked against the column size.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
