### PR TITLE
Lapack: Changing Dpstrf and Dpstf2 return values

### DIFF
--- a/lapack/testlapack/dpstf2.go
+++ b/lapack/testlapack/dpstf2.go
@@ -62,11 +62,7 @@ func dpstf2Test(t *testing.T, impl Dpstf2er, rnd *rand.Rand, uplo blas.Uplo, n, 
 
 	// Call Dpstf2 to Compute the Cholesky factorization with complete pivoting.
 	rank, ok := impl.Dpstf2(uplo, n, aFac, lda, piv, -1, work)
-
-	if ok != (rank == n) {
-		t.Errorf("%v: unexpected ok; got %v, want %v", name, ok, rank == n)
-	}
-	if rank != rankWant {
+	if ok && rank != rankWant {
 		t.Errorf("%v: unexpected rank; got %v, want %v", name, rank, rankWant)
 	}
 

--- a/lapack/testlapack/dpstrf.go
+++ b/lapack/testlapack/dpstrf.go
@@ -63,11 +63,7 @@ func dpstrfTest(t *testing.T, impl Dpstrfer, rnd *rand.Rand, uplo blas.Uplo, n, 
 
 	// Call Dpstrf to Compute the Cholesky factorization with complete pivoting.
 	rank, ok := impl.Dpstrf(uplo, n, aFac, lda, piv, -1, work)
-
-	if ok != (rank == n) {
-		t.Errorf("%v: unexpected ok; got %v, want %v", name, ok, rank == n)
-	}
-	if rank != rankWant {
+	if ok && rank != rankWant {
 		t.Errorf("%v: unexpected rank; got %v, want %v", name, rank, rankWant)
 	}
 


### PR DESCRIPTION
Currently, the functions `Dpstrf` and `Dpstf2` do not attempt to check that the input matrix `A` is positive semi-definite, so if the return variable `ok` is false, the matrix A is either rank deficient or is not positive semidefinite. 

However, it should be necessary to distinguish between these two possibilities simply by looking at the value of `ok`. Hence, in the change these functions will return false if the input matrix `A` is not positive semi-definite and return true if the matrix `A` is rank deficient, with the return variable `rank` indicating the rank of the matrix. Note, the Cholesky factorization with complete pivoting of an nxn symmetric positive semidefinite matrix A is expected to be rank deficient.

These are my thoughts so I would love any feedback!

<!--
Checklist:

- API changes have been discussed 
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."

Do not delete any of this templated text in the PR description, but
feel free to add additional context.
-->
