### PR TITLE
spatial: add Umeyama's algorithm for the estimation of transformation parameters between two point patterns

### DIFF
--- a/spatial/umeyama/doc.go
+++ b/spatial/umeyama/doc.go
@@ -1,0 +1,8 @@
+// Copyright ©2025 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package umeyama provides a function to estimate the similarity transformation parameters between two point patterns
+// as described in "Least-Squares Estimation of Transformation Parameters Between Two Point Patterns"
+// by Shinji Umeyama
+package umeyama // import "gonum.org/v1/gonum/spatial/umeyama"

--- a/spatial/umeyama/umeyama.go
+++ b/spatial/umeyama/umeyama.go
@@ -2,6 +2,7 @@ package umeyama
 
 import (
 	"errors"
+
 	"gonum.org/v1/gonum/mat"
 	"gonum.org/v1/gonum/stat"
 )

--- a/spatial/umeyama/umeyama.go
+++ b/spatial/umeyama/umeyama.go
@@ -9,9 +9,9 @@ import (
 
 const (
 	// ErrMsgSVDFailed is the error message for SVD factorization failure
-	ErrMsgSVDFailed = "SVD factorization failed"
+	ErrMsgSVDFailed = "umeyama: SVD factorization failed"
 	// ErrMsgDegenerateInput is the error message for degenerate input data
-	ErrMsgDegenerateInput = "degenerate input: variance of X is too small"
+	ErrMsgDegenerateInput = "umeyama: variance of X is too small"
 )
 
 // Umeyama estimates the similarity transformation parameters between two matrices X and Y.
@@ -19,7 +19,7 @@ const (
 // This is an implementation of the algorithm presented in:
 // "Least-Squares Estimation of Transformation Parameters Between Two Point Patterns"
 // by Shinji Umeyama, IEEE Transactions on Pattern Analysis and Machine Intelligence,
-// Vol. 13, No. 4, April 1991.
+// Vol. 13, No. 4, April 1991, which can be found here: https://doi.org/10.1109/34.88573
 //
 // The algorithm finds the optimal similarity transformation [c, R, t] ∈ Sim(m)
 // that minimizes the mean squared error between two point patterns.
@@ -31,7 +31,7 @@ const (
 // The points require consistent indexing. This means
 // that point i of X needs to correspond to point i of Y.
 //
-// Umeyama returns the scale factor c, the rotation matrix R and the translation vector t.
+// Umeyama returns the scale factor c, the rotation matrix r and the translation vector t.
 // If a computation fails, Umeyama will return an error.
 func Umeyama(X, Y *mat.Dense) (float64, *mat.Dense, *mat.VecDense, error) {
 	rowsX, colsX := X.Dims()

--- a/spatial/umeyama/umeyama.go
+++ b/spatial/umeyama/umeyama.go
@@ -1,0 +1,145 @@
+package umeyama
+
+import (
+	"errors"
+	"gonum.org/v1/gonum/mat"
+	"gonum.org/v1/gonum/stat"
+)
+
+const (
+	// ErrMsgSVDFailed is the error message for SVD factorization failure
+	ErrMsgSVDFailed = "SVD factorization failed"
+	// ErrMsgDegenerateInput is the error message for degenerate input data
+	ErrMsgDegenerateInput = "degenerate input: variance of X is too small"
+)
+
+// Umeyama estimates the similarity transformation parameters between two matrices X and Y.
+//
+// This is an implementation of the algorithm presented in:
+// "Least-Squares Estimation of Transformation Parameters Between Two Point Patterns"
+// by Shinji Umeyama, IEEE Transactions on Pattern Analysis and Machine Intelligence,
+// Vol. 13, No. 4, April 1991.
+//
+// The algorithm finds the optimal similarity transformation [c, R, t] ∈ Sim(m)
+// that minimizes the mean squared error between two point patterns.
+//
+// The transformation relates the point sets as:
+// Y ≈ c * R * X + t
+//
+// The dimensions of X and Y must be equal. The function will panic if they are not.
+// The points require consistent indexing. This means
+// that point i of X needs to correspond to point i of Y.
+//
+// Umeyama returns the scale factor c, the rotation matrix R and the translation vector t.
+// If a computation fails, Umeyama will return an error.
+func Umeyama(X, Y *mat.Dense) (float64, *mat.Dense, *mat.VecDense, error) {
+	rowsX, colsX := X.Dims()
+	rowsY, colsY := Y.Dims()
+
+	// Check dimensions.
+	if rowsX != rowsY || colsX != colsY {
+		panic("umeyama: dimensions of X and Y do not match")
+	}
+
+	rows, cols := rowsX, colsX
+
+	// Calculate means.
+	muX := mat.NewVecDense(rows, nil)
+	muY := mat.NewVecDense(rows, nil)
+
+	for i := 0; i < rows; i++ {
+		muX.SetVec(i, stat.Mean(mat.Row(nil, i, X), nil))
+		muY.SetVec(i, stat.Mean(mat.Row(nil, i, Y), nil))
+	}
+
+	// Calculate variance of X.
+	varX := 0.0
+	for j := 0; j < cols; j++ {
+		for i := 0; i < rows; i++ {
+			diff := X.At(i, j) - muX.AtVec(i)
+			varX += diff * diff
+		}
+	}
+	varX /= float64(cols)
+
+	// Check for degenerate case.
+	if varX < 1e-10 {
+		return 0, nil, nil, errors.New(ErrMsgDegenerateInput)
+	}
+
+	// Calculate covariance matrix.
+	covXY := mat.NewDense(rows, rows, nil)
+	for j := 0; j < cols; j++ {
+		for i := 0; i < rows; i++ {
+			diffY := Y.At(i, j) - muY.AtVec(i)
+			for k := 0; k < rows; k++ {
+				diffX := X.At(k, j) - muX.AtVec(k)
+				covXY.Set(i, k, covXY.At(i, k)+diffY*diffX/float64(cols))
+			}
+		}
+	}
+
+	// Singular Value Decomposition
+	var svd mat.SVD
+	ok := svd.Factorize(covXY, mat.SVDFull)
+	if !ok {
+		return 0, nil, nil, errors.New(ErrMsgSVDFailed)
+	}
+
+	// Get U, Σ, and V.
+	u := mat.NewDense(rows, rows, nil)
+	vt := mat.NewDense(rows, rows, nil)
+	svd.UTo(u)
+	svd.VTo(vt)
+
+	// Transpose V to get VH.
+	vh := mat.NewDense(rows, rows, nil)
+	vh.Copy(vt.T())
+
+	// Create S matrix (identity matrix).
+	s := mat.NewDiagDense(rows, nil)
+	for i := 0; i < rows; i++ {
+		s.SetDiag(i, 1.0)
+	}
+
+	// Check determinants to ensure proper rotation matrix (not reflection).
+	// This is a key contribution of Umeyama's paper - ensuring a proper rotation.
+	uDet := mat.Det(u)
+	vhDet := mat.Det(vh)
+	if uDet*vhDet < 0 {
+		s.SetDiag(rows-1, -1.0)
+	}
+
+	// Calculate scale factor c.
+	c := 0.0
+	singularValues := svd.Values(nil)
+	for i := 0; i < rows; i++ {
+		c += singularValues[i] * s.At(i, i)
+	}
+	c /= varX
+
+	// Calculate rotation matrix R.
+	tmp := mat.NewDense(rows, rows, nil)
+	r := mat.NewDense(rows, rows, nil)
+	tmp.Mul(u, s)
+	r.Mul(tmp, vh)
+
+	// Calculate translation vector t.
+	t := mat.NewVecDense(rows, nil)
+	rMuX := mat.NewVecDense(rows, nil)
+	tmp2 := mat.NewDense(rows, 1, nil)
+	for i := 0; i < rows; i++ {
+		for j := 0; j < rows; j++ {
+			tmp2.Set(i, 0, tmp2.At(i, 0)+r.At(i, j)*muX.AtVec(j))
+		}
+	}
+	for i := 0; i < rows; i++ {
+		rMuX.SetVec(i, tmp2.At(i, 0))
+	}
+
+	for i := 0; i < rows; i++ {
+		t.SetVec(i, muY.AtVec(i)-c*rMuX.AtVec(i))
+	}
+
+	return c, r, t, nil
+}

--- a/spatial/umeyama/umeyama_test.go
+++ b/spatial/umeyama/umeyama_test.go
@@ -1,0 +1,108 @@
+package umeyama
+
+import (
+	"math"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func TestUmeyama(t *testing.T) {
+	tol := 1e-10
+
+	testCases := []struct {
+		name      string
+		src       *mat.Dense
+		dst       *mat.Dense
+		wantScale float64
+		wantRot   *mat.Dense
+		wantTrans *mat.VecDense
+		tolerance float64
+	}{
+		{
+			name:      "2D_case_from_paper",
+			src:       mat.NewDense(2, 3, []float64{0, 1, 0, 0, 0, 2}),
+			dst:       mat.NewDense(2, 3, []float64{0, -1, 0, 0, 0, 2}),
+			wantScale: 0.7211102550927978,
+			wantRot:   mat.NewDense(2, 2, []float64{0.8320502943378437, 0.554700196225229, -0.554700196225229, 0.8320502943378436}),
+			wantTrans: mat.NewVecDense(2, []float64{-0.7999999999999998, 0.4}),
+			tolerance: tol,
+		},
+		{
+			name:      "2D_identity",
+			src:       mat.NewDense(2, 3, []float64{0, 1, 2, 0, 1, 2}),
+			dst:       mat.NewDense(2, 3, []float64{0, 1, 2, 0, 1, 2}),
+			wantScale: 1.0,
+			wantRot:   mat.NewDense(2, 2, []float64{1.0, 1.2116883882008518e-16, 1.2116883882008518e-16, 1.0}),
+			wantTrans: mat.NewVecDense(2, []float64{-2.220446049250313e-16, -2.220446049250313e-16}),
+			tolerance: tol,
+		},
+		{
+			name:      "2D_rotation_90deg",
+			src:       mat.NewDense(2, 3, []float64{0, 1, 1, 0, 0, 1}),
+			dst:       mat.NewDense(2, 3, []float64{0, 0, -1, 0, 1, 1}),
+			wantScale: 0.9999999999999999,
+			wantRot:   mat.NewDense(2, 2, []float64{-5.613347976343136e-17, -0.9999999999999998, 0.9999999999999998, -2.9040269150165053e-16}),
+			wantTrans: mat.NewVecDense(2, []float64{-5.551115123125783e-17, 3.3306690738754696e-16}),
+			tolerance: tol,
+		},
+		{
+			name:      "2D_scale_2x",
+			src:       mat.NewDense(2, 3, []float64{0, 1, 2, 0, 1, 2}),
+			dst:       mat.NewDense(2, 3, []float64{0, 2, 4, 0, 2, 4}),
+			wantScale: 2.0,
+			wantRot:   mat.NewDense(2, 2, []float64{1.0, 1.2116883882008518e-16, 1.2116883882008518e-16, 1.0}),
+			wantTrans: mat.NewVecDense(2, []float64{-4.440892098500626e-16, -4.440892098500626e-16}),
+			tolerance: tol,
+		},
+		{
+			name:      "2D_translation",
+			src:       mat.NewDense(2, 3, []float64{0, 1, 2, 0, 1, 2}),
+			dst:       mat.NewDense(2, 3, []float64{3, 4, 5, 3, 4, 5}),
+			wantScale: 1.0,
+			wantRot:   mat.NewDense(2, 2, []float64{1.0, 1.2116883882008518e-16, 1.2116883882008518e-16, 1.0}),
+			wantTrans: mat.NewVecDense(2, []float64{3.0, 3.0}),
+			tolerance: tol,
+		},
+		{
+			name:      "3D_case",
+			src:       mat.NewDense(3, 3, []float64{0, 1, 2, 0, 0, 5, 1, 3, 8}),
+			dst:       mat.NewDense(3, 3, []float64{1, 0, 1, 2, 1, 7, 4, 6, 11}),
+			wantScale: 1.0205423989219404,
+			wantRot:   mat.NewDense(3, 3, []float64{0.5699453289954445, 0.5900767342443888, -0.5718144538744644, -0.5030534073108366, 0.8008235178014148, 0.324990711758234, 0.6496919203355019, 0.10242627123762431, 0.7532657350571071}),
+			wantTrans: mat.NewVecDense(3, []float64{1.4155929948174535, 1.1579295387121973, 3.0877861136679647}),
+			tolerance: tol,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			scale, rotation, translation, err := Umeyama(tc.src, tc.dst)
+			if err != nil {
+				t.Fatalf("Umeyama returned error: %v", err)
+			}
+
+			// Check scale
+			if math.Abs(scale-tc.wantScale) > tc.tolerance {
+				t.Errorf("Scale = %v, want %v", scale, tc.wantScale)
+			}
+
+			// Check rotation
+			d, _ := tc.wantRot.Dims()
+			for i := 0; i < d; i++ {
+				for j := 0; j < d; j++ {
+					if math.Abs(rotation.At(i, j)-tc.wantRot.At(i, j)) > tc.tolerance {
+						t.Errorf("Rotation[%d,%d] = %v, want %v", i, j, rotation.At(i, j), tc.wantRot.At(i, j))
+					}
+				}
+			}
+
+			// Check translation
+			for i := 0; i < d; i++ {
+				if math.Abs(translation.AtVec(i)-tc.wantTrans.AtVec(i)) > tc.tolerance {
+					t.Errorf("Translation[%d] = %v, want %v", i, translation.AtVec(i), tc.wantTrans.AtVec(i))
+				}
+			}
+		})
+	}
+}

--- a/spatial/umeyama/umeyama_test.go
+++ b/spatial/umeyama/umeyama_test.go
@@ -20,54 +20,102 @@ func TestUmeyama(t *testing.T) {
 		tolerance float64
 	}{
 		{
-			name:      "2D_case_from_paper",
-			src:       mat.NewDense(2, 3, []float64{0, 1, 0, 0, 0, 2}),
-			dst:       mat.NewDense(2, 3, []float64{0, -1, 0, 0, 0, 2}),
+			name: "2D_case_from_paper",
+			src: mat.NewDense(3, 2, []float64{
+				0, 0,
+				1, 0,
+				0, 2,
+			}),
+			dst: mat.NewDense(3, 2, []float64{
+				0, 0,
+				-1, 0,
+				0, 2,
+			}),
 			wantScale: 0.7211102550927978,
 			wantRot:   mat.NewDense(2, 2, []float64{0.8320502943378437, 0.554700196225229, -0.554700196225229, 0.8320502943378436}),
 			wantTrans: mat.NewVecDense(2, []float64{-0.7999999999999998, 0.4}),
 			tolerance: tol,
 		},
 		{
-			name:      "2D_identity",
-			src:       mat.NewDense(2, 3, []float64{0, 1, 2, 0, 1, 2}),
-			dst:       mat.NewDense(2, 3, []float64{0, 1, 2, 0, 1, 2}),
+			name: "2D_identity",
+			src: mat.NewDense(3, 2, []float64{
+				0, 0,
+				1, 1,
+				2, 2,
+			}),
+			dst: mat.NewDense(3, 2, []float64{
+				0, 0,
+				1, 1,
+				2, 2,
+			}),
 			wantScale: 1.0,
 			wantRot:   mat.NewDense(2, 2, []float64{1.0, 1.2116883882008518e-16, 1.2116883882008518e-16, 1.0}),
 			wantTrans: mat.NewVecDense(2, []float64{-2.220446049250313e-16, -2.220446049250313e-16}),
 			tolerance: tol,
 		},
 		{
-			name:      "2D_rotation_90deg",
-			src:       mat.NewDense(2, 3, []float64{0, 1, 1, 0, 0, 1}),
-			dst:       mat.NewDense(2, 3, []float64{0, 0, -1, 0, 1, 1}),
+			name: "2D_rotation_90deg",
+			src: mat.NewDense(3, 2, []float64{
+				0, 0,
+				1, 0,
+				1, 1,
+			}),
+			dst: mat.NewDense(3, 2, []float64{
+				0, 0,
+				0, 1,
+				-1, 1,
+			}),
 			wantScale: 0.9999999999999999,
 			wantRot:   mat.NewDense(2, 2, []float64{-5.613347976343136e-17, -0.9999999999999998, 0.9999999999999998, -2.9040269150165053e-16}),
 			wantTrans: mat.NewVecDense(2, []float64{-5.551115123125783e-17, 3.3306690738754696e-16}),
 			tolerance: tol,
 		},
 		{
-			name:      "2D_scale_2x",
-			src:       mat.NewDense(2, 3, []float64{0, 1, 2, 0, 1, 2}),
-			dst:       mat.NewDense(2, 3, []float64{0, 2, 4, 0, 2, 4}),
+			name: "2D_scale_2x",
+			src: mat.NewDense(3, 2, []float64{
+				0, 0,
+				1, 1,
+				2, 2,
+			}),
+			dst: mat.NewDense(3, 2, []float64{
+				0, 0,
+				2, 2,
+				4, 4,
+			}),
 			wantScale: 2.0,
 			wantRot:   mat.NewDense(2, 2, []float64{1.0, 1.2116883882008518e-16, 1.2116883882008518e-16, 1.0}),
 			wantTrans: mat.NewVecDense(2, []float64{-4.440892098500626e-16, -4.440892098500626e-16}),
 			tolerance: tol,
 		},
 		{
-			name:      "2D_translation",
-			src:       mat.NewDense(2, 3, []float64{0, 1, 2, 0, 1, 2}),
-			dst:       mat.NewDense(2, 3, []float64{3, 4, 5, 3, 4, 5}),
+			name: "2D_translation",
+			src: mat.NewDense(3, 2, []float64{
+				0, 0,
+				1, 1,
+				2, 2,
+			}),
+			dst: mat.NewDense(3, 2, []float64{
+				3, 3,
+				4, 4,
+				5, 5,
+			}),
 			wantScale: 1.0,
 			wantRot:   mat.NewDense(2, 2, []float64{1.0, 1.2116883882008518e-16, 1.2116883882008518e-16, 1.0}),
 			wantTrans: mat.NewVecDense(2, []float64{3.0, 3.0}),
 			tolerance: tol,
 		},
 		{
-			name:      "3D_case",
-			src:       mat.NewDense(3, 3, []float64{0, 1, 2, 0, 0, 5, 1, 3, 8}),
-			dst:       mat.NewDense(3, 3, []float64{1, 0, 1, 2, 1, 7, 4, 6, 11}),
+			name: "3D_case",
+			src: mat.NewDense(3, 3, []float64{
+				0, 0, 1,
+				1, 0, 3,
+				2, 5, 8,
+			}),
+			dst: mat.NewDense(3, 3, []float64{
+				1, 2, 4,
+				0, 1, 6,
+				1, 7, 11,
+			}),
 			wantScale: 1.0205423989219404,
 			wantRot:   mat.NewDense(3, 3, []float64{0.5699453289954445, 0.5900767342443888, -0.5718144538744644, -0.5030534073108366, 0.8008235178014148, 0.324990711758234, 0.6496919203355019, 0.10242627123762431, 0.7532657350571071}),
 			wantTrans: mat.NewVecDense(3, []float64{1.4155929948174535, 1.1579295387121973, 3.0877861136679647}),
@@ -88,7 +136,7 @@ func TestUmeyama(t *testing.T) {
 			}
 
 			// Check rotation
-			d, _ := tc.wantRot.Dims()
+			_, d := tc.wantRot.Dims()
 			for i := 0; i < d; i++ {
 				for j := 0; j < d; j++ {
 					if math.Abs(rotation.At(i, j)-tc.wantRot.At(i, j)) > tc.tolerance {


### PR DESCRIPTION
This PR focuses on adding Umeyama's algorithm for the estimation of transformation parameters between two point patterns as described in this paper: https://doi.org/10.1109/34.88573 

The algorithm has been placed in an own package alongside other spatial packages.


Checklist:

- API changes have been discussed --- Doesn't apply
- code is goformated correctly (goimports) --- Yes
- packages with generated code have had code generation run --- Doesnt' apply
- tests pass locally --- Yes
- linked to relevant issues --- Doesn't apply
