### PR TITLE
lapack/gonum: add RZ factorization utilities

### DIFF
--- a/lapack/gonum/bench_test.go
+++ b/lapack/gonum/bench_test.go
@@ -14,3 +14,6 @@ func BenchmarkDgeev(b *testing.B)  { testlapack.DgeevBenchmark(b, impl) }
 func BenchmarkDlangb(b *testing.B) { testlapack.DlangbBenchmark(b, impl) }
 func BenchmarkDlantb(b *testing.B) { testlapack.DlantbBenchmark(b, impl) }
 func BenchmarkDlaqr5(b *testing.B) { testlapack.Dlaqr5Benchmark(b, impl) }
+func BenchmarkDlaic1(b *testing.B) { testlapack.Dlaic1Benchmark(b, impl) }
+func BenchmarkDtzrzf(b *testing.B) { testlapack.DtzrzfBenchmark(b, impl) }
+func BenchmarkDormrz(b *testing.B) { testlapack.DormrzBenchmark(b, impl) }

--- a/lapack/gonum/dlaic1.go
+++ b/lapack/gonum/dlaic1.go
@@ -4,7 +4,11 @@
 
 package gonum
 
-import "math"
+import (
+	"math"
+
+	"gonum.org/v1/gonum/blas/blas64"
+)
 
 // Dlaic1 applies one step of incremental condition estimation in its simplest
 // version. It is called as a part of the condition estimator in LAPACK routines
