### PR TITLE
graph/path: Improve performance of `YenKShortestPaths`

### DIFF
--- a/graph/path/dijkstra.go
+++ b/graph/path/dijkstra.go
@@ -42,7 +42,7 @@ func DijkstraFromTo(u, t graph.Node, g traverse.Graph) (path []graph.Node, weigh
 
 func dijkstraFrom(u, t graph.Node, g traverse.Graph) Shortest {
 	var path Shortest
-	// Use the incremental version when a target is provided
+	// Use the incremental version when a target is provided.
 	if h, ok := g.(graph.Graph); t == nil && ok {
 		if h.Node(u.ID()) == nil {
 			return Shortest{from: u}

--- a/graph/path/dijkstra.go
+++ b/graph/path/dijkstra.go
@@ -23,27 +23,27 @@ func DijkstraFrom(u graph.Node, g traverse.Graph) Shortest {
 	return dijkstraFrom(u, nil, g)
 }
 
-// DijkstraFromTo returns a shortest path from u to v in the graph g. The
-// result is equivalent to DijkstraFrom(u, g).To(v), but DijkstraFromTo can be
-// more efficient, as it can terminate early if v is reached. If the graph does
-// not implement Weighted, UniformCost is used. DijkstraFromTo will panic if g
-// has a u-reachable negative edge weight that is discovered before reaching v.
+// DijkstraFromTo returns a shortest path from u to t in the graph g. The
+// result is equivalent to DijkstraFrom(u, g).To(t.ID()), but DijkstraFromTo
+// can be more efficient, as it can terminate early if t is reached. If the
+// graph does not implement Weighted, UniformCost is used. DijkstraFromTo will
+// panic if g has a u-reachable negative edge weight that is discovered before
+// reaching t.
 //
 // The time complexity of DijkstraFromTo is O(|E|.log|V|).
-func DijkstraFromTo(u graph.Node, v graph.Node, g traverse.Graph) (path []graph.Node, weight float64) {
+func DijkstraFromTo(u, t graph.Node, g traverse.Graph) (path []graph.Node, weight float64) {
 	// An implementation of Bidirectional Dijkstra's algorithm could be even
 	// more efficient, but it requires a transposed (or undirected) graph.
-	if v == nil {
+	if t == nil {
 		panic("dijkstra: nil target node")
 	}
-	return dijkstraFrom(u, v, g).To(v.ID())
+	return dijkstraFrom(u, t, g).To(t.ID())
 }
 
-// Shared implementation of DijkstraFrom and DijkstraFromTo.
-func dijkstraFrom(u, target graph.Node, g traverse.Graph) Shortest {
+func dijkstraFrom(u, t graph.Node, g traverse.Graph) Shortest {
 	var path Shortest
 	// Use the incremental version when a target is provided
-	if h, ok := g.(graph.Graph); target == nil && ok {
+	if h, ok := g.(graph.Graph); t == nil && ok {
 		if h.Node(u.ID()) == nil {
 			return Shortest{from: u}
 		}
@@ -80,7 +80,7 @@ func dijkstraFrom(u, target graph.Node, g traverse.Graph) Shortest {
 			continue
 		}
 		mnid := mid.node.ID()
-		if target != nil && mnid == target.ID() {
+		if t != nil && mnid == t.ID() {
 			break
 		}
 		to := g.From(mnid)

--- a/graph/path/yen_ksp.go
+++ b/graph/path/yen_ksp.go
@@ -33,7 +33,7 @@ func YenKShortestPaths(g graph.Graph, k int, cost float64, s, t graph.Node) [][]
 		yk.weight = UniformCost(g)
 	}
 
-	shortest, weight := DijkstraFrom(s, yk).To(t.ID())
+	shortest, weight := DijkstraFromTo(s, t, yk)
 	cost += weight // Set cost to absolute cost limit.
 	switch len(shortest) {
 	case 0:
@@ -73,7 +73,7 @@ func YenKShortestPaths(g graph.Graph, k int, cost float64, s, t graph.Node) [][]
 				yk.removeNode(u.ID())
 			}
 
-			spath, weight := DijkstraFrom(spur, yk).To(t.ID())
+			spath, weight := DijkstraFromTo(spur, t, yk)
 			if weight > cost || math.IsInf(weight, 1) {
 				continue
 			}


### PR DESCRIPTION
`YenKShortestPaths`'s running time is dominated by calls to Dijkstra's shortest path algorithm, so it makes sense to focus on improvements there.
For Yen's algorithm, we are not interested in shortest path trees, but only _a_ shortest path between some source and target node. We can exploit this in Dijkstra's algorithm by terminating when the target is discovered.
Of course this does not improve the worst-case complexity, but it should be a worthwhile optimization for many practical uses.