### PR TITLE
stat: document ordering of PCA direction vectors

### DIFF
--- a/stat/pca_cca.go
+++ b/stat/pca_cca.go
@@ -48,6 +48,9 @@ func (c *PC) PrincipalComponents(a mat.Matrix, weights []float64) (ok bool) {
 
 // VectorsTo returns the component direction vectors of a principal components
 // analysis. The vectors are returned in the columns of a d×min(n, d) matrix.
+// The columns are ordered to correspond to the variances returned by VarsTo,
+// so the first column is the direction of greatest variance and subsequent
+// columns are in order of decreasing variance.
 //
 // If dst is empty, VectorsTo will resize dst to be d×min(n, d). When dst is
 // non-empty, VectorsTo will panic if dst is not d×min(n, d). VectorsTo will also

--- a/stat/pca_cca.go
+++ b/stat/pca_cca.go
@@ -48,9 +48,7 @@ func (c *PC) PrincipalComponents(a mat.Matrix, weights []float64) (ok bool) {
 
 // VectorsTo returns the component direction vectors of a principal components
 // analysis. The vectors are returned in the columns of a d×min(n, d) matrix.
-// The columns are ordered to correspond to the variances returned by VarsTo,
-// so the first column is the direction of greatest variance and subsequent
-// columns are in order of decreasing variance.
+// The columns are ordered to correspond to the variances returned by VarsTo.
 //
 // If dst is empty, VectorsTo will resize dst to be d×min(n, d). When dst is
 // non-empty, VectorsTo will panic if dst is not d×min(n, d). VectorsTo will also


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."

Do not delete any of this templated text in the PR description, but
feel free to add additional context.
-->

Fixes #698.

`VarsTo` documents that the variances are returned in descending order, but `VectorsTo` did not state that its columns are in the corresponding order. As the issue notes, a reader can only infer it, since otherwise the analysis would be meaningless.

Documentation only; no behaviour change.

Apologies for the missing template text on the first push — restored above, and the review comment is addressed in the follow-up commit.