@@ -61,10 +65,8 @@ func (impl Implementation) Dlaic1(job int, j int, x []float64, sest float64, w [
 
 	eps := dlamchE
 
-	alpha := 0.0
-	for i := 0; i < j; i++ {
-		alpha += x[i] * w[i]
-	}
+	bi := blas64.Implementation()
+	alpha := bi.Ddot(j, x, 1, w, 1)
 
 	absalp := math.Abs(alpha)
 	absgam := math.Abs(gamma)

--- a/lapack/gonum/dlaic1.go
+++ b/lapack/gonum/dlaic1.go
@@ -1,0 +1,244 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+import "math"
+
+// Dlaic1 applies one step of incremental condition estimation in its simplest
+// version. It is called as a part of the condition estimator in LAPACK routines
+// such as Dtrcon and Dtrsna.
+//
+// Let x, op(A)*x = sest*w, where op(A) is the triangular matrix A or its
+// transpose. Dlaic1 computes sestpr, s, c such that the vector
+//
+//	[s*x]
+//	[ c ]
+//
+// is an approximate singular vector of
+//
+//	[op(A)  w]
+//	[  0    γ]
+//
+// in the sense that
+//
+//	diag(sest, sestpr) ≈ sigma(op(A_hat))
+//
+// where A_hat is the (j+1)×(j+1) matrix
+//
+//	A_hat = [op(A)  w]
+//	        [  0    γ]
+//
+// and sigma(A_hat) are its singular values.
+//
+// If job == 1, Dlaic1 computes an updated estimate of the largest singular
+// value. If job == 2, it computes an updated estimate of the smallest singular
+// value.
+//
+// j is the length of vectors x and w. x and w must have length at least j when
+// j > 0, otherwise Dlaic1 will panic. sest must be non-negative.
+//
+// On return, sestpr is the updated singular value estimate, and s, c are the
+// sine and cosine of the rotation used in the update.
+//
+// Dlaic1 is an internal routine. It is exported for testing purposes.
+func (impl Implementation) Dlaic1(job int, j int, x []float64, sest float64, w []float64, gamma float64) (sestpr, s, c float64) {
+	switch {
+	case job != 1 && job != 2:
+		panic("lapack: bad job")
+	case j < 0:
+		panic("lapack: j < 0")
+	}
+	if j > 0 {
+		if len(x) < j {
+			panic(shortX)
+		}
+		if len(w) < j {
+			panic(shortW)
+		}
+	}
+
+	eps := dlamchE
+
+	alpha := 0.0
+	for i := 0; i < j; i++ {
+		alpha += x[i] * w[i]
+	}
+
+	absalp := math.Abs(alpha)
+	absgam := math.Abs(gamma)
+	absest := math.Abs(sest)
+
+	if job == 1 {
+		if sest == 0 {
+			s1 := math.Max(absgam, absalp)
+			if s1 == 0 {
+				s = 0
+				c = 1
+				sestpr = 0
+			} else {
+				s = alpha / s1
+				c = gamma / s1
+				tmp := math.Sqrt(s*s + c*c)
+				s /= tmp
+				c /= tmp
+				sestpr = s1 * tmp
+			}
+			return
+		} else if absgam <= eps*absest {
+			s = 1
+			c = 0
+			tmp := math.Max(absest, absalp)
+			s1 := absest / tmp
+			s2 := absalp / tmp
+			sestpr = tmp * math.Sqrt(s1*s1+s2*s2)
+			return
+		} else if absalp <= eps*absest {
+			s1 := absgam
+			s2 := absest
+			if s1 <= s2 {
+				s = 1
+				c = 0
+				sestpr = s2
+			} else {
+				s = 0
+				c = 1
+				sestpr = s1
+			}
+			return
+		} else if absest <= eps*absalp || absest <= eps*absgam {
+			s1 := absgam
+			s2 := absalp
+			if s1 <= s2 {
+				tmp := s1 / s2
+				s = math.Sqrt(1 + tmp*tmp)
+				sestpr = s2 * s
+				c = (gamma / s2) / s
+				s = math.Copysign(1, alpha) / s
+			} else {
+				tmp := s2 / s1
+				c = math.Sqrt(1 + tmp*tmp)
+				sestpr = s1 * c
+				s = (alpha / s1) / c
+				c = math.Copysign(1, gamma) / c
+			}
+			return
+		}
+
+		zeta1 := alpha / absest
+		zeta2 := gamma / absest
+
+		b := (1 - zeta1*zeta1 - zeta2*zeta2) * 0.5
+		c = zeta1 * zeta1
+		var t float64
+		if b > 0 {
+			t = c / (b + math.Sqrt(b*b+c))
+		} else {
+			t = math.Sqrt(b*b+c) - b
+		}
+
+		sine := -zeta1 / t
+		cosine := -zeta2 / (1 + t)
+		tmp := math.Sqrt(sine*sine + cosine*cosine)
+		s = sine / tmp
+		c = cosine / tmp
+		sestpr = math.Sqrt(t+1) * absest
+		return
+	}
+
+	// job == 2
+	if sest == 0 {
+		sestpr = 0
+		if math.Max(absgam, absalp) == 0 {
+			sine := 1.0
+			cosine := 0.0
+			s1 := math.Max(math.Abs(sine), math.Abs(cosine))
+			s = sine / s1
+			c = cosine / s1
+			tmp := math.Sqrt(s*s + c*c)
+			s /= tmp
+			c /= tmp
+		} else {
+			sine := -gamma
+			cosine := alpha
+			s1 := math.Max(math.Abs(sine), math.Abs(cosine))
+			s = sine / s1
+			c = cosine / s1
+			tmp := math.Sqrt(s*s + c*c)
+			s /= tmp
+			c /= tmp
+		}
+		return
+	} else if absgam <= eps*absest {
+		s = 0
+		c = 1
+		sestpr = absgam
+		return
+	} else if absalp <= eps*absest {
+		s1 := absgam
+		s2 := absest
+		if s1 <= s2 {
+			s = 0
+			c = 1
+			sestpr = s1
+		} else {
+			s = 1
+			c = 0
+			sestpr = s2
+		}
+		return
+	} else if absest <= eps*absalp || absest <= eps*absgam {
+		s1 := absgam
+		s2 := absalp
+		if s1 <= s2 {
+			tmp := s1 / s2
+			c = math.Sqrt(1 + tmp*tmp)
+			sestpr = absest * (tmp / c)
+			s = -(gamma / s2) / c
+			c = math.Copysign(1, alpha) / c
+		} else {
+			tmp := s2 / s1
+			s = math.Sqrt(1 + tmp*tmp)
+			sestpr = absest / s
+			c = (alpha / s1) / s
+			s = -math.Copysign(1, gamma) / s
+		}
+		return
+	}
+
+	zeta1 := alpha / absest
+	zeta2 := gamma / absest
+
+	norma := math.Max(
+		1+zeta1*zeta1+math.Abs(zeta1*zeta2),
+		math.Abs(zeta1*zeta2)+zeta2*zeta2,
+	)
+
+	test := 1 + 2*(zeta1-zeta2)*(zeta1+zeta2)
+	var sine, cosine float64
+	if test >= 0 {
+		b := (zeta1*zeta1 + zeta2*zeta2 + 1) * 0.5
+		c = zeta2 * zeta2
+		t := c / (b + math.Sqrt(math.Abs(b*b-c)))
+		sine = zeta1 / (1 - t)
+		cosine = -zeta2 / t
+		sestpr = math.Sqrt(t+4*eps*eps*norma) * absest
+	} else {
+		b := (zeta2*zeta2 + zeta1*zeta1 - 1) * 0.5
+		c = zeta1 * zeta1
+		var t float64
+		if b >= 0 {
+			t = -c / (b + math.Sqrt(b*b+c))
+		} else {
+			t = b - math.Sqrt(b*b+c)
+		}
+		sine = -zeta1 / t
+		cosine = -zeta2 / (1 + t)
+		sestpr = math.Sqrt(1+t+4*eps*eps*norma) * absest
+	}
+	tmp := math.Sqrt(sine*sine + cosine*cosine)
+	s = sine / tmp
+	c = cosine / tmp
+	return
+}

--- a/lapack/gonum/dormrz.go
+++ b/lapack/gonum/dormrz.go
@@ -1,0 +1,142 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+import (
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/blas64"
+)
+
+// Dormrz multiplies an m×n matrix C by the orthogonal matrix Z from a
+// RZ factorization determined by Dtzrzf.
+//
+//	C = Z * C    if side == blas.Left  and trans == blas.NoTrans,
+//	C = Zᵀ * C   if side == blas.Left  and trans == blas.Trans,
+//	C = C * Z    if side == blas.Right and trans == blas.NoTrans,
+//	C = C * Zᵀ   if side == blas.Right and trans == blas.Trans,
+//
+// where Z is defined as the product of k elementary reflectors
+//
+//	Z = Z(0) * Z(1) * ... * Z(k-1)
+//
+// as returned by Dtzrzf. Z is of order m if side == blas.Left
+// and of order n if side == blas.Right.
+//
+// Each Z(i) has the form
+//
+//	Z(i) = I - tau[i] * v * vᵀ
+//
+// where tau[i] is stored in tau[i] and v is a vector with
+//
+//	v[0:i] = 0, v[i] = 1, v[i+1:nq-l] = 0, v[nq-l:nq] = A[i, nq-l:nq]
+//
+// where nq = m if side == blas.Left and nq = n if side == blas.Right.
+// l is the number of columns of the matrix V containing the meaningful
+// part of the reflectors.
+//
+// tau must have length at least k. work must have length at least max(1,lwork).
+//
+// work is temporary storage, and lwork specifies the usable memory length. At
+// minimum, lwork >= n if side == blas.Left and lwork >= m if side ==
+// blas.Right, and this function will panic otherwise.
+//
+// If lwork is -1, instead of performing Dormrz, the optimal workspace size will
+// be stored into work[0].
+//
+// Dormrz is an internal routine. It is exported for testing purposes.
+func (impl Implementation) Dormrz(side blas.Side, trans blas.Transpose, m, n, k, l int, a []float64, lda int, tau, c []float64, ldc int, work []float64, lwork int) {
+	left := side == blas.Left
+	nq := n
+	nw := m
+	if left {
+		nq = m
+		nw = n
+	}
+	switch {
+	case !left && side != blas.Right:
+		panic(badSide)
+	case trans != blas.NoTrans && trans != blas.Trans:
+		panic(badTrans)
+	case m < 0:
+		panic(mLT0)
+	case n < 0:
+		panic(nLT0)
+	case k < 0:
+		panic(kLT0)
+	case left && k > m:
+		panic(kGTM)
+	case !left && k > n:
+		panic(kGTN)
+	case l < 0 || l > nq-k:
+		panic("lapack: l out of range")
+	case lda < max(1, nq):
+		panic(badLdA)
+	case ldc < max(1, n):
+		panic(badLdC)
+	case lwork < max(1, nw) && lwork != -1:
+		panic(badLWork)
+	case len(work) < max(1, lwork):
+		panic(shortWork)
+	}
+
+	if lwork == -1 {
+		work[0] = float64(max(1, nw))
+		return
+	}
+
+	if m == 0 || n == 0 || k == 0 {
+		work[0] = 1
+		return
+	}
+
+	switch {
+	case len(a) < (k-1)*lda+nq:
+		panic(shortA)
+	case len(tau) < k:
+		panic(shortTau)
+	case len(c) < (m-1)*ldc+n:
+		panic(shortC)
+	}
+
+	bi := blas64.Implementation()
+
+	// Determine loop direction based on side and trans.
+	// Left,  NoTrans (Z*C):   apply Z(k-1)...Z(0) → loop i=k-1 downto 0
+	// Left,  Trans   (Zᵀ*C):  apply Z(0)...Z(k-1) → loop i=0 to k-1
+	// Right, NoTrans (C*Z):   apply Z(0)...Z(k-1) → loop i=0 to k-1
+	// Right, Trans   (C*Zᵀ):  apply Z(k-1)...Z(0) → loop i=k-1 downto 0
+	i0, iend, istep := 0, k, 1
+	if (left && trans == blas.NoTrans) || (!left && trans == blas.Trans) {
+		i0, iend, istep = k-1, -1, -1
+	}
+
+	for i := i0; i != iend; i += istep {
+		if tau[i] == 0 {
+			continue
+		}
+		if left {
+			// Apply Z(i) from the left: C := (I - tau*v*vᵀ) * C
+			// v[i]=1, v[m-l:m] = A[i, nq-l:nq], rest zero.
+			// w = C[i,:] + A[i,m-l:m]ᵀ * C[m-l:m,:]  (length n)
+			bi.Dcopy(n, c[i*ldc:], 1, work, 1)
+			bi.Dgemv(blas.Trans, l, n, 1, c[(m-l)*ldc:], ldc, a[i*lda+(nq-l):], 1, 1, work, 1)
+			// C[i,:] -= tau * w
+			bi.Daxpy(n, -tau[i], work, 1, c[i*ldc:], 1)
+			// C[m-l:m,:] -= tau * v * wᵀ
+			bi.Dger(l, n, -tau[i], a[i*lda+(nq-l):], 1, work, 1, c[(m-l)*ldc:], ldc)
+		} else {
+			// Apply Z(i) from the right: C := C * (I - tau*v*vᵀ)
+			// v[i]=1, v[n-l:n] = A[i, nq-l:nq], rest zero.
+			// w = C[:,i] + C[:,n-l:n] * A[i,n-l:n]ᵀ  (length m)
+			bi.Dcopy(m, c[i:], ldc, work, 1)
+			bi.Dgemv(blas.NoTrans, m, l, 1, c[n-l:], ldc, a[i*lda+(nq-l):], 1, 1, work, 1)
+			// C[:,i] -= tau * w
+			bi.Daxpy(m, -tau[i], work, 1, c[i:], ldc)
+			// C[:,n-l:n] -= tau * w * vᵀ
+			bi.Dger(m, l, -tau[i], work, 1, a[i*lda+(nq-l):], 1, c[n-l:], ldc)
+		}
+	}
+	work[0] = float64(max(1, nw))
+}

--- a/lapack/gonum/dtzrzf.go
+++ b/lapack/gonum/dtzrzf.go
@@ -1,0 +1,96 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+import "gonum.org/v1/gonum/blas/blas64"
+
+// Dtzrzf reduces the m×n (m ≤ n) upper trapezoidal matrix A to upper
+// triangular form by means of orthogonal transformations.
+//
+// The upper trapezoidal matrix A is factored as
+//
+//	A = [R 0] * Z
+//
+// where Z is an n×n orthogonal matrix and R is an m×m upper triangular matrix.
+//
+// Z is stored as a product of m elementary reflectors
+//
+//	Z = Z(0) * Z(1) * ... * Z(m-1)
+//
+// Each Z(i) has the form
+//
+//	Z(i) = I - tau[i] * v * vᵀ
+//
+// where tau[i] is stored in tau[i] and v is a vector with
+//
+//	v[0:i] = 0, v[i] = 1, v[i+1:m] = 0, v[m:n] = A[i, m:n]
+//
+// on exit.
+//
+// tau must have length at least m. work must have length at least max(1,lwork).
+//
+// If lwork is -1, instead of performing Dtzrzf, only the optimal workspace
+// size is stored into work[0].
+//
+// Dtzrzf is an internal routine. It is exported for testing purposes.
+func (impl Implementation) Dtzrzf(m, n int, a []float64, lda int, tau, work []float64, lwork int) {
+	switch {
+	case m < 0:
+		panic(mLT0)
+	case n < m:
+		panic(nLTM)
+	case lda < max(1, n):
+		panic(badLdA)
+	case lwork < max(1, m) && lwork != -1:
+		panic(badLWork)
+	case len(work) < max(1, lwork):
+		panic(shortWork)
+	}
+
+	if lwork == -1 {
+		work[0] = float64(m)
+		return
+	}
+
+	if m == 0 {
+		work[0] = 1
+		return
+	}
+
+	switch {
+	case len(a) < (m-1)*lda+n:
+		panic(shortA)
+	case len(tau) < m:
+		panic(shortTau)
+	}
+
+	if m == n {
+		for i := range tau[:m] {
+			tau[i] = 0
+		}
+		work[0] = 1
+		return
+	}
+
+	bi := blas64.Implementation()
+	l := n - m
+	for i := m - 1; i >= 0; i-- {
+		beta, t := impl.Dlarfg(l+1, a[i*lda+i], a[i*lda+m:i*lda+n], 1)
+		tau[i] = t
+		a[i*lda+i] = beta
+
+		if t != 0 && i > 0 {
+			// Apply Z(i) to A[0:i, i:n] from the right.
+			// w = A[0:i, i] + A[0:i, m:n] * v
+			bi.Dcopy(i, a[i:], lda, work, 1)
+			bi.Dgemv('N', i, l, 1, a[m:], lda, a[i*lda+m:], 1, 1, work, 1)
+			// A[0:i, i] -= tau * w
+			bi.Daxpy(i, -t, work, 1, a[i:], lda)
+			// A[0:i, m:n] -= tau * w * v^T
+			bi.Dger(i, l, -t, work, 1, a[i*lda+m:], 1, a[m:], lda)
+		}
+	}
+	work[0] = float64(m)
+}

--- a/lapack/gonum/lapack_test.go
+++ b/lapack/gonum/lapack_test.go
@@ -638,6 +638,21 @@ func TestDtbtrs(t *testing.T) {
 	testlapack.DtbtrsTest(t, impl)
 }
 
+func TestDlaic1(t *testing.T) {
+	t.Parallel()
+	testlapack.Dlaic1Test(t, impl)
+}
+
+func TestDormrz(t *testing.T) {
+	t.Parallel()
+	testlapack.DormrzTest(t, impl)
+}
+
+func TestDtzrzf(t *testing.T) {
+	t.Parallel()
+	testlapack.DtzrzfTest(t, impl)
+}
+
 func TestDtrcon(t *testing.T) {
 	t.Parallel()
 	testlapack.DtrconTest(t, impl)

--- a/lapack/testlapack/dlaic1.go
+++ b/lapack/testlapack/dlaic1.go
@@ -1,0 +1,105 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+)
+
+type Dlaic1er interface {
+	Dlaic1(job int, j int, x []float64, sest float64, w []float64, gamma float64) (sestpr, s, c float64)
+}
+
+func Dlaic1Test(t *testing.T, impl Dlaic1er) {
+	rnd := rand.New(rand.NewPCG(1, 1))
+	const tol = 1e-12
+
+	// Test basic properties for random inputs.
+	for _, j := range []int{0, 1, 2, 5, 10} {
+		for trial := 0; trial < 20; trial++ {
+			x := make([]float64, j)
+			w := make([]float64, j)
+			for i := range x {
+				x[i] = rnd.NormFloat64()
+				w[i] = rnd.NormFloat64()
+			}
+			sest := math.Abs(rnd.NormFloat64()) + 0.1
+			gamma := rnd.NormFloat64()
+
+			for _, job := range []int{1, 2} {
+				sestpr, s, c := impl.Dlaic1(job, j, x, sest, w, gamma)
+
+				// s^2 + c^2 should be approximately 1.
+				norm := s*s + c*c
+				if math.Abs(norm-1) > tol {
+					t.Errorf("job=%d j=%d trial=%d: s²+c²=%g want 1", job, j, trial, norm)
+				}
+
+				// sestpr should be non-negative.
+				if sestpr < -tol {
+					t.Errorf("job=%d j=%d trial=%d: sestpr=%g < 0", job, j, trial, sestpr)
+				}
+
+				if job == 1 {
+					// For max estimation, sestpr >= sest (augmenting can't decrease max sv).
+					if sestpr < sest-tol*sest {
+						t.Errorf("job=1 j=%d trial=%d: sestpr=%g < sest=%g", j, trial, sestpr, sest)
+					}
+				}
+			}
+		}
+	}
+
+	// Test with sest=0.
+	for _, job := range []int{1, 2} {
+		sestpr, s, c := impl.Dlaic1(job, 2, []float64{1, 0}, 0, []float64{0, 1}, 3)
+		norm := s*s + c*c
+		if math.Abs(norm-1) > tol {
+			t.Errorf("sest=0 job=%d: s²+c²=%g want 1", job, norm)
+		}
+		_ = sestpr
+	}
+
+	// Test with zero gamma and w: should return sest unchanged for job=1.
+	{
+		sestpr, s, c := impl.Dlaic1(1, 3, []float64{1, 0, 0}, 5.0, []float64{0, 0, 0}, 0)
+		if math.Abs(s*s+c*c-1) > tol {
+			t.Errorf("zero gamma/w: s²+c²=%g want 1", s*s+c*c)
+		}
+		_ = sestpr
+	}
+
+	// Test 1×1 → 2×2 explicitly.
+	// T = [3], w = [1], gamma = 4 → T_hat = [3 1; 0 4]
+	// Singular values of T_hat: eigenvalues of T_hat^T * T_hat = [9 3; 3 17]
+	// λ = (26 ± sqrt(676-4*144))/2 = (26 ± sqrt(100))/2 = 18 or 8
+	// sigma_max = sqrt(18), sigma_min = sqrt(8)
+	{
+		sest := 3.0
+		x := []float64{1.0}
+		w := []float64{1.0}
+		gamma := 4.0
+
+		sestpr1, s1, c1 := impl.Dlaic1(1, 1, x, sest, w, gamma)
+		if math.Abs(s1*s1+c1*c1-1) > tol {
+			t.Errorf("1x1→2x2 job=1: s²+c²=%g", s1*s1+c1*c1)
+		}
+		sigmaMax := math.Sqrt(18)
+		if math.Abs(sestpr1-sigmaMax) > 0.5*sigmaMax {
+			t.Errorf("1x1→2x2 job=1: sestpr=%g want≈%g", sestpr1, sigmaMax)
+		}
+
+		sestpr2, s2, c2 := impl.Dlaic1(2, 1, x, sest, w, gamma)
+		if math.Abs(s2*s2+c2*c2-1) > tol {
+			t.Errorf("1x1→2x2 job=2: s²+c²=%g", s2*s2+c2*c2)
+		}
+		sigmaMin := math.Sqrt(8)
+		if math.Abs(sestpr2-sigmaMin) > 0.5*sigmaMin {
+			t.Errorf("1x1→2x2 job=2: sestpr=%g want≈%g", sestpr2, sigmaMin)
+		}
+	}
+}

--- a/lapack/testlapack/dlaic1_bench.go
+++ b/lapack/testlapack/dlaic1_bench.go
@@ -1,0 +1,33 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"testing"
+)
+
+func Dlaic1Benchmark(b *testing.B, impl Dlaic1er) {
+	rnd := rand.New(rand.NewPCG(1, 1))
+	for _, j := range []int{10, 100, 1000, 10000} {
+		x := make([]float64, j)
+		w := make([]float64, j)
+		for i := range x {
+			x[i] = rnd.NormFloat64()
+			w[i] = rnd.NormFloat64()
+		}
+		sest := rnd.Float64() + 1
+		gamma := rnd.NormFloat64()
+
+		for _, job := range []int{1, 2} {
+			b.Run(fmt.Sprintf("job=%d/j=%d", job, j), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					impl.Dlaic1(job, j, x, sest, w, gamma)
+				}
+			})
+		}
+	}
+}

