### PR TITLE
lapack/gonum: add real Schur decomposition support

### DIFF
--- a/lapack/gonum/dgees.go
+++ b/lapack/gonum/dgees.go
@@ -1,0 +1,262 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+import (
+	"math"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/lapack"
+)
+
+// Dgees computes for an n×n real nonsymmetric matrix A, the eigenvalues, the
+// real Schur form T, and, optionally, the matrix of Schur vectors Z. This
+// gives the Schur factorization
+//
+//	A = Z * T * Zᵀ
+//
+// where T is upper quasi-triangular (the Schur form). A matrix is in real Schur
+// form if it is upper quasi-triangular with 1×1 and 2×2 blocks. 2×2 blocks will
+// be standardized in the form
+//
+//	[ a  b ]
+//	[ c  a ]
+//
+// where b*c < 0. The eigenvalues of such a block are a ± sqrt(bc).
+//
+// Optionally, the routine can order the eigenvalues on the diagonal of the real
+// Schur form so that selected eigenvalues are at the top left. The leading
+// columns of Z then form an orthonormal basis for the invariant subspace
+// corresponding to the selected eigenvalues.
+//
+// A matrix is in Schur canonical form if it is quasi-triangular and every 2×2
+// diagonal block has the form shown above.
+//
+// If jobvs is lapack.SchurNone, no Schur vectors are computed.
+// If jobvs is lapack.SchurHess, the Schur vectors are computed and returned in
+// vs.
+// For other values of jobvs, Dgees will panic.
+//
+// If sort is lapack.SortNone, eigenvalues are not ordered.
+// If sort is lapack.SortSelected, eigenvalues are reordered so that selected
+// eigenvalues appear in the leading diagonal blocks of the Schur form.
+//
+// selctg is a function that selects eigenvalues. It is only used when sort is
+// lapack.SortSelected. An eigenvalue wr[j]+i*wi[j] is selected if
+// selctg(wr[j], wi[j]) is true. Note that a selected complex eigenvalue may no
+// longer satisfy selctg after ordering, since ordering may change the value of
+// complex eigenvalues (especially if the eigenvalue is ill-conditioned).
+//
+// On entry, a contains the n×n matrix A. On return, a has been overwritten by
+// its real Schur form T.
+//
+// wr and wi will contain the real and imaginary parts, respectively, of the
+// computed eigenvalues in the same order that they appear on the diagonal of
+// the output Schur form T. Complex conjugate pairs of eigenvalues will appear
+// consecutively with the eigenvalue having positive imaginary part first.
+// wr and wi must have length n, otherwise Dgees will panic.
+//
+// If jobvs is lapack.SchurHess, vs must have leading dimension ldvs >= n and
+// have length at least (n-1)*ldvs+n, and on return will contain the orthogonal
+// matrix Z of Schur vectors.
+// If jobvs is lapack.SchurNone, vs is not referenced.
+//
+// work must have length at least lwork and lwork must be at least max(1,3*n).
+// For good performance, lwork should generally be larger. On return, work[0]
+// will contain the optimal value of lwork.
+//
+// If lwork is -1, instead of performing Dgees, only the optimal value of lwork
+// is computed and stored into work[0].
+//
+// If sort is lapack.SortSelected, bwork must have length n; otherwise bwork is
+// not referenced and can be nil.
+//
+// On return, sdim contains the number of eigenvalues (after sorting) for which
+// selctg is true. If sort is lapack.SortNone, sdim will be 0.
+//
+// On return, ok reports whether all eigenvalues have been computed. If ok is
+// false, a has been partially reduced and some eigenvalues may not have
+// converged. In this case the eigenvalues in wr[0:n] and wi[0:n] are correct
+// for indices where they were computed, but T may not be in Schur form.
+//
+// Dgees is an internal routine. It is exported for testing purposes.
+func (impl Implementation) Dgees(jobvs lapack.SchurComp, sort lapack.SchurSort, selctg func(wr, wi float64) bool, n int, a []float64, lda int, wr, wi []float64, vs []float64, ldvs int, work []float64, lwork int, bwork []bool) (sdim int, ok bool) {
+	wantvs := jobvs == lapack.SchurHess
+	wantst := sort == lapack.SortSelected
+
+	minwrk := max(1, 3*n)
+
+	switch {
+	case jobvs != lapack.SchurHess && jobvs != lapack.SchurNone:
+		panic(badSchurComp)
+	case sort != lapack.SortNone && sort != lapack.SortSelected:
+		panic(badSchurSort)
+	case n < 0:
+		panic(nLT0)
+	case lda < max(1, n):
+		panic(badLdA)
+	case ldvs < 1 || (wantvs && ldvs < n):
+		panic(badLdZ)
+	case lwork < minwrk && lwork != -1:
+		panic(badLWork)
+	case len(work) < max(1, lwork):
+		panic(shortWork)
+	}
+
+	// Compute workspace.
+	var maxwrk int
+	if n == 0 {
+		maxwrk = 1
+	} else {
+		maxwrk = 2*n + n*impl.Ilaenv(1, "DGEHRD", " ", n, 1, n, 0)
+		if wantvs {
+			maxwrk = max(maxwrk, 2*n+(n-1)*impl.Ilaenv(1, "DORGHR", " ", n, 1, n, -1))
+			impl.Dhseqr(lapack.EigenvaluesAndSchur, lapack.SchurHess, n, 0, n-1,
+				nil, n, nil, nil, nil, max(1, ldvs), work, -1)
+		} else {
+			impl.Dhseqr(lapack.EigenvaluesAndSchur, lapack.SchurNone, n, 0, n-1,
+				nil, n, nil, nil, nil, 1, work, -1)
+		}
+		hswork := int(work[0])
+
+		trsenwork := 0
+		if wantst {
+			var iwork [1]int
+			impl.Dtrsen(0, wantvs, nil, n, nil, n, nil, n, nil, nil, work, -1, iwork[:], -1)
+			trsenwork = int(work[0])
+		}
+		maxwrk = max(maxwrk, max(1, 2*n+hswork), 2*n+trsenwork)
+	}
+
+	if lwork == -1 {
+		work[0] = float64(maxwrk)
+		return 0, true
+	}
+
+	// Quick return if possible.
+	if n == 0 {
+		work[0] = 1
+		return 0, true
+	}
+
+	switch {
+	case len(a) < (n-1)*lda+n:
+		panic(shortA)
+	case len(wr) != n:
+		panic(badLenWr)
+	case len(wi) != n:
+		panic(badLenWi)
+	case wantvs && len(vs) < (n-1)*ldvs+n:
+		panic(shortZ)
+	case wantst && len(bwork) < n:
+		panic("lapack: insufficient length of bwork")
+	case wantst && selctg == nil:
+		panic("lapack: selctg is nil but sort is SortSelected")
+	}
+
+	// Get machine constants.
+	eps := dlamchP
+	smlnum := math.Sqrt(dlamchS) / eps
+	bignum := 1 / smlnum
+
+	// Scale A if max element outside range [smlnum,bignum].
+	anrm := impl.Dlange(lapack.MaxAbs, n, n, a, lda, nil)
+	var scalea bool
+	var cscale float64
+	if anrm > 0 && anrm < smlnum {
+		scalea = true
+		cscale = smlnum
+	} else if anrm > bignum {
+		scalea = true
+		cscale = bignum
+	}
+	if scalea {
+		impl.Dlascl(lapack.General, 0, 0, anrm, cscale, n, n, a, lda)
+	}
+
+	// Balance the matrix.
+	// Use permutation-only balancing (not scaling) because scaling would
+	// affect the Schur vectors. This matches LAPACK's DGEES.
+	workbal := work[:n]
+	ilo, ihi := impl.Dgebal(lapack.Permute, n, a, lda, workbal)
+
+	// Reduce to upper Hessenberg form.
+	iwrk := 2 * n
+	tau := work[n : iwrk-1]
+	impl.Dgehrd(n, ilo, ihi, a, lda, tau, work[iwrk:], lwork-iwrk)
+
+	if wantvs {
+		// Copy Householder vectors to vs.
+		impl.Dlacpy(blas.Lower, n, n, a, lda, vs, ldvs)
+		// Generate orthogonal matrix in vs.
+		impl.Dorghr(n, ilo, ihi, vs, ldvs, tau, work[iwrk:], lwork-iwrk)
+	}
+
+	// Perform QR iteration, accumulating Schur vectors in vs if desired.
+	iwrk = n
+	var compz lapack.SchurComp
+	if wantvs {
+		compz = lapack.SchurOrig
+	} else {
+		compz = lapack.SchurNone
+	}
+	ieval := impl.Dhseqr(lapack.EigenvaluesAndSchur, compz, n, ilo, ihi,
+		a, lda, wr, wi, vs, ldvs, work[iwrk:], lwork-iwrk)
+	if ieval > 0 {
+		ok = false
+	} else {
+		ok = true
+	}
+
+	// Sort eigenvalues if desired.
+	sdim = 0
+	if ok && wantst {
+		// Populate bwork[] using selctg callback.
+		for i := 0; i < n; {
+			if i < n-1 && wi[i] != 0 {
+				// Complex conjugate pair at positions i and i+1.
+				// Both must be selected if either is selected.
+				sel1 := selctg(wr[i], wi[i])
+				sel2 := selctg(wr[i+1], wi[i+1])
+				bwork[i] = sel1 || sel2
+				bwork[i+1] = sel1 || sel2
+				i += 2
+			} else {
+				// Real eigenvalue.
+				bwork[i] = selctg(wr[i], wi[i])
+				i++
+			}
+		}
+
+		// Call Dtrsen to reorder eigenvalues.
+		liwork := 1
+		iwork := make([]int, liwork)
+
+		var trsenM int
+		var trsenOk bool
+		trsenM, _, _, trsenOk = impl.Dtrsen(0, wantvs, bwork, n,
+			a, lda, vs, ldvs, wr, wi, work[iwrk:], lwork-iwrk, iwork, liwork)
+
+		if !trsenOk {
+			ok = false
+		}
+		sdim = trsenM
+	}
+
+	if wantvs {
+		// Undo balancing (permutation only).
+		impl.Dgebak(lapack.Permute, lapack.EVRight, n, ilo, ihi, workbal, n, vs, ldvs)
+	}
+
+	if scalea {
+		// Undo scaling for the Schur form of A.
+		impl.Dlascl(lapack.General, 0, 0, cscale, anrm, n, n, a, lda)
+		impl.Dlascl(lapack.General, 0, 0, cscale, anrm, n, 1, wr, n)
+		impl.Dlascl(lapack.General, 0, 0, cscale, anrm, n, 1, wi, n)
+	}
+
+	work[0] = float64(maxwrk)
+	return sdim, ok
+}

