### PR TITLE
lapack: fix eigenvector normalization residual calculation

### DIFF
--- a/lapack/testlapack/dtrevc3.go
+++ b/lapack/testlapack/dtrevc3.go
@@ -400,7 +400,7 @@ func residualEVNormalization(emat blas64.General, wi []float64) float64 {
 			ipair = 0
 		}
 	}
-	return math.Max(math.Abs(enrmin-1), math.Abs(enrmin-1))
+	return math.Max(math.Abs(enrmin-1), math.Abs(enrmax-1))
 }
 
 // normalizeEV normalizes eigenvectors in the columns of E so that the element


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->


In the residualEVNormalization function, there was an error in the final return statement where both arguments to math.Max used enrmin . The correct calculation should compare deviations of both minimum and maximum norms from 1.