--- a/lapack/testlapack/dormrz.go
+++ b/lapack/testlapack/dormrz.go
@@ -1,0 +1,130 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"math/rand/v2"
+	"testing"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/blas64"
+	"gonum.org/v1/gonum/floats"
+)
+
+type Dormrzer interface {
+	Dtzrzfer
+	Dormrz(side blas.Side, trans blas.Transpose, m, n, k, l int, a []float64, lda int, tau, c []float64, ldc int, work []float64, lwork int)
+}
+
+func DormrzTest(t *testing.T, impl Dormrzer) {
+	rnd := rand.New(rand.NewPCG(1, 1))
+	for _, side := range []blas.Side{blas.Left, blas.Right} {
+		for _, trans := range []blas.Transpose{blas.NoTrans, blas.Trans} {
+			for _, test := range []struct {
+				k, mc, nc int
+			}{
+				{1, 4, 5},
+				{2, 5, 5},
+				{3, 8, 6},
+				{2, 6, 6},
+				{3, 10, 8},
+				{1, 1, 5},
+				{1, 5, 1},
+				{4, 4, 6},
+				{4, 6, 4},
+			} {
+				k := test.k
+				mc := test.mc
+				nc := test.nc
+
+				var nq int
+				if side == blas.Left {
+					nq = mc
+				} else {
+					nq = nc
+				}
+				if k > nq {
+					continue
+				}
+				l := nq - k
+
+				// Build upper trapezoidal matrix of size k×nq and factor with Dtzrzf.
+				ldaz := nq
+				az := make([]float64, k*ldaz)
+				for i := 0; i < k; i++ {
+					for j := i; j < nq; j++ {
+						az[i*ldaz+j] = rnd.NormFloat64()
+					}
+				}
+				tau := make([]float64, k)
+				work := make([]float64, 1)
+				impl.Dtzrzf(k, nq, nil, ldaz, nil, work, -1)
+				lwork := max(int(work[0]), max(mc, nc))
+				work = make([]float64, lwork)
+				impl.Dtzrzf(k, nq, az, ldaz, tau, work, k)
+
+				// Construct Z explicitly.
+				z := blas64.General{Rows: nq, Cols: nq, Stride: nq, Data: make([]float64, nq*nq)}
+				for i := 0; i < nq; i++ {
+					z.Data[i*nq+i] = 1
+				}
+				for i := k - 1; i >= 0; i-- {
+					if tau[i] == 0 {
+						continue
+					}
+					v := make([]float64, nq)
+					v[i] = 1
+					for j := k; j < nq; j++ {
+						v[j] = az[i*ldaz+j]
+					}
+					tmp := make([]float64, nq)
+					for c := 0; c < nq; c++ {
+						for r := 0; r < nq; r++ {
+							tmp[c] += v[r] * z.Data[r*nq+c]
+						}
+					}
+					for r := 0; r < nq; r++ {
+						for c := 0; c < nq; c++ {
+							z.Data[r*nq+c] -= tau[i] * v[r] * tmp[c]
+						}
+					}
+				}
+
+				// Generate random C.
+				ldc := nc
+				c := make([]float64, mc*ldc)
+				for i := range c {
+					c[i] = rnd.NormFloat64()
+				}
+				cOrig := make([]float64, len(c))
+				copy(cOrig, c)
+
+				// Compute expected result using Dgemm.
+				cMat := blas64.General{Rows: mc, Cols: nc, Stride: ldc, Data: make([]float64, len(c))}
+				copy(cMat.Data, cOrig)
+				cExp := blas64.General{Rows: mc, Cols: nc, Stride: ldc, Data: make([]float64, len(c))}
+				switch {
+				case side == blas.Left && trans == blas.NoTrans:
+					blas64.Gemm(blas.NoTrans, blas.NoTrans, 1, z, cMat, 0, cExp)
+				case side == blas.Left && trans == blas.Trans:
+					blas64.Gemm(blas.Trans, blas.NoTrans, 1, z, cMat, 0, cExp)
+				case side == blas.Right && trans == blas.NoTrans:
+					blas64.Gemm(blas.NoTrans, blas.NoTrans, 1, cMat, z, 0, cExp)
+				case side == blas.Right && trans == blas.Trans:
+					blas64.Gemm(blas.NoTrans, blas.Trans, 1, cMat, z, 0, cExp)
+				}
+
+				// Apply Dormrz.
+				copy(c, cOrig)
+				impl.Dormrz(side, trans, mc, nc, k, l, az, ldaz, tau, c, ldc, work, lwork)
+
+				if !floats.EqualApprox(c, cExp.Data, 1e-13) {
+					t.Errorf("side=%c trans=%c k=%d l=%d mc=%d nc=%d: result mismatch",
+						byte(side), byte(trans), k, l, mc, nc)
+				}
+			}
+		}
+	}
+}

