### PR TITLE
graph/coloring: add example to demonstrate DsaturExact termination

### DIFF
--- a/graph/coloring/color_exact_example_test.go
+++ b/graph/coloring/color_exact_example_test.go
@@ -1,0 +1,74 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package coloring_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/coloring"
+	"gonum.org/v1/gonum/graph/encoding/graph6"
+)
+
+func Example_color_exact() {
+	// Queen 6-6 graph.
+	g := graph6.Graph("c~~}FDrMw~`~goSwtMYhvIF{SN{dEAQfCehrcTMyPO~ca`~acgoPQSwcCtMWcahvaQIF|CcSN{KSdEAAIQfC__ehrCCcTMwSQPO~ogca`~")
+	if !graph6.IsValid(g) {
+		log.Fatal("invalid g6 graph")
+	}
+
+	k, _, err := nDsaturExact(context.Background(), g, 2)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(k)
+
+	// Output:
+	// 7
+}
+
+// nDsaturExact starts n DsaturExact routines and returns the results
+// from the first one that completes, terminating the others. This can
+// be used to improve performance for difficult graphs at the cost of
+// increased memory use and discarded computation.
+func nDsaturExact(ctx context.Context, g graph.Undirected, n int) (k int, colors map[int64]int, err error) {
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(context.Canceled)
+
+	type result struct {
+		k      int
+		colors map[int64]int
+		err    error
+	}
+
+	r := make(chan result, n)
+	done := errors.New("done")
+	for range n {
+		go func() {
+			k, colors, err := coloring.DsaturExact(ctx, g)
+			r <- result{k, colors, err}
+			if err == nil {
+				cancel(done)
+			}
+		}()
+	}
+
+	for range n {
+		coloring := <-r
+		if coloring.err == nil {
+			return coloring.k, coloring.colors, nil
+		}
+
+		if context.Cause(ctx) != done {
+			return coloring.k, coloring.colors, coloring.err
+		}
+	}
+
+	panic("unreachable")
+}


### PR DESCRIPTION
This gives an example that shows how running simultaneous DsaturExact coloring solvers can be used to improve solve time. The rationale for it and when to use it is demonstrated by the following plots.

The first shows the ranges of distributions of times the different Queens graphs take to solve with either no first-win parallel solving (n=1), or predicted n first-win parallel solvers (n=2,3,4). In practice the benefits in the Queens 5×5, 6×6 and 7×7 are not worth the effort due to concurrency overhead (which can actually make the situation worse), but there is a predicted benefit in the 8×8 case which can be demonstrated practically.

<img width="567" height="378" alt="distribution" src="https://github.com/user-attachments/assets/cb518071-a291-4c3c-9a95-59ddd4057bcf" />

The second shows the distribution of Queens 8×8 solve times without log transformation, and predicted improvements from competitive solving.

<img width="567" height="378" alt="queen8_8_distribution" src="https://github.com/user-attachments/assets/1504012e-ed91-4ab3-8bf1-5c53cb89e905" />

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."

Do not delete any of this templated text in the PR description, but
feel free to add additional context.
-->
