### PR TITLE
lapack/testlapack: fix random source use

### DIFF
--- a/lapack/testlapack/dlaln2.go
+++ b/lapack/testlapack/dlaln2.go
@@ -41,9 +41,9 @@ func testDlaln2(t *testing.T, impl Dlaln2er, trans bool, na, nw, extra int, rnd 
 
 	var w complex128
 	if nw == 1 {
-		w = complex(rand.NormFloat64(), 0)
+		w = complex(rnd.NormFloat64(), 0)
 	} else {
-		w = complex(rand.NormFloat64(), rand.NormFloat64())
+		w = complex(rnd.NormFloat64(), rnd.NormFloat64())
 	}
 	smin := dlamchP * (math.Abs(real(w)) + math.Abs(imag(w)))
 


### PR DESCRIPTION
This replaces a use of the global rand with the intended local rnd which was missed.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."

Do not delete any of this templated text in the PR description, but
feel free to add additional context.
-->