--- a/lapack/testlapack/dormrz_bench.go
+++ b/lapack/testlapack/dormrz_bench.go
@@ -1,0 +1,83 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"testing"
+
+	"gonum.org/v1/gonum/blas"
+)
+
+func DormrzBenchmark(b *testing.B, impl Dormrzer) {
+	rnd := rand.New(rand.NewPCG(1, 1))
+	for _, sz := range []int{10, 50, 100, 200} {
+		for _, side := range []blas.Side{blas.Left, blas.Right} {
+			sideName := "Left"
+			if side == blas.Right {
+				sideName = "Right"
+			}
+
+			// Z is of order nq where nq=m (Left) or nq=n (Right).
+			// Dtzrzf(k, nq, ...) produces k reflectors with l = nq - k.
+			mc := sz
+			nc := sz
+			k := sz / 2
+			nq := mc
+			if side == blas.Right {
+				nq = nc
+			}
+			// Expand nq so factorization is non-trivial.
+			nq = 2 * nq
+			if side == blas.Left {
+				mc = nq
+			} else {
+				nc = nq
+			}
+			l := nq - k
+			lda := nq
+			ldc := nc
+
+			aOrig := make([]float64, k*lda)
+			for i := range aOrig {
+				aOrig[i] = rnd.NormFloat64()
+			}
+			a := make([]float64, len(aOrig))
+			tau := make([]float64, k)
+
+			copy(a, aOrig)
+			fwork := make([]float64, k)
+			impl.Dtzrzf(k, nq, a, lda, tau, fwork, len(fwork))
+			aFact := make([]float64, len(a))
+			copy(aFact, a)
+			tauFact := make([]float64, len(tau))
+			copy(tauFact, tau)
+
+			cOrig := make([]float64, mc*ldc)
+			for i := range cOrig {
+				cOrig[i] = rnd.NormFloat64()
+			}
+			c := make([]float64, len(cOrig))
+
+			nw := nc
+			if side == blas.Right {
+				nw = mc
+			}
+
+			b.Run(fmt.Sprintf("%s/m=%d/n=%d", sideName, mc, nc), func(b *testing.B) {
+				workDormrz := make([]float64, nw)
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+					copy(c, cOrig)
+					copy(a, aFact)
+					copy(tau, tauFact)
+					b.StartTimer()
+					impl.Dormrz(side, blas.NoTrans, mc, nc, k, l, a, lda, tau, c, ldc, workDormrz, len(workDormrz))
+				}
+			})
+		}
+	}
+}

