### PR TITLE
graph/iterator: reflect the swiss map iterator shape

### DIFF
--- a/graph/iterator/hiter_noswiss.go
+++ b/graph/iterator/hiter_noswiss.go
@@ -1,0 +1,42 @@
+// Copyright ©2020 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !safe && !go1.24
+// +build !safe,!go1.24
+
+package iterator
+
+import "unsafe"
+
+// hiter's structure matches runtime.hiter's structure.
+// Having a clone here allows us to embed a map iterator
+// inside type mapIter so that mapIters can be re-used
+// without doing any allocations.
+//
+//lint:ignore U1000 This is a verbatim copy of the runtime type.
+type hiter struct {
+	key         unsafe.Pointer
+	elem        unsafe.Pointer
+	t           unsafe.Pointer
+	h           unsafe.Pointer
+	buckets     unsafe.Pointer
+	bptr        unsafe.Pointer
+	overflow    *[]unsafe.Pointer
+	oldoverflow *[]unsafe.Pointer
+	startBucket uintptr
+	offset      uint8
+	wrapped     bool
+	B           uint8
+	i           uint8
+	bucket      uintptr
+	checkBucket uintptr
+}
+
+func (h *hiter) initialized() bool {
+	return h.t != nil
+}

--- a/graph/iterator/hiter_swiss.go
+++ b/graph/iterator/hiter_swiss.go
@@ -1,0 +1,45 @@
+// Copyright ©2025 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !safe && go1.24
+// +build !safe,go1.24
+
+package iterator
+
+import "unsafe"
+
+// hiter's structure matches internal/runtime/maps.Iter's
+// structure.
+// Having a clone here allows us to embed a map iterator
+// inside type mapIter so that mapIters can be re-used
+// without doing any allocations.
+//
+//lint:ignore U1000 This is a verbatim copy of the runtime type.
+type hiter struct {
+	key         unsafe.Pointer // Must be in first position.  Write nil to indicate iteration end (see cmd/compile/internal/walk/range.go).
+	elem        unsafe.Pointer // Must be in second position (see cmd/compile/internal/walk/range.go).
+	typ         unsafe.Pointer
+	m           unsafe.Pointer
+	entryOffset uint64
+	dirOffset   uint64
+	clearSeq    uint64
+	globalDepth uint8
+	dirIdx      int
+	tab         unsafe.Pointer
+	group       groupReference
+	entryIdx    uint64
+}
+
+//lint:ignore U1000 This is a verbatim copy of the runtime type.
+type groupReference struct {
+	data unsafe.Pointer // data *typ.Group
+}
+
+func (h *hiter) initialized() bool {
+	return h.typ != nil
+}

--- a/graph/iterator/map.go
+++ b/graph/iterator/map.go
@@ -27,34 +27,6 @@ type emptyInterface struct {
 	typ, word unsafe.Pointer
 }
 
-// hiter's structure matches runtime.hiter's structure.
-// Having a clone here allows us to embed a map iterator
-// inside type mapIter so that mapIters can be re-used
-// without doing any allocations.
-//
-//lint:ignore U1000 This is a verbatim copy of the runtime type.
-type hiter struct {
-	key         unsafe.Pointer
-	elem        unsafe.Pointer
-	t           unsafe.Pointer
-	h           unsafe.Pointer
-	buckets     unsafe.Pointer
-	bptr        unsafe.Pointer
-	overflow    *[]unsafe.Pointer
-	oldoverflow *[]unsafe.Pointer
-	startBucket uintptr
-	offset      uint8
-	wrapped     bool
-	B           uint8
-	i           uint8
-	bucket      uintptr
-	checkBucket uintptr
-}
-
-func (h *hiter) initialized() bool {
-	return h.t != nil
-}
-
 // newMapIterNodes returns a range iterator for a map of nodes.
 // The returned mapIter must not have its line or weightedLine methods called.
 func newMapIterNodes(m map[int64]graph.Node) *mapIter {


### PR DESCRIPTION
This is a safety change to ensure we are allocating the correct size for the iterator.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
