### PR TITLE
stat: implement Wasserstein distance calculation

### DIFF
--- a/stat/stat.go
+++ b/stat/stat.go
@@ -30,7 +30,6 @@ const (
 // between two 1D distributions p and q with optional weights. p and q are
 // the support points of each distribution. pWeights and qWeights are the weights
 // for each point.
-// The lengths of p and q don't have to be equal.
 // If a weights slice is nil, then uniform weights are used. If it is not nil,
 // then the length of the weights slice must equal the length of the corresponding points.
 // Otherwise, the function will panic.
@@ -167,10 +166,9 @@ func WassersteinDistance(p, q, pWeights, qWeights []float64) float64 {
 // between two n-dimensional distributions p and q with optional weights. p and q are
 // matrices where each row represents a point. pWeights and qWeights are the weights for each point.
 // The number of columns in p and q must be equal.
-// The number of points (= rows) in p and q doesn't have to be equal.
 // If a weights slice is nil, then uniform weights are used. If it is not nil, then the
 // length of the weights slice must equal the number of rows in the corresponding matrix.
-// The function will panic if the described conditions are not met.
+// WassersteinDistanceND will panic if these conditions are not met.
 //
 // This implementation uses linear programming to solve the optimal transport problem.
 // tol controls the solver's tolerance. See lp.Simplex for more information on this.

--- a/stat/stat.go
+++ b/stat/stat.go
@@ -185,6 +185,11 @@ func WassersteinDistanceND(p, q [][]float64, pWeights, qWeights []float64) (floa
 
 	validateNDInputs(p, q)
 
+	// Special case for single-point distributions
+	if len(p) == 1 && len(q) == 1 {
+		return floats.Distance(p[0], q[0], 2), nil
+	}
+
 	// Handle identical distributions case.
 	if len(p) == len(q) {
 		identical := true
@@ -195,9 +200,7 @@ func WassersteinDistanceND(p, q [][]float64, pWeights, qWeights []float64) (floa
 			}
 		}
 		if identical {
-			// Also check if weights are equal when provided.
-			if (pWeights == nil && qWeights == nil) ||
-				(pWeights != nil && qWeights != nil && floats.Equal(pWeights, qWeights)) {
+			if floats.Equal(pWeights, qWeights) {
 				return 0, nil
 			}
 		}
@@ -216,11 +219,6 @@ func WassersteinDistanceND(p, q [][]float64, pWeights, qWeights []float64) (floa
 		floats.AddConst(1/float64(len(q)), qWeights)
 	} else {
 		normalizeWeights(qWeights)
-	}
-
-	// Special case for single-point distributions
-	if len(p) == 1 && len(q) == 1 {
-		return floats.Distance(p[0], q[0], 2), nil
 	}
 
 	// Create cost matrix using Euclidean distance.

--- a/stat/stat.go
+++ b/stat/stat.go
@@ -192,7 +192,7 @@ func WassersteinDistanceND(p, q mat.Matrix, pWeights, qWeights []float64) (float
 		var sumSquares float64
 		for j := 0; j < pCols; j++ {
 			diff := p.At(0, j) - q.At(0, j)
-			sumSquares += diff * diff
+			sumSquares += float64(diff * diff)
 		}
 		return math.Sqrt(sumSquares), nil
 	}
@@ -239,7 +239,7 @@ func WassersteinDistanceND(p, q mat.Matrix, pWeights, qWeights []float64) (float
 			var sumSquares float64
 			for k := 0; k < pCols; k++ {
 				diff := p.At(i, k) - q.At(j, k)
-				sumSquares += diff * diff
+				sumSquares += float64(diff * diff)
 			}
 			dist := math.Sqrt(sumSquares)
 			cost.Set(i, j, dist)
@@ -251,13 +251,16 @@ func WassersteinDistanceND(p, q mat.Matrix, pWeights, qWeights []float64) (float
 
 // normalizeWeights checks and normalizes the provided weight array if needed.
 func normalizeWeights(weights []float64) {
-	total := floats.Sum(weights)
+	var sum float64
 
-	if total <= 0 {
-		panic("stat: weights must sum to positive values")
+	for _, w := range weights {
+		if w <= 0 {
+			panic("stat: all weights must be positive")
+		}
+		sum += w
 	}
 
-	floats.Scale(1/total, weights)
+	floats.Scale(1/sum, weights)
 }
 
 // solveOptimalTransportLP solves the optimal transport problem.

--- a/stat/stat.go
+++ b/stat/stat.go
@@ -43,10 +43,6 @@ func WassersteinDistance(p, q, pWeights, qWeights []float64) float64 {
 		panic("stat: input distributions cannot be empty")
 	}
 
-	if len(p) != len(pWeights) || len(q) != len(qWeights) {
-		panic("stat: input distributions and their weights must have same length")
-	}
-
 	// Handle identical distributions case
 	if len(p) == len(q) && floats.Equal(p, q) {
 		if (pWeights == nil && qWeights == nil) ||
@@ -58,16 +54,16 @@ func WassersteinDistance(p, q, pWeights, qWeights []float64) float64 {
 	// Use uniform weights if not provided
 	if pWeights == nil {
 		pWeights = make([]float64, len(p))
-		for i := range pWeights {
-			pWeights[i] = 1.0 / float64(len(p))
-		}
+		floats.AddConst(1.0/float64(len(p)), pWeights)
 	}
 
 	if qWeights == nil {
 		qWeights = make([]float64, len(q))
-		for i := range qWeights {
-			qWeights[i] = 1.0 / float64(len(q))
-		}
+		floats.AddConst(1.0/float64(len(q)), qWeights)
+	}
+
+	if len(p) != len(pWeights) || len(q) != len(qWeights) {
+		panic("stat: input distributions and their weights must have same length")
 	}
 
 	normalizeWeights(pWeights, qWeights)

--- a/stat/stat_test.go
+++ b/stat/stat_test.go
@@ -1899,6 +1899,11 @@ func TestWassersteinDistance(t *testing.T) {
 		t.Errorf("WassersteinDistance returned %f, expected 0", dist)
 	}
 
+	dist = WassersteinDistance(p, q, nil, nil)
+	if dist != 0 {
+		t.Errorf("WassersteinDistance returned %f, expected 0", dist)
+	}
+
 	p = []float64{0, 1, 2}
 	q = []float64{1, 2, 3}
 	u = []float64{0.2, 0.3, 0.5}
@@ -1916,7 +1921,12 @@ func TestWassersteinDistanceNd(t *testing.T) {
 	qPoints := [][]float64{{0, 0}, {1, 1}, {2, 2}}
 	qWeights := [][]float64{{0.2}, {0.3}, {0.5}}
 
-	dist := WassersteinDistanceNd(pPoints, pWeights, qPoints, qWeights)
+	dist := WassersteinDistanceNd(pPoints, qPoints, pWeights, qWeights)
+	if dist != 0 {
+		t.Errorf("WassersteinDistanceNd returned %f, expected 0", dist)
+	}
+
+	dist = WassersteinDistanceNd(pPoints, qPoints, nil, nil)
 	if dist != 0 {
 		t.Errorf("WassersteinDistanceNd returned %f, expected 0", dist)
 	}
@@ -1926,7 +1936,7 @@ func TestWassersteinDistanceNd(t *testing.T) {
 	qPoints = [][]float64{{1, 1}, {2, 2}, {3, 3}}
 	qWeights = [][]float64{{0.2}, {0.3}, {0.5}}
 
-	dist = WassersteinDistanceNd(pPoints, pWeights, qPoints, qWeights)
+	dist = WassersteinDistanceNd(pPoints, qPoints, pWeights, qWeights)
 	if math.Abs(dist-math.Sqrt(2)) > 1e-9 {
 		t.Errorf("WassersteinDistanceNd returned %f, expected sqrt(2)", dist)
 	}

--- a/stat/stat_test.go
+++ b/stat/stat_test.go
@@ -1938,13 +1938,12 @@ func TestWassersteinDistance(t *testing.T) {
 
 // TestWassersteinDistanceEdgeCases tests specific edge cases
 func TestWassersteinDistanceEdgeCases(t *testing.T) {
-	// Test panic on empty distributions
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("Expected panic for empty distributions, but none occurred")
-		}
-	}()
-	WassersteinDistance([]float64{}, []float64{1.0}, nil, nil)
+	// Test empty distribution.
+	result := WassersteinDistance([]float64{}, []float64{1.0}, nil, nil)
+
+	if !math.IsNaN(result) {
+		t.Errorf("WassersteinDistance() = %v, want %v", result, math.NaN())
+	}
 }
 
 // TestWassersteinDistanceWeightNormalization tests that weights are properly normalized
@@ -2109,7 +2108,12 @@ func TestWassersteinDistanceND(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := WassersteinDistanceND(test.p, test.q, test.pWeights, test.qWeights)
+			got, err := WassersteinDistanceND(test.p, test.q, test.pWeights, test.qWeights)
+
+			if err != nil {
+				t.Errorf("WassersteinDistanceND() error: %v", err)
+			}
+
 			if math.Abs(got-test.want) > tol {
 				t.Errorf("WassersteinDistanceND() = %v, want %v", got, test.want)
 			}
@@ -2119,11 +2123,10 @@ func TestWassersteinDistanceND(t *testing.T) {
 
 // TestWassersteinDistanceNDEdgeCases tests specific edge cases
 func TestWassersteinDistanceNDEdgeCases(t *testing.T) {
-	// Test panic on empty distributions
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("Expected panic for empty distributions, but none occurred")
-		}
-	}()
-	WassersteinDistanceND([][]float64{}, [][]float64{{1, 2}}, nil, nil)
+	// Test empty distributions.
+	result, err := WassersteinDistanceND([][]float64{}, [][]float64{{1, 2}}, nil, nil)
+
+	if !math.IsNaN(result) && err != nil {
+		t.Errorf("WassersteinDistanceND() = %v, want %v", result, math.NaN())
+	}
 }

--- a/stat/stat_test.go
+++ b/stat/stat_test.go
@@ -6,7 +6,6 @@ package stat
 
 import (
 	"fmt"
-	"gonum.org/v1/gonum/mat"
 	"math"
 	"math/rand/v2"
 	"reflect"
@@ -15,6 +14,7 @@ import (
 
 	"gonum.org/v1/gonum/floats"
 	"gonum.org/v1/gonum/floats/scalar"
+	"gonum.org/v1/gonum/mat"
 )
 
 func ExampleCircularMean() {

--- a/stat/stat_test.go
+++ b/stat/stat_test.go
@@ -2109,7 +2109,7 @@ func TestWassersteinDistanceND(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := WassersteinDistanceND(test.p, test.q, test.pWeights, test.qWeights)
+			got, err := WassersteinDistanceND(test.p, test.q, test.pWeights, test.qWeights, tol)
 
 			if err != nil {
 				t.Errorf("WassersteinDistanceND() error: %v", err)

--- a/stat/stat_test.go
+++ b/stat/stat_test.go
@@ -1949,7 +1949,7 @@ func TestWassersteinDistanceEdgeCases(t *testing.T) {
 
 // TestWassersteinDistanceWeightNormalization tests that weights are properly normalized
 func TestWassersteinDistanceWeightNormalization(t *testing.T) {
-	const tol = 1e-14
+	const tol = 1e-8
 
 	p := []float64{1.0, 2.0, 3.0}
 	q := []float64{2.0, 3.0, 4.0}
@@ -1977,7 +1977,7 @@ func TestWassersteinDistanceWeightNormalization(t *testing.T) {
 }
 
 func TestWassersteinDistanceND(t *testing.T) {
-	const tol = 1e-14
+	const tol = 1e-8
 
 	tests := []struct {
 		name     string
@@ -2120,4 +2120,30 @@ func TestWassersteinDistanceND(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNormalizeWeights(t *testing.T) {
+	t.Run("panics on zero weight", func(t *testing.T) {
+		weights := []float64{1.0, 0.0, 3.0}
+
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("expected panic on zero weight, but got none")
+			}
+		}()
+
+		normalizeWeights(weights)
+	})
+
+	t.Run("panics on negative weight", func(t *testing.T) {
+		weights := []float64{1.0, -2.0, 3.0}
+
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("expected panic on negative weight, but got none")
+			}
+		}()
+
+		normalizeWeights(weights)
+	})
 }

--- a/stat/stat_test.go
+++ b/stat/stat_test.go
@@ -1887,3 +1887,77 @@ func TestStdScore(t *testing.T) {
 		}
 	}
 }
+
+func TestWassersteinDistance(t *testing.T) {
+	p := []float64{0, 1, 2}
+	q := []float64{0, 1, 2}
+	u := []float64{0.2, 0.3, 0.5}
+	v := []float64{0.2, 0.3, 0.5}
+
+	dist := WassersteinDistance(p, q, u, v)
+	if dist != 0 {
+		t.Errorf("WassersteinDistance returned %f, expected 0", dist)
+	}
+
+	p = []float64{0, 1, 2}
+	q = []float64{1, 2, 3}
+	u = []float64{0.2, 0.3, 0.5}
+	v = []float64{0.2, 0.3, 0.5}
+
+	dist = WassersteinDistance(p, q, u, v)
+	if math.Abs(dist-1) > 1e-9 {
+		t.Errorf("WassersteinDistance returned %f, expected 1", dist)
+	}
+}
+
+func TestWassersteinDistanceNd(t *testing.T) {
+	pPoints := [][]float64{{0, 0}, {1, 1}, {2, 2}}
+	pWeights := [][]float64{{0.2}, {0.3}, {0.5}}
+	qPoints := [][]float64{{0, 0}, {1, 1}, {2, 2}}
+	qWeights := [][]float64{{0.2}, {0.3}, {0.5}}
+
+	dist := WassersteinDistanceNd(pPoints, pWeights, qPoints, qWeights)
+	if dist != 0 {
+		t.Errorf("WassersteinDistanceNd returned %f, expected 0", dist)
+	}
+
+	pPoints = [][]float64{{0, 0}, {1, 1}, {2, 2}}
+	pWeights = [][]float64{{0.2}, {0.3}, {0.5}}
+	qPoints = [][]float64{{1, 1}, {2, 2}, {3, 3}}
+	qWeights = [][]float64{{0.2}, {0.3}, {0.5}}
+
+	dist = WassersteinDistanceNd(pPoints, pWeights, qPoints, qWeights)
+	if math.Abs(dist-math.Sqrt(2)) > 1e-9 {
+		t.Errorf("WassersteinDistanceNd returned %f, expected sqrt(2)", dist)
+	}
+}
+
+func TestWassersteinDistanceInvalidInput(t *testing.T) {
+	p := []float64{0, 1, 2}
+	q := []float64{0, 1}
+	u := []float64{0.2, 0.3, 0.5}
+	v := []float64{0.2, 0.3, 0.5}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("WassersteinDistance did not panic with invalid input")
+		}
+	}()
+
+	WassersteinDistance(p, q, u, v)
+}
+
+func TestWassersteinDistanceNdInvalidInput(t *testing.T) {
+	pPoints := [][]float64{{0, 0}, {1, 1}, {2, 2}}
+	pWeights := [][]float64{{0.2}, {0.3}, {0.5}}
+	qPoints := [][]float64{{0, 0}, {1, 1}}
+	qWeights := [][]float64{{0.2}, {0.3}, {0.5}}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("WassersteinDistanceNd did not panic with invalid input")
+		}
+	}()
+
+	WassersteinDistanceNd(pPoints, pWeights, qPoints, qWeights)
+}

--- a/stat/stat_test.go
+++ b/stat/stat_test.go
@@ -6,6 +6,7 @@ package stat
 
 import (
 	"fmt"
+	"gonum.org/v1/gonum/mat"
 	"math"
 	"math/rand/v2"
 	"reflect"
@@ -1980,126 +1981,126 @@ func TestWassersteinDistanceND(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		p        [][]float64
-		q        [][]float64
+		p        *mat.Dense
+		q        *mat.Dense
 		pWeights []float64
 		qWeights []float64
 		want     float64
 	}{
 		{
 			name: "Example 1: 2D with uniform weights",
-			p: [][]float64{
-				{0, 0},
-				{1, 1},
-				{2, 2},
-			},
-			q: [][]float64{
-				{0, 1},
-				{1, 2},
-				{2, 3},
-			},
+			p: mat.NewDense(3, 2, []float64{
+				0, 0,
+				1, 1,
+				2, 2,
+			}),
+			q: mat.NewDense(3, 2, []float64{
+				0, 1,
+				1, 2,
+				2, 3,
+			}),
 			pWeights: []float64{1.0 / 3, 1.0 / 3, 1.0 / 3},
 			qWeights: []float64{1.0 / 3, 1.0 / 3, 1.0 / 3},
 			want:     1.0,
 		},
 		{
 			name: "Example 2: 2D with different sizes",
-			p: [][]float64{
-				{0, 0},
-				{1, 1},
-			},
-			q: [][]float64{
-				{0, 1},
-				{1, 2},
-				{2, 3},
-			},
+			p: mat.NewDense(2, 2, []float64{
+				0, 0,
+				1, 1,
+			}),
+			q: mat.NewDense(3, 2, []float64{
+				0, 1,
+				1, 2,
+				2, 3,
+			}),
 			pWeights: []float64{0.5, 0.5},
 			qWeights: []float64{1.0 / 3, 1.0 / 3, 1.0 / 3},
 			want:     1.618033988749895,
 		},
 		{
 			name: "Example 3: 2D with custom weights",
-			p: [][]float64{
-				{0, 0},
-				{1, 1},
-				{2, 2},
-			},
-			q: [][]float64{
-				{0, 0},
-				{1, 1},
-				{2, 2},
-			},
+			p: mat.NewDense(3, 2, []float64{
+				0, 0,
+				1, 1,
+				2, 2,
+			}),
+			q: mat.NewDense(3, 2, []float64{
+				0, 0,
+				1, 1,
+				2, 2,
+			}),
 			pWeights: []float64{0.2, 0.3, 0.5},
 			qWeights: []float64{0.5, 0.3, 0.2},
 			want:     0.848528137423857,
 		},
 		{
 			name: "Example 4: 3D with uniform weights",
-			p: [][]float64{
-				{0, 0, 0},
-				{1, 1, 1},
-				{2, 2, 2},
-			},
-			q: [][]float64{
-				{0, 1, 0},
-				{1, 2, 1},
-				{2, 3, 2},
-			},
+			p: mat.NewDense(3, 3, []float64{
+				0, 0, 0,
+				1, 1, 1,
+				2, 2, 2,
+			}),
+			q: mat.NewDense(3, 3, []float64{
+				0, 1, 0,
+				1, 2, 1,
+				2, 3, 2,
+			}),
 			pWeights: []float64{1.0 / 3, 1.0 / 3, 1.0 / 3},
 			qWeights: []float64{1.0 / 3, 1.0 / 3, 1.0 / 3},
 			want:     1.0,
 		},
 		{
 			name: "Example 5: Single points",
-			p: [][]float64{
-				{1, 2},
-			},
-			q: [][]float64{
-				{3, 4},
-			},
+			p: mat.NewDense(1, 2, []float64{
+				1, 2,
+			}),
+			q: mat.NewDense(1, 2, []float64{
+				3, 4,
+			}),
 			pWeights: []float64{1.0},
 			qWeights: []float64{1.0},
 			want:     2.8284271247461903,
 		},
 		{
 			name: "Example 6: Identical distributions",
-			p: [][]float64{
-				{1, 2},
-				{3, 4},
-			},
-			q: [][]float64{
-				{1, 2},
-				{3, 4},
-			},
+			p: mat.NewDense(2, 2, []float64{
+				1, 2,
+				3, 4,
+			}),
+			q: mat.NewDense(2, 2, []float64{
+				1, 2,
+				3, 4,
+			}),
 			pWeights: nil,
 			qWeights: nil,
 			want:     0.0,
 		},
 		{
 			name: "Example 7: 3D points from SciPy docs",
-			p: [][]float64{
-				{0, 2, 3},
-				{1, 2, 5},
-			},
-			q: [][]float64{
-				{3, 2, 3},
-				{4, 2, 5},
-			},
+			p: mat.NewDense(2, 3, []float64{
+				0, 2, 3,
+				1, 2, 5,
+			}),
+			q: mat.NewDense(2, 3, []float64{
+				3, 2, 3,
+				4, 2, 5,
+			}),
 			pWeights: nil,
 			qWeights: nil,
 			want:     3.0,
 		},
 		{
 			name: "Example 8: 2D with custom weights from SciPy docs",
-			p: [][]float64{
-				{0, 2.75},
-				{2, 209.3},
-				{0, 0},
-			},
-			q: [][]float64{
-				{0.2, 0.322},
-				{4.5, 25.1808},
-			},
+			p: mat.NewDense(3, 2, []float64{
+				0, 2.75,
+				2, 209.3,
+				0, 0,
+			}),
+			q: mat.NewDense(2, 2, []float64{
+				0.2, 0.322,
+				4.5, 25.1808,
+			}),
 			pWeights: []float64{0.4, 5.2, 0.114},
 			qWeights: []float64{0.8, 1.5},
 			want:     174.15840245217169,
@@ -2118,15 +2119,5 @@ func TestWassersteinDistanceND(t *testing.T) {
 				t.Errorf("WassersteinDistanceND() = %v, want %v", got, test.want)
 			}
 		})
-	}
-}
-
-// TestWassersteinDistanceNDEdgeCases tests specific edge cases
-func TestWassersteinDistanceNDEdgeCases(t *testing.T) {
-	// Test empty distributions.
-	result, err := WassersteinDistanceND([][]float64{}, [][]float64{{1, 2}}, nil, nil)
-
-	if !math.IsNaN(result) && err != nil {
-		t.Errorf("WassersteinDistanceND() = %v, want %v", result, math.NaN())
 	}
 }


### PR DESCRIPTION
This PR focuses on implementing the Wasserstein Distance (also known as Earth Mover's Distance) for both 1-d and n-d distributions. The implementation was heavily inspired by Scipy - some test cases were taken from there.

The functions include:
- optional weights: if nil, uniform weights are used
- weight normalization
- extensive validity checks
- comments to document and explain the steps taken
- tests

This is my first contribution to Gonum.
I apologize for any rules I may have missed and would welcome suggestions. Some brackets in the stat package were removed as a result to an auto-refactor.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."

Do not delete any of this templated text in the PR description, but
feel free to add additional context.
-->
