### PR TITLE
Fix/dstarlite fixes

### DIFF
--- a/graph/path/dynamic/dstarlite.go
+++ b/graph/path/dynamic/dstarlite.go
@@ -281,6 +281,7 @@ func (d *DStarLite) MoveTo(n graph.Node) {
 	d.last = d.s
 	d.s = d.model.Node(n.ID()).(*dStarLiteNode)
 	d.keyModifier += d.heuristic(d.last, d.s)
+	d.findShortestPath()
 }
 
 // UpdateWorld updates or adds edges in the world graph. UpdateWorld will

--- a/graph/path/dynamic/dstarlite.go
+++ b/graph/path/dynamic/dstarlite.go
@@ -63,6 +63,9 @@ func NewDStarLite(s, t graph.Node, g graph.Graph, h path.Heuristic, m WorldModel
 		heuristic: h,
 	}
 	d.t.rhs = 0
+	if d.s.ID() == d.t.ID() {
+		d.s.rhs = 0
+	}
 
 	/*
 		procedure Main()

--- a/graph/path/dynamic/dstarlite_test.go
+++ b/graph/path/dynamic/dstarlite_test.go
@@ -632,6 +632,29 @@ func TestDStarLiteDynamic(t *testing.T) {
 	}
 }
 
+func TestMoveToAway(t *testing.T) {
+	t.Parallel()
+
+	g := simple.NewWeightedDirectedGraph(0, math.Inf(1))
+	p0 := simple.Node(0)
+	p1 := simple.Node(1)
+	p2 := simple.Node(2)
+	g.SetWeightedEdge(simple.WeightedEdge{F: p0, T: p1, W: 1})
+	g.SetWeightedEdge(simple.WeightedEdge{F: p1, T: p2, W: 1})
+
+	d := NewDStarLite(p1, p2, g, path.NullHeuristic, simple.NewWeightedDirectedGraph(0, math.Inf(1)))
+	_, _ = d.Path()
+
+	d.MoveTo(p0)
+	p, w := d.Path()
+	wantP := []graph.Node{p0, p1, p2}
+	wantW := 2.0
+
+	if !samePath(p, wantP) || w != wantW {
+		t.Errorf("unexpected path after move. got %v (weight %v), want %v (weight %v)", p, w, wantP, wantW)
+	}
+}
+
 type memory bool
 
 func (m memory) String() string {

--- a/graph/path/dynamic/dstarlite_test.go
+++ b/graph/path/dynamic/dstarlite_test.go
@@ -636,79 +636,43 @@ func TestDStarLiteDynamic(t *testing.T) {
 func TestMoveToAway(t *testing.T) {
 	t.Parallel()
 
-	g := simple.NewWeightedDirectedGraph(0, math.Inf(1))
-	p0 := simple.Node(0)
-	p1 := simple.Node(1)
-	p2 := simple.Node(2)
-	g.SetWeightedEdge(simple.WeightedEdge{F: p0, T: p1, W: 1})
-	g.SetWeightedEdge(simple.WeightedEdge{F: p1, T: p2, W: 1})
+	g := simple.NewUndirectedGraph()
+	for i := range 2 {
+		g.SetEdge(simple.Edge{F: simple.Node(i), T: simple.Node(i + 1)})
+	}
 
-	d := NewDStarLite(p1, p2, g, path.NullHeuristic, simple.NewWeightedDirectedGraph(0, math.Inf(1)))
-	_, _ = d.Path()
+	d := NewDStarLite(simple.Node(1), simple.Node(2), g, path.NullHeuristic, simple.NewWeightedDirectedGraph(0, math.Inf(1)))
 
-	d.MoveTo(p0)
+	// Shortest path so far would be 1->2. Now move off the shortest path to force a replan.
+	d.MoveTo(simple.Node(0))
+
+	wantP := []graph.Node{simple.Node(0), simple.Node(1), simple.Node(2)}
 	p, w := d.Path()
-	wantP := []graph.Node{p0, p1, p2}
-	wantW := 2.0
-
-	if !samePath(p, wantP) || w != wantW {
-		t.Errorf("unexpected path after move. got %v (weight %v), want %v (weight %v)", p, w, wantP, wantW)
+	if !samePath(p, wantP) || w != float64(len(wantP)-1) {
+		t.Errorf("unexpected path after move. got %v (weight %v), want %v (weight %v)", p, w, wantP, len(wantP)-1)
 	}
 }
 
 func TestStartEqualsTarget(t *testing.T) {
-	t.Parallel()
-
-	// Before the fix, the second call to d.Path() would go into an infinite loop
-	// So we use a timeout to bail from the test if that happens.
-	done := make(chan error)
-
+	ok := make(chan struct{})
 	go func() {
-		defer close(done)
-
-		g := simple.NewWeightedUndirectedGraph(0, math.Inf(1))
-		p0 := simple.Node(0)
-		p1 := simple.Node(1)
-		p2 := simple.Node(2)
-		for _, n := range []graph.Node{p0, p1, p2} {
-			for _, m := range []graph.Node{p0, p1, p2} {
-				if n.ID() != m.ID() {
-					g.SetWeightedEdge(simple.WeightedEdge{F: n, T: m, W: 1})
-				}
-			}
+		select {
+		case <-time.After(time.Second):
+			panic("timed out")
+		case <-ok:
 		}
-		d := NewDStarLite(p2, p2, g, path.NullHeuristic, simple.NewWeightedDirectedGraph(0, math.Inf(1)))
-
-		p, weight := d.Path()
-		wantP := []graph.Node{p2}
-		wantW := 0.0
-
-		if !samePath(p, wantP) || weight != wantW {
-			done <- fmt.Errorf("unexpected path. got %v (weight %v), want %v (weight %v)", p, weight, wantP, wantW)
-			return
-		}
-
-		d.MoveTo(p0)
-		p, weight = d.Path()
-		wantP = []graph.Node{p0, p2}
-		wantW = 1.0
-
-		if !samePath(p, wantP) || weight != wantW {
-			done <- fmt.Errorf("unexpected path after move. got %v (weight %v), want %v (weight %v)", p, weight, wantP, wantW)
-			return
-		}
-
 	}()
 
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Error(err)
-		}
-
-	case <-time.After(1 * time.Second):
-		t.Error("test timed out => potential infinite loop in DStarLite.Path() when start equals target")
+	g := simple.NewUndirectedGraph()
+	for i := range 2 {
+		g.SetEdge(simple.Edge{F: simple.Node(i), T: simple.Node(i + 1)})
 	}
+
+	d := NewDStarLite(simple.Node(0), simple.Node(0), g, path.NullHeuristic, simple.NewWeightedDirectedGraph(0, math.Inf(1)))
+	d.MoveTo(simple.Node(1))
+	d.Path()
+
+	close(ok)
 }
 
 type memory bool

--- a/graph/path/dynamic/dstarlite_test.go
+++ b/graph/path/dynamic/dstarlite_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/path"
@@ -652,6 +653,61 @@ func TestMoveToAway(t *testing.T) {
 
 	if !samePath(p, wantP) || w != wantW {
 		t.Errorf("unexpected path after move. got %v (weight %v), want %v (weight %v)", p, w, wantP, wantW)
+	}
+}
+
+func TestStartEqualsTarget(t *testing.T) {
+	t.Parallel()
+
+	// Before the fix, the second call to d.Path() would go into an infinite loop
+	// So we use a timeout to bail from the test if that happens.
+	done := make(chan error)
+
+	go func() {
+		defer close(done)
+
+		g := simple.NewWeightedUndirectedGraph(0, math.Inf(1))
+		p0 := simple.Node(0)
+		p1 := simple.Node(1)
+		p2 := simple.Node(2)
+		for _, n := range []graph.Node{p0, p1, p2} {
+			for _, m := range []graph.Node{p0, p1, p2} {
+				if n.ID() != m.ID() {
+					g.SetWeightedEdge(simple.WeightedEdge{F: n, T: m, W: 1})
+				}
+			}
+		}
+		d := NewDStarLite(p2, p2, g, path.NullHeuristic, simple.NewWeightedDirectedGraph(0, math.Inf(1)))
+
+		p, weight := d.Path()
+		wantP := []graph.Node{p2}
+		wantW := 0.0
+
+		if !samePath(p, wantP) || weight != wantW {
+			done <- fmt.Errorf("unexpected path. got %v (weight %v), want %v (weight %v)", p, weight, wantP, wantW)
+			return
+		}
+
+		d.MoveTo(p0)
+		p, weight = d.Path()
+		wantP = []graph.Node{p0, p2}
+		wantW = 1.0
+
+		if !samePath(p, wantP) || weight != wantW {
+			done <- fmt.Errorf("unexpected path after move. got %v (weight %v), want %v (weight %v)", p, weight, wantP, wantW)
+			return
+		}
+
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Error(err)
+		}
+
+	case <-time.After(1 * time.Second):
+		t.Error("test timed out => potential infinite loop in DStarLite.Path() when start equals target")
 	}
 }
 

--- a/graph/path/dynamic/dstarlite_test.go
+++ b/graph/path/dynamic/dstarlite_test.go
@@ -655,10 +655,11 @@ func TestMoveToAway(t *testing.T) {
 
 func TestStartEqualsTarget(t *testing.T) {
 	ok := make(chan struct{})
+	hang := make(chan struct{})
 	go func() {
 		select {
 		case <-time.After(time.Second):
-			panic("timed out")
+			close(hang)
 		case <-ok:
 		}
 	}()
@@ -668,11 +669,18 @@ func TestStartEqualsTarget(t *testing.T) {
 		g.SetEdge(simple.Edge{F: simple.Node(i), T: simple.Node(i + 1)})
 	}
 
-	d := NewDStarLite(simple.Node(0), simple.Node(0), g, path.NullHeuristic, simple.NewWeightedDirectedGraph(0, math.Inf(1)))
-	d.MoveTo(simple.Node(1))
-	d.Path()
+	go func() {
+		defer close(ok)
+		d := NewDStarLite(simple.Node(0), simple.Node(0), g, path.NullHeuristic, simple.NewWeightedDirectedGraph(0, math.Inf(1)))
+		d.MoveTo(simple.Node(1))
+		d.Path()
+	}()
 
-	close(ok)
+	select {
+	case <-ok:
+	case <-hang:
+		t.Error("timed out")
+	}
 }
 
 type memory bool


### PR DESCRIPTION
Fixes two issues that are kind of connected, so I combined them in one PR - let me know if you want to have it differently.

- When initializing DStarLite with the start node being the same as the target node, that leaves the instance in an inconsisten state (the target's `g` value is `+Inf`). After moving and trying to calculate a path, it would either return an invalid path or even go into an infinte loop, osciallting between two or more nodes next to the target.

- When using `MoveTo` to go to a node that has not previously been expanded, `Path` would return an invalid path because a new shortest route was never calculated.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."

Do not delete any of this templated text in the PR description, but
feel free to add additional context.
-->