--- a/lapack/testlapack/dtzrzf.go
+++ b/lapack/testlapack/dtzrzf.go
@@ -1,0 +1,134 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"math/rand/v2"
+	"testing"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/blas64"
+	"gonum.org/v1/gonum/floats"
+)
+
+type Dtzrzfer interface {
+	Dlarfger
+	Dtzrzf(m, n int, a []float64, lda int, tau, work []float64, lwork int)
+}
+
+func DtzrzfTest(t *testing.T, impl Dtzrzfer) {
+	rnd := rand.New(rand.NewPCG(1, 1))
+	for _, test := range []struct {
+		m, n, lda int
+	}{
+		{1, 1, 0},
+		{1, 5, 0},
+		{2, 2, 0},
+		{2, 5, 0},
+		{3, 5, 0},
+		{3, 10, 0},
+		{5, 5, 0},
+		{5, 10, 0},
+		{5, 20, 0},
+		{10, 20, 0},
+		{3, 10, 15},
+		{5, 10, 15},
+	} {
+		m := test.m
+		n := test.n
+		lda := test.lda
+		if lda == 0 {
+			lda = n
+		}
+
+		aOrig := make([]float64, m*lda)
+		for i := 0; i < m; i++ {
+			for j := i; j < n; j++ {
+				aOrig[i*lda+j] = rnd.NormFloat64()
+			}
+		}
+
+		a := make([]float64, len(aOrig))
+		copy(a, aOrig)
+		tau := make([]float64, m)
+
+		// Workspace query.
+		work := make([]float64, 1)
+		impl.Dtzrzf(m, n, nil, lda, nil, work, -1)
+		lwork := int(work[0])
+		work = make([]float64, lwork)
+
+		impl.Dtzrzf(m, n, a, lda, tau, work, lwork)
+
+		// Check R is upper triangular.
+		for i := 0; i < m; i++ {
+			for j := 0; j < i; j++ {
+				if a[i*lda+j] != 0 {
+					t.Errorf("m=%d n=%d: R not upper triangular at (%d,%d)", m, n, i, j)
+				}
+			}
+		}
+
+		// Construct Z = Z(0)*Z(1)*...*Z(m-1) by applying Z(i) from the left.
+		z := blas64.General{Rows: n, Cols: n, Stride: n, Data: make([]float64, n*n)}
+		for i := 0; i < n; i++ {
+			z.Data[i*n+i] = 1
+		}
+		for i := m - 1; i >= 0; i-- {
+			if tau[i] == 0 {
+				continue
+			}
+			v := make([]float64, n)
+			v[i] = 1
+			for j := m; j < n; j++ {
+				v[j] = a[i*lda+j]
+			}
+			// Z = (I - tau*v*v^T) * Z
+			// tmp = v^T * Z  (length n)
+			tmp := make([]float64, n)
+			for c := 0; c < n; c++ {
+				for r := 0; r < n; r++ {
+					tmp[c] += v[r] * z.Data[r*n+c]
+				}
+			}
+			// Z -= tau * v * tmp^T
+			for r := 0; r < n; r++ {
+				for c := 0; c < n; c++ {
+					z.Data[r*n+c] -= tau[i] * v[r] * tmp[c]
+				}
+			}
+		}
+
+		// Verify Z is orthogonal: Z*Z^T = I.
+		var zzT blas64.General
+		zzT.Rows, zzT.Cols, zzT.Stride = n, n, n
+		zzT.Data = make([]float64, n*n)
+		blas64.Gemm(blas.NoTrans, blas.Trans, 1, z, z, 0, zzT)
+		eye := make([]float64, n*n)
+		for i := 0; i < n; i++ {
+			eye[i*n+i] = 1
+		}
+		if !floats.EqualApprox(zzT.Data, eye, 1e-13) {
+			t.Errorf("m=%d n=%d: Z is not orthogonal", m, n)
+		}
+
+		// Verify [R 0]*Z = A_orig.
+		rz := blas64.General{Rows: m, Cols: n, Stride: n, Data: make([]float64, m*n)}
+		rMat := blas64.General{Rows: m, Cols: n, Stride: n, Data: make([]float64, m*n)}
+		for i := 0; i < m; i++ {
+			for j := i; j < m; j++ {
+				rMat.Data[i*n+j] = a[i*lda+j]
+			}
+		}
+		blas64.Gemm(blas.NoTrans, blas.NoTrans, 1, rMat, z, 0, rz)
+		aOrigFlat := make([]float64, m*n)
+		for i := 0; i < m; i++ {
+			copy(aOrigFlat[i*n:i*n+n], aOrig[i*lda:i*lda+n])
+		}
+		if !floats.EqualApprox(rz.Data, aOrigFlat, 1e-13) {
+			t.Errorf("m=%d n=%d: [R 0]*Z != A_orig", m, n)
+		}
+	}
+}

--- a/lapack/testlapack/dtzrzf_bench.go
+++ b/lapack/testlapack/dtzrzf_bench.go
@@ -1,0 +1,35 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"testing"
+)
+
+func DtzrzfBenchmark(b *testing.B, impl Dtzrzfer) {
+	rnd := rand.New(rand.NewPCG(1, 1))
+	for _, m := range []int{10, 50, 100, 200} {
+		n := 2 * m
+		lda := n
+		aOrig := make([]float64, m*lda)
+		for i := range aOrig {
+			aOrig[i] = rnd.NormFloat64()
+		}
+		a := make([]float64, len(aOrig))
+		tau := make([]float64, m)
+		work := make([]float64, m)
+
+		b.Run(fmt.Sprintf("m=%d/n=%d", m, n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				copy(a, aOrig)
+				b.StartTimer()
+				impl.Dtzrzf(m, n, a, lda, tau, work, len(work))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds the RZ factorization and application routines, plus incremental condition estimation support.

Includes `Dlaic1`, `Dtzrzf`, and `Dormrz` with Gonum test-suite coverage.

Validation:
- `go test ./lapack/gonum -run "Test(Dlaic1|Dormrz|Dtzrzf)$" -count=1`