### PR TITLE
optimize: add configurable MinimumStepSize

### DIFF
--- a/optimize/backtracking.go
+++ b/optimize/backtracking.go
@@ -28,6 +28,7 @@ var _ Linesearcher = (*Backtracking)(nil)
 type Backtracking struct {
 	DecreaseFactor    float64 // Constant factor in the sufficient decrease (Armijo) condition.
 	ContractionFactor float64 // Step size multiplier at each iteration (step *= ContractionFactor).
+	MinimumStepSize   float64 // Smallest allowed step size; line search fails if step shrinks below this value.
 
 	stepSize float64
 	initF    float64
@@ -50,11 +51,17 @@ func (b *Backtracking) Init(f, g float64, step float64) Operation {
 	if b.DecreaseFactor == 0 {
 		b.DecreaseFactor = defaultBacktrackingDecrease
 	}
+	if b.MinimumStepSize == 0 {
+		b.MinimumStepSize = minimumBacktrackingStepSize
+	}
 	if b.ContractionFactor <= 0 || b.ContractionFactor >= 1 {
 		panic("backtracking: ContractionFactor must be between 0 and 1")
 	}
 	if b.DecreaseFactor <= 0 || b.DecreaseFactor >= 1 {
 		panic("backtracking: DecreaseFactor must be between 0 and 1")
+	}
+	if b.MinimumStepSize <= 0 {
+		panic("backtracking: MinimumStepSize must be strictly positive")
 	}
 
 	b.stepSize = step
@@ -75,7 +82,7 @@ func (b *Backtracking) Iterate(f, _ float64) (Operation, float64, error) {
 		return b.lastOp, b.stepSize, nil
 	}
 	b.stepSize *= b.ContractionFactor
-	if b.stepSize < minimumBacktrackingStepSize {
+	if b.stepSize < b.MinimumStepSize {
 		b.lastOp = NoOperation
 		return b.lastOp, b.stepSize, ErrLinesearcherFailure
 	}

--- a/optimize/backtracking.go
+++ b/optimize/backtracking.go
@@ -60,8 +60,8 @@ func (b *Backtracking) Init(f, g float64, step float64) Operation {
 	if b.DecreaseFactor <= 0 || b.DecreaseFactor >= 1 {
 		panic("backtracking: DecreaseFactor must be between 0 and 1")
 	}
-	if b.MinimumStepSize <= 0 {
-		panic("backtracking: MinimumStepSize must be strictly positive")
+	if b.MinimumStepSize < 0 {
+		panic("backtracking: MinimumStepSize must be positive")
 	}
 
 	b.stepSize = step

--- a/optimize/unconstrained_test.go
+++ b/optimize/unconstrained_test.go
@@ -1055,6 +1055,15 @@ func TestGradientDescentBacktracking(t *testing.T) {
 	t.Parallel()
 	testLocal(t, gradientDescentTests, &GradientDescent{
 		Linesearcher: &Backtracking{
+			DecreaseFactor: 0.1,
+		},
+	})
+}
+
+func TestGradientDescentBacktrackingWithMinimumStepSize(t *testing.T) {
+	t.Parallel()
+	testLocal(t, gradientDescentTests, &GradientDescent{
+		Linesearcher: &Backtracking{
 			DecreaseFactor:  0.1,
 			MinimumStepSize: 2e-8,
 		},

--- a/optimize/unconstrained_test.go
+++ b/optimize/unconstrained_test.go
@@ -82,19 +82,19 @@ var gradFreeTests = []unconstrainedTest{
 		},
 		x: []float64{-5, 4, 16, 3},
 	},
-    {
+	{
 		name: "Sphere5D",
 		p: Problem{
 			Func: functions.Sphere{}.Func,
 		},
-		x:       []float64{0.00001, 1.00001, 2.00001, 3.00001, 4.00001},
+		x: []float64{0.00001, 1.00001, 2.00001, 3.00001, 4.00001},
 	},
 	{
 		name: "Sphere10D",
 		p: Problem{
 			Func: functions.Sphere{}.Func,
 		},
-		x:       []float64{0.00001, 1.00001, 2.00001, 3.00001, 4.00001, 5.00001, 6.00001, 7.00001, 8.00001, 9.00001},
+		x: []float64{0.00001, 1.00001, 2.00001, 3.00001, 4.00001, 5.00001, 6.00001, 7.00001, 8.00001, 9.00001},
 	},
 }
 
@@ -1055,7 +1055,8 @@ func TestGradientDescentBacktracking(t *testing.T) {
 	t.Parallel()
 	testLocal(t, gradientDescentTests, &GradientDescent{
 		Linesearcher: &Backtracking{
-			DecreaseFactor: 0.1,
+			DecreaseFactor:  0.1,
+			MinimumStepSize: 2e-8,
 		},
 	})
 }


### PR DESCRIPTION
The following PR enhance the `Backtracking` line searcher by allowing `MinimumStepSize` to be configurable


Checklist:

- [ ] API changes have been discussed -> Does not apply
- [x] Code is goformatted correctly (goimports)
- [ ] Packages with generated code have had code generation run -> Does not apply
- [x] Tests pass locally
- [x] Linked to relevant issues: [2064](https://github.com/gonum/gonum/issues/2064)
- [x] Added new test case

Closes #2064

