### PR TITLE
graph/network: add diameter example for eccentricity func

### DIFF
--- a/graph/network/distance_example_test.go
+++ b/graph/network/distance_example_test.go
@@ -12,20 +12,18 @@ import (
 	"gonum.org/v1/gonum/graph/simple"
 )
 
-// ExampleEccentricity_diameter shows how to compute the diameter of a graph
-// based on its eccentricity map.
 func ExampleEccentricity_diameter() {
-	// Build a simple graph: n1--n2--n3
+	// Build a simple graph: n1--n2--n3.
 	var n1, n2, n3 simple.Node = 1, 2, 3
 	g := simple.NewUndirectedGraph()
 	g.SetEdge(simple.Edge{F: n1, T: n2})
 	g.SetEdge(simple.Edge{F: n2, T: n3})
 
-	// Get eccentricity map
+	// Find shortest paths and calculate eccentricity values.
 	paths := path.DijkstraAllPaths(g)
 	e := network.Eccentricity(g, paths)
 
-	// Compute diameter
+	// Compute the graph's diameter from the eccentricities.
 	var diameter float64
 	for _, d := range e {
 		diameter = max(d, diameter)


### PR DESCRIPTION
Here is an example showing how to comute the diameter of a graph based on its eccentricity map.

Please take a look.

Closes: #2042
<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."

Do not delete any of this templated text in the PR description, but
feel free to add additional context.
-->
