### PR TITLE
stat: add an example to compute a confidence interval

### DIFF
--- a/stat/stat_example_test.go
+++ b/stat/stat_example_test.go
@@ -46,14 +46,14 @@ func ExampleLinearRegression() {
 	// R^2: 0.999999
 }
 
-// Example_confidenceInterval shows how one can compute a confidence
-// interval to quantify the uncertainty around an estimated parameter,
-// when working with a small sample.
+// This example shows how one can compute a confidence interval to quantify
+// the uncertainty around an estimated parameter, when working with a small
+// sample from a normally distributed variable.
 //
 // For small samples (N ≤ 30), confidence intervals are computed with
 // the t-distribution:
 //
-//	Conf.Interval = $\hat{x} \pm t \frac{s}{\sqrt{n}}
+//	Conf.Interval = $\hat{x} ± t \frac{s}{\sqrt{n}}
 //
 // where:
 //   - x is the sample mean,
@@ -67,12 +67,10 @@ func ExampleLinearRegression() {
 //	https://en.wikipedia.org/wiki/Student's_t-distribution
 func Example_confidenceInterval() {
 
-	// example data derived from:
-	//  https://datagy.io/python-confidence-intervals/
-
 	var (
-		xs = []float64{25, 28, 30, 32, 29, 27, 31, 26, 28, 30} // sample data
-		ws = []float64(nil)                                    // weights
+		// First 10 sepal widths from iris data set.
+		xs = []float64{3.5, 3.0, 3.2, 3.1, 3.6, 3.9, 3.4, 3.4, 2.9, 3.1}
+		ws = []float64(nil) // weights
 		n  = float64(len(xs))
 		df = n - 1
 
@@ -95,6 +93,6 @@ func Example_confidenceInterval() {
 	fmt.Printf("CI(@%g%%): [%.2f, %.2f]\n", lvl*100, lo, hi)
 
 	// Output:
-	// Mean:     28.60
-	// CI(@95%): [27.01, 30.19]
+	// Mean:     3.31
+	// CI(@95%): [3.09, 3.53]
 }

--- a/stat/stat_example_test.go
+++ b/stat/stat_example_test.go
@@ -46,26 +46,26 @@ func ExampleLinearRegression() {
 	// R^2: 0.999999
 }
 
-// This example shows how one can compute a confidence interval to quantify
-// the uncertainty around an estimated parameter, when working with a small
-// sample from a normally distributed variable.
-//
-// For small samples (N ≤ 30), confidence intervals are computed with
-// the t-distribution:
-//
-//	Conf.Interval = $\hat{x} ± t \frac{s}{\sqrt{n}}
-//
-// where:
-//   - x is the sample mean,
-//   - s is the sample standard deviation,
-//   - n is the sample size, and
-//   - t is the critical value from the t-distribution based on the desired
-//     confidence level and degrees of freedom (df=n-1)
-//
-// For more details, see:
-//
-//	https://en.wikipedia.org/wiki/Student's_t-distribution
 func Example_confidenceInterval() {
+	// This example shows how one can compute a confidence interval to quantify
+	// the uncertainty around an estimated parameter, when working with a small
+	// sample from a normally distributed variable.
+	//
+	// For small samples (N ≤ 30), confidence intervals are computed with
+	// the t-distribution:
+	//
+	//	Conf.Interval = $\hat{x} ± t \frac{s}{\sqrt{n}}
+	//
+	// where:
+	//   - x is the sample mean,
+	//   - s is the sample standard deviation,
+	//   - n is the sample size, and
+	//   - t is the critical value from the t-distribution based on the desired
+	//     confidence level and degrees of freedom (df=n-1)
+	//
+	// For more details, see:
+	//
+	//	https://en.wikipedia.org/wiki/Student's_t-distribution
 
 	var (
 		// First 10 sepal widths from iris data set.


### PR DESCRIPTION
This CL adds an example showing how to compute the confidence interval of the mean for a small sample.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
