### PR TITLE
fix: repeat args from sub-func call

### DIFF
--- a/lapack/testlapack/dtrevc3.go
+++ b/lapack/testlapack/dtrevc3.go
@@ -400,7 +400,7 @@ func residualEVNormalization(emat blas64.General, wi []float64) float64 {
 			ipair = 0
 		}
 	}
-	return math.Max(math.Abs(enrmin-1), math.Abs(enrmin-1))
+	return math.Max(math.Abs(enrmax-1), math.Abs(enrmin-1))
 }
 
 // normalizeEV normalizes eigenvectors in the columns of E so that the element


### PR DESCRIPTION
```
return math.Max(math.Abs(enrmin-1), math.Abs(enrmin-1))
```

is a copyandpaste bug