### PR TITLE
all: use Go-1.24, drop Go-1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # Do not move this line; it is referred to by README.md.
         # Versions of Go that are explicitly supported by Gonum.
-        go-version: [1.23.x, 1.22.x]
+        go-version: [1.24.x, 1.23.x]
         platform: [ubuntu-latest, macos-latest]
         force-goarch: ["", "386"]
         tags: 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.merged == true
     strategy:
       matrix:
-        go-version: [1.23.x]
+        go-version: [1.24.x]
         platform: [ubuntu-latest]
         tags: 
           - ""

--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -8,7 +8,7 @@ jobs:
     name: lint
     strategy:
       matrix:
-        go: ["1.22.x"]
+        go: ["1.24.x"]
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on

--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - uses: WillAbides/setup-go-faster@v1.7.0
+      - uses: WillAbides/setup-go-faster@v1.14.0
         with:
           go-version: ${{ matrix.go }}
       - uses: dominikh/staticcheck-action@v1

--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -19,8 +19,8 @@ jobs:
       - uses: WillAbides/setup-go-faster@v1.7.0
         with:
           go-version: ${{ matrix.go }}
-      - uses: dominikh/staticcheck-action@v1.3.0
+      - uses: dominikh/staticcheck-action@v1
         with:
-          version: "2023.1.6"
+          version: "2025.1"
           install-go: false
           cache-key: ${{ matrix.go }}

--- a/blas/testblas/level1double.go
+++ b/blas/testblas/level1double.go
@@ -1434,7 +1434,7 @@ func IdamaxTest(t *testing.T, blasser Idamaxer) {
 			if floats.HasNaN(c.X) {
 				t.Log(s)
 			} else {
-				t.Errorf(s)
+				t.Error(s)
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
 module gonum.org/v1/gonum
 
-go 1.22
+go 1.23
 
 require (
 	github.com/goccmack/gocc v0.0.0-20230228185258-2292f9e40198
 	github.com/google/go-cmp v0.6.0
-	golang.org/x/exp v0.0.0-20240823005443-9b4947da3948
 	golang.org/x/tools v0.24.0
 	gonum.org/v1/plot v0.14.0
 )
@@ -19,6 +18,7 @@ require (
 	github.com/go-pdf/fpdf v0.9.0 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/exp v0.0.0-20240823005443-9b4947da3948 // indirect
 	golang.org/x/image v0.19.0 // indirect
 	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/text v0.17.0 // indirect

--- a/optimize/unconstrained_test.go
+++ b/optimize/unconstrained_test.go
@@ -1350,7 +1350,7 @@ func TestNelderMeadOneD(t *testing.T) {
 	var s *Settings
 	result, err := Minimize(p, x, s, m)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Fatalf("could not minimize: %v", err)
 	}
 	if !floats.EqualApprox(result.X, []float64{0}, 1e-10) {
 		t.Errorf("Minimum not found")


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
