### PR TITLE
stat: add example for BivariateMoment

### DIFF
--- a/stat/stat_example_test.go
+++ b/stat/stat_example_test.go
@@ -13,6 +13,52 @@ import (
 	"gonum.org/v1/gonum/stat/distuv"
 )
 
+func ExampleBivariateMoment() {
+	// The bivariate central moment
+	//
+	//	μ_rs = E[(x-μ_x)^r*(y-μ_y)^s]
+	//
+	// generalises the covariance, which is the (1,1) moment. The (2,2)
+	// moment gives the leading term of the sampling variance of a
+	// covariance estimate,
+	//
+	//	Var(cov) ≈ (μ_22 - μ_11^2)/n
+	//
+	// so BivariateMoment can be used to attach a standard error to a
+	// covariance. See https://stats.stackexchange.com/q/48366.
+	const n = 1000
+
+	xs := make([]float64, n)
+	ys := make([]float64, n)
+
+	// Draw ys with a fixed linear dependence on xs so that the covariance
+	// is known to be non-zero.
+	rnd := rand.New(rand.NewPCG(1, 1))
+	for i := range xs {
+		xs[i] = rnd.NormFloat64()
+		ys[i] = 0.5*xs[i] + rnd.NormFloat64()
+	}
+
+	// BivariateMoment applies no degrees of freedom correction, so the
+	// (1,1) moment divides by n where Covariance divides by n-1.
+	m11 := stat.BivariateMoment(1, 1, xs, ys, nil)
+	m22 := stat.BivariateMoment(2, 2, xs, ys, nil)
+	cov := stat.Covariance(xs, ys, nil)
+
+	stdErr := math.Sqrt((m22 - m11*m11) / n)
+
+	fmt.Printf("μ_11     = %.6f\n", m11)
+	fmt.Printf("cov      = %.6f\n", cov)
+	fmt.Printf("μ_22     = %.6f\n", m22)
+	fmt.Printf("std err  = %.6f\n", stdErr)
+
+	// Output:
+	// μ_11     = 0.490614
+	// cov      = 0.491105
+	// μ_22     = 1.685326
+	// std err  = 0.038008
+}
+
 func ExampleLinearRegression() {
 	var (
 		xs      = make([]float64, 100)

--- a/stat/stat_example_test.go
+++ b/stat/stat_example_test.go
@@ -14,18 +14,6 @@ import (
 )
 
 func ExampleBivariateMoment() {
-	// The bivariate central moment
-	//
-	//	μ_rs = E[(x-μ_x)^r*(y-μ_y)^s]
-	//
-	// generalises the covariance, which is the (1,1) moment. The (2,2)
-	// moment gives the leading term of the sampling variance of a
-	// covariance estimate,
-	//
-	//	Var(cov) ≈ (μ_22 - μ_11^2)/n
-	//
-	// so BivariateMoment can be used to attach a standard error to a
-	// covariance. See https://stats.stackexchange.com/q/48366.
 	const n = 1000
 
 	xs := make([]float64, n)
@@ -39,24 +27,29 @@ func ExampleBivariateMoment() {
 		ys[i] = 0.5*xs[i] + rnd.NormFloat64()
 	}
 
+	// The (2,2) moment leads the sampling variance of a covariance
+	// estimate, Var(cov) ≈ (μ_22 - μ_11^2)/n, so BivariateMoment can be
+	// used to attach a standard error to a covariance. See
+	// https://stats.stackexchange.com/q/48366.
+	//
 	// BivariateMoment applies no degrees of freedom correction, so the
 	// (1,1) moment divides by n where Covariance divides by n-1.
 	m11 := stat.BivariateMoment(1, 1, xs, ys, nil)
 	m22 := stat.BivariateMoment(2, 2, xs, ys, nil)
-	cov := stat.Covariance(xs, ys, nil)
-
 	stdErr := math.Sqrt((m22 - m11*m11) / n)
 
-	fmt.Printf("μ_11     = %.6f\n", m11)
-	fmt.Printf("cov      = %.6f\n", cov)
-	fmt.Printf("μ_22     = %.6f\n", m22)
-	fmt.Printf("std err  = %.6f\n", stdErr)
+	cov := stat.Covariance(xs, ys, nil)
+
+	fmt.Printf("μ_11    = %.6f\n", m11)
+	fmt.Printf("cov     = %.6f\n", cov)
+	fmt.Printf("μ_22    = %.6f\n", m22)
+	fmt.Printf("std err = %.6f\n", stdErr)
 
 	// Output:
-	// μ_11     = 0.490614
-	// cov      = 0.491105
-	// μ_22     = 1.685326
-	// std err  = 0.038008
+	// μ_11    = 0.490614
+	// cov     = 0.491105
+	// μ_22    = 1.685326
+	// std err = 0.038008
 }
 
 func ExampleLinearRegression() {


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."

Do not delete any of this templated text in the PR description, but
feel free to add additional context.
-->

Fixes #247.

The issue suggested that a good example would show the error in the covariance, linking https://stats.stackexchange.com/questions/48366. The example does that: it uses the (2,2) moment to attach a standard error to a covariance estimate, and notes that `BivariateMoment` applies no degrees of freedom correction where `Covariance` does.

The data is generated with a fixed linear dependence so the true covariance is 0.5 by construction, which makes the printed values checkable against theory. For that bivariate normal the analytic μ_22 is `Var(x)Var(y) + 2Cov² = 1.75`, so the estimate lands about 0.23 standard errors from the true value and the reported standard error is demonstrably the right size.

Seeding follows the existing style in `stat_example_test.go`.

`go test ./stat/...`, `go vet ./stat/` and `gofmt -l` are clean.

Apologies for the missing template text on the first push — restored above, and the review comments are addressed in the follow-up commit.
