### PR TITLE
refactor: use slices.Equal to simplify code

### DIFF
--- a/mat/eigen_test.go
+++ b/mat/eigen_test.go
@@ -7,6 +7,7 @@ package mat
 import (
 	"math"
 	"math/rand/v2"
+	"slices"
 	"sort"
 	"testing"
 
@@ -114,12 +115,7 @@ func TestEigen(t *testing.T) {
 }
 
 func cmplxEqual(v1, v2 []complex128) bool {
-	for i, v := range v1 {
-		if v != v2[i] {
-			return false
-		}
-	}
-	return true
+	return slices.Equal(v1, v2)
 }
 
 func cmplxEqualTol(v1, v2 []complex128, tol float64) bool {


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->


In the Go 1.21 standard library, a new function has been introduced that enhances code conciseness and readability. It can be find  [here](https://pkg.go.dev/slices@go1.21.1#Equal).