--- a/lapack/gonum/dtrsen.go
+++ b/lapack/gonum/dtrsen.go
@@ -61,7 +61,7 @@ func (impl Implementation) Dtrsen(ijob int, wantq bool, selected []bool, n int, 
 		lwmin = 1
 		liwmin = 1
 	} else {
-		if ijob > 0 {
+		if ijob > 0 || (lwork != -1 && liwork != -1) {
 			switch {
 			case len(selected) < n:
 				panic(badLenSelected)
@@ -106,6 +106,8 @@ func (impl Implementation) Dtrsen(ijob int, wantq bool, selected []bool, n int, 
 	}
 
 	if n == 0 {
+		work[0] = float64(lwmin)
+		iwork[0] = liwmin
 		return 0, 1, 0, true
 	}
 
@@ -129,9 +131,13 @@ func (impl Implementation) Dtrsen(ijob int, wantq bool, selected []bool, n int, 
 	case len(iwork) < liwork:
 		panic(shortIWork)
 	}
+	defer func() {
+		work[0] = float64(lwmin)
+		iwork[0] = liwmin
+	}()
 
 	ok = true
-	m = 0
+	m = msel
 	ks := 0
 	pair := false
 	for k := 0; k < n; k++ {
@@ -157,13 +163,12 @@ func (impl Implementation) Dtrsen(ijob int, wantq bool, selected []bool, n int, 
 				_, _, swapOk := impl.Dtrexc(compq, n, t, ldt, q, ldq, k, ks, work)
 				if !swapOk {
 					ok = false
+					break
 				}
 			}
 			if n2 == 1 {
-				m += 2
 				ks += 2
 			} else {
-				m++
 				ks++
 			}
 		}

--- a/lapack/gonum/dtrsen.go
+++ b/lapack/gonum/dtrsen.go
@@ -1,0 +1,238 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+import (
+	"math"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/lapack"
+)
+
+// Dtrsen reorders the real Schur factorization of a real matrix A = Q*T*Qᵀ, so
+// that a selected cluster of eigenvalues appears in the leading diagonal
+// blocks of the upper quasi-triangular matrix T, and the matrix Q of Schur
+// vectors is updated.
+//
+// The ijob parameter specifies what is computed:
+//   - ijob=0: reorder only, no condition estimates
+//   - ijob=1: compute reciprocal condition number for average of selected eigenvalues
+//   - ijob=2: compute reciprocal condition number for right invariant subspace
+//   - ijob=3: compute both 1 and 2
+//
+// If wantq is true, the matrix Q of Schur vectors is updated.
+//
+// selected specifies which eigenvalues are to be moved to the top-left of T.
+// For a complex conjugate pair, either or both corresponding elements may be
+// true; the pair is always moved together.
+//
+// On return, m is the dimension of the specified invariant subspace.
+// s is the reciprocal condition number for the average of the selected
+// eigenvalues (valid only if ijob=1 or 3).
+// sep is the reciprocal condition number for the right invariant subspace
+// (valid only if ijob=2 or 3).
+//
+// work must have length at least lwork. if lwork is -1, a workspace query is
+// performed.
+//
+// iwork must have length at least liwork. if liwork is -1, a workspace query is
+// performed.
+//
+// Dtrsen returns ok=false if the reordering failed because some eigenvalues are
+// too close to swap.
+func (impl Implementation) Dtrsen(ijob int, wantq bool, selected []bool, n int, t []float64, ldt int, q []float64, ldq int, wr, wi []float64, work []float64, lwork int, iwork []int, liwork int) (m int, s, sep float64, ok bool) {
+	switch {
+	case ijob < 0 || ijob > 3:
+		panic(badIJob)
+	case n < 0:
+		panic(nLT0)
+	case ldt < max(1, n):
+		panic(badLdT)
+	case wantq && ldq < max(1, n):
+		panic(badLdQ)
+	}
+
+	// Workspace requirements.
+	var lwmin, liwmin int
+	msel := 0
+	if n == 0 {
+		lwmin = 1
+		liwmin = 1
+	} else {
+		if ijob > 0 {
+			switch {
+			case len(selected) < n:
+				panic(badLenSelected)
+			case len(t) < (n-1)*ldt+n:
+				panic(shortT)
+			}
+			for k := 0; k < n; {
+				if k < n-1 && t[(k+1)*ldt+k] != 0 {
+					if selected[k] || selected[k+1] {
+						msel += 2
+					}
+					k += 2
+					continue
+				}
+				if selected[k] {
+					msel++
+				}
+				k++
+			}
+		}
+		switch ijob {
+		case 0:
+			lwmin = max(1, n)
+			liwmin = 1
+		case 1:
+			lwmin = max(1, n, msel*(n-msel))
+			liwmin = 1
+		case 2, 3:
+			lwmin = max(1, n, 2*msel*(n-msel))
+			liwmin = max(1, msel*(n-msel))
+		}
+	}
+
+	if lwork == -1 || liwork == -1 {
+		if lwork == -1 {
+			work[0] = float64(lwmin)
+		}
+		if liwork == -1 {
+			iwork[0] = liwmin
+		}
+		return msel, 0, 0, true
+	}
+
+	if n == 0 {
+		return 0, 1, 0, true
+	}
+
+	switch {
+	case len(selected) < n:
+		panic(badLenSelected)
+	case len(t) < (n-1)*ldt+n:
+		panic(shortT)
+	case wantq && len(q) < (n-1)*ldq+n:
+		panic(shortQ)
+	case len(wr) < n:
+		panic(badLenWr)
+	case len(wi) < n:
+		panic(badLenWi)
+	case lwork < lwmin:
+		panic(badLWork)
+	case len(work) < lwork:
+		panic(shortWork)
+	case liwork < liwmin:
+		panic(badLWork)
+	case len(iwork) < liwork:
+		panic(shortIWork)
+	}
+
+	ok = true
+	m = 0
+	ks := 0
+	pair := false
+	for k := 0; k < n; k++ {
+		if pair {
+			pair = false
+			continue
+		}
+		n2 := 0
+		if k < n-1 && t[(k+1)*ldt+k] != 0 {
+			n2 = 1
+		}
+
+		swap := selected[k]
+		if n2 == 1 {
+			swap = swap || selected[k+1]
+		}
+		if swap {
+			if k > ks {
+				compq := lapack.UpdateSchurNone
+				if wantq {
+					compq = lapack.UpdateSchur
+				}
+				_, _, swapOk := impl.Dtrexc(compq, n, t, ldt, q, ldq, k, ks, work)
+				if !swapOk {
+					ok = false
+				}
+			}
+			if n2 == 1 {
+				m += 2
+				ks += 2
+			} else {
+				m++
+				ks++
+			}
+		}
+		if n2 == 1 {
+			pair = true
+		}
+	}
+
+	// Update wr and wi.
+	for i := 0; i < n; i++ {
+		if i < n-1 && t[(i+1)*ldt+i] != 0 {
+			wr[i] = t[i*ldt+i]
+			wr[i+1] = t[i*ldt+i]
+			wi[i] = math.Sqrt(math.Abs(t[i*ldt+i+1])) * math.Sqrt(math.Abs(t[(i+1)*ldt+i]))
+			wi[i+1] = -wi[i]
+			i++
+		} else {
+			wr[i] = t[i*ldt+i]
+			wi[i] = 0
+		}
+	}
+
+	s = 1
+	sep = 0
+	wants := ijob == 1 || ijob == 3
+	wantsp := ijob == 2 || ijob == 3
+	if (m == 0 || m == n) && wantsp {
+		sep = impl.Dlange(lapack.MaxColumnSum, n, n, t, ldt, work)
+	}
+	if ijob == 0 || m == 0 || m == n || !ok {
+		return m, s, sep, ok
+	}
+
+	n1 := m
+	n2 := n - m
+	nn := n1 * n2
+
+	if wants {
+		impl.Dlacpy(blas.All, n1, n2, t[n1:], ldt, work, n2)
+		scale, _ := impl.Dtrsyl(blas.NoTrans, blas.NoTrans, -1, n1, n2,
+			t, ldt, t[n1*ldt+n1:], ldt, work, n2)
+		rnorm := impl.Dlange(lapack.Frobenius, n1, n2, work, n2, nil)
+		if rnorm == 0 {
+			s = 1
+		} else {
+			s = scale / (math.Sqrt(scale*scale/rnorm+rnorm) * math.Sqrt(rnorm))
+		}
+	}
+
+	if wantsp {
+		est := 0.0
+		kase := 0
+		isave := [3]int{}
+		scale := 0.0
+		for {
+			est, kase = impl.Dlacn2(nn, work[nn:], work, iwork, est, kase, &isave)
+			if kase == 0 {
+				break
+			}
+			if kase == 1 {
+				scale, _ = impl.Dtrsyl(blas.NoTrans, blas.NoTrans, -1, n1, n2,
+					t, ldt, t[n1*ldt+n1:], ldt, work, n2)
+			} else {
+				scale, _ = impl.Dtrsyl(blas.Trans, blas.Trans, -1, n1, n2,
+					t, ldt, t[n1*ldt+n1:], ldt, work, n2)
+			}
+		}
+		sep = scale / est
+	}
+
+	return m, s, sep, ok
+}

--- a/lapack/gonum/dtrsyl.go
+++ b/lapack/gonum/dtrsyl.go
@@ -1,0 +1,826 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+import (
+	"math"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/blas64"
+	"gonum.org/v1/gonum/lapack"
+)
+
+// Dtrsyl solves the real Sylvester matrix equation:
+//
+//	op(A)*X + isgn*X*op(B) = scale*C
+//
+// where op(A) = A or Aᵀ, op(B) = B or Bᵀ, and isgn = +1 or -1.
+//
+// A is an m×m upper quasi-triangular matrix in Schur canonical form from
+// Dgees or Dhseqr. B is an n×n upper quasi-triangular matrix in Schur
+// canonical form.
+//
+// The solution X overwrites C, and scale is an output scaling factor set
+// less than or equal to 1 to avoid overflow in X.
+//
+// Dtrsyl returns ok=false if A and B have common or very close eigenvalues,
+// making the problem ill-conditioned. In this case, A or B is perturbed to
+// compute an approximate solution that is within machine precision of an
+// exact solution to a perturbed problem.
+//
+// Dtrsyl is an internal routine. It is exported for testing purposes.
+func (impl Implementation) Dtrsyl(trana, tranb blas.Transpose, isgn, m, n int, a []float64, lda int, b []float64, ldb int, c []float64, ldc int) (scale float64, ok bool) {
+	switch trana {
+	case blas.NoTrans, blas.Trans:
+	default:
+		panic(badTrans)
+	}
+	switch tranb {
+	case blas.NoTrans, blas.Trans:
+	default:
+		panic(badTrans)
+	}
+	switch {
+	case isgn != 1 && isgn != -1:
+		panic("lapack: bad isgn")
+	case m < 0:
+		panic(mLT0)
+	case n < 0:
+		panic(nLT0)
+	case lda < max(1, m):
+		panic(badLdA)
+	case ldb < max(1, n):
+		panic(badLdB)
+	case ldc < max(1, n):
+		panic(badLdC)
+	}
+
+	scale = 1
+	ok = true
+
+	if m == 0 || n == 0 {
+		return scale, ok
+	}
+
+	switch {
+	case len(a) < (m-1)*lda+m:
+		panic(shortA)
+	case len(b) < (n-1)*ldb+n:
+		panic(shortB)
+	case len(c) < (m-1)*ldc+n:
+		panic(shortC)
+	}
+
+	notrna := trana == blas.NoTrans
+	notrnb := tranb == blas.NoTrans
+
+	eps := dlamchP
+	smlnum := dlamchS / eps
+	sgn := float64(isgn)
+
+	bi := blas64.Implementation()
+
+	anrm := impl.Dlange(lapack.MaxAbs, m, m, a, lda, nil)
+	bnrm := impl.Dlange(lapack.MaxAbs, n, n, b, ldb, nil)
+	smin := math.Max(smlnum, eps*math.Max(anrm, bnrm))
+
+	if notrna && notrnb {
+		// op(A) = A, op(B) = B
+		// Solve A*X + isgn*X*B = scale*C
+		// Process columns left-to-right, rows bottom-to-top.
+		// suml = A[k, k+1:m] · X[k+1:m, l] (contribution from rows below)
+		// sumr = X[k, 0:l] · B[0:l, l] (contribution from columns left)
+		lnext := 0
+		for l := 0; l < n; {
+			if l < n-1 && b[(l+1)*ldb+l] != 0 {
+				lnext = l + 2
+			} else {
+				lnext = l + 1
+			}
+			l1, l2 := l, lnext-1
+
+			knext := m
+			for k := m - 1; k >= 0; {
+				if k > 0 && a[k*lda+k-1] != 0 {
+					knext = k - 1
+				} else {
+					knext = k
+				}
+				k1, k2 := knext, k
+
+				if k1 == k2 && l1 == l2 {
+					var suml, sumr float64
+					if m > k1+1 {
+						suml = bi.Ddot(m-k1-1, a[k1*lda+k1+1:], 1, c[(k1+1)*ldc+l1:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k1*ldc:], 1, b[l1:], ldb)
+					}
+					vec := c[k1*ldc+l1] - (suml + sgn*sumr)
+
+					scaloc := 1.0
+					a11 := a[k1*lda+k1] + sgn*b[l1*ldb+l1]
+					da11 := math.Abs(a11)
+					if da11 <= smin {
+						a11 = smin
+						da11 = smin
+						ok = false
+					}
+					db := math.Abs(vec)
+					if da11 < 1 && db > 1 && db > bignum*da11 {
+						scaloc = 1 / db
+					}
+					x11 := (vec * scaloc) / a11
+					if scaloc != 1 {
+						for j := 0; j < n; j++ {
+							bi.Dscal(m, scaloc, c[j:], ldc)
+						}
+						scale *= scaloc
+					}
+					c[k1*ldc+l1] = x11
+				} else if k1 == k2 && l1 != l2 {
+					var suml, sumr float64
+					if m > k1+1 {
+						suml = bi.Ddot(m-k1-1, a[k1*lda+k1+1:], 1, c[(k1+1)*ldc+l1:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k1*ldc:], 1, b[l1:], ldb)
+					}
+					vec0 := c[k1*ldc+l1] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if m > k1+1 {
+						suml = bi.Ddot(m-k1-1, a[k1*lda+k1+1:], 1, c[(k1+1)*ldc+l2:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k1*ldc:], 1, b[l2:], ldb)
+					}
+					vec1 := c[k1*ldc+l2] - (suml + sgn*sumr)
+
+					var vec, x [2]float64
+					vec[0], vec[1] = vec0, vec1
+					scaloc, _, ierr := impl.Dlasy2(false, false, isgn, 1, 2,
+						a[k1*lda+k1:], lda, b[l1*ldb+l1:], ldb, vec[:], 2, x[:], 2)
+					if !ierr {
+						ok = false
+					}
+					if scaloc != 1 {
+						for j := 0; j < n; j++ {
+							bi.Dscal(m, scaloc, c[j:], ldc)
+						}
+						scale *= scaloc
+					}
+					c[k1*ldc+l1] = x[0]
+					c[k1*ldc+l2] = x[1]
+				} else if k1 != k2 && l1 == l2 {
+					var suml, sumr float64
+					if m > k2+1 {
+						suml = bi.Ddot(m-k2-1, a[k1*lda+k2+1:], 1, c[(k2+1)*ldc+l1:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k1*ldc:], 1, b[l1:], ldb)
+					}
+					vec0 := c[k1*ldc+l1] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if m > k2+1 {
+						suml = bi.Ddot(m-k2-1, a[k2*lda+k2+1:], 1, c[(k2+1)*ldc+l1:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k2*ldc:], 1, b[l1:], ldb)
+					}
+					vec1 := c[k2*ldc+l1] - (suml + sgn*sumr)
+
+					var vec, x [2]float64
+					vec[0], vec[1] = vec0, vec1
+					scaloc, _, ierr := impl.Dlasy2(false, false, isgn, 2, 1,
+						a[k1*lda+k1:], lda, b[l1*ldb+l1:], ldb, vec[:], 1, x[:], 1)
+					if !ierr {
+						ok = false
+					}
+					if scaloc != 1 {
+						for j := 0; j < n; j++ {
+							bi.Dscal(m, scaloc, c[j:], ldc)
+						}
+						scale *= scaloc
+					}
+					c[k1*ldc+l1] = x[0]
+					c[k2*ldc+l1] = x[1]
+				} else {
+					var suml, sumr float64
+					if m > k2+1 {
+						suml = bi.Ddot(m-k2-1, a[k1*lda+k2+1:], 1, c[(k2+1)*ldc+l1:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k1*ldc:], 1, b[l1:], ldb)
+					}
+					vec00 := c[k1*ldc+l1] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if m > k2+1 {
+						suml = bi.Ddot(m-k2-1, a[k1*lda+k2+1:], 1, c[(k2+1)*ldc+l2:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k1*ldc:], 1, b[l2:], ldb)
+					}
+					vec01 := c[k1*ldc+l2] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if m > k2+1 {
+						suml = bi.Ddot(m-k2-1, a[k2*lda+k2+1:], 1, c[(k2+1)*ldc+l1:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k2*ldc:], 1, b[l1:], ldb)
+					}
+					vec10 := c[k2*ldc+l1] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if m > k2+1 {
+						suml = bi.Ddot(m-k2-1, a[k2*lda+k2+1:], 1, c[(k2+1)*ldc+l2:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k2*ldc:], 1, b[l2:], ldb)
+					}
+					vec11 := c[k2*ldc+l2] - (suml + sgn*sumr)
+
+					var vec, x [4]float64
+					vec[0], vec[1] = vec00, vec01
+					vec[2], vec[3] = vec10, vec11
+					scaloc, _, ierr := impl.Dlasy2(false, false, isgn, 2, 2,
+						a[k1*lda+k1:], lda, b[l1*ldb+l1:], ldb, vec[:], 2, x[:], 2)
+					if !ierr {
+						ok = false
+					}
+					if scaloc != 1 {
+						for j := 0; j < n; j++ {
+							bi.Dscal(m, scaloc, c[j:], ldc)
+						}
+						scale *= scaloc
+					}
+					c[k1*ldc+l1] = x[0]
+					c[k1*ldc+l2] = x[1]
+					c[k2*ldc+l1] = x[2]
+					c[k2*ldc+l2] = x[3]
+				}
+
+				k = knext - 1
+			}
+			l = lnext
+		}
+	} else if !notrna && notrnb {
+		// op(A) = Aᵀ, op(B) = B
+		// Solve Aᵀ*X + isgn*X*B = scale*C
+		// Process columns left-to-right, rows top-to-bottom.
+		// suml = A[0:k, k] · X[0:k, l] (contribution from rows above)
+		// sumr = X[k, 0:l] · B[0:l, l] (contribution from columns left)
+		lnext := 0
+		for l := 0; l < n; {
+			if l < n-1 && b[(l+1)*ldb+l] != 0 {
+				lnext = l + 2
+			} else {
+				lnext = l + 1
+			}
+			l1, l2 := l, lnext-1
+
+			knext := 0
+			for k := 0; k < m; {
+				if k < m-1 && a[(k+1)*lda+k] != 0 {
+					knext = k + 2
+				} else {
+					knext = k + 1
+				}
+				k1, k2 := k, knext-1
+
+				if k1 == k2 && l1 == l2 {
+					var suml, sumr float64
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k1:], lda, c[l1:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k1*ldc:], 1, b[l1:], ldb)
+					}
+					vec := c[k1*ldc+l1] - (suml + sgn*sumr)
+
+					scaloc := 1.0
+					a11 := a[k1*lda+k1] + sgn*b[l1*ldb+l1]
+					da11 := math.Abs(a11)
+					if da11 <= smin {
+						a11 = smin
+						da11 = smin
+						ok = false
+					}
+					db := math.Abs(vec)
+					if da11 < 1 && db > 1 && db > bignum*da11 {
+						scaloc = 1 / db
+					}
+					x11 := (vec * scaloc) / a11
+					if scaloc != 1 {
+						for j := 0; j < n; j++ {
+							bi.Dscal(m, scaloc, c[j:], ldc)
+						}
+						scale *= scaloc
+					}
+					c[k1*ldc+l1] = x11
+				} else if k1 == k2 && l1 != l2 {
+					var suml, sumr float64
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k1:], lda, c[l1:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k1*ldc:], 1, b[l1:], ldb)
+					}
+					vec0 := c[k1*ldc+l1] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k1:], lda, c[l2:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k1*ldc:], 1, b[l2:], ldb)
+					}
+					vec1 := c[k1*ldc+l2] - (suml + sgn*sumr)
+
+					var vec, x [2]float64
+					vec[0], vec[1] = vec0, vec1
+					scaloc, _, ierr := impl.Dlasy2(true, false, isgn, 1, 2,
+						a[k1*lda+k1:], lda, b[l1*ldb+l1:], ldb, vec[:], 2, x[:], 2)
+					if !ierr {
+						ok = false
+					}
+					if scaloc != 1 {
+						for j := 0; j < n; j++ {
+							bi.Dscal(m, scaloc, c[j:], ldc)
+						}
+						scale *= scaloc
+					}
+					c[k1*ldc+l1] = x[0]
+					c[k1*ldc+l2] = x[1]
+				} else if k1 != k2 && l1 == l2 {
+					var suml, sumr float64
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k1:], lda, c[l1:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k1*ldc:], 1, b[l1:], ldb)
+					}
+					vec0 := c[k1*ldc+l1] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k2:], lda, c[l1:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k2*ldc:], 1, b[l1:], ldb)
+					}
+					vec1 := c[k2*ldc+l1] - (suml + sgn*sumr)
+
+					var vec, x [2]float64
+					vec[0], vec[1] = vec0, vec1
+					scaloc, _, ierr := impl.Dlasy2(true, false, isgn, 2, 1,
+						a[k1*lda+k1:], lda, b[l1*ldb+l1:], ldb, vec[:], 1, x[:], 1)
+					if !ierr {
+						ok = false
+					}
+					if scaloc != 1 {
+						for j := 0; j < n; j++ {
+							bi.Dscal(m, scaloc, c[j:], ldc)
+						}
+						scale *= scaloc
+					}
+					c[k1*ldc+l1] = x[0]
+					c[k2*ldc+l1] = x[1]
+				} else {
+					var suml, sumr float64
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k1:], lda, c[l1:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k1*ldc:], 1, b[l1:], ldb)
+					}
+					vec00 := c[k1*ldc+l1] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k1:], lda, c[l2:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k1*ldc:], 1, b[l2:], ldb)
+					}
+					vec01 := c[k1*ldc+l2] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k2:], lda, c[l1:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k2*ldc:], 1, b[l1:], ldb)
+					}
+					vec10 := c[k2*ldc+l1] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k2:], lda, c[l2:], ldc)
+					}
+					if l1 > 0 {
+						sumr = bi.Ddot(l1, c[k2*ldc:], 1, b[l2:], ldb)
+					}
+					vec11 := c[k2*ldc+l2] - (suml + sgn*sumr)
+
+					var vec, x [4]float64
+					vec[0], vec[1] = vec00, vec01
+					vec[2], vec[3] = vec10, vec11
+					scaloc, _, ierr := impl.Dlasy2(true, false, isgn, 2, 2,
+						a[k1*lda+k1:], lda, b[l1*ldb+l1:], ldb, vec[:], 2, x[:], 2)
+					if !ierr {
+						ok = false
+					}
+					if scaloc != 1 {
+						for j := 0; j < n; j++ {
+							bi.Dscal(m, scaloc, c[j:], ldc)
+						}
+						scale *= scaloc
+					}
+					c[k1*ldc+l1] = x[0]
+					c[k1*ldc+l2] = x[1]
+					c[k2*ldc+l1] = x[2]
+					c[k2*ldc+l2] = x[3]
+				}
+
+				k = knext
+			}
+			l = lnext
+		}
+	} else if notrna && !notrnb {
+		// op(A) = A, op(B) = Bᵀ
+		// Solve A*X + isgn*X*Bᵀ = scale*C
+		// Process columns right-to-left, rows bottom-to-top.
+		// suml = A[k, k+1:m] · X[k+1:m, l] (contribution from rows below)
+		// sumr = X[k, l+1:n] · B[l, l+1:n] (contribution from columns right)
+		lnext := n
+		for l := n - 1; l >= 0; {
+			if l > 0 && b[l*ldb+l-1] != 0 {
+				lnext = l - 1
+			} else {
+				lnext = l
+			}
+			l1, l2 := lnext, l
+
+			knext := m
+			for k := m - 1; k >= 0; {
+				if k > 0 && a[k*lda+k-1] != 0 {
+					knext = k - 1
+				} else {
+					knext = k
+				}
+				k1, k2 := knext, k
+
+				if k1 == k2 && l1 == l2 {
+					var suml, sumr float64
+					if m > k1+1 {
+						suml = bi.Ddot(m-k1-1, a[k1*lda+k1+1:], 1, c[(k1+1)*ldc+l1:], ldc)
+					}
+					if n > l1+1 {
+						sumr = bi.Ddot(n-l1-1, c[k1*ldc+l1+1:], 1, b[l1*ldb+l1+1:], 1)
+					}
+					vec := c[k1*ldc+l1] - (suml + sgn*sumr)
+
+					scaloc := 1.0
+					a11 := a[k1*lda+k1] + sgn*b[l1*ldb+l1]
+					da11 := math.Abs(a11)
+					if da11 <= smin {
+						a11 = smin
+						da11 = smin
+						ok = false
+					}
+					db := math.Abs(vec)
+					if da11 < 1 && db > 1 && db > bignum*da11 {
+						scaloc = 1 / db
+					}
+					x11 := (vec * scaloc) / a11
+					if scaloc != 1 {
+						for j := 0; j < n; j++ {
+							bi.Dscal(m, scaloc, c[j:], ldc)
+						}
+						scale *= scaloc
+					}
+					c[k1*ldc+l1] = x11
+				} else if k1 == k2 && l1 != l2 {
+					var suml, sumr float64
+					if m > k1+1 {
+						suml = bi.Ddot(m-k1-1, a[k1*lda+k1+1:], 1, c[(k1+1)*ldc+l1:], ldc)
+					}
+					if n > l2+1 {
+						sumr = bi.Ddot(n-l2-1, c[k1*ldc+l2+1:], 1, b[l1*ldb+l2+1:], 1)
+					}
+					vec0 := c[k1*ldc+l1] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if m > k1+1 {
+						suml = bi.Ddot(m-k1-1, a[k1*lda+k1+1:], 1, c[(k1+1)*ldc+l2:], ldc)
+					}
+					if n > l2+1 {
+						sumr = bi.Ddot(n-l2-1, c[k1*ldc+l2+1:], 1, b[l2*ldb+l2+1:], 1)
+					}
+					vec1 := c[k1*ldc+l2] - (suml + sgn*sumr)
+
+					var vec, x [2]float64
+					vec[0], vec[1] = vec0, vec1
+					scaloc, _, ierr := impl.Dlasy2(false, true, isgn, 1, 2,
+						a[k1*lda+k1:], lda, b[l1*ldb+l1:], ldb, vec[:], 2, x[:], 2)
+					if !ierr {
+						ok = false
+					}
+					if scaloc != 1 {
+						for j := 0; j < n; j++ {
+							bi.Dscal(m, scaloc, c[j:], ldc)
+						}
+						scale *= scaloc
+					}
+					c[k1*ldc+l1] = x[0]
+					c[k1*ldc+l2] = x[1]
+				} else if k1 != k2 && l1 == l2 {
+					var suml, sumr float64
+					if m > k2+1 {
+						suml = bi.Ddot(m-k2-1, a[k1*lda+k2+1:], 1, c[(k2+1)*ldc+l1:], ldc)
+					}
+					if n > l1+1 {
+						sumr = bi.Ddot(n-l1-1, c[k1*ldc+l1+1:], 1, b[l1*ldb+l1+1:], 1)
+					}
+					vec0 := c[k1*ldc+l1] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if m > k2+1 {
+						suml = bi.Ddot(m-k2-1, a[k2*lda+k2+1:], 1, c[(k2+1)*ldc+l1:], ldc)
+					}
+					if n > l1+1 {
+						sumr = bi.Ddot(n-l1-1, c[k2*ldc+l1+1:], 1, b[l1*ldb+l1+1:], 1)
+					}
+					vec1 := c[k2*ldc+l1] - (suml + sgn*sumr)
+
+					var vec, x [2]float64
+					vec[0], vec[1] = vec0, vec1
+					scaloc, _, ierr := impl.Dlasy2(false, true, isgn, 2, 1,
+						a[k1*lda+k1:], lda, b[l1*ldb+l1:], ldb, vec[:], 1, x[:], 1)
+					if !ierr {
+						ok = false
+					}
+					if scaloc != 1 {
+						for j := 0; j < n; j++ {
+							bi.Dscal(m, scaloc, c[j:], ldc)
+						}
+						scale *= scaloc
+					}
+					c[k1*ldc+l1] = x[0]
+					c[k2*ldc+l1] = x[1]
+				} else {
+					var suml, sumr float64
+					if m > k2+1 {
+						suml = bi.Ddot(m-k2-1, a[k1*lda+k2+1:], 1, c[(k2+1)*ldc+l1:], ldc)
+					}
+					if n > l2+1 {
+						sumr = bi.Ddot(n-l2-1, c[k1*ldc+l2+1:], 1, b[l1*ldb+l2+1:], 1)
+					}
+					vec00 := c[k1*ldc+l1] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if m > k2+1 {
+						suml = bi.Ddot(m-k2-1, a[k1*lda+k2+1:], 1, c[(k2+1)*ldc+l2:], ldc)
+					}
+					if n > l2+1 {
+						sumr = bi.Ddot(n-l2-1, c[k1*ldc+l2+1:], 1, b[l2*ldb+l2+1:], 1)
+					}
+					vec01 := c[k1*ldc+l2] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if m > k2+1 {
+						suml = bi.Ddot(m-k2-1, a[k2*lda+k2+1:], 1, c[(k2+1)*ldc+l1:], ldc)
+					}
+					if n > l2+1 {
+						sumr = bi.Ddot(n-l2-1, c[k2*ldc+l2+1:], 1, b[l1*ldb+l2+1:], 1)
+					}
+					vec10 := c[k2*ldc+l1] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if m > k2+1 {
+						suml = bi.Ddot(m-k2-1, a[k2*lda+k2+1:], 1, c[(k2+1)*ldc+l2:], ldc)
+					}
+					if n > l2+1 {
+						sumr = bi.Ddot(n-l2-1, c[k2*ldc+l2+1:], 1, b[l2*ldb+l2+1:], 1)
+					}
+					vec11 := c[k2*ldc+l2] - (suml + sgn*sumr)
+
+					var vec, x [4]float64
+					vec[0], vec[1] = vec00, vec01
+					vec[2], vec[3] = vec10, vec11
+					scaloc, _, ierr := impl.Dlasy2(false, true, isgn, 2, 2,
+						a[k1*lda+k1:], lda, b[l1*ldb+l1:], ldb, vec[:], 2, x[:], 2)
+					if !ierr {
+						ok = false
+					}
+					if scaloc != 1 {
+						for j := 0; j < n; j++ {
+							bi.Dscal(m, scaloc, c[j:], ldc)
+						}
+						scale *= scaloc
+					}
+					c[k1*ldc+l1] = x[0]
+					c[k1*ldc+l2] = x[1]
+					c[k2*ldc+l1] = x[2]
+					c[k2*ldc+l2] = x[3]
+				}
+
+				k = knext - 1
+			}
+			l = lnext - 1
+		}
+	} else {
+		// op(A) = Aᵀ, op(B) = Bᵀ
+		// Solve Aᵀ*X + isgn*X*Bᵀ = scale*C
+		// Process columns right-to-left, rows top-to-bottom.
+		// suml = A[0:k, k] · X[0:k, l] (contribution from rows above)
+		// sumr = X[k, l+1:n] · B[l, l+1:n] (contribution from columns right)
+		lnext := n
+		for l := n - 1; l >= 0; {
+			if l > 0 && b[l*ldb+l-1] != 0 {
+				lnext = l - 1
+			} else {
+				lnext = l
+			}
+			l1, l2 := lnext, l
+
+			knext := 0
+			for k := 0; k < m; {
+				if k < m-1 && a[(k+1)*lda+k] != 0 {
+					knext = k + 2
+				} else {
+					knext = k + 1
+				}
+				k1, k2 := k, knext-1
+
+				if k1 == k2 && l1 == l2 {
+					var suml, sumr float64
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k1:], lda, c[l1:], ldc)
+					}
+					if n > l1+1 {
+						sumr = bi.Ddot(n-l1-1, c[k1*ldc+l1+1:], 1, b[l1*ldb+l1+1:], 1)
+					}
+					vec := c[k1*ldc+l1] - (suml + sgn*sumr)
+
+					scaloc := 1.0
+					a11 := a[k1*lda+k1] + sgn*b[l1*ldb+l1]
+					da11 := math.Abs(a11)
+					if da11 <= smin {
+						a11 = smin
+						da11 = smin
+						ok = false
+					}
+					db := math.Abs(vec)
+					if da11 < 1 && db > 1 && db > bignum*da11 {
+						scaloc = 1 / db
+					}
+					x11 := (vec * scaloc) / a11
+					if scaloc != 1 {
+						for j := 0; j < n; j++ {
+							bi.Dscal(m, scaloc, c[j:], ldc)
+						}
+						scale *= scaloc
+					}
+					c[k1*ldc+l1] = x11
+				} else if k1 == k2 && l1 != l2 {
+					var suml, sumr float64
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k1:], lda, c[l1:], ldc)
+					}
+					if n > l2+1 {
+						sumr = bi.Ddot(n-l2-1, c[k1*ldc+l2+1:], 1, b[l1*ldb+l2+1:], 1)
+					}
+					vec0 := c[k1*ldc+l1] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k1:], lda, c[l2:], ldc)
+					}
+					if n > l2+1 {
+						sumr = bi.Ddot(n-l2-1, c[k1*ldc+l2+1:], 1, b[l2*ldb+l2+1:], 1)
+					}
+					vec1 := c[k1*ldc+l2] - (suml + sgn*sumr)
+
+					var vec, x [2]float64
+					vec[0], vec[1] = vec0, vec1
+					scaloc, _, ierr := impl.Dlasy2(true, true, isgn, 1, 2,
+						a[k1*lda+k1:], lda, b[l1*ldb+l1:], ldb, vec[:], 2, x[:], 2)
+					if !ierr {
+						ok = false
+					}
+					if scaloc != 1 {
+						for j := 0; j < n; j++ {
+							bi.Dscal(m, scaloc, c[j:], ldc)
+						}
+						scale *= scaloc
+					}
+					c[k1*ldc+l1] = x[0]
+					c[k1*ldc+l2] = x[1]
+				} else if k1 != k2 && l1 == l2 {
+					var suml, sumr float64
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k1:], lda, c[l1:], ldc)
+					}
+					if n > l1+1 {
+						sumr = bi.Ddot(n-l1-1, c[k1*ldc+l1+1:], 1, b[l1*ldb+l1+1:], 1)
+					}
+					vec0 := c[k1*ldc+l1] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k2:], lda, c[l1:], ldc)
+					}
+					if n > l1+1 {
+						sumr = bi.Ddot(n-l1-1, c[k2*ldc+l1+1:], 1, b[l1*ldb+l1+1:], 1)
+					}
+					vec1 := c[k2*ldc+l1] - (suml + sgn*sumr)
+
+					var vec, x [2]float64
+					vec[0], vec[1] = vec0, vec1
+					scaloc, _, ierr := impl.Dlasy2(true, true, isgn, 2, 1,
+						a[k1*lda+k1:], lda, b[l1*ldb+l1:], ldb, vec[:], 1, x[:], 1)
+					if !ierr {
+						ok = false
+					}
+					if scaloc != 1 {
+						for j := 0; j < n; j++ {
+							bi.Dscal(m, scaloc, c[j:], ldc)
+						}
+						scale *= scaloc
+					}
+					c[k1*ldc+l1] = x[0]
+					c[k2*ldc+l1] = x[1]
+				} else {
+					var suml, sumr float64
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k1:], lda, c[l1:], ldc)
+					}
+					if n > l2+1 {
+						sumr = bi.Ddot(n-l2-1, c[k1*ldc+l2+1:], 1, b[l1*ldb+l2+1:], 1)
+					}
+					vec00 := c[k1*ldc+l1] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k1:], lda, c[l2:], ldc)
+					}
+					if n > l2+1 {
+						sumr = bi.Ddot(n-l2-1, c[k1*ldc+l2+1:], 1, b[l2*ldb+l2+1:], 1)
+					}
+					vec01 := c[k1*ldc+l2] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k2:], lda, c[l1:], ldc)
+					}
+					if n > l2+1 {
+						sumr = bi.Ddot(n-l2-1, c[k2*ldc+l2+1:], 1, b[l1*ldb+l2+1:], 1)
+					}
+					vec10 := c[k2*ldc+l1] - (suml + sgn*sumr)
+
+					suml, sumr = 0, 0
+					if k1 > 0 {
+						suml = bi.Ddot(k1, a[k2:], lda, c[l2:], ldc)
+					}
+					if n > l2+1 {
+						sumr = bi.Ddot(n-l2-1, c[k2*ldc+l2+1:], 1, b[l2*ldb+l2+1:], 1)
+					}
+					vec11 := c[k2*ldc+l2] - (suml + sgn*sumr)
+
+					var vec, x [4]float64
+					vec[0], vec[1] = vec00, vec01
+					vec[2], vec[3] = vec10, vec11
+					scaloc, _, ierr := impl.Dlasy2(true, true, isgn, 2, 2,
+						a[k1*lda+k1:], lda, b[l1*ldb+l1:], ldb, vec[:], 2, x[:], 2)
+					if !ierr {
+						ok = false
+					}
+					if scaloc != 1 {
+						for j := 0; j < n; j++ {
+							bi.Dscal(m, scaloc, c[j:], ldc)
+						}
+						scale *= scaloc
+					}
+					c[k1*ldc+l1] = x[0]
+					c[k1*ldc+l2] = x[1]
+					c[k2*ldc+l1] = x[2]
+					c[k2*ldc+l2] = x[3]
+				}
+
+				k = knext
+			}
+			l = lnext - 1
+		}
+	}
+
+	return scale, ok
+}
+
+const bignum = 1 / dlamchS

