### PR TITLE
internal/asm/f64: add AVX2/FMA optimizations for key BLAS operations

### DIFF
--- a/blas/gonum/dgemm_test.go
+++ b/blas/gonum/dgemm_test.go
@@ -1,0 +1,53 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+import (
+	"fmt"
+	"testing"
+	"gonum.org/v1/gonum/blas"
+)
+
+func BenchmarkDgemmOptimized(b *testing.B) {
+	sizes := []struct {
+		m, n, k int
+	}{
+		{10, 10, 10},
+		{20, 20, 20},
+		{50, 50, 50},
+		{100, 100, 100},
+		{200, 200, 200},
+		{500, 500, 500},
+	}
+	
+	impl := Implementation{}
+	
+	for _, size := range sizes {
+		// Allocate matrices
+		a := make([]float64, size.m*size.k)
+		bb := make([]float64, size.k*size.n)
+		c := make([]float64, size.m*size.n)
+		
+		// Initialize with some data
+		for i := range a {
+			a[i] = float64(i)
+		}
+		for i := range bb {
+			bb[i] = float64(i)
+		}
+		
+		b.Run(fmt.Sprintf("Size%dx%dx%d", size.m, size.n, size.k), func(b *testing.B) {
+			b.SetBytes(int64(size.m*size.k + size.k*size.n + size.m*size.n) * 8)
+			for i := 0; i < b.N; i++ {
+				// Reset C
+				for j := range c {
+					c[j] = 0
+				}
+				impl.Dgemm(blas.NoTrans, blas.NoTrans, size.m, size.n, size.k, 
+					1.0, a, size.k, bb, size.n, 0.0, c, size.n)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/image v0.25.0 // indirect
 	golang.org/x/mod v0.21.0 // indirect
+	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	rsc.io/pdf v0.1.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
+golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=

--- a/internal/asm/f64/axpy_amd64.go
+++ b/internal/asm/f64/axpy_amd64.go
@@ -1,0 +1,56 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !noasm && !gccgo && !safe
+// +build !noasm,!gccgo,!safe
+
+package f64
+
+import "golang.org/x/sys/cpu"
+
+// Function pointers for runtime CPU feature detection
+var (
+	axpyUnitaryImpl      func(alpha float64, x, y []float64)
+	axpyUnitaryToImpl    func(dst []float64, alpha float64, x, y []float64)
+)
+
+// Assembly functions
+func axpyUnitarySSE2Asm(alpha float64, x, y []float64)
+func axpyUnitaryToSSE2Asm(dst []float64, alpha float64, x, y []float64)
+func AxpyUnitaryAVX2(alpha float64, x, y []float64)
+func AxpyUnitaryFMA(alpha float64, x, y []float64)
+func axpyUnitaryToAVX2(dst []float64, alpha float64, x, y []float64)
+
+func init() {
+	if cpu.X86.HasAVX2 && cpu.X86.HasFMA {
+		axpyUnitaryImpl = AxpyUnitaryFMA
+		// axpyUnitaryToImpl = axpyUnitaryToAVX2 // TODO: implement AVX2 version
+		axpyUnitaryToImpl = axpyUnitaryToSSE2Asm
+	} else if cpu.X86.HasAVX2 {
+		axpyUnitaryImpl = AxpyUnitaryAVX2
+		axpyUnitaryToImpl = axpyUnitaryToSSE2Asm
+	} else {
+		axpyUnitaryImpl = axpyUnitarySSE2Asm
+		axpyUnitaryToImpl = axpyUnitaryToSSE2Asm
+	}
+}
+
+// AxpyUnitary is
+//
+//	for i, v := range x {
+//		y[i] += alpha * v
+//	}
+func AxpyUnitary(alpha float64, x, y []float64) {
+	axpyUnitaryImpl(alpha, x, y)
+}
+
+// AxpyUnitaryTo is
+//
+//	for i, v := range x {
+//		dst[i] = alpha*v + y[i]
+//	}
+func AxpyUnitaryTo(dst []float64, alpha float64, x, y []float64) {
+	axpyUnitaryToImpl(dst, alpha, x, y)
+}
+

--- a/internal/asm/f64/axpy_bench_test.go
+++ b/internal/asm/f64/axpy_bench_test.go
@@ -1,0 +1,115 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package f64
+
+import (
+	"fmt"
+	"testing"
+	"unsafe"
+	"golang.org/x/sys/cpu"
+)
+
+// Direct access to implementations for benchmarking
+func BenchmarkAxpyUnitaryAVX2(b *testing.B) {
+	sizes := []int{10, 100, 1000, 10000, 100000}
+	
+	for _, size := range sizes {
+		x := make([]float64, size)
+		y := make([]float64, size)
+		
+		// Initialize with some data
+		for i := range x {
+			x[i] = float64(i)
+			y[i] = float64(i * 2)
+		}
+		
+		alpha := 2.5
+		
+		b.Run("Size"+fmt.Sprintf("%d", size), func(b *testing.B) {
+			b.Run("Current", func(b *testing.B) {
+				b.SetBytes(int64(size * 8 * 2)) // 2 arrays of float64
+				for i := 0; i < b.N; i++ {
+					AxpyUnitary(alpha, x, y)
+				}
+			})
+			
+			// Benchmark SSE2 directly
+			b.Run("SSE2", func(b *testing.B) {
+				b.SetBytes(int64(size * 8 * 2))
+				for i := 0; i < b.N; i++ {
+					axpyUnitarySSE2Asm(alpha, x, y)
+				}
+			})
+			
+			// Benchmark AVX2 if available
+			if cpu.X86.HasAVX2 {
+				b.Run("AVX2", func(b *testing.B) {
+					b.SetBytes(int64(size * 8 * 2))
+					for i := 0; i < b.N; i++ {
+						AxpyUnitaryAVX2(alpha, x, y)
+					}
+				})
+			}
+			
+			// Benchmark FMA if available
+			if cpu.X86.HasAVX2 && cpu.X86.HasFMA {
+				b.Run("FMA", func(b *testing.B) {
+					b.SetBytes(int64(size * 8 * 2))
+					for i := 0; i < b.N; i++ {
+						AxpyUnitaryFMA(alpha, x, y)
+					}
+				})
+			}
+		})
+	}
+}
+
+// Benchmark comparing aligned vs unaligned data
+func BenchmarkAxpyUnitaryAlignmentAVX2(b *testing.B) {
+	size := 10000
+	
+	// Aligned allocation (32-byte aligned for AVX2)
+	xAligned := make([]float64, size+4)
+	yAligned := make([]float64, size+4)
+	
+	// Find 32-byte aligned offset
+	xOffset := 0
+	for i := 0; i < 4; i++ {
+		if uintptr(unsafe.Pointer(&xAligned[i]))%32 == 0 {
+			xOffset = i
+			break
+		}
+	}
+	yOffset := 0
+	for i := 0; i < 4; i++ {
+		if uintptr(unsafe.Pointer(&yAligned[i]))%32 == 0 {
+			yOffset = i
+			break
+		}
+	}
+	
+	x := xAligned[xOffset : xOffset+size]
+	y := yAligned[yOffset : yOffset+size]
+	
+	// Unaligned (deliberately misaligned)
+	xUnaligned := make([]float64, size+1)[1:]
+	yUnaligned := make([]float64, size+1)[1:]
+	
+	alpha := 2.5
+	
+	b.Run("Aligned", func(b *testing.B) {
+		b.SetBytes(int64(size * 8 * 2))
+		for i := 0; i < b.N; i++ {
+			AxpyUnitary(alpha, x, y)
+		}
+	})
+	
+	b.Run("Unaligned", func(b *testing.B) {
+		b.SetBytes(int64(size * 8 * 2))
+		for i := 0; i < b.N; i++ {
+			AxpyUnitary(alpha, xUnaligned, yUnaligned)
+		}
+	})
+}

--- a/internal/asm/f64/axpyunitary_amd64.s
+++ b/internal/asm/f64/axpyunitary_amd64.s
@@ -47,8 +47,8 @@
 #define ALPHA X0
 #define ALPHA_2 X1
 
-// func AxpyUnitary(alpha float64, x, y []float64)
-TEXT ·AxpyUnitary(SB), NOSPLIT, $0
+// func axpyUnitarySSE2Asm(alpha float64, x, y []float64)
+TEXT ·axpyUnitarySSE2Asm(SB), NOSPLIT, $0
 	MOVQ    x_base+8(FP), X_PTR  // X_PTR := &x
 	MOVQ    y_base+32(FP), Y_PTR // Y_PTR := &y
 	MOVQ    x_len+16(FP), LEN    // LEN = min( len(x), len(y) )

--- a/internal/asm/f64/axpyunitary_avx2_amd64.s
+++ b/internal/asm/f64/axpyunitary_avx2_amd64.s
@@ -1,0 +1,131 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// AVX2/FMA optimized version of AxpyUnitary
+// y[i] += alpha * x[i]
+
+// +build !noasm,!gccgo,!safe
+
+#include "textflag.h"
+
+#define X_PTR SI
+#define Y_PTR DI
+#define DST_PTR DI
+#define IDX AX
+#define LEN CX
+#define TAIL BX
+#define ALPHA Y0
+#define ALPHA_2 Y1
+
+// func AxpyUnitaryAVX2(alpha float64, x, y []float64)
+TEXT ·AxpyUnitaryAVX2(SB), NOSPLIT, $0
+	MOVQ    x_base+8(FP), X_PTR  // X_PTR := &x
+	MOVQ    y_base+32(FP), Y_PTR // Y_PTR := &y
+	MOVQ    x_len+16(FP), LEN    // LEN = min( len(x), len(y) )
+	CMPQ    y_len+40(FP), LEN
+	CMOVQLE y_len+40(FP), LEN
+	CMPQ    LEN, $0              // if LEN == 0 { return }
+	JE      end
+	XORQ    IDX, IDX
+	
+	// Broadcast alpha to all lanes of YMM register
+	VBROADCASTSD alpha+0(FP), ALPHA   // ALPHA := { alpha, alpha, alpha, alpha }
+	VMOVUPD      ALPHA, ALPHA_2       // ALPHA_2 := ALPHA for pipelining
+	
+	MOVQ    Y_PTR, TAIL          // Check memory alignment
+	ANDQ    $31, TAIL            // TAIL = &y % 32 (for 32-byte AVX2 alignment)
+	JZ      no_trim              // if TAIL == 0 { goto no_trim }
+
+	// Align on 32-byte boundary using scalar operations
+align_loop:
+	MOVSD (X_PTR)(IDX*8), X2     // X2 := x[i]
+	MULSD alpha+0(FP), X2        // X2 *= alpha (scalar)
+	ADDSD (Y_PTR)(IDX*8), X2     // X2 += y[i]
+	MOVSD X2, (DST_PTR)(IDX*8)   // y[i] = X2
+	INCQ  IDX                    // i++
+	DECQ  LEN                    // LEN--
+	JZ    end                    // if LEN == 0 { return }
+	MOVQ  Y_PTR, TAIL
+	LEAQ  (TAIL)(IDX*8), TAIL
+	ANDQ  $31, TAIL
+	JNZ   align_loop
+
+no_trim:
+	MOVQ LEN, TAIL
+	ANDQ $15, TAIL   // TAIL := n % 16 (16 doubles with AVX2)
+	SHRQ $4, LEN     // LEN = floor( n / 16 )
+	JZ   tail_start  // if LEN == 0 { goto tail_start }
+
+loop:  // Main loop: process 16 doubles per iteration using AVX2/FMA
+	// Load x[i:i+16] into 4 YMM registers
+	VMOVUPD (X_PTR)(IDX*8), Y2        // Y2 = x[i:i+4]
+	VMOVUPD 32(X_PTR)(IDX*8), Y3      // Y3 = x[i+4:i+8]
+	VMOVUPD 64(X_PTR)(IDX*8), Y4      // Y4 = x[i+8:i+12]
+	VMOVUPD 96(X_PTR)(IDX*8), Y5      // Y5 = x[i+12:i+16]
+	
+	// Load y[i:i+16] and perform multiply-add: y = y + alpha * x
+	VMULPD ALPHA, Y2, Y2               // Y2 = alpha * x[i:i+4]
+	VMULPD ALPHA_2, Y3, Y3             // Y3 = alpha * x[i+4:i+8]
+	VMULPD ALPHA, Y4, Y4               // Y4 = alpha * x[i+8:i+12]
+	VMULPD ALPHA_2, Y5, Y5             // Y5 = alpha * x[i+12:i+16]
+	
+	VADDPD (Y_PTR)(IDX*8), Y2, Y2      // Y2 = y[i:i+4] + alpha * x[i:i+4]
+	VADDPD 32(Y_PTR)(IDX*8), Y3, Y3    // Y3 = y[i+4:i+8] + alpha * x[i+4:i+8]
+	VADDPD 64(Y_PTR)(IDX*8), Y4, Y4    // Y4 = y[i+8:i+12] + alpha * x[i+8:i+12]
+	VADDPD 96(Y_PTR)(IDX*8), Y5, Y5    // Y5 = y[i+12:i+16] + alpha * x[i+12:i+16]
+	
+	// Store results back to y
+	VMOVUPD Y2, (DST_PTR)(IDX*8)       // y[i:i+4] = Y2
+	VMOVUPD Y3, 32(DST_PTR)(IDX*8)    // y[i+4:i+8] = Y3
+	VMOVUPD Y4, 64(DST_PTR)(IDX*8)    // y[i+8:i+12] = Y4
+	VMOVUPD Y5, 96(DST_PTR)(IDX*8)    // y[i+12:i+16] = Y5
+	
+	ADDQ $16, IDX  // i += 16
+	DECQ LEN
+	JNZ  loop      // } while --LEN > 0
+	CMPQ TAIL, $0  // if TAIL == 0 { return }
+	JE   end
+
+tail_start: // Handle remaining elements
+	MOVQ TAIL, LEN // Loop counter: LEN = TAIL
+	SHRQ $2, LEN   // LEN = floor( TAIL / 4 ) for AVX2
+	JZ   tail_sse  // if LEN == 0 { goto tail_sse }
+
+tail_avx2: // Process 4 doubles at a time
+	VMOVUPD (X_PTR)(IDX*8), Y2         // Y2 = x[i:i+4]
+	VMULPD ALPHA, Y2, Y2               // Y2 = alpha * x[i:i+4]
+	VADDPD (Y_PTR)(IDX*8), Y2, Y2      // Y2 = y[i:i+4] + alpha * x[i:i+4]
+	VMOVUPD Y2, (DST_PTR)(IDX*8)       // y[i:i+4] = Y2
+	ADDQ   $4, IDX                     // i += 4
+	DECQ   LEN
+	JNZ    tail_avx2                   // } while --LEN > 0
+
+tail_sse:
+	MOVQ TAIL, LEN
+	ANDQ $3, LEN    // LEN = TAIL % 4
+	SHRQ $1, LEN    // LEN = LEN / 2
+	JZ   tail_one   // if TAIL == 0 { goto tail_one }
+
+	// Process 2 doubles using SSE
+	MOVUPD (X_PTR)(IDX*8), X2          // X2 = x[i:i+2]
+	MOVSD  alpha+0(FP), X3             // X3 = alpha
+	SHUFPD $0, X3, X3                  // X3 = {alpha, alpha}
+	MULPD  X3, X2                      // X2 *= alpha
+	ADDPD  (Y_PTR)(IDX*8), X2          // X2 += y[i:i+2]
+	MOVUPD X2, (DST_PTR)(IDX*8)        // y[i:i+2] = X2
+	ADDQ   $2, IDX                     // i += 2
+
+tail_one:
+	ANDQ   $1, TAIL
+	JZ     end      // if no more elements { goto end }
+	
+	// Process last element
+	MOVSD (X_PTR)(IDX*8), X2          // X2 = x[i]
+	MULSD alpha+0(FP), X2              // X2 *= alpha
+	ADDSD (Y_PTR)(IDX*8), X2           // X2 += y[i]
+	MOVSD X2, (DST_PTR)(IDX*8)         // y[i] = X2
+
+end:
+	VZEROUPPER  // Clear upper YMM state
+	RET

--- a/internal/asm/f64/axpyunitary_fma_amd64.s
+++ b/internal/asm/f64/axpyunitary_fma_amd64.s
@@ -1,0 +1,132 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// AVX2/FMA3 optimized version of AxpyUnitary
+// y[i] += alpha * x[i]
+
+// +build !noasm,!gccgo,!safe
+
+#include "textflag.h"
+
+#define X_PTR SI
+#define Y_PTR DI
+#define DST_PTR DI
+#define IDX AX
+#define LEN CX
+#define TAIL BX
+#define ALPHA Y0
+#define ALPHA_2 Y1
+
+// func AxpyUnitaryFMA(alpha float64, x, y []float64)
+TEXT ·AxpyUnitaryFMA(SB), NOSPLIT, $0
+	MOVQ    x_base+8(FP), X_PTR  // X_PTR := &x
+	MOVQ    y_base+32(FP), Y_PTR // Y_PTR := &y
+	MOVQ    x_len+16(FP), LEN    // LEN = min( len(x), len(y) )
+	CMPQ    y_len+40(FP), LEN
+	CMOVQLE y_len+40(FP), LEN
+	CMPQ    LEN, $0              // if LEN == 0 { return }
+	JE      end
+	XORQ    IDX, IDX
+	
+	// Broadcast alpha to all lanes of YMM register
+	VBROADCASTSD alpha+0(FP), ALPHA   // ALPHA := { alpha, alpha, alpha, alpha }
+	VMOVUPD      ALPHA, ALPHA_2       // ALPHA_2 := ALPHA for pipelining
+	
+	MOVQ    Y_PTR, TAIL          // Check memory alignment
+	ANDQ    $31, TAIL            // TAIL = &y % 32 (for 32-byte AVX2 alignment)
+	JZ      no_trim              // if TAIL == 0 { goto no_trim }
+
+	// Align on 32-byte boundary using scalar operations
+align_loop:
+	MOVSD (X_PTR)(IDX*8), X2     // X2 := x[i]
+	MULSD alpha+0(FP), X2        // X2 *= alpha (scalar)
+	ADDSD (Y_PTR)(IDX*8), X2     // X2 += y[i]
+	MOVSD X2, (DST_PTR)(IDX*8)   // y[i] = X2
+	INCQ  IDX                    // i++
+	DECQ  LEN                    // LEN--
+	JZ    end                    // if LEN == 0 { return }
+	MOVQ  Y_PTR, TAIL
+	LEAQ  (TAIL)(IDX*8), TAIL
+	ANDQ  $31, TAIL
+	JNZ   align_loop
+
+no_trim:
+	MOVQ LEN, TAIL
+	ANDQ $15, TAIL   // TAIL := n % 16 (16 doubles with AVX2)
+	SHRQ $4, LEN     // LEN = floor( n / 16 )
+	JZ   tail_start  // if LEN == 0 { goto tail_start }
+
+loop:  // Main loop: process 16 doubles per iteration using AVX2/FMA
+	// Load x[i:i+16] into 4 YMM registers
+	VMOVUPD (X_PTR)(IDX*8), Y2        // Y2 = x[i:i+4]
+	VMOVUPD 32(X_PTR)(IDX*8), Y3      // Y3 = x[i+4:i+8]
+	VMOVUPD 64(X_PTR)(IDX*8), Y4      // Y4 = x[i+8:i+12]
+	VMOVUPD 96(X_PTR)(IDX*8), Y5      // Y5 = x[i+12:i+16]
+	
+	// Use FMA to compute y[i] = y[i] + alpha * x[i] in one instruction
+	// VFMADD213PD: Y2 = Y2 * ALPHA + (Y_PTR)
+	VMOVUPD (Y_PTR)(IDX*8), Y6         // Y6 = y[i:i+4]
+	VMOVUPD 32(Y_PTR)(IDX*8), Y7       // Y7 = y[i+4:i+8]
+	VMOVUPD 64(Y_PTR)(IDX*8), Y8       // Y8 = y[i+8:i+12]
+	VMOVUPD 96(Y_PTR)(IDX*8), Y9       // Y9 = y[i+12:i+16]
+	
+	VFMADD213PD Y6, ALPHA, Y2          // Y2 = x[i:i+4] * alpha + y[i:i+4]
+	VFMADD213PD Y7, ALPHA_2, Y3        // Y3 = x[i+4:i+8] * alpha + y[i+4:i+8]
+	VFMADD213PD Y8, ALPHA, Y4          // Y4 = x[i+8:i+12] * alpha + y[i+8:i+12]
+	VFMADD213PD Y9, ALPHA_2, Y5        // Y5 = x[i+12:i+16] * alpha + y[i+12:i+16]
+	
+	// Store results back to y
+	VMOVUPD Y2, (DST_PTR)(IDX*8)       // y[i:i+4] = Y2
+	VMOVUPD Y3, 32(DST_PTR)(IDX*8)    // y[i+4:i+8] = Y3
+	VMOVUPD Y4, 64(DST_PTR)(IDX*8)    // y[i+8:i+12] = Y4
+	VMOVUPD Y5, 96(DST_PTR)(IDX*8)    // y[i+12:i+16] = Y5
+	
+	ADDQ $16, IDX  // i += 16
+	DECQ LEN
+	JNZ  loop      // } while --LEN > 0
+	CMPQ TAIL, $0  // if TAIL == 0 { return }
+	JE   end
+
+tail_start: // Handle remaining elements
+	MOVQ TAIL, LEN // Loop counter: LEN = TAIL
+	SHRQ $2, LEN   // LEN = floor( TAIL / 4 ) for AVX2
+	JZ   tail_sse  // if LEN == 0 { goto tail_sse }
+
+tail_avx2: // Process 4 doubles at a time with FMA
+	VMOVUPD (X_PTR)(IDX*8), Y2         // Y2 = x[i:i+4]
+	VMOVUPD (Y_PTR)(IDX*8), Y3         // Y3 = y[i:i+4]
+	VFMADD213PD Y3, ALPHA, Y2          // Y2 = x * alpha + y
+	VMOVUPD Y2, (DST_PTR)(IDX*8)       // y[i:i+4] = Y2
+	ADDQ   $4, IDX                     // i += 4
+	DECQ   LEN
+	JNZ    tail_avx2                   // } while --LEN > 0
+
+tail_sse:
+	MOVQ TAIL, LEN
+	ANDQ $3, LEN    // LEN = TAIL % 4
+	SHRQ $1, LEN    // LEN = LEN / 2
+	JZ   tail_one   // if TAIL == 0 { goto tail_one }
+
+	// Process 2 doubles using SSE
+	MOVUPD (X_PTR)(IDX*8), X2          // X2 = x[i:i+2]
+	MOVSD  alpha+0(FP), X3             // X3 = alpha
+	SHUFPD $0, X3, X3                  // X3 = {alpha, alpha}
+	MULPD  X3, X2                      // X2 *= alpha
+	ADDPD  (Y_PTR)(IDX*8), X2          // X2 += y[i:i+2]
+	MOVUPD X2, (DST_PTR)(IDX*8)        // y[i:i+2] = X2
+	ADDQ   $2, IDX                     // i += 2
+
+tail_one:
+	ANDQ   $1, TAIL
+	JZ     end      // if no more elements { goto end }
+	
+	// Process last element
+	MOVSD (X_PTR)(IDX*8), X2          // X2 = x[i]
+	MULSD alpha+0(FP), X2              // X2 *= alpha
+	ADDSD (Y_PTR)(IDX*8), X2           // X2 += y[i]
+	MOVSD X2, (DST_PTR)(IDX*8)         // y[i] = X2
+
+end:
+	VZEROUPPER  // Clear upper YMM state
+	RET

--- a/internal/asm/f64/axpyunitaryto_amd64.s
+++ b/internal/asm/f64/axpyunitaryto_amd64.s
@@ -47,8 +47,8 @@
 #define ALPHA X0
 #define ALPHA_2 X1
 
-// func AxpyUnitaryTo(dst []float64, alpha float64, x, y []float64)
-TEXT ·AxpyUnitaryTo(SB), NOSPLIT, $0
+// func axpyUnitaryToSSE2Asm(dst []float64, alpha float64, x, y []float64)
+TEXT ·axpyUnitaryToSSE2Asm(SB), NOSPLIT, $0
 	MOVQ    dst_base+0(FP), DST_PTR // DST_PTR := &dst
 	MOVQ    x_base+32(FP), X_PTR    // X_PTR := &x
 	MOVQ    y_base+56(FP), Y_PTR    // Y_PTR := &y

--- a/internal/asm/f64/dot_amd64.go
+++ b/internal/asm/f64/dot_amd64.go
@@ -1,0 +1,43 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !noasm && !gccgo && !safe
+// +build !noasm,!gccgo,!safe
+
+package f64
+
+import "golang.org/x/sys/cpu"
+
+// Function pointers for runtime CPU feature detection
+var (
+	dotUnitaryImpl func(x, y []float64) float64
+	hasDotAVX2     bool
+)
+
+// Assembly functions - rename to avoid conflicts
+func dotUnitarySSE2Asm(x, y []float64) float64
+func DotUnitaryAVX2(x, y []float64) float64
+
+func init() {
+	if cpu.X86.HasAVX2 && cpu.X86.HasFMA {
+		dotUnitaryImpl = DotUnitaryAVX2
+		hasDotAVX2 = true
+	} else {
+		dotUnitaryImpl = dotUnitarySSE2Asm
+		hasDotAVX2 = false
+	}
+}
+
+// DotUnitary is
+//
+//	for i, v := range x {
+//		sum += y[i] * v
+//	}
+//	return sum
+func DotUnitary(x, y []float64) float64 {
+	return dotUnitaryImpl(x, y)
+}
+
+// Export hasDotAVX2 for testing
+var HasDotAVX2 = &hasDotAVX2

--- a/internal/asm/f64/dot_amd64.s
+++ b/internal/asm/f64/dot_amd64.s
@@ -38,9 +38,9 @@
 
 #include "textflag.h"
 
-// func DdotUnitary(x, y []float64) (sum float64)
+// func dotUnitary(x, y []float64) (sum float64)
 // This function assumes len(y) >= len(x).
-TEXT ·DotUnitary(SB), NOSPLIT, $0
+TEXT ·dotUnitary(SB), NOSPLIT, $0
 	MOVQ x+0(FP), R8
 	MOVQ x_len+8(FP), DI // n = len(x)
 	MOVQ y+24(FP), R9
@@ -90,6 +90,11 @@ end_uni:
 	ADDSD    X0, X7
 	MOVSD    X7, sum+48(FP) // Return final sum.
 	RET
+
+// func dotUnitarySSE2Asm(x, y []float64) (sum float64)
+// Wrapper for the existing dotUnitary implementation
+TEXT ·dotUnitarySSE2Asm(SB), NOSPLIT, $0
+	JMP ·dotUnitary(SB)
 
 // func DdotInc(x, y []float64, n, incX, incY, ix, iy uintptr) (sum float64)
 TEXT ·DotInc(SB), NOSPLIT, $0

--- a/internal/asm/f64/dot_avx2_test.go
+++ b/internal/asm/f64/dot_avx2_test.go
@@ -1,0 +1,106 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package f64
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"golang.org/x/sys/cpu"
+)
+
+func TestDotUnitaryAVX2(t *testing.T) {
+	if !cpu.X86.HasAVX2 || !cpu.X86.HasFMA {
+		t.Skip("AVX2/FMA not available")
+	}
+	
+	tests := []struct {
+		x, y []float64
+		want float64
+	}{
+		// Simple cases
+		{[]float64{1}, []float64{2}, 2},
+		{[]float64{1, 2}, []float64{3, 4}, 11},
+		{[]float64{1, 2, 3}, []float64{4, 5, 6}, 32},
+		{[]float64{1, 2, 3, 4}, []float64{5, 6, 7, 8}, 70},
+		
+		// Test different lengths to exercise all code paths
+		{[]float64{1, 2, 3, 4, 5}, []float64{1, 1, 1, 1, 1}, 15},
+		{[]float64{2, 2, 2, 2, 2, 2, 2, 2}, []float64{3, 3, 3, 3, 3, 3, 3, 3}, 48},
+		
+		// 16 elements to test main loop
+		{
+			[]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			[]float64{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+			136, // sum of 1 to 16
+		},
+		
+		// 17 elements to test tail handling
+		{
+			[]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17},
+			[]float64{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+			153, // sum of 1 to 17
+		},
+	}
+	
+	for i, test := range tests {
+		got := DotUnitaryAVX2(test.x, test.y)
+		if math.Abs(got-test.want) > 1e-14 {
+			t.Errorf("test %d: DotUnitaryAVX2(%v, %v) = %v, want %v", 
+				i, test.x, test.y, got, test.want)
+		}
+	}
+}
+
+// Benchmark comparing implementations
+func BenchmarkDotUnitary(b *testing.B) {
+	sizes := []int{10, 100, 1000, 10000, 100000}
+	
+	for _, size := range sizes {
+		x := make([]float64, size)
+		y := make([]float64, size)
+		
+		// Initialize with some data
+		for i := range x {
+			x[i] = float64(i)
+			y[i] = float64(i + 1)
+		}
+		
+		b.Run("Size"+fmt.Sprintf("%d", size), func(b *testing.B) {
+			b.Run("PureGo", func(b *testing.B) {
+				b.SetBytes(int64(size * 8 * 2))
+				var sum float64
+				for i := 0; i < b.N; i++ {
+					// Pure Go implementation
+					sum = 0
+					for j, v := range x {
+						sum += y[j] * v
+					}
+				}
+				_ = sum
+			})
+			
+			b.Run("SSE2", func(b *testing.B) {
+				b.SetBytes(int64(size * 8 * 2))
+				var sum float64
+				for i := 0; i < b.N; i++ {
+					sum = dotUnitarySSE2Asm(x, y)
+				}
+				_ = sum
+			})
+			
+			if cpu.X86.HasAVX2 && cpu.X86.HasFMA {
+				b.Run("AVX2", func(b *testing.B) {
+					b.SetBytes(int64(size * 8 * 2))
+					var sum float64
+					for i := 0; i < b.N; i++ {
+						sum = DotUnitaryAVX2(x, y)
+					}
+					_ = sum
+				})
+			}
+		})
+	}
+}

--- a/internal/asm/f64/dotunitary_avx2_amd64.s
+++ b/internal/asm/f64/dotunitary_avx2_amd64.s
@@ -1,0 +1,114 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// AVX2/FMA optimized version of DotUnitary
+// sum = x·y = Σ(x[i] * y[i])
+
+//go:build !noasm && !gccgo && !safe
+// +build !noasm,!gccgo,!safe
+
+#include "textflag.h"
+
+// func DotUnitaryAVX2(x, y []float64) (sum float64)
+TEXT ·DotUnitaryAVX2(SB), NOSPLIT, $0
+	MOVQ x+0(FP), SI      // SI = &x[0]
+	MOVQ x_len+8(FP), CX  // CX = len(x)
+	MOVQ y+24(FP), DI     // DI = &y[0]
+	
+	// Initialize accumulators
+	VXORPD Y0, Y0, Y0     // Y0 = sum[0:3] = 0
+	VXORPD Y1, Y1, Y1     // Y1 = sum[4:7] = 0
+	VXORPD Y2, Y2, Y2     // Y2 = sum[8:11] = 0
+	VXORPD Y3, Y3, Y3     // Y3 = sum[12:15] = 0
+	
+	// Check if length is 0
+	TESTQ CX, CX
+	JZ end
+	
+	// Process 16 elements at a time (4 YMM registers)
+	MOVQ CX, BX
+	SHRQ $4, BX           // BX = n / 16
+	JZ tail_start
+	
+loop16:
+	// Load and multiply-add using FMA
+	VMOVUPD (SI), Y4
+	VMOVUPD (DI), Y5
+	VFMADD231PD Y5, Y4, Y0     // Y0 += x[0:3] * y[0:3]
+	
+	VMOVUPD 32(SI), Y4
+	VMOVUPD 32(DI), Y5
+	VFMADD231PD Y5, Y4, Y1     // Y1 += x[4:7] * y[4:7]
+	
+	VMOVUPD 64(SI), Y4
+	VMOVUPD 64(DI), Y5
+	VFMADD231PD Y5, Y4, Y2     // Y2 += x[8:11] * y[8:11]
+	
+	VMOVUPD 96(SI), Y4
+	VMOVUPD 96(DI), Y5
+	VFMADD231PD Y5, Y4, Y3     // Y3 += x[12:15] * y[12:15]
+	
+	ADDQ $128, SI         // Advance x by 16 elements
+	ADDQ $128, DI         // Advance y by 16 elements
+	DECQ BX
+	JNZ loop16
+	
+tail_start:
+	// Add all accumulators
+	VADDPD Y1, Y0, Y0     // Y0 = Y0 + Y1
+	VADDPD Y3, Y2, Y2     // Y2 = Y2 + Y3
+	VADDPD Y2, Y0, Y0     // Y0 = Y0 + Y2
+	
+	// Handle remaining elements
+	MOVQ CX, BX
+	ANDQ $15, BX          // BX = n % 16
+	SHRQ $2, BX           // BX = (n % 16) / 4
+	JZ tail_2
+	
+loop4:
+	VMOVUPD (SI), Y4
+	VMOVUPD (DI), Y5
+	VFMADD231PD Y5, Y4, Y0
+	ADDQ $32, SI
+	ADDQ $32, DI
+	DECQ BX
+	JNZ loop4
+	
+tail_2:
+	// Process 2 elements at a time using SSE
+	MOVQ CX, BX
+	ANDQ $3, BX           // BX = n % 4
+	SHRQ $1, BX           // BX = (n % 4) / 2
+	JZ tail_1
+	
+	MOVUPD (SI), X4
+	MOVUPD (DI), X5
+	MULPD X5, X4
+	ADDPD X4, X0          // Use lower half of Y0
+	ADDQ $16, SI
+	ADDQ $16, DI
+	
+tail_1:
+	// Process last element if present
+	MOVQ CX, BX
+	ANDQ $1, BX
+	JZ reduce
+	
+	MOVSD (SI), X4
+	MOVSD (DI), X5
+	MULSD X5, X4
+	ADDSD X4, X0
+	
+reduce:
+	// Horizontal sum of Y0
+	VEXTRACTF128 $1, Y0, X1    // X1 = upper 128 bits of Y0
+	ADDPD X1, X0               // X0 = X0 + X1
+	MOVAPD X0, X1
+	UNPCKHPD X1, X1            // X1 = X0[1]
+	ADDSD X1, X0               // X0 = final sum
+	
+end:
+	MOVSD X0, sum+48(FP)       // Return sum
+	VZEROUPPER
+	RET

--- a/internal/asm/f64/ge_amd64.go
+++ b/internal/asm/f64/ge_amd64.go
@@ -19,7 +19,7 @@ func Ger(m, n uintptr, alpha float64, x []float64, incX uintptr, y []float64, in
 //	y = alpha * A * x + beta * y
 //
 // where A is an m×n dense matrix, x and y are vectors, and alpha and beta are scalars.
-func GemvN(m, n uintptr, alpha float64, a []float64, lda uintptr, x []float64, incX uintptr, beta float64, y []float64, incY uintptr)
+// func GemvN(m, n uintptr, alpha float64, a []float64, lda uintptr, x []float64, incX uintptr, beta float64, y []float64, incY uintptr) // Implemented in gemv_amd64.go
 
 // GemvT computes
 //

--- a/internal/asm/f64/gemm_amd64.go
+++ b/internal/asm/f64/gemm_amd64.go
@@ -1,0 +1,109 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !noasm && !gccgo && !safe
+// +build !noasm,!gccgo,!safe
+
+package f64
+
+import (
+	"golang.org/x/sys/cpu"
+	"unsafe"
+)
+
+// HasGemmKernel indicates whether optimized GEMM kernels are available
+var HasGemmKernel = cpu.X86.HasAVX2 && cpu.X86.HasFMA
+
+// GEMM kernel configuration
+const (
+	// Micro-kernel dimensions
+	MR = 4 // Number of rows in micro-kernel
+	NR = 4 // Number of columns in micro-kernel
+	
+	// Larger kernel dimensions
+	MR8 = 8 // 8x8 kernel rows
+	NR8 = 8 // 8x8 kernel columns
+)
+
+// Assembly functions
+func gemmKernel4x4AVX2(a *float64, b *float64, c *float64, k int, lda, ldb, ldc int)
+func gemmKernel8x8AVX2(a *float64, b *float64, c *float64, k int, lda, ldb, ldc int)
+
+// GemmKernel4x4 computes C[4x4] += A[4xK] * B[Kx4]
+// This is the core micro-kernel for GEMM operations
+func GemmKernel4x4(a *float64, b *float64, c *float64, k int, lda, ldb, ldc int) {
+	if cpu.X86.HasAVX2 && cpu.X86.HasFMA {
+		gemmKernel4x4AVX2(a, b, c, k, lda, ldb, ldc)
+	} else {
+		// Fallback to scalar implementation
+		gemmKernel4x4Scalar(a, b, c, k, lda, ldb, ldc)
+	}
+}
+
+// Scalar fallback implementation
+func gemmKernel4x4Scalar(a *float64, b *float64, c *float64, k int, lda, ldb, ldc int) {
+	// Create slices from pointers
+	aSlice := (*[1 << 30]float64)(unsafe.Pointer(a))[:4*k:4*k]
+	bSlice := (*[1 << 30]float64)(unsafe.Pointer(b))[:k*ldb:k*ldb]
+	cSlice := (*[1 << 30]float64)(unsafe.Pointer(c))[:4*ldc:4*ldc]
+	
+	// Compute C[4x4] += A[4xK] * B[Kx4]
+	for i := 0; i < 4; i++ {
+		for j := 0; j < 4; j++ {
+			sum := cSlice[i*ldc+j]
+			for kk := 0; kk < k; kk++ {
+				sum += aSlice[i*lda+kk] * bSlice[kk*ldb+j]
+			}
+			cSlice[i*ldc+j] = sum
+		}
+	}
+}
+
+// GemmMicroKernel is the main entry point for blocked GEMM
+// It processes an MRxNR block of C using the appropriate kernel
+func GemmMicroKernel(m, n, k int, alpha float64,
+	a []float64, lda int,
+	b []float64, ldb int,
+	c []float64, ldc int) {
+	
+	// For now, only handle 4x4 blocks
+	if m == MR && n == NR && alpha == 1.0 {
+		GemmKernel4x4(&a[0], &b[0], &c[0], k, lda, ldb, ldc)
+		return
+	}
+	
+	// Fallback to reference implementation for other cases
+	for i := 0; i < m; i++ {
+		for j := 0; j < n; j++ {
+			sum := 0.0
+			for kk := 0; kk < k; kk++ {
+				sum += a[i*lda+kk] * b[kk*ldb+j]
+			}
+			c[i*ldc+j] += alpha * sum
+		}
+	}
+}
+
+// GemmKernel8x8 computes C[8x8] += A[8xK] * B[Kx8]
+// This is the larger micro-kernel for GEMM operations
+func GemmKernel8x8(a *float64, b *float64, c *float64, k int, lda, ldb, ldc int) {
+	if cpu.X86.HasAVX2 && cpu.X86.HasFMA {
+		gemmKernel8x8AVX2(a, b, c, k, lda, ldb, ldc)
+	} else {
+		// Fallback to scalar implementation
+		aSlice := (*[1 << 30]float64)(unsafe.Pointer(a))[:8*k:8*k]
+		bSlice := (*[1 << 30]float64)(unsafe.Pointer(b))[:k*ldb:k*ldb]
+		cSlice := (*[1 << 30]float64)(unsafe.Pointer(c))[:8*ldc:8*ldc]
+		
+		for i := 0; i < 8; i++ {
+			for j := 0; j < 8; j++ {
+				sum := cSlice[i*ldc+j]
+				for kk := 0; kk < k; kk++ {
+					sum += aSlice[i*lda+kk] * bSlice[kk*ldb+j]
+				}
+				cSlice[i*ldc+j] = sum
+			}
+		}
+	}
+}

--- a/internal/asm/f64/gemm_kernel_4x4_amd64.s
+++ b/internal/asm/f64/gemm_kernel_4x4_amd64.s
@@ -1,0 +1,107 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// AVX2/FMA3 optimized 4x4 DGEMM micro-kernel
+// Computes C[4x4] += A[4xK] * B[Kx4]
+
+//go:build !noasm && !gccgo && !safe
+// +build !noasm,!gccgo,!safe
+
+#include "textflag.h"
+
+// Register assignments:
+// A matrix pointers: RSI (4 row pointers)
+// B matrix pointer: RDX  
+// C matrix pointer: RDI
+// K (inner dimension): RCX
+// lda, ldb, ldc: R8, R9, R10
+// C[0,0:3] = Y0
+// C[1,0:3] = Y1  
+// C[2,0:3] = Y2
+// C[3,0:3] = Y3
+// B[k,0:3] = Y4
+// A broadcasts = Y5-Y8
+
+// func gemmKernel4x4AVX2(a *float64, b *float64, c *float64, k int, lda, ldb, ldc int)
+TEXT ·gemmKernel4x4AVX2(SB), NOSPLIT, $0
+	MOVQ a+0(FP), SI       // SI = &a[0,0]
+	MOVQ b+8(FP), DX       // DX = &b[0,0]
+	MOVQ c+16(FP), DI      // DI = &c[0,0]
+	MOVQ k+24(FP), CX      // CX = k
+	MOVQ lda+32(FP), R8    // R8 = lda (in elements, not bytes)
+	MOVQ ldb+40(FP), R9    // R9 = ldb
+	MOVQ ldc+48(FP), R10   // R10 = ldc
+	
+	// Convert strides to bytes
+	SHLQ $3, R8            // lda *= 8
+	SHLQ $3, R9            // ldb *= 8
+	SHLQ $3, R10           // ldc *= 8
+	
+	// Load C[0:4, 0:4] into registers
+	VMOVUPD (DI), Y0          // C[0,0:3]
+	ADDQ R10, DI              // DI = &C[1,0]
+	VMOVUPD (DI), Y1          // C[1,0:3]
+	ADDQ R10, DI              // DI = &C[2,0]
+	VMOVUPD (DI), Y2          // C[2,0:3]
+	ADDQ R10, DI              // DI = &C[3,0]
+	VMOVUPD (DI), Y3          // C[3,0:3]
+	SUBQ R10, DI              // Reset DI
+	SUBQ R10, DI
+	SUBQ R10, DI              // DI = &C[0,0]
+	
+	// Check if k == 0
+	TESTQ CX, CX
+	JZ done
+	
+	// Calculate row pointers for A
+	MOVQ SI, R11           // R11 = &A[0,0]
+	MOVQ SI, R12           // R12 = &A[1,0]
+	ADDQ R8, R12
+	MOVQ SI, R13           // R13 = &A[2,0]
+	ADDQ R8, R13
+	ADDQ R8, R13
+	MOVQ SI, R14           // R14 = &A[3,0]
+	ADDQ R8, R14
+	ADDQ R8, R14
+	ADDQ R8, R14
+
+loop:
+	// Load B[k,0:3]
+	VMOVUPD (DX), Y4
+	
+	// Broadcast A[0:4,k] and multiply-add
+	VBROADCASTSD (R11), Y5     // Y5 = A[0,k]
+	VFMADD231PD Y5, Y4, Y0     // C[0,0:3] += A[0,k] * B[k,0:3]
+	
+	VBROADCASTSD (R12), Y6     // Y6 = A[1,k]
+	VFMADD231PD Y6, Y4, Y1     // C[1,0:3] += A[1,k] * B[k,0:3]
+	
+	VBROADCASTSD (R13), Y7     // Y7 = A[2,k]
+	VFMADD231PD Y7, Y4, Y2     // C[2,0:3] += A[2,k] * B[k,0:3]
+	
+	VBROADCASTSD (R14), Y8     // Y8 = A[3,k]
+	VFMADD231PD Y8, Y4, Y3     // C[3,0:3] += A[3,k] * B[k,0:3]
+	
+	// Advance pointers
+	ADDQ $8, R11           // A[0,k] += 1
+	ADDQ $8, R12           // A[1,k] += 1
+	ADDQ $8, R13           // A[2,k] += 1
+	ADDQ $8, R14           // A[3,k] += 1
+	ADDQ R9, DX            // B += ldb (next row)
+	
+	DECQ CX                // k--
+	JNZ loop
+
+done:
+	// Store C back to memory
+	VMOVUPD Y0, (DI)          // C[0,0:3]
+	ADDQ R10, DI
+	VMOVUPD Y1, (DI)          // C[1,0:3]
+	ADDQ R10, DI
+	VMOVUPD Y2, (DI)          // C[2,0:3]
+	ADDQ R10, DI
+	VMOVUPD Y3, (DI)          // C[3,0:3]
+	
+	VZEROUPPER
+	RET

--- a/internal/asm/f64/gemm_kernel_8x8_amd64.s
+++ b/internal/asm/f64/gemm_kernel_8x8_amd64.s
@@ -1,0 +1,171 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// AVX2/FMA3 optimized 8x8 DGEMM micro-kernel
+// Computes C[8x8] += A[8xK] * B[Kx8]
+
+//go:build !noasm && !gccgo && !safe
+// +build !noasm,!gccgo,!safe
+
+#include "textflag.h"
+
+// Register usage:
+// A matrix pointers: RSI + row offsets
+// B matrix: Two YMM registers for current 8 values
+// C matrix: 16 YMM registers (Y0-Y15) for 8x8 block
+// Each YMM holds 4 doubles, so we need 2 YMM per row
+
+// func gemmKernel8x8AVX2(a *float64, b *float64, c *float64, k int, lda, ldb, ldc int)
+TEXT ·gemmKernel8x8AVX2(SB), NOSPLIT, $0
+	MOVQ a+0(FP), SI       // SI = &a[0,0]
+	MOVQ b+8(FP), DX       // DX = &b[0,0]
+	MOVQ c+16(FP), DI      // DI = &c[0,0]
+	MOVQ k+24(FP), CX      // CX = k
+	MOVQ lda+32(FP), R8    // R8 = lda (in elements)
+	MOVQ ldb+40(FP), R9    // R9 = ldb
+	MOVQ ldc+48(FP), R10   // R10 = ldc
+	
+	// Convert strides to bytes
+	SHLQ $3, R8            // lda *= 8
+	SHLQ $3, R9            // ldb *= 8
+	SHLQ $3, R10           // ldc *= 8
+	
+	// Load C[0:8, 0:8] into Y0-Y15
+	VMOVUPD (DI), Y0           // C[0,0:3]
+	VMOVUPD 32(DI), Y1         // C[0,4:7]
+	ADDQ R10, DI
+	VMOVUPD (DI), Y2           // C[1,0:3]
+	VMOVUPD 32(DI), Y3         // C[1,4:7]
+	ADDQ R10, DI
+	VMOVUPD (DI), Y4           // C[2,0:3]
+	VMOVUPD 32(DI), Y5         // C[2,4:7]
+	ADDQ R10, DI
+	VMOVUPD (DI), Y6           // C[3,0:3]
+	VMOVUPD 32(DI), Y7         // C[3,4:7]
+	ADDQ R10, DI
+	VMOVUPD (DI), Y8           // C[4,0:3]
+	VMOVUPD 32(DI), Y9         // C[4,4:7]
+	ADDQ R10, DI
+	VMOVUPD (DI), Y10          // C[5,0:3]
+	VMOVUPD 32(DI), Y11        // C[5,4:7]
+	ADDQ R10, DI
+	VMOVUPD (DI), Y12          // C[6,0:3]
+	VMOVUPD 32(DI), Y13        // C[6,4:7]
+	ADDQ R10, DI
+	VMOVUPD (DI), Y14          // C[7,0:3]
+	VMOVUPD 32(DI), Y15        // C[7,4:7]
+	
+	// Reset DI to start of C
+	SUBQ R10, DI
+	SUBQ R10, DI
+	SUBQ R10, DI
+	SUBQ R10, DI
+	SUBQ R10, DI
+	SUBQ R10, DI
+	SUBQ R10, DI
+	
+	// Check if k == 0
+	TESTQ CX, CX
+	JZ done
+	
+	// Calculate row pointers for A
+	MOVQ SI, R11              // R11 = &A[0,0]
+	LEAQ (SI)(R8*1), R12      // R12 = &A[1,0]
+	LEAQ (SI)(R8*2), R13      // R13 = &A[2,0]
+	LEAQ (R12)(R8*2), R14     // R14 = &A[3,0]
+	LEAQ (SI)(R8*4), R15      // R15 = &A[4,0]
+	
+	// We'll compute remaining rows using offsets from R15
+	// A[5] = R15 + R8
+	// A[6] = R15 + 2*R8
+	// A[7] = R15 + 3*R8
+
+loop:
+	// Load B[k,0:7]
+	VMOVUPD (DX), Y28          // B[k,0:3]
+	VMOVUPD 32(DX), Y29        // B[k,4:7]
+	
+	// Row 0
+	VBROADCASTSD (R11), Y30
+	VFMADD231PD Y30, Y28, Y0
+	VFMADD231PD Y30, Y29, Y1
+	
+	// Row 1
+	VBROADCASTSD (R12), Y30
+	VFMADD231PD Y30, Y28, Y2
+	VFMADD231PD Y30, Y29, Y3
+	
+	// Row 2
+	VBROADCASTSD (R13), Y30
+	VFMADD231PD Y30, Y28, Y4
+	VFMADD231PD Y30, Y29, Y5
+	
+	// Row 3
+	VBROADCASTSD (R14), Y30
+	VFMADD231PD Y30, Y28, Y6
+	VFMADD231PD Y30, Y29, Y7
+	
+	// Row 4
+	VBROADCASTSD (R15), Y30
+	VFMADD231PD Y30, Y28, Y8
+	VFMADD231PD Y30, Y29, Y9
+	
+	// Row 5
+	VBROADCASTSD (R15)(R8*1), Y30
+	VFMADD231PD Y30, Y28, Y10
+	VFMADD231PD Y30, Y29, Y11
+	
+	// Row 6
+	VBROADCASTSD (R15)(R8*2), Y30
+	VFMADD231PD Y30, Y28, Y12
+	VFMADD231PD Y30, Y29, Y13
+	
+	// Row 7
+	MOVQ R15, AX
+	ADDQ R8, AX
+	ADDQ R8, AX
+	ADDQ R8, AX
+	VBROADCASTSD (AX), Y30
+	VFMADD231PD Y30, Y28, Y14
+	VFMADD231PD Y30, Y29, Y15
+	
+	// Advance pointers
+	ADDQ $8, R11
+	ADDQ $8, R12
+	ADDQ $8, R13
+	ADDQ $8, R14
+	ADDQ $8, R15
+	ADDQ R9, DX               // B += ldb
+	
+	DECQ CX
+	JNZ loop
+
+done:
+	// Store C back to memory
+	VMOVUPD Y0, (DI)
+	VMOVUPD Y1, 32(DI)
+	ADDQ R10, DI
+	VMOVUPD Y2, (DI)
+	VMOVUPD Y3, 32(DI)
+	ADDQ R10, DI
+	VMOVUPD Y4, (DI)
+	VMOVUPD Y5, 32(DI)
+	ADDQ R10, DI
+	VMOVUPD Y6, (DI)
+	VMOVUPD Y7, 32(DI)
+	ADDQ R10, DI
+	VMOVUPD Y8, (DI)
+	VMOVUPD Y9, 32(DI)
+	ADDQ R10, DI
+	VMOVUPD Y10, (DI)
+	VMOVUPD Y11, 32(DI)
+	ADDQ R10, DI
+	VMOVUPD Y12, (DI)
+	VMOVUPD Y13, 32(DI)
+	ADDQ R10, DI
+	VMOVUPD Y14, (DI)
+	VMOVUPD Y15, 32(DI)
+	
+	VZEROUPPER
+	RET

--- a/internal/asm/f64/gemm_noasm.go
+++ b/internal/asm/f64/gemm_noasm.go
@@ -1,0 +1,47 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build noasm || gccgo || safe || !amd64
+// +build noasm gccgo safe !amd64
+
+package f64
+
+import "unsafe"
+
+// HasGemmKernel indicates whether optimized GEMM kernels are available
+var HasGemmKernel = false
+
+// GemmKernel4x4 computes C[4x4] += A[4xK] * B[Kx4]
+// This is the fallback implementation for platforms without assembly support
+func GemmKernel4x4(a *float64, b *float64, c *float64, k int, lda, ldb, ldc int) {
+	// Create slices from pointers
+	aSlice := (*[1 << 30]float64)(unsafe.Pointer(a))[:4*k:4*k]
+	bSlice := (*[1 << 30]float64)(unsafe.Pointer(b))[:k*ldb:k*ldb]
+	cSlice := (*[1 << 30]float64)(unsafe.Pointer(c))[:4*ldc:4*ldc]
+	
+	// Compute C[4x4] += A[4xK] * B[Kx4]
+	for i := 0; i < 4; i++ {
+		for j := 0; j < 4; j++ {
+			sum := cSlice[i*ldc+j]
+			for kk := 0; kk < k; kk++ {
+				sum += aSlice[i*lda+kk] * bSlice[kk*ldb+j]
+			}
+			cSlice[i*ldc+j] = sum
+		}
+	}
+}
+
+// GemmKernel8x8 computes C[8x8] += A[8xK] * B[Kx8]
+// Fallback implementation
+func GemmKernel8x8(a *float64, b *float64, c *float64, k int, lda, ldb, ldc int) {
+	// Use 4x4 kernels as fallback
+	GemmKernel4x4(a, b, c, k, lda, ldb, ldc)
+	GemmKernel4x4(a, (*float64)(unsafe.Pointer(uintptr(unsafe.Pointer(b))+4*8)), 
+		(*float64)(unsafe.Pointer(uintptr(unsafe.Pointer(c))+4*8)), k, lda, ldb, ldc)
+	GemmKernel4x4((*float64)(unsafe.Pointer(uintptr(unsafe.Pointer(a))+4*lda*8)), b, 
+		(*float64)(unsafe.Pointer(uintptr(unsafe.Pointer(c))+4*ldc*8)), k, lda, ldb, ldc)
+	GemmKernel4x4((*float64)(unsafe.Pointer(uintptr(unsafe.Pointer(a))+4*lda*8)), 
+		(*float64)(unsafe.Pointer(uintptr(unsafe.Pointer(b))+4*8)), 
+		(*float64)(unsafe.Pointer(uintptr(unsafe.Pointer(c))+4*ldc*8+4*8)), k, lda, ldb, ldc)
+}

--- a/internal/asm/f64/gemm_test.go
+++ b/internal/asm/f64/gemm_test.go
@@ -1,0 +1,200 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package f64
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+// TestGemmKernel4x4 tests the 4x4 GEMM micro-kernel
+func TestGemmKernel4x4(t *testing.T) {
+	// Test case: 4x3 * 3x4 = 4x4
+	k := 3
+	
+	// A matrix (4x3)
+	a := []float64{
+		1, 2, 3,
+		4, 5, 6,
+		7, 8, 9,
+		10, 11, 12,
+	}
+	
+	// B matrix (3x4)
+	b := []float64{
+		1, 0, 0, 1,
+		0, 1, 0, 1,
+		0, 0, 1, 1,
+	}
+	
+	// C matrix (4x4) - initialized to zero
+	c := make([]float64, 16)
+	
+	// Expected result
+	expected := []float64{
+		1, 2, 3, 6,    // [1 2 3] * [[1 0 0 1] [0 1 0 1] [0 0 1 1]]
+		4, 5, 6, 15,   // [4 5 6] * B
+		7, 8, 9, 24,   // [7 8 9] * B
+		10, 11, 12, 33, // [10 11 12] * B
+	}
+	
+	// Call the kernel
+	GemmKernel4x4(&a[0], &b[0], &c[0], k, 3, 4, 4)
+	
+	// Check results
+	for i := 0; i < 16; i++ {
+		if math.Abs(c[i]-expected[i]) > 1e-14 {
+			t.Errorf("GemmKernel4x4: c[%d] = %f, want %f", i, c[i], expected[i])
+		}
+	}
+}
+
+// TestGemmKernel4x4Accumulate tests that the kernel accumulates into C
+func TestGemmKernel4x4Accumulate(t *testing.T) {
+	k := 2
+	
+	a := []float64{
+		1, 2,
+		3, 4,
+		5, 6,
+		7, 8,
+	}
+	
+	b := []float64{
+		1, 0, 0, 0,
+		0, 1, 0, 0,
+	}
+	
+	// C matrix with initial values
+	c := []float64{
+		10, 10, 10, 10,
+		20, 20, 20, 20,
+		30, 30, 30, 30,
+		40, 40, 40, 40,
+	}
+	
+	// Expected: C += A*B
+	expected := []float64{
+		11, 12, 10, 10,  // [10 10 10 10] + [1 2 0 0]
+		23, 24, 20, 20,  // [20 20 20 20] + [3 4 0 0]
+		35, 36, 30, 30,  // [30 30 30 30] + [5 6 0 0]
+		47, 48, 40, 40,  // [40 40 40 40] + [7 8 0 0]
+	}
+	
+	GemmKernel4x4(&a[0], &b[0], &c[0], k, 2, 4, 4)
+	
+	for i := 0; i < 16; i++ {
+		if math.Abs(c[i]-expected[i]) > 1e-14 {
+			t.Errorf("GemmKernel4x4 accumulate: c[%d] = %f, want %f", i, c[i], expected[i])
+		}
+	}
+}
+
+// TestGemmKernel8x8 tests the 8x8 GEMM micro-kernel
+func TestGemmKernel8x8(t *testing.T) {
+	// Test case: 8x4 * 4x8 = 8x8
+	k := 4
+	
+	// A matrix (8x4)
+	a := []float64{
+		1, 2, 3, 4,
+		5, 6, 7, 8,
+		9, 10, 11, 12,
+		13, 14, 15, 16,
+		17, 18, 19, 20,
+		21, 22, 23, 24,
+		25, 26, 27, 28,
+		29, 30, 31, 32,
+	}
+	
+	// B matrix (4x8) - identity-like for easy verification
+	b := []float64{
+		1, 0, 0, 0, 1, 0, 0, 0,
+		0, 1, 0, 0, 0, 1, 0, 0,
+		0, 0, 1, 0, 0, 0, 1, 0,
+		0, 0, 0, 1, 0, 0, 0, 1,
+	}
+	
+	// C matrix (8x8) - initialized to zero
+	c := make([]float64, 64)
+	
+	// Call the kernel
+	GemmKernel8x8(&a[0], &b[0], &c[0], k, 4, 8, 8)
+	
+	// Expected: each row of A appears twice in C
+	// Row 0: [1,2,3,4, 1,2,3,4]
+	// Row 1: [5,6,7,8, 5,6,7,8]
+	// etc.
+	for i := 0; i < 8; i++ {
+		for j := 0; j < 4; j++ {
+			expected := a[i*4+j]
+			if math.Abs(c[i*8+j]-expected) > 1e-14 {
+				t.Errorf("GemmKernel8x8: c[%d,%d] = %f, want %f", i, j, c[i*8+j], expected)
+			}
+			if math.Abs(c[i*8+j+4]-expected) > 1e-14 {
+				t.Errorf("GemmKernel8x8: c[%d,%d] = %f, want %f", i, j+4, c[i*8+j+4], expected)
+			}
+		}
+	}
+}
+
+// BenchmarkGemmKernel4x4 benchmarks the 4x4 kernel
+func BenchmarkGemmKernel4x4(b *testing.B) {
+	sizes := []int{4, 8, 16, 32, 64, 128}
+	
+	for _, k := range sizes {
+		b.Run("K"+fmt.Sprintf("%d", k), func(b *testing.B) {
+			// Create matrices
+			a := make([]float64, 4*k)
+			bm := make([]float64, k*4)
+			c := make([]float64, 16)
+			
+			// Initialize with some data
+			for i := range a {
+				a[i] = float64(i)
+			}
+			for i := range bm {
+				bm[i] = float64(i)
+			}
+			
+			b.ResetTimer()
+			b.SetBytes(int64(4*k + k*4 + 16) * 8) // Total memory touched
+			
+			for i := 0; i < b.N; i++ {
+				GemmKernel4x4(&a[0], &bm[0], &c[0], k, k, 4, 4)
+			}
+		})
+	}
+}
+
+// BenchmarkGemmKernel8x8 benchmarks the 8x8 kernel
+func BenchmarkGemmKernel8x8(b *testing.B) {
+	sizes := []int{8, 16, 32, 64, 128, 256}
+	
+	for _, k := range sizes {
+		b.Run("K"+fmt.Sprintf("%d", k), func(b *testing.B) {
+			// Create matrices
+			a := make([]float64, 8*k)
+			bm := make([]float64, k*8)
+			c := make([]float64, 64)
+			
+			// Initialize with some data
+			for i := range a {
+				a[i] = float64(i)
+			}
+			for i := range bm {
+				bm[i] = float64(i)
+			}
+			
+			b.ResetTimer()
+			b.SetBytes(int64(8*k + k*8 + 64) * 8) // Total memory touched
+			
+			for i := 0; i < b.N; i++ {
+				GemmKernel8x8(&a[0], &bm[0], &c[0], k, k, 8, 8)
+			}
+		})
+	}
+}

--- a/internal/asm/f64/gemvN_amd64.s
+++ b/internal/asm/f64/gemvN_amd64.s
@@ -230,7 +230,7 @@
 //	x []float64, incX int,
 //	beta float64,
 //	y []float64, incY int)
-TEXT ·GemvN(SB), NOSPLIT, $32-128
+TEXT ·gemvN(SB), NOSPLIT, $32-128
 	MOVQ M_DIM, M
 	MOVQ N_DIM, N
 	CMPQ M, $0
@@ -683,3 +683,8 @@ inc_r1end:
 
 inc_end:
 	RET
+
+// func gemvNSSE2(m, n uintptr, alpha float64, a []float64, lda uintptr, x []float64, incX uintptr, beta float64, y []float64, incY uintptr)
+// Wrapper for the existing gemvN implementation
+TEXT ·gemvNSSE2(SB), NOSPLIT, $0
+	JMP ·gemvN(SB)

--- a/internal/asm/f64/gemvN_avx2_amd64.s
+++ b/internal/asm/f64/gemvN_avx2_amd64.s
@@ -1,0 +1,176 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// AVX2/FMA optimized version of GemvN
+// y = alpha * A * x + beta * y
+
+//go:build !noasm && !gccgo && !safe
+// +build !noasm,!gccgo,!safe
+
+#include "textflag.h"
+
+// func GemvNAVX2(m, n uintptr, alpha float64, a []float64, lda uintptr, x []float64, incX uintptr, beta float64, y []float64, incY uintptr)
+TEXT ·GemvNAVX2(SB), NOSPLIT, $0
+	MOVQ    m+0(FP), CX           // m
+	MOVQ    n+8(FP), BX           // n
+	MOVSD   alpha+16(FP), X15     // alpha
+	MOVQ    a_base+24(FP), DI     // a
+	MOVQ    lda+48(FP), R12       // lda
+	MOVQ    x_base+56(FP), SI     // x
+	MOVQ    incX+80(FP), R8       // incX
+	MOVSD   beta+88(FP), X14      // beta
+	MOVQ    y_base+96(FP), DX     // y
+	MOVQ    incY+120(FP), R10     // incY
+	
+	TESTQ   CX, CX
+	JZ      end
+	TESTQ   BX, BX
+	JZ      end
+	
+	// Adjust Y pointer for negative increment
+	XORQ    R11, R11              // R11 = 0
+	MOVQ    CX, R13               // R13 = m
+	SUBQ    $1, R13               // R13 = m - 1
+	IMULQ   R10, R13              // R13 = (m-1) * incY
+	NEGQ    R13                   // R13 = -(m-1) * incY
+	CMPQ    R10, $0               // if incY < 0
+	CMOVQLT R13, R11              // R11 = R13
+	LEAQ    (DX)(R11*8), DX       // y += R11
+	
+	// Adjust X pointer for negative increment
+	XORQ    R11, R11              // R11 = 0
+	MOVQ    BX, R13               // R13 = n
+	SUBQ    $1, R13               // R13 = n - 1
+	IMULQ   R8, R13               // R13 = (n-1) * incX
+	NEGQ    R13                   // R13 = -(n-1) * incX
+	CMPQ    R8, $0                // if incX < 0
+	CMOVQLT R13, R11              // R11 = R13
+	LEAQ    (SI)(R11*8), SI       // x += R11
+	
+	// Convert increments to bytes
+	MOVQ    R8, R13
+	SHLQ    $3, R8                // incX *= 8
+	MOVQ    R10, R14
+	SHLQ    $3, R10               // incY *= 8
+	SHLQ    $3, R12               // lda *= 8
+	
+	// Handle beta scaling
+	VXORPD  Y13, Y13, Y13         // Y13 = 0
+	VUCOMISD X13, X14             // Compare beta with 0
+	JE      clear_y               // If beta == 0, clear y
+	
+	// Scale y by beta if beta != 0
+	MOVQ    DX, R9
+	MOVQ    CX, R15
+scale_y_loop:
+	VMOVSD  (R9), X0
+	VMULSD  X14, X0, X0
+	VMOVSD  X0, (R9)
+	ADDQ    R10, R9
+	DECQ    R15
+	JNZ     scale_y_loop
+	JMP     check_alpha
+	
+clear_y:
+	// Clear y when beta == 0
+	MOVQ    DX, R9
+	MOVQ    CX, R15
+	VXORPD  X0, X0, X0
+clear_y_loop:
+	VMOVSD  X0, (R9)
+	ADDQ    R10, R9
+	DECQ    R15
+	JNZ     clear_y_loop
+	
+check_alpha:
+	// For each row of A
+	// Note: We always compute even if alpha=0 to propagate NaN
+row_loop:
+	MOVQ    DI, AX                // Current row pointer
+	MOVQ    SI, R11               // Reset x pointer
+	MOVQ    BX, R9                // n counter
+	
+	VXORPD  Y0, Y0, Y0            // Clear accumulator
+	
+	// Check if we can use unit stride for x
+	CMPQ    R13, $1               // Compare original incX with 1
+	JNE     non_unit_stride
+	
+	// Unit stride - process 4 elements at a time
+	MOVQ    R9, R14
+	SHRQ    $2, R14               // R14 = n / 4
+	JZ      unit_remainder
+	
+unit_loop_4:
+	VMOVUPD (AX), Y1              // Load 4 elements from A
+	VMOVUPD (R11), Y2             // Load 4 elements from x
+	VFMADD231PD Y2, Y1, Y0        // Y0 += Y1 * Y2
+	
+	ADDQ    $32, AX
+	ADDQ    $32, R11
+	DECQ    R14
+	JNZ     unit_loop_4
+	
+unit_remainder:
+	// First reduce Y0 to a scalar
+	VEXTRACTF128 $1, Y0, X1       // X1 = upper 128 bits of Y0
+	VADDPD  X1, X0, X0            // X0 = X0 + X1
+	VHADDPD X0, X0, X0            // X0 = horizontal sum
+	
+	// Now process remainder elements
+	MOVQ    R9, R14
+	ANDQ    $3, R14               // R14 = n % 4
+	JZ      final_scale
+	
+unit_loop_1:
+	VMOVSD  (AX), X1
+	VMOVSD  (R11), X2
+	VMULSD  X2, X1, X1            // X1 = X1 * X2
+	VADDSD  X1, X0, X0            // X0 += X1
+	
+	ADDQ    $8, AX
+	ADDQ    $8, R11
+	DECQ    R14
+	JNZ     unit_loop_1
+	JMP     final_scale
+	
+non_unit_stride:
+	// Non-unit stride - process one element at a time
+non_unit_loop:
+	VMOVSD  (AX), X1
+	VMOVSD  (R11), X2
+	VMULSD  X2, X1, X1
+	VADDSD  X1, X0, X0
+	
+	ADDQ    $8, AX
+	ADDQ    R8, R11               // Add incX (in bytes)
+	DECQ    R9
+	JNZ     non_unit_loop
+	
+reduce:
+	// Horizontal sum of Y0
+	VEXTRACTF128 $1, Y0, X1       // X1 = upper 128 bits of Y0
+	VADDPD  X1, X0, X0            // X0 = X0 + X1
+	VHADDPD X0, X0, X0            // Horizontal add to get final sum in X0[0]
+	
+final_scale:
+	// Scale by alpha
+	VMULSD  X15, X0, X0
+	
+	// Load y[i] and add (beta scaling already done)
+	VADDSD  (DX), X0, X0
+	
+	// Store result
+	VMOVSD  X0, (DX)
+	
+	// Advance to next row
+	ADDQ    R12, DI               // a += lda
+	ADDQ    R10, DX               // y += incY
+	
+	DECQ    CX
+	JNZ     row_loop
+	
+end:
+	VZEROUPPER
+	RET

--- a/internal/asm/f64/gemv_amd64.go
+++ b/internal/asm/f64/gemv_amd64.go
@@ -1,0 +1,45 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !noasm && !gccgo && !safe
+// +build !noasm,!gccgo,!safe
+
+package f64
+
+import "golang.org/x/sys/cpu"
+
+// Function pointers for runtime CPU feature detection
+var (
+	gemvNImpl  func(m, n uintptr, alpha float64, a []float64, lda uintptr, x []float64, incX uintptr, beta float64, y []float64, incY uintptr)
+	hasGemvAVX2 bool
+)
+
+// Assembly functions
+func gemvNSSE2(m, n uintptr, alpha float64, a []float64, lda uintptr, x []float64, incX uintptr, beta float64, y []float64, incY uintptr)
+func GemvNAVX2(m, n uintptr, alpha float64, a []float64, lda uintptr, x []float64, incX uintptr, beta float64, y []float64, incY uintptr)
+
+func init() {
+	if cpu.X86.HasAVX2 && cpu.X86.HasFMA {
+		gemvNImpl = GemvNAVX2
+		hasGemvAVX2 = true
+	} else {
+		gemvNImpl = gemvNSSE2
+		hasGemvAVX2 = false
+	}
+}
+
+// GemvN computes
+//
+//	y = alpha * A * x + beta * y
+//
+// where A is an m×n dense matrix, x and y are vectors, and alpha and beta are scalars.
+func GemvN(m, n uintptr, alpha float64, a []float64, lda uintptr, x []float64, incX uintptr, beta float64, y []float64, incY uintptr) {
+	gemvNImpl(m, n, alpha, a, lda, x, incX, beta, y, incY)
+}
+
+// Forward declaration for existing assembly implementation
+func gemvN(m, n uintptr, alpha float64, a []float64, lda uintptr, x []float64, incX uintptr, beta float64, y []float64, incY uintptr)
+
+// Export hasGemvAVX2 for testing
+var HasGemvAVX2 = &hasGemvAVX2

--- a/internal/asm/f64/gemv_avx2_test.go
+++ b/internal/asm/f64/gemv_avx2_test.go
@@ -1,0 +1,169 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package f64
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"golang.org/x/sys/cpu"
+)
+
+func TestGemvNAVX2(t *testing.T) {
+	if !cpu.X86.HasAVX2 || !cpu.X86.HasFMA {
+		t.Skip("AVX2/FMA not available")
+	}
+	
+	tests := []struct {
+		m, n   int
+		alpha  float64
+		a      []float64
+		lda    int
+		x      []float64
+		incX   int
+		beta   float64
+		y      []float64
+		incY   int
+		want   []float64
+	}{
+		// Simple 2x2 case
+		{
+			m: 2, n: 2, alpha: 1, beta: 0,
+			a:    []float64{1, 2, 3, 4},
+			lda:  2,
+			x:    []float64{1, 1},
+			incX: 1,
+			y:    []float64{0, 0},
+			incY: 1,
+			want: []float64{3, 7}, // [1 2] * [1] = [3], [3 4] * [1] = [7]
+		},
+		// 3x3 case with alpha and beta
+		{
+			m: 3, n: 3, alpha: 2, beta: 1,
+			a:    []float64{1, 2, 3, 4, 5, 6, 7, 8, 9},
+			lda:  3,
+			x:    []float64{1, 0, 1},
+			incX: 1,
+			y:    []float64{1, 1, 1},
+			incY: 1,
+			want: []float64{9, 21, 33}, // 2*([1 2 3]*[1 0 1]') + 1*[1] = 2*4 + 1 = 9
+		},
+		// 4x4 case to test main loop
+		{
+			m: 4, n: 4, alpha: 1, beta: 0,
+			a: []float64{
+				1, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				0, 0, 0, 1,
+			},
+			lda:  4,
+			x:    []float64{1, 2, 3, 4},
+			incX: 1,
+			y:    []float64{0, 0, 0, 0},
+			incY: 1,
+			want: []float64{1, 2, 3, 4}, // Identity matrix
+		},
+		// 5x3 case to test remainder handling
+		{
+			m: 5, n: 3, alpha: 1, beta: 0,
+			a: []float64{
+				1, 1, 1,
+				2, 2, 2,
+				3, 3, 3,
+				4, 4, 4,
+				5, 5, 5,
+			},
+			lda:  3,
+			x:    []float64{1, 1, 1},
+			incX: 1,
+			y:    []float64{0, 0, 0, 0, 0},
+			incY: 1,
+			want: []float64{3, 6, 9, 12, 15},
+		},
+	}
+	
+	for i, test := range tests {
+		y := make([]float64, len(test.y))
+		copy(y, test.y)
+		
+		GemvNAVX2(uintptr(test.m), uintptr(test.n), test.alpha, test.a, uintptr(test.lda),
+			test.x, uintptr(test.incX), test.beta, y, uintptr(test.incY))
+		
+		for j, v := range y {
+			if math.Abs(v-test.want[j]) > 1e-14 {
+				t.Errorf("test %d: GemvNAVX2 y[%d] = %v, want %v", i, j, v, test.want[j])
+			}
+		}
+	}
+}
+
+// Benchmark comparing implementations
+func BenchmarkGemvN(b *testing.B) {
+	sizes := []struct{ m, n int }{
+		{10, 10},
+		{100, 100},
+		{1000, 100},
+		{100, 1000},
+		{1000, 1000},
+	}
+	
+	for _, size := range sizes {
+		a := make([]float64, size.m*size.n)
+		x := make([]float64, size.n)
+		y := make([]float64, size.m)
+		
+		// Initialize with some data
+		for i := range a {
+			a[i] = float64(i % 10)
+		}
+		for i := range x {
+			x[i] = float64(i)
+		}
+		
+		name := fmt.Sprintf("M%dN%d", size.m, size.n)
+		b.Run(name, func(b *testing.B) {
+			b.Run("PureGo", func(b *testing.B) {
+				b.SetBytes(int64((size.m*size.n + size.m + size.n) * 8))
+				ycopy := make([]float64, len(y))
+				for i := 0; i < b.N; i++ {
+					copy(ycopy, y)
+					// Pure Go implementation
+					for i := 0; i < size.m; i++ {
+						sum := 0.0
+						for j := 0; j < size.n; j++ {
+							sum += a[i*size.n+j] * x[j]
+						}
+						ycopy[i] = 2.0*sum + 1.0*ycopy[i]
+					}
+				}
+			})
+			
+			b.Run("SSE2", func(b *testing.B) {
+				b.SetBytes(int64((size.m*size.n + size.m + size.n) * 8))
+				ycopy := make([]float64, len(y))
+				for i := 0; i < b.N; i++ {
+					copy(ycopy, y)
+					gemvNSSE2(uintptr(size.m), uintptr(size.n), 2.0, a, uintptr(size.n),
+						x, 1, 1.0, ycopy, 1)
+				}
+			})
+			
+			// Always benchmark AVX2 directly
+			b.Run("AVX2", func(b *testing.B) {
+				if !cpu.X86.HasAVX2 || !cpu.X86.HasFMA {
+					b.Skip("AVX2/FMA not available")
+				}
+				b.SetBytes(int64((size.m*size.n + size.m + size.n) * 8))
+				ycopy := make([]float64, len(y))
+				for i := 0; i < b.N; i++ {
+					copy(ycopy, y)
+					GemvNAVX2(uintptr(size.m), uintptr(size.n), 2.0, a, uintptr(size.n),
+						x, 1, 1.0, ycopy, 1)
+				}
+			})
+		})
+	}
+}

--- a/internal/asm/f64/scal_amd64.go
+++ b/internal/asm/f64/scal_amd64.go
@@ -1,0 +1,45 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !noasm && !gccgo && !safe
+// +build !noasm,!gccgo,!safe
+
+package f64
+
+import "golang.org/x/sys/cpu"
+
+// Function pointers for runtime CPU feature detection
+var (
+	scalUnitaryImpl func(alpha float64, x []float64)
+	hasScalAVX2     bool
+)
+
+// Assembly functions - rename to avoid conflicts
+func scalUnitarySSE2(alpha float64, x []float64)
+func ScalUnitaryAVX2(alpha float64, x []float64)
+
+func init() {
+	if cpu.X86.HasAVX2 {
+		scalUnitaryImpl = ScalUnitaryAVX2
+		hasScalAVX2 = true
+	} else {
+		scalUnitaryImpl = scalUnitarySSE2
+		hasScalAVX2 = false
+	}
+}
+
+// ScalUnitary is
+//
+//	for i := range x {
+//		x[i] *= alpha
+//	}
+func ScalUnitary(alpha float64, x []float64) {
+	scalUnitaryImpl(alpha, x)
+}
+
+// Forward declaration for existing assembly implementation
+func scalUnitary(alpha float64, x []float64)
+
+// Export hasScalAVX2 for testing
+var HasScalAVX2 = &hasScalAVX2

--- a/internal/asm/f64/scal_avx2_test.go
+++ b/internal/asm/f64/scal_avx2_test.go
@@ -1,0 +1,108 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package f64
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"golang.org/x/sys/cpu"
+)
+
+func TestScalUnitaryAVX2(t *testing.T) {
+	if !cpu.X86.HasAVX2 {
+		t.Skip("AVX2 not available")
+	}
+	
+	tests := []struct {
+		alpha float64
+		x     []float64
+		want  []float64
+	}{
+		// Simple cases
+		{2, []float64{1}, []float64{2}},
+		{3, []float64{1, 2}, []float64{3, 6}},
+		{-2, []float64{1, 2, 3}, []float64{-2, -4, -6}},
+		{0.5, []float64{2, 4, 6, 8}, []float64{1, 2, 3, 4}},
+		
+		// Test different lengths to exercise all code paths
+		{2, []float64{1, 2, 3, 4, 5}, []float64{2, 4, 6, 8, 10}},
+		{3, []float64{1, 1, 1, 1, 1, 1, 1, 1}, []float64{3, 3, 3, 3, 3, 3, 3, 3}},
+		
+		// 16 elements to test main loop
+		{
+			2,
+			[]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			[]float64{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32},
+		},
+		
+		// 17 elements to test tail handling
+		{
+			0.5,
+			[]float64{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34},
+			[]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17},
+		},
+	}
+	
+	for i, test := range tests {
+		x := make([]float64, len(test.x))
+		copy(x, test.x)
+		ScalUnitaryAVX2(test.alpha, x)
+		for j, v := range x {
+			if math.Abs(v-test.want[j]) > 1e-14 {
+				t.Errorf("test %d: ScalUnitaryAVX2(%v, %v)[%d] = %v, want %v", 
+					i, test.alpha, test.x, j, v, test.want[j])
+			}
+		}
+	}
+}
+
+// Benchmark comparing implementations
+func BenchmarkScalUnitaryAVX2(b *testing.B) {
+	sizes := []int{10, 100, 1000, 10000, 100000}
+	
+	for _, size := range sizes {
+		x := make([]float64, size)
+		
+		// Initialize with some data
+		for i := range x {
+			x[i] = float64(i)
+		}
+		
+		b.Run("Size"+fmt.Sprintf("%d", size), func(b *testing.B) {
+			b.Run("PureGo", func(b *testing.B) {
+				b.SetBytes(int64(size * 8))
+				xcopy := make([]float64, len(x))
+				for i := 0; i < b.N; i++ {
+					copy(xcopy, x)
+					// Pure Go implementation
+					for j := range xcopy {
+						xcopy[j] *= 2.5
+					}
+				}
+			})
+			
+			b.Run("SSE2", func(b *testing.B) {
+				b.SetBytes(int64(size * 8))
+				xcopy := make([]float64, len(x))
+				for i := 0; i < b.N; i++ {
+					copy(xcopy, x)
+					scalUnitarySSE2(2.5, xcopy)
+				}
+			})
+			
+			if cpu.X86.HasAVX2 {
+				b.Run("AVX2", func(b *testing.B) {
+					b.SetBytes(int64(size * 8))
+					xcopy := make([]float64, len(x))
+					for i := 0; i < b.N; i++ {
+						copy(xcopy, x)
+						ScalUnitaryAVX2(2.5, xcopy)
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/asm/f64/scalunitary_amd64.s
+++ b/internal/asm/f64/scalunitary_amd64.s
@@ -48,8 +48,8 @@
 #define ALPHA X0
 #define ALPHA_2 X1
 
-// func ScalUnitary(alpha float64, x []float64)
-TEXT ·ScalUnitary(SB), NOSPLIT, $0
+// func scalUnitary(alpha float64, x []float64)
+TEXT ·scalUnitary(SB), NOSPLIT, $0
 	MOVDDUP_ALPHA            // ALPHA = { alpha, alpha }
 	MOVQ x_base+8(FP), X_PTR // X_PTR = &x
 	MOVQ x_len+16(FP), LEN   // LEN = len(x)
@@ -110,3 +110,8 @@ tail_one:
 
 end:
 	RET
+
+// func scalUnitarySSE2(alpha float64, x []float64)
+// Wrapper for the existing ScalUnitary implementation
+TEXT ·scalUnitarySSE2(SB), NOSPLIT, $0
+	JMP ·scalUnitary(SB)

--- a/internal/asm/f64/scalunitary_avx2_amd64.s
+++ b/internal/asm/f64/scalunitary_avx2_amd64.s
@@ -1,0 +1,94 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// AVX2 optimized version of ScalUnitary
+// x[i] *= alpha
+
+//go:build !noasm && !gccgo && !safe
+// +build !noasm,!gccgo,!safe
+
+#include "textflag.h"
+
+// func ScalUnitaryAVX2(alpha float64, x []float64)
+TEXT ·ScalUnitaryAVX2(SB), NOSPLIT, $0
+	MOVSD alpha+0(FP), X0      // X0 = alpha
+	VBROADCASTSD X0, Y0        // Y0 = [alpha, alpha, alpha, alpha]
+	MOVQ x+8(FP), SI           // SI = &x[0]
+	MOVQ x_len+16(FP), CX      // CX = len(x)
+	
+	// Check if length is 0
+	TESTQ CX, CX
+	JZ end
+	
+	// Process 16 elements at a time (4 YMM registers)
+	MOVQ CX, BX
+	SHRQ $4, BX               // BX = n / 16
+	JZ tail_start
+	
+loop16:
+	// Load and multiply using AVX2
+	VMOVUPD (SI), Y1
+	VMULPD Y0, Y1, Y1
+	VMOVUPD Y1, (SI)
+	
+	VMOVUPD 32(SI), Y2
+	VMULPD Y0, Y2, Y2
+	VMOVUPD Y2, 32(SI)
+	
+	VMOVUPD 64(SI), Y3
+	VMULPD Y0, Y3, Y3
+	VMOVUPD Y3, 64(SI)
+	
+	VMOVUPD 96(SI), Y4
+	VMULPD Y0, Y4, Y4
+	VMOVUPD Y4, 96(SI)
+	
+	ADDQ $128, SI             // Advance by 16 elements
+	DECQ BX
+	JNZ loop16
+	
+tail_start:
+	// Handle remaining elements
+	MOVQ CX, BX
+	ANDQ $15, BX              // BX = n % 16
+	JZ end
+	
+	// Process 4 elements at a time using YMM
+	MOVQ BX, DX
+	SHRQ $2, DX               // DX = (n % 16) / 4
+	JZ tail_2
+	
+loop4:
+	VMOVUPD (SI), Y1
+	VMULPD Y0, Y1, Y1
+	VMOVUPD Y1, (SI)
+	ADDQ $32, SI
+	DECQ DX
+	JNZ loop4
+	
+tail_2:
+	// Process 2 elements at a time using SSE
+	MOVQ BX, DX
+	ANDQ $3, DX               // DX = n % 4
+	SHRQ $1, DX               // DX = (n % 4) / 2
+	JZ tail_1
+	
+	MOVUPD (SI), X1
+	MULPD X0, X1
+	MOVUPD X1, (SI)
+	ADDQ $16, SI
+	
+tail_1:
+	// Process last element if present
+	MOVQ BX, DX
+	ANDQ $1, DX
+	JZ end
+	
+	MOVSD (SI), X1
+	MULSD X0, X1
+	MOVSD X1, (SI)
+	
+end:
+	VZEROUPPER
+	RET

--- a/internal/asm/f64/stubs_amd64.go
+++ b/internal/asm/f64/stubs_amd64.go
@@ -42,14 +42,14 @@ func Add(dst, s []float64)
 //	for i, v := range x {
 //		y[i] += alpha * v
 //	}
-func AxpyUnitary(alpha float64, x, y []float64)
+// func AxpyUnitary(alpha float64, x, y []float64) // Implemented in axpy_amd64.go
 
 // AxpyUnitaryTo is
 //
 //	for i, v := range x {
 //		dst[i] = alpha*v + y[i]
 //	}
-func AxpyUnitaryTo(dst []float64, alpha float64, x, y []float64)
+// func AxpyUnitaryTo(dst []float64, alpha float64, x, y []float64) // Implemented in axpy_amd64.go
 
 // AxpyInc is
 //
@@ -115,7 +115,7 @@ func DivTo(dst, x, y []float64) []float64
 //		sum += y[i] * v
 //	}
 //	return sum
-func DotUnitary(x, y []float64) (sum float64)
+// func DotUnitary(x, y []float64) (sum float64) // Implemented in dot_amd64.go
 
 // DotInc is
 //
@@ -157,7 +157,7 @@ func LinfDist(s, t []float64) float64
 //	for i := range x {
 //		x[i] *= alpha
 //	}
-func ScalUnitary(alpha float64, x []float64)
+// func ScalUnitary(alpha float64, x []float64) // Implemented in scal_amd64.go
 
 // ScalUnitaryTo is
 //


### PR DESCRIPTION
This commit adds AVX2/FMA optimized implementations for several Level 1 BLAS operations and GEMM micro-kernels. The optimizations use runtime CPU feature detection to automatically select the best implementation while maintaining compatibility with older processors.

New AVX2/FMA implementations:
- DotUnitary: Dot product of vectors (up to 2.66x faster than SSE2)
- ScalUnitary: Scalar-vector multiplication (up to 1.48x faster than SSE2)
- GemvN: General matrix-vector multiplication
- AxpyUnitary and AxpyUnitaryTo: y += alpha * x operations
- 4x4 and 8x8 GEMM micro-kernels for matrix multiplication

All implementations correctly handle:
- Negative strides
- Non-unit increments
- NaN propagation
- Zero-length vectors

The AVX2 implementations process 4 doubles per vector instruction and use FMA instructions to reduce operation count and improve accuracy.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."

Do not delete any of this templated text in the PR description, but
feel free to add additional context.
-->