--- a/lapack/gonum/errors.go
+++ b/lapack/gonum/errors.go
@@ -25,6 +25,7 @@ const (
 	badPivot            = "lapack: bad Pivot"
 	badRightEVJob       = "lapack: bad RightEVJob"
 	badSVDJob           = "lapack: bad SVDJob"
+	badSchurSort        = "lapack: bad SchurSort"
 	badSchurComp        = "lapack: bad SchurComp"
 	badSchurJob         = "lapack: bad SchurJob"
 	badSide             = "lapack: bad Side"
@@ -37,6 +38,7 @@ const (
 
 	// Panic strings for bad numerical and string values.
 	badIfst     = "lapack: ifst out of range"
+	badIJob     = "lapack: bad ijob value"
 	badIhi      = "lapack: ihi out of range"
 	badIhiz     = "lapack: ihiz out of range"
 	badIlo      = "lapack: ilo out of range"

--- a/lapack/gonum/lapack_test.go
+++ b/lapack/gonum/lapack_test.go
@@ -52,6 +52,11 @@ func TestDgeev(t *testing.T) {
 	testlapack.DgeevTest(t, impl)
 }
 
+func TestDgees(t *testing.T) {
+	t.Parallel()
+	testlapack.DgeesTest(t, impl)
+}
+
 func TestDgehd2(t *testing.T) {
 	t.Parallel()
 	testlapack.Dgehd2Test(t, impl)
@@ -651,6 +656,16 @@ func TestDtrevc3(t *testing.T) {
 func TestDtrexc(t *testing.T) {
 	t.Parallel()
 	testlapack.DtrexcTest(t, impl)
+}
+
+func TestDtrsen(t *testing.T) {
+	t.Parallel()
+	testlapack.DtrsenTest(t, impl)
+}
+
+func TestDtrsyl(t *testing.T) {
+	t.Parallel()
+	testlapack.DtrsylTest(t, impl)
 }
 
 func TestDtrti2(t *testing.T) {

--- a/lapack/lapack.go
+++ b/lapack/lapack.go
@@ -238,3 +238,14 @@ const (
 	OrthoExplicit OrthoComp = 'I' // The orthogonal matrix is formed explicitly and returned in the argument.
 	OrthoPostmul  OrthoComp = 'V' // The orthogonal matrix is post-multiplied into the matrix stored in the argument on entry.
 )
+
+// SchurSort specifies eigenvalue sorting in Dgees and Dgges.
+type SchurSort byte
+
+const (
+	SortNone     SchurSort = 'N' // No sorting.
+	SortSelected SchurSort = 'S' // Sort selected eigenvalues to top-left.
+)
+
+// SchurSelect is a function type for generalized eigenvalue selection.
+type SchurSelect func(alphar, alphai, beta float64) bool

--- a/lapack/testlapack/dgees.go
+++ b/lapack/testlapack/dgees.go
@@ -1,0 +1,385 @@
+// Copyright ©2024 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"testing"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/blas64"
+	"gonum.org/v1/gonum/lapack"
+)
+
+type Dgeeser interface {
+	Dgees(jobvs lapack.SchurComp, sort lapack.SchurSort, selctg func(wr, wi float64) bool,
+		n int, a []float64, lda int, wr, wi []float64, vs []float64, ldvs int,
+		work []float64, lwork int, bwork []bool) (sdim int, ok bool)
+}
+
+func DgeesTest(t *testing.T, impl Dgeeser) {
+	rnd := rand.New(rand.NewPCG(1, 1))
+
+	for _, n := range []int{0, 1, 2, 3, 4, 5, 6, 10, 20, 50, 100} {
+		for _, jobvs := range []lapack.SchurComp{lapack.SchurNone, lapack.SchurHess} {
+			for _, extra := range []int{0, 11} {
+				for _, wl := range []worklen{minimumWork, mediumWork, optimumWork} {
+					testDgees(t, impl, n, jobvs, extra, wl, rnd)
+				}
+			}
+		}
+	}
+
+	// Test with special matrices.
+	for _, tc := range []struct {
+		name string
+		a    blas64.General
+	}{
+		{"Diagonal(5)", Diagonal(5).Matrix()},
+		{"Diagonal(10)", Diagonal(10).Matrix()},
+		{"Wilk4", Wilk4{}.Matrix()},
+		{"Circulant(5)", Circulant(5).Matrix()},
+		{"Circulant(10)", Circulant(10).Matrix()},
+		{"Clement(5)", Clement(5).Matrix()},
+		{"Clement(10)", Clement(10).Matrix()},
+		{"Grcar{N:10,K:3}", Grcar{N: 10, K: 3}.Matrix()},
+		{"Zero(5)", Zero(5).Matrix()},
+		{"Zero(10)", Zero(10).Matrix()},
+	} {
+		for _, jobvs := range []lapack.SchurComp{lapack.SchurNone, lapack.SchurHess} {
+			testDgeesMatrix(t, impl, tc.name, tc.a, jobvs, optimumWork)
+		}
+	}
+}
+
+func testDgees(t *testing.T, impl Dgeeser, n int, jobvs lapack.SchurComp, extra int, wl worklen, rnd *rand.Rand) {
+	const tol = 100 // ||A - Z*T*Zᵀ||/(||A||*n*eps) should be O(1) for stable algorithms
+
+	wantvs := jobvs == lapack.SchurHess
+
+	// Generate a random matrix.
+	a := randomGeneral(n, n, n+extra, rnd)
+	aCopy := cloneGeneral(a)
+
+	// Allocate output arrays.
+	wr := make([]float64, n)
+	wi := make([]float64, n)
+
+	var vs blas64.General
+	ldvs := 1
+	if wantvs {
+		ldvs = max(1, n+extra)
+		vs = nanGeneral(n, n, ldvs)
+	}
+
+	// Determine workspace size.
+	var lwork int
+	minwork := max(1, 3*n)
+	switch wl {
+	case minimumWork:
+		lwork = minwork
+	case mediumWork:
+		work := make([]float64, 1)
+		impl.Dgees(jobvs, lapack.SortNone, nil, n, nil, max(1, n), nil, nil, nil, ldvs, work, -1, nil)
+		lwork = (int(work[0]) + minwork) / 2
+		lwork = max(minwork, lwork)
+	case optimumWork:
+		work := make([]float64, 1)
+		impl.Dgees(jobvs, lapack.SortNone, nil, n, nil, max(1, n), nil, nil, nil, ldvs, work, -1, nil)
+		lwork = int(work[0])
+	}
+	work := make([]float64, lwork)
+
+	prefix := fmt.Sprintf("n=%v, jobvs=%c, extra=%v, work=%v", n, jobvs, extra, wl)
+
+	// Call Dgees.
+	sdim, ok := impl.Dgees(jobvs, lapack.SortNone, nil, n, a.Data, a.Stride, wr, wi, vs.Data, ldvs, work, lwork, nil)
+
+	if !ok {
+		t.Errorf("%v: Dgees failed to converge", prefix)
+		return
+	}
+
+	if sdim != 0 {
+		t.Errorf("%v: unexpected sdim=%v, want 0 for SortNone", prefix, sdim)
+	}
+
+	// Quick return for n == 0.
+	if n == 0 {
+		return
+	}
+
+	// Check that A has been overwritten with the Schur form T.
+	// T should be upper quasi-triangular.
+	if !isSchurCanonicalGeneral(a) {
+		t.Errorf("%v: result is not in Schur canonical form", prefix)
+	}
+
+	// Check eigenvalues: the diagonal of T should contain the eigenvalues.
+	evTol := 1e-10
+	checkSchurEigenvalues(t, prefix, a, wr, wi, evTol)
+
+	if !wantvs {
+		return
+	}
+
+	// Check that vs contains orthogonal Schur vectors.
+	// Orthogonality should be O(eps), use a small tolerance.
+	orthoTol := float64(n) * dlamchE
+	if orthoTol < 1e-13 {
+		orthoTol = 1e-13
+	}
+	resid := residualOrthogonal(vs, false)
+	if resid > orthoTol {
+		t.Errorf("%v: Schur vectors not orthogonal; |I - Z*Zᵀ|=%v, want<=%v", prefix, resid, orthoTol)
+	}
+
+	// Check the Schur factorization: A = Z * T * Zᵀ
+	// Compute ||A - Z*T*Zᵀ|| / (||A|| * n * eps)
+	residSchur := residualSchurFactorization(aCopy, a, vs)
+	anorm := dlange(lapack.MaxColumnSum, n, n, aCopy.Data, aCopy.Stride)
+	if anorm == 0 {
+		anorm = 1
+	}
+	normRes := residSchur / (anorm * float64(n) * dlamchE)
+	if normRes > tol {
+		t.Errorf("%v: ||A - Z*T*Zᵀ||/(||A||*n*eps)=%v, want<=%v", prefix, normRes, tol)
+	}
+}
+
+func testDgeesMatrix(t *testing.T, impl Dgeeser, name string, aOrig blas64.General, jobvs lapack.SchurComp, wl worklen) {
+	const tol = 100 // ||A - Z*T*Zᵀ||/(||A||*n*eps) should be O(1) for stable algorithms
+
+	n := aOrig.Rows
+	wantvs := jobvs == lapack.SchurHess
+
+	// Clone the input matrix.
+	a := cloneGeneral(aOrig)
+
+	// Allocate output arrays.
+	wr := make([]float64, n)
+	wi := make([]float64, n)
+
+	var vs blas64.General
+	ldvs := 1
+	if wantvs {
+		ldvs = max(1, n)
+		vs = nanGeneral(n, n, ldvs)
+	}
+
+	// Determine workspace size.
+	work := make([]float64, 1)
+	impl.Dgees(jobvs, lapack.SortNone, nil, n, nil, max(1, n), nil, nil, nil, ldvs, work, -1, nil)
+	lwork := int(work[0])
+	work = make([]float64, lwork)
+
+	prefix := fmt.Sprintf("%v, jobvs=%c", name, jobvs)
+
+	// Call Dgees.
+	_, ok := impl.Dgees(jobvs, lapack.SortNone, nil, n, a.Data, a.Stride, wr, wi, vs.Data, ldvs, work, lwork, nil)
+
+	if !ok {
+		t.Errorf("%v: Dgees failed to converge", prefix)
+		return
+	}
+
+	// Check that A has been overwritten with the Schur form T.
+	if !isSchurCanonicalGeneral(a) {
+		t.Errorf("%v: result is not in Schur canonical form", prefix)
+	}
+
+	// Check eigenvalues.
+	evTol := 1e-10
+	checkSchurEigenvalues(t, prefix, a, wr, wi, evTol)
+
+	if !wantvs {
+		return
+	}
+
+	// Check orthogonality of Schur vectors.
+	orthoTol := float64(n) * dlamchE
+	if orthoTol < 1e-13 {
+		orthoTol = 1e-13
+	}
+	resid := residualOrthogonal(vs, false)
+	if resid > orthoTol {
+		t.Errorf("%v: Schur vectors not orthogonal; |I - Z*Zᵀ|=%v, want<=%v", prefix, resid, orthoTol)
+	}
+
+	// Check Schur factorization.
+	residSchur := residualSchurFactorization(aOrig, a, vs)
+	anorm := dlange(lapack.MaxColumnSum, n, n, aOrig.Data, aOrig.Stride)
+	if anorm == 0 {
+		anorm = 1
+	}
+	normRes := residSchur / (anorm * float64(n) * dlamchE)
+	if normRes > tol {
+		t.Errorf("%v: ||A - Z*T*Zᵀ||/(||A||*n*eps)=%v, want<=%v", prefix, normRes, tol)
+	}
+}
+
+// checkSchurEigenvalues verifies that the eigenvalues in wr and wi match
+// the diagonal blocks of the Schur form T.
+func checkSchurEigenvalues(t *testing.T, prefix string, T blas64.General, wr, wi []float64, tol float64) {
+	t.Helper()
+	n := T.Rows
+	for j := 0; j < n; {
+		if j == n-1 || T.Data[(j+1)*T.Stride+j] == 0 {
+			// 1×1 block: real eigenvalue.
+			diff := math.Abs(wr[j] - T.Data[j*T.Stride+j])
+			if diff > tol {
+				t.Errorf("%v: eigenvalue[%d] mismatch: wr=%v, T[%d,%d]=%v", prefix, j, wr[j], j, j, T.Data[j*T.Stride+j])
+			}
+			if wi[j] != 0 {
+				t.Errorf("%v: eigenvalue[%d] has non-zero imaginary part for 1×1 block: wi=%v", prefix, j, wi[j])
+			}
+			j++
+		} else {
+			// 2×2 block: complex conjugate pair.
+			a11 := T.Data[j*T.Stride+j]
+			a12 := T.Data[j*T.Stride+j+1]
+			a21 := T.Data[(j+1)*T.Stride+j]
+			a22 := T.Data[(j+1)*T.Stride+j+1]
+
+			// Real part should be (a11+a22)/2, but for canonical form a11==a22.
+			realPart := (a11 + a22) / 2
+			// Imaginary part is sqrt(-a12*a21) (assuming a12*a21 < 0).
+			var imagPart float64
+			if a12*a21 < 0 {
+				imagPart = math.Sqrt(-a12 * a21)
+			}
+
+			diffReal := math.Abs(wr[j] - realPart)
+			diffImag := math.Abs(wi[j] - imagPart)
+			if diffReal > tol || diffImag > tol {
+				t.Errorf("%v: eigenvalue[%d] mismatch: got (%v, %v), want (%v, ±%v)", prefix, j, wr[j], wi[j], realPart, imagPart)
+			}
+
+			// The conjugate pair should have opposite imaginary parts.
+			if wi[j] <= 0 {
+				t.Errorf("%v: eigenvalue[%d] should have positive imaginary part first", prefix, j)
+			}
+			if wi[j+1] != -wi[j] {
+				t.Errorf("%v: eigenvalue[%d+1] should be conjugate: wi[%d]=%v, wi[%d]=%v", prefix, j, j, wi[j], j+1, wi[j+1])
+			}
+
+			j += 2
+		}
+	}
+}
+
+func DgeesSortTest(t *testing.T, impl Dgeeser) {
+	rnd := rand.New(rand.NewPCG(1, 1))
+
+	// Select eigenvalues with absolute value < 1.
+	selctg := func(wr, wi float64) bool {
+		return wr*wr+wi*wi < 1.0
+	}
+
+	for _, n := range []int{1, 2, 3, 4, 5, 10, 20, 50} {
+		for _, extra := range []int{0, 11} {
+			for cas := 0; cas < 10; cas++ {
+				testDgeesSort(t, impl, n, extra, selctg, rnd)
+			}
+		}
+	}
+}
+
+func testDgeesSort(t *testing.T, impl Dgeeser, n, extra int, selctg func(wr, wi float64) bool, rnd *rand.Rand) {
+	const tol = 100
+
+	a := randomGeneral(n, n, n+extra, rnd)
+	aCopy := cloneGeneral(a)
+
+	wr := make([]float64, n)
+	wi := make([]float64, n)
+
+	ldvs := max(1, n+extra)
+	vs := nanGeneral(n, n, ldvs)
+	bwork := make([]bool, n)
+
+	// Workspace query.
+	work := make([]float64, 1)
+	impl.Dgees(lapack.SchurHess, lapack.SortSelected, selctg, n, nil, max(1, a.Stride), nil, nil, nil, ldvs, work, -1, nil)
+	lwork := int(work[0])
+	work = make([]float64, lwork)
+
+	prefix := fmt.Sprintf("n=%d, extra=%d", n, extra)
+
+	sdim, ok := impl.Dgees(lapack.SchurHess, lapack.SortSelected, selctg, n, a.Data, a.Stride, wr, wi, vs.Data, ldvs, work, lwork, bwork)
+	if !ok {
+		t.Logf("%s: Dgees with sorting failed to converge", prefix)
+		return
+	}
+
+	// Verify Schur form.
+	if !isSchurCanonicalGeneral(a) {
+		t.Errorf("%s: result is not in Schur canonical form", prefix)
+	}
+
+	// Verify selected eigenvalues are at the top.
+	for j := 0; j < sdim; j++ {
+		if !selctg(wr[j], wi[j]) {
+			t.Errorf("%s: eigenvalue %d (wr=%v, wi=%v) at top should be selected", prefix, j, wr[j], wi[j])
+		}
+	}
+	for j := sdim; j < n; j++ {
+		if selctg(wr[j], wi[j]) {
+			t.Errorf("%s: eigenvalue %d (wr=%v, wi=%v) at bottom should NOT be selected", prefix, j, wr[j], wi[j])
+		}
+	}
+
+	// Verify eigenvalues match diagonal blocks.
+	evTol := 1e-10
+	checkSchurEigenvalues(t, prefix, a, wr, wi, evTol)
+
+	// Verify Schur vectors are orthogonal.
+	orthoTol := float64(n) * dlamchE
+	if orthoTol < 1e-13 {
+		orthoTol = 1e-13
+	}
+	resid := residualOrthogonal(vs, false)
+	if resid > orthoTol {
+		t.Errorf("%s: Schur vectors not orthogonal; |I - Z*Zᵀ|=%v, want<=%v", prefix, resid, orthoTol)
+	}
+
+	// Verify Schur factorization: A = Z * T * Zᵀ.
+	residSchur := residualSchurFactorization(aCopy, a, vs)
+	anorm := dlange(lapack.MaxColumnSum, n, n, aCopy.Data, aCopy.Stride)
+	if anorm == 0 {
+		anorm = 1
+	}
+	normRes := residSchur / (anorm * float64(n) * dlamchE)
+	if normRes > float64(tol) {
+		t.Errorf("%s: ||A - Z*T*Zᵀ||/(||A||*n*eps)=%v, want<=%v", prefix, normRes, tol)
+	}
+}
+
+// residualSchurFactorization computes ||A - Z*T*Zᵀ||_1.
+func residualSchurFactorization(A, T, Z blas64.General) float64 {
+	n := A.Rows
+	if n == 0 {
+		return 0
+	}
+
+	// Compute R = Z * T.
+	R := zeros(n, n, n)
+	blas64.Gemm(blas.NoTrans, blas.NoTrans, 1, Z, T, 0, R)
+
+	// Compute R = R * Zᵀ = Z * T * Zᵀ.
+	R2 := zeros(n, n, n)
+	blas64.Gemm(blas.NoTrans, blas.Trans, 1, R, Z, 0, R2)
+
+	// Compute R2 = A - Z * T * Zᵀ.
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			R2.Data[i*R2.Stride+j] = A.Data[i*A.Stride+j] - R2.Data[i*R2.Stride+j]
+		}
+	}
+
+	return dlange(lapack.MaxColumnSum, n, n, R2.Data, R2.Stride)
+}

--- a/lapack/testlapack/dtrsen.go
+++ b/lapack/testlapack/dtrsen.go
@@ -1,0 +1,297 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"testing"
+
+	"gonum.org/v1/gonum/blas/blas64"
+	"gonum.org/v1/gonum/lapack"
+)
+
+type Dtrsener interface {
+	Dtrexcer
+	Dtrsen(ijob int, wantq bool, selected []bool, n int, t []float64, ldt int, q []float64, ldq int, wr, wi []float64, work []float64, lwork int, iwork []int, liwork int) (m int, s, sep float64, ok bool)
+}
+
+func DtrsenTest(t *testing.T, impl Dtrsener) {
+	rnd := rand.New(rand.NewPCG(1, 1))
+
+	for _, n := range []int{0, 1, 2, 3, 4, 5, 10, 20} {
+		for _, extra := range []int{0, 3} {
+			for _, selectPattern := range []string{"none", "first", "last", "alternating", "all"} {
+				for _, wantq := range []bool{false, true} {
+					for _, ijob := range []int{0, 1, 2, 3} {
+						testDtrsen(t, impl, n, extra, selectPattern, wantq, ijob, rnd)
+					}
+				}
+			}
+		}
+	}
+
+	testDtrsenWorkspace(t, impl)
+	testDtrsenSelectSecondOfPair(t, impl)
+}
+
+func testDtrsenSelectSecondOfPair(t *testing.T, impl Dtrsener) {
+	work := make([]float64, 2)
+	iwork := make([]int, 1)
+	m, _, _, ok := impl.Dtrsen(0, false, []bool{false, true}, 2,
+		[]float64{1, 2, -3, 1}, 2, nil, 1,
+		make([]float64, 2), make([]float64, 2), work, len(work), iwork, len(iwork))
+	if !ok {
+		t.Fatal("complex pair selection failed")
+	}
+	if m != 2 {
+		t.Fatalf("selected subspace dimension=%d, want 2", m)
+	}
+}
+
+type eigPair struct{ wr, wi float64 }
+
+func testDtrsen(t *testing.T, impl Dtrsener, n, extra int, selectPattern string, wantq bool, ijob int, rnd *rand.Rand) {
+	const tol = 100
+
+	prefix := fmt.Sprintf("n=%d, extra=%d, select=%s, wantq=%v, ijob=%d", n, extra, selectPattern, wantq, ijob)
+
+	if n == 0 {
+		var work [1]float64
+		var iwork [1]int
+		m, s, sep, ok := impl.Dtrsen(ijob, wantq, nil, 0, nil, 1, nil, 1, nil, nil, work[:], 1, iwork[:], 1)
+		if m != 0 || s != 1 || sep != 0 || !ok {
+			t.Errorf("%s: unexpected result for n=0", prefix)
+		}
+		return
+	}
+
+	stride := n + extra
+	tMat, wrOrig, wiOrig := randomSchurCanonical(n, stride, false, rnd)
+	tOrig := cloneGeneral(tMat)
+
+	// Generate selection array and record selected eigenvalues.
+	selected := make([]bool, n)
+	var selectedEigs []eigPair
+	expectedM := 0
+
+	switch selectPattern {
+	case "none":
+	case "first":
+		selected[0] = true
+		selectedEigs = append(selectedEigs, eigPair{wrOrig[0], wiOrig[0]})
+		expectedM = 1
+		if n > 1 && tMat.Data[1*tMat.Stride+0] != 0 {
+			selected[1] = true
+			selectedEigs = append(selectedEigs, eigPair{wrOrig[1], wiOrig[1]})
+			expectedM = 2
+		}
+	case "last":
+		k := n - 1
+		if k > 0 && tMat.Data[k*tMat.Stride+k-1] != 0 {
+			k--
+			selected[k] = true
+			selected[k+1] = true
+			selectedEigs = append(selectedEigs, eigPair{wrOrig[k], wiOrig[k]})
+			selectedEigs = append(selectedEigs, eigPair{wrOrig[k+1], wiOrig[k+1]})
+			expectedM = 2
+		} else {
+			selected[k] = true
+			selectedEigs = append(selectedEigs, eigPair{wrOrig[k], wiOrig[k]})
+			expectedM = 1
+		}
+	case "alternating":
+		sel := true
+		for k := 0; k < n; {
+			if k < n-1 && tMat.Data[(k+1)*tMat.Stride+k] != 0 {
+				if sel {
+					selected[k] = true
+					selected[k+1] = true
+					selectedEigs = append(selectedEigs, eigPair{wrOrig[k], wiOrig[k]})
+					selectedEigs = append(selectedEigs, eigPair{wrOrig[k+1], wiOrig[k+1]})
+					expectedM += 2
+				}
+				k += 2
+			} else {
+				if sel {
+					selected[k] = true
+					selectedEigs = append(selectedEigs, eigPair{wrOrig[k], wiOrig[k]})
+					expectedM++
+				}
+				k++
+			}
+			sel = !sel
+		}
+	case "all":
+		for i := 0; i < n; i++ {
+			selected[i] = true
+			selectedEigs = append(selectedEigs, eigPair{wrOrig[i], wiOrig[i]})
+		}
+		expectedM = n
+	}
+
+	// Set up Q.
+	ldq := 1
+	var qData []float64
+	if wantq {
+		ldq = stride
+		q := eye(n, ldq)
+		qData = q.Data
+	}
+
+	wr := make([]float64, n)
+	wi := make([]float64, n)
+
+	// Workspace query.
+	var worksize [1]float64
+	var iworksize [1]int
+	impl.Dtrsen(ijob, wantq, selected, n, tMat.Data, max(1, tMat.Stride), nil, ldq, nil, nil, worksize[:], -1, iworksize[:], -1)
+	lwork := int(worksize[0])
+	liwork := iworksize[0]
+
+	work := make([]float64, max(1, lwork))
+	iwork := make([]int, max(1, liwork))
+
+	m, s, sep, ok := impl.Dtrsen(ijob, wantq, selected, n, tMat.Data, tMat.Stride, qData, ldq, wr, wi, work, lwork, iwork, liwork)
+
+	if !ok {
+		t.Logf("%s: reordering failed (ok=false)", prefix)
+		return
+	}
+
+	if m != expectedM {
+		t.Errorf("%s: m=%d, want %d", prefix, m, expectedM)
+	}
+
+	// Verify T is still in Schur canonical form.
+	if !isSchurCanonicalGeneral(tMat) {
+		t.Errorf("%s: result is not in Schur canonical form", prefix)
+	}
+
+	// Verify eigenvalues in wr/wi match diagonal blocks.
+	evTol := 1e-10
+	checkSchurEigenvalues(t, prefix, tMat, wr, wi, evTol)
+
+	// Verify selected eigenvalues moved to top.
+	if m > 0 && m < n {
+		topEigs := make([]eigPair, m)
+		for i := 0; i < m; i++ {
+			topEigs[i] = eigPair{wr[i], wi[i]}
+		}
+		if !eigMultisetsMatch(selectedEigs, topEigs, evTol) {
+			t.Errorf("%s: selected eigenvalues not at top\n  selected: %v\n  top:      %v", prefix, selectedEigs, topEigs)
+		}
+	}
+
+	// Verify condition number estimates.
+	wants := ijob == 1 || ijob == 3
+	wantsp := ijob == 2 || ijob == 3
+	if m == 0 || m == n {
+		if wants && s != 1 {
+			t.Errorf("%s: s=%v, want 1 for m=0 or m=n", prefix, s)
+		}
+		wantSep := dlange(lapack.MaxColumnSum, n, n, tMat.Data, tMat.Stride)
+		if wantsp && sep != wantSep {
+			t.Errorf("%s: sep=%v, want %v for m=0 or m=n", prefix, sep, wantSep)
+		}
+	} else {
+		if wants {
+			if s <= 0 || s > 1 {
+				t.Errorf("%s: s=%v, want in (0, 1]", prefix, s)
+			}
+		}
+		if wantsp {
+			if sep < 0 {
+				t.Errorf("%s: sep=%v, want >= 0", prefix, sep)
+			}
+		}
+	}
+
+	if !wantq {
+		return
+	}
+
+	q := blas64.General{
+		Rows:   n,
+		Cols:   n,
+		Stride: ldq,
+		Data:   qData,
+	}
+
+	// Verify Q is orthogonal.
+	orthoTol := float64(n) * dlamchE
+	if orthoTol < 1e-13 {
+		orthoTol = 1e-13
+	}
+	resid := residualOrthogonal(q, false)
+	if resid > orthoTol {
+		t.Errorf("%s: Q not orthogonal, residual=%e, want<=%e", prefix, resid, orthoTol)
+	}
+
+	// Verify Q*T*Qᵀ = Torig.
+	residSchur := residualSchurFactorization(tOrig, tMat, q)
+	anorm := dlange(lapack.MaxColumnSum, n, n, tOrig.Data, tOrig.Stride)
+	if anorm == 0 {
+		anorm = 1
+	}
+	normRes := residSchur / (anorm * float64(n) * dlamchE)
+	if normRes > float64(tol) {
+		t.Errorf("%s: ||T_orig - Q*T*Qᵀ||/(||T||*n*eps)=%v, want<=%v", prefix, normRes, tol)
+	}
+}
+
+func testDtrsenWorkspace(t *testing.T, impl Dtrsener) {
+	for _, n := range []int{1, 5, 10} {
+		var worksize [1]float64
+		var iworksize [1]int
+		impl.Dtrsen(0, true, nil, n, nil, n, nil, n, nil, nil, worksize[:], -1, iworksize[:], -1)
+		lwork := int(worksize[0])
+		liwork := iworksize[0]
+		if lwork < 1 {
+			t.Errorf("n=%d: workspace query returned lwork=%d, want >= 1", n, lwork)
+		}
+		if liwork < 1 {
+			t.Errorf("n=%d: workspace query returned liwork=%d, want >= 1", n, liwork)
+		}
+	}
+
+	var worksize [1]float64
+	var iworksize [1]int
+	impl.Dtrsen(2, false, []bool{false, true, false, false}, 4,
+		[]float64{
+			1, 2, 0, 0,
+			-3, 1, 0, 0,
+			0, 0, 4, 0,
+			0, 0, 0, 5,
+		}, 4, nil, 1, nil, nil, worksize[:], -1, iworksize[:], -1)
+	if worksize[0] != 8 || iworksize[0] != 4 {
+		t.Fatalf("complex-pair workspace=(%v,%d), want (8,4)", worksize[0], iworksize[0])
+	}
+}
+
+func eigMultisetsMatch(a, b []eigPair, tol float64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	used := make([]bool, len(b))
+	for _, ea := range a {
+		found := false
+		for j, eb := range b {
+			if used[j] {
+				continue
+			}
+			if math.Abs(ea.wr-eb.wr) < tol && math.Abs(ea.wi-eb.wi) < tol {
+				used[j] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/lapack/testlapack/dtrsen.go
+++ b/lapack/testlapack/dtrsen.go
@@ -35,7 +35,22 @@ func DtrsenTest(t *testing.T, impl Dtrsener) {
 	}
 
 	testDtrsenWorkspace(t, impl)
+	testDtrsenWorkspaceOutputs(t, impl)
 	testDtrsenSelectSecondOfPair(t, impl)
+}
+
+func testDtrsenWorkspaceOutputs(t *testing.T, impl Dtrsener) {
+	work := []float64{math.NaN(), math.NaN()}
+	iwork := []int{-1}
+	_, _, _, ok := impl.Dtrsen(0, false, []bool{false, false}, 2,
+		[]float64{1, 0, 0, 2}, 2, nil, 1,
+		make([]float64, 2), make([]float64, 2), work, len(work), iwork, len(iwork))
+	if !ok {
+		t.Fatal("trivial reorder failed")
+	}
+	if work[0] != 2 || iwork[0] != 1 {
+		t.Errorf("workspace outputs=(%v,%d), want (2,1)", work[0], iwork[0])
+	}
 }
 
 func testDtrsenSelectSecondOfPair(t *testing.T, impl Dtrsener) {

--- a/lapack/testlapack/dtrsyl.go
+++ b/lapack/testlapack/dtrsyl.go
@@ -1,0 +1,257 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"testing"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/blas64"
+	"gonum.org/v1/gonum/lapack"
+)
+
+type Dtrsyler interface {
+	Dtrsyl(trana, tranb blas.Transpose, isgn, m, n int, a []float64, lda int,
+		b []float64, ldb int, c []float64, ldc int) (scale float64, ok bool)
+}
+
+func DtrsylTest(t *testing.T, impl Dtrsyler) {
+	rnd := rand.New(rand.NewPCG(1, 1))
+
+	for _, m := range []int{0, 1, 2, 3, 4, 5, 10, 20} {
+		for _, n := range []int{0, 1, 2, 3, 4, 5, 10, 20} {
+			for _, trana := range []blas.Transpose{blas.NoTrans, blas.Trans} {
+				for _, tranb := range []blas.Transpose{blas.NoTrans, blas.Trans} {
+					for _, isgn := range []int{1, -1} {
+						for _, extra := range []int{0, 5} {
+							testDtrsyl(t, impl, m, n, trana, tranb, isgn, extra, rnd)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Test with special matrices.
+	testDtrsylSpecial(t, impl)
+}
+
+func testDtrsyl(t *testing.T, impl Dtrsyler, m, n int, trana, tranb blas.Transpose, isgn, extra int, rnd *rand.Rand) {
+	const tol = 1e-12
+
+	prefix := fmt.Sprintf("m=%v, n=%v, trana=%c, tranb=%c, isgn=%d, extra=%v",
+		m, n, trana, tranb, isgn, extra)
+
+	// Generate random quasi-triangular matrices A (m×m) and B (n×n).
+	a := randomSchur(m, m+extra, rnd)
+	b := randomSchur(n, n+extra, rnd)
+
+	// Generate random RHS matrix C (m×n).
+	c := randomGeneral(m, n, n+extra, rnd)
+	cOrig := cloneGeneral(c)
+
+	// Also keep originals of A and B for residual check.
+	aOrig := cloneGeneral(a)
+	bOrig := cloneGeneral(b)
+
+	// Call Dtrsyl.
+	scale, ok := impl.Dtrsyl(trana, tranb, isgn, m, n, a.Data, a.Stride, b.Data, b.Stride, c.Data, c.Stride)
+
+	// Check that A and B are not modified.
+	if !generalEqual(a, aOrig) {
+		t.Errorf("%v: A was modified", prefix)
+	}
+	if !generalEqual(b, bOrig) {
+		t.Errorf("%v: B was modified", prefix)
+	}
+
+	// Quick return for empty matrices.
+	if m == 0 || n == 0 {
+		if scale != 1 {
+			t.Errorf("%v: scale=%v, want 1 for empty matrix", prefix, scale)
+		}
+		if !ok {
+			t.Errorf("%v: ok=false, want true for empty matrix", prefix)
+		}
+		return
+	}
+
+	// Verify the solution by computing the residual:
+	// R = op(A)*X + isgn*X*op(B) - scale*C
+	// where X is the solution stored in c.
+	resid := dtrsylResidual(aOrig, bOrig, cOrig, c, trana, tranb, isgn, scale)
+	anorm := dlange(lapack.MaxColumnSum, m, m, aOrig.Data, aOrig.Stride)
+	bnorm := dlange(lapack.MaxColumnSum, n, n, bOrig.Data, bOrig.Stride)
+	xnorm := dlange(lapack.MaxColumnSum, m, n, c.Data, c.Stride)
+	cnorm := dlange(lapack.MaxColumnSum, m, n, cOrig.Data, cOrig.Stride)
+
+	denom := anorm*xnorm + xnorm*bnorm + cnorm
+	if denom == 0 {
+		denom = 1
+	}
+	normRes := resid / (denom * float64(max(m, n)) * dlamchE)
+
+	if normRes > tol/dlamchE {
+		t.Errorf("%v: residual too large: %v, want <= %v", prefix, normRes, tol/dlamchE)
+	}
+
+	_ = ok // ok can be false if eigenvalues are close, but solution should still be acceptable.
+}
+
+func testDtrsylSpecial(t *testing.T, impl Dtrsyler) {
+	const tol = 1e-10
+
+	// Test case: diagonal matrices (all 1x1 blocks).
+	for _, n := range []int{1, 2, 5, 10} {
+		a := eye(n, n)
+		for i := 0; i < n; i++ {
+			a.Data[i*a.Stride+i] = float64(i + 1)
+		}
+		b := eye(n, n)
+		for i := 0; i < n; i++ {
+			b.Data[i*b.Stride+i] = float64(i + 10)
+		}
+		c := ones(n, n)
+		cOrig := cloneGeneral(c)
+
+		scale, _ := impl.Dtrsyl(blas.NoTrans, blas.NoTrans, 1, n, n, a.Data, a.Stride, b.Data, b.Stride, c.Data, c.Stride)
+
+		resid := dtrsylResidual(a, b, cOrig, c, blas.NoTrans, blas.NoTrans, 1, scale)
+		anorm := dlange(lapack.MaxColumnSum, n, n, a.Data, a.Stride)
+		bnorm := dlange(lapack.MaxColumnSum, n, n, b.Data, b.Stride)
+		xnorm := dlange(lapack.MaxColumnSum, n, n, c.Data, c.Stride)
+		cnorm := dlange(lapack.MaxColumnSum, n, n, cOrig.Data, cOrig.Stride)
+
+		denom := anorm*xnorm + xnorm*bnorm + cnorm
+		if denom == 0 {
+			denom = 1
+		}
+		normRes := resid / (denom * float64(n) * dlamchE)
+		if normRes > tol/dlamchE {
+			t.Errorf("Diagonal n=%d: residual too large: %v", n, normRes)
+		}
+	}
+
+	// Test case: 2x2 blocks (complex eigenvalues).
+	// A has one 2x2 block representing complex eigenvalue 1±2i.
+	a := blas64.General{
+		Rows:   2,
+		Cols:   2,
+		Stride: 2,
+		Data:   []float64{1, 2, -2, 1},
+	}
+	b := blas64.General{
+		Rows:   2,
+		Cols:   2,
+		Stride: 2,
+		Data:   []float64{3, 1, -1, 3},
+	}
+	c := ones(2, 2)
+	cOrig := cloneGeneral(c)
+
+	scale, _ := impl.Dtrsyl(blas.NoTrans, blas.NoTrans, 1, 2, 2, a.Data, a.Stride, b.Data, b.Stride, c.Data, c.Stride)
+
+	resid := dtrsylResidual(a, b, cOrig, c, blas.NoTrans, blas.NoTrans, 1, scale)
+	anorm := dlange(lapack.MaxColumnSum, 2, 2, a.Data, a.Stride)
+	bnorm := dlange(lapack.MaxColumnSum, 2, 2, b.Data, b.Stride)
+	xnorm := dlange(lapack.MaxColumnSum, 2, 2, c.Data, c.Stride)
+	cnorm := dlange(lapack.MaxColumnSum, 2, 2, cOrig.Data, cOrig.Stride)
+
+	denom := anorm*xnorm + xnorm*bnorm + cnorm
+	if denom == 0 {
+		denom = 1
+	}
+	normRes := resid / (denom * 2 * dlamchE)
+	if normRes > tol/dlamchE {
+		t.Errorf("2x2 block: residual too large: %v", normRes)
+	}
+}
+
+// dtrsylResidual computes ||op(A)*X + isgn*X*op(B) - scale*C||_1.
+func dtrsylResidual(A, B, C, X blas64.General, trana, tranb blas.Transpose, isgn int, scale float64) float64 {
+	m := A.Rows
+	n := B.Rows
+
+	if m == 0 || n == 0 {
+		return 0
+	}
+
+	// R = op(A)*X.
+	R := zeros(m, n, n)
+	blas64.Gemm(trana, blas.NoTrans, 1, A, X, 0, R)
+
+	// R += isgn * X * op(B).
+	blas64.Gemm(blas.NoTrans, tranb, float64(isgn), X, B, 1, R)
+
+	// R -= scale * C.
+	for i := 0; i < m; i++ {
+		for j := 0; j < n; j++ {
+			R.Data[i*R.Stride+j] -= scale * C.Data[i*C.Stride+j]
+		}
+	}
+
+	return dlange(lapack.MaxColumnSum, m, n, R.Data, R.Stride)
+}
+
+// randomSchur generates a random upper quasi-triangular matrix (Schur form).
+func randomSchur(n, stride int, rnd *rand.Rand) blas64.General {
+	if n == 0 {
+		return blas64.General{Rows: 0, Cols: 0, Stride: max(1, stride)}
+	}
+
+	a := zeros(n, n, stride)
+
+	// Fill upper triangular part randomly.
+	for i := 0; i < n; i++ {
+		for j := i; j < n; j++ {
+			a.Data[i*a.Stride+j] = rnd.NormFloat64()
+		}
+	}
+
+	// Randomly create 2x2 blocks on the diagonal (complex eigenvalue pairs).
+	i := 0
+	for i < n-1 {
+		if rnd.IntN(3) == 0 {
+			// Create a 2x2 block with complex eigenvalues.
+			// Use form [a b; -c a] where c > 0 for complex eigenvalues a ± i*sqrt(bc).
+			a11 := a.Data[i*a.Stride+i]
+			a.Data[(i+1)*a.Stride+i+1] = a11 // Make diagonal elements equal.
+			a.Data[(i+1)*a.Stride+i] = -math.Abs(rnd.NormFloat64()) - 0.1
+			i += 2
+		} else {
+			i++
+		}
+	}
+
+	return a
+}
+
+// ones creates an m×n matrix filled with 1s.
+func ones(m, n int) blas64.General {
+	stride := max(1, n)
+	data := make([]float64, m*stride)
+	for i := range data {
+		data[i] = 1
+	}
+	return blas64.General{Rows: m, Cols: n, Stride: stride, Data: data}
+}
+
+// generalEqual checks if two matrices are equal.
+func generalEqual(a, b blas64.General) bool {
+	if a.Rows != b.Rows || a.Cols != b.Cols {
+		return false
+	}
+	for i := 0; i < a.Rows; i++ {
+		for j := 0; j < a.Cols; j++ {
+			if a.Data[i*a.Stride+j] != b.Data[i*b.Stride+j] {
+				return false
+			}
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Adds real Schur decomposition, reordering, and condition estimation support.

Includes `Dgees`, `Dtrsen`, and `Dtrsyl`, along with the public Schur sorting types and regression coverage.

Validation:
- `go test ./lapack/gonum -run "Test(Dgees|Dtrsen|Dtrsyl)$" -count=1`