### PR TITLE
dsp/window: report ENBW, fix leakage measurement and check convergence

### DIFF
--- a/dsp/window/cmd/leakage/leakage.go
+++ b/dsp/window/cmd/leakage/leakage.go
@@ -143,13 +143,14 @@ func main() {
 	name := flag.String("window", "", "specify a built-in window name (required if csv not given)")
 	param := flag.Float64("param", math.NaN(), "specify parameter for parametric windows")
 	symm := flag.Bool("symm", true, "specify whether the window is symmetric")
-	n := flag.Int("n", 20, "specify window length")
-	m := flag.Int("m", 1000, "specify sample length (must be greater than n)")
+	n := flag.Int("n", 1024, "specify window length")
+	m := flag.Int("m", 1<<16, "specify sample length (must be greater than n)")
 	csv := flag.String("csv", "", "specify an input file of dB transformed frequency amplitudes (required if window not given)")
 	out := flag.String("o", "", "specify output file for plot (required, formats eps, jpg, jpeg, pdf, png, svg, tex or tif)")
 	width := flag.Float64("width", 16, "specify plot width (cm)")
 	height := flag.Float64("height", 8, "specify plot height (cm)")
 	comment := flag.Bool("comment", false, "output a comment line for the window (only for window function)")
+	eps := flag.Float64("eps", 1e-3, "warn if parameters have not converged to this relative tolerance at -n (zero disables the check)")
 	flag.Parse()
 
 	win := windows[strings.ToLower(*name)]
@@ -190,9 +191,12 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+		if *eps > 0 {
+			warnUnconverged(os.Stderr, win.fn(*param), *n, *m, *symm, c, *eps)
+		}
 		if *comment {
-			fmt.Printf("// Spectral leakage parameters: ΔF_0 = %2f, ΔF_0.5 = %.2f, K = %.2f, ɣ_max = %2f, β = %2f.\n",
-				c.deltaF0, c.deltaFhalf, c.k(), c.gammaMax, c.beta)
+			fmt.Printf("// Spectral leakage parameters: ΔF_0 = %2f, ΔF_0.5 = %.2f, ENBW = %.3f, K = %.2f, ɣ_max = %2f, β = %2f.\n",
+				c.deltaF0, c.deltaFhalf, c.enbw, c.k(), c.gammaMax, c.beta)
 		}
 	} else {
 		f, err := os.Open(*csv)
@@ -266,6 +270,11 @@ type characteristics struct {
 	deltaFhalf float64
 	gammaMax   float64
 	beta       float64
+
+	// enbw is the equivalent noise bandwidth, which is a distinct
+	// parameter from deltaFhalf. It is NaN when the window itself is not
+	// available, as when reading a spectrum from csv.
+	enbw float64
 }
 
 // k returns the K window parameter which is the ratio of the window's
@@ -309,7 +318,7 @@ func funcCharacteristics(fn func([]float64) []float64, n, m int, symm bool) (c *
 		xy[i] = plotter.XY{X: float64(i) * float64(n) / float64(m), Y: a - max}
 	}
 
-	c = &characteristics{beta: db(stat.Mean(w, nil))}
+	c = &characteristics{beta: db(stat.Mean(w, nil)), enbw: enbw(w)}
 	c.deltaF0, c.deltaFhalf, c.gammaMax = parameters(t, n, m)
 
 	return c, xy, min - max, nil
@@ -361,22 +370,58 @@ func csvCharacteristics(r io.Reader, n, m int) (c *characteristics, xy plotter.X
 }
 
 func parameters(spectrum []float64, n, m int) (deltaF0, deltaFhalf, gammaMax float64) {
-	max := spectrum[0]
-	var peaks []float64
-	for i, r := range spectrum {
-		if i > 1 {
-			if spectrum[i-1] < r && deltaF0 == 0 {
-				deltaF0 = 2 * float64((i-1)*n) / float64(m)
-			}
-			if thresh := max - 3; thresh < spectrum[i-1] && r <= thresh {
-				deltaFhalf = 2 * float64((i-1)*n) / float64(m)
-			}
+	// Locate the peak rather than assuming it is at DC. A flat top window
+	// is designed to have a flat passband and its maximum lies a little
+	// away from zero frequency, so taking spectrum[0] as the reference
+	// makes its main lobe width and maximum sidelobe meaningless.
+	half := len(spectrum) / 2
+	pk := 0
+	for i := 1; i < half; i++ {
+		if spectrum[i] > spectrum[pk] {
+			pk = i
 		}
-		if i > 2 && spectrum[i-2] <= spectrum[i-1] && spectrum[i-1] > r {
-			peaks = append(peaks, spectrum[i-1])
+	}
+	max := spectrum[pk]
+
+	// Frequency of bin i in DFT bins of the window.
+	freq := func(i int) float64 { return float64(i) * float64(n) / float64(m) }
+
+	// First null: the first point past the peak where the response stops
+	// falling, refined to the local minimum.
+	null := half - 1
+	for i := pk + 1; i < half; i++ {
+		if spectrum[i] > spectrum[i-1] {
+			null = i - 1
+			break
+		}
+	}
+	deltaF0 = 2 * (freq(null) - freq(pk))
+
+	// Half power width, linearly interpolated between the samples that
+	// straddle the -3 dB crossing. Taking the last sample above the
+	// threshold instead biases the result low by up to one bin.
+	thresh := max - 3
+	for i := pk + 1; i <= null; i++ {
+		if spectrum[i] <= thresh {
+			x0, x1 := freq(i-1), freq(i)
+			y0, y1 := spectrum[i-1], spectrum[i]
+			cross := x0
+			if y0 != y1 {
+				cross = x0 + (x1-x0)*(y0-thresh)/(y0-y1)
+			}
+			deltaFhalf = 2 * (cross - freq(pk))
+			break
 		}
 	}
 
+	// Highest sidelobe, measured beyond the main lobe and relative to the
+	// true peak.
+	var peaks []float64
+	for i := null + 1; i < half-1; i++ {
+		if spectrum[i-1] <= spectrum[i] && spectrum[i] > spectrum[i+1] {
+			peaks = append(peaks, spectrum[i])
+		}
+	}
 	if len(peaks) == 0 {
 		gammaMax = math.NaN()
 	} else {
@@ -384,6 +429,56 @@ func parameters(spectrum []float64, n, m int) (deltaF0, deltaFhalf, gammaMax flo
 	}
 
 	return deltaF0, deltaFhalf, gammaMax
+}
+
+// enbw returns the equivalent noise bandwidth of the window w, in DFT bins.
+//
+// ENBW is the width of the ideal rectangular filter passing the same noise
+// power as the window, and is a distinct parameter from the half power width
+// ΔF_0.5: for a Hann window ENBW is 1.5 bins while ΔF_0.5 is about 1.44.
+func enbw(w []float64) float64 {
+	var sum, sumSq float64
+	for _, v := range w {
+		sum += v
+		sumSq += v * v
+	}
+	if sum == 0 {
+		return math.NaN()
+	}
+	return float64(len(w)) * sumSq / (sum * sum)
+}
+
+// warnUnconverged recomputes the characteristics at twice the window length
+// and reports any parameter that still moves by more than eps in relative
+// terms. The leakage parameters are asymptotic in the window length, so a
+// short window reports values that have not settled: at n = 20 a Blackman
+// Nuttall window appears to have a maximum sidelobe of -85 dB where the
+// converged figure is -98 dB.
+func warnUnconverged(w io.Writer, fn func([]float64) []float64, n, m int, symm bool, c *characteristics, eps float64) {
+	ref, _, _, err := funcCharacteristics(fn, 2*n, 2*m, symm)
+	if err != nil {
+		fmt.Fprintf(w, "warning: cannot check convergence: %v\n", err)
+		return
+	}
+	for _, p := range []struct {
+		name     string
+		got, ref float64
+	}{
+		{"ΔF_0", c.deltaF0, ref.deltaF0},
+		{"ΔF_0.5", c.deltaFhalf, ref.deltaFhalf},
+		{"ENBW", c.enbw, ref.enbw},
+		{"K", c.k(), ref.k()},
+		{"ɣ_max", c.gammaMax, ref.gammaMax},
+		{"β", c.beta, ref.beta},
+	} {
+		if math.IsNaN(p.got) || math.IsNaN(p.ref) || p.ref == 0 {
+			continue
+		}
+		if d := math.Abs(p.got-p.ref) / math.Abs(p.ref); d > eps {
+			fmt.Fprintf(w, "warning: %s has not converged at n=%d: %.6g here against %.6g at n=%d (%.2g relative)\n",
+				p.name, n, p.got, p.ref, 2*n, d)
+		}
+	}
 }
 
 func db(m float64) float64 {

--- a/dsp/window/doc.go
+++ b/dsp/window/doc.go
@@ -17,7 +17,7 @@
 //
 // The characteristic changes associated with each window function may
 // be described using a set of spectral leakage parameters; β, ΔF_0, ΔF_0.5,
-// K and ɣ_max.
+// ENBW, K and ɣ_max.
 //
 // The β, attenuation, coefficient of a window is the ratio of the
 // constant component of the spectrum resulting from use of the window
@@ -30,7 +30,16 @@
 // the frequency spectrum at zero amplitude.
 //
 // The ΔF_0.5 parameter describes the normalized width of the main lobe of
-// the frequency spectrum at -3 dB (half maximum amplitude).
+// the frequency spectrum at -3 dB, that is at half the power of the peak.
+//
+// The ENBW parameter is the equivalent noise bandwidth: the width of the
+// ideal rectangular filter that would pass the same noise power as the
+// window, in DFT bins,
+//
+//	ENBW = N sum(w[i]^2) / (sum(w[i]))^2
+//
+// ENBW and ΔF_0.5 are distinct and should not be substituted for one
+// another; for the Hann window ENBW is 1.5 bins while ΔF_0.5 is 1.44.
 //
 // The K parameter describes the relative width of the main lobe of the
 // frequency spectrum produced by the window compared with the rectangular

--- a/dsp/window/window.go
+++ b/dsp/window/window.go
@@ -21,7 +21,7 @@ import "math"
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 2, ΔF_0.5 = 0.89, K = 1, ɣ_max = -13, β = 0.
+// Spectral leakage parameters: ΔF_0 = 2, ΔF_0.5 = 0.88, ENBW = 1, K = 1, ɣ_max = -13.3, β = 0.
 func Rectangular(seq []float64) []float64 {
 	return seq
 }
@@ -38,7 +38,7 @@ func Rectangular(seq []float64) []float64 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 3, ΔF_0.5 = 1.23, K = 1.5, ɣ_max = -23, β = -3.93.
+// Spectral leakage parameters: ΔF_0 = 3, ΔF_0.5 = 1.19, ENBW = 1.23, K = 1.5, ɣ_max = -23, β = -3.92.
 func Sine(seq []float64) []float64 {
 	k := math.Pi / float64(len(seq)-1)
 	for i := range seq {
@@ -59,7 +59,7 @@ func Sine(seq []float64) []float64 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 3.24, ΔF_0.5 = 1.3, K = 1.62, ɣ_max = -26.4, β = -4.6.
+// Spectral leakage parameters: ΔF_0 = 3.28, ΔF_0.5 = 1.25, ENBW = 1.3, K = 1.64, ɣ_max = -26.4, β = -4.59.
 func Lanczos(seq []float64) []float64 {
 	k := 2 / float64(len(seq)-1)
 	for i := range seq {
@@ -86,7 +86,7 @@ func Lanczos(seq []float64) []float64 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 4, ΔF_0.5 = 1.33, K = 2, ɣ_max = -26.5, β = -6.
+// Spectral leakage parameters: ΔF_0 = 4, ΔF_0.5 = 1.27, ENBW = 1.33, K = 2, ɣ_max = -26.5, β = -6.02.
 func Triangular(seq []float64) []float64 {
 	a := float64(len(seq)-1) / 2
 	for i := range seq {
@@ -107,7 +107,7 @@ func Triangular(seq []float64) []float64 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 4, ΔF_0.5 = 1.5, K = 2, ɣ_max = -31.5, β = -6.
+// Spectral leakage parameters: ΔF_0 = 4, ΔF_0.5 = 1.44, ENBW = 1.5, K = 2, ɣ_max = -31.5, β = -6.02.
 func Hann(seq []float64) []float64 {
 	k := 2 * math.Pi / float64(len(seq)-1)
 	for i := range seq {
@@ -129,7 +129,7 @@ func Hann(seq []float64) []float64 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 4, ΔF_0.5 = 1.45, K = 2, ɣ_max = -35.9, β = -6.
+// Spectral leakage parameters: ΔF_0 = 4, ΔF_0.5 = 1.39, ENBW = 1.46, K = 2, ɣ_max = -35.9, β = -6.02.
 func BartlettHann(seq []float64) []float64 {
 	const (
 		a0 = 0.62
@@ -157,7 +157,7 @@ func BartlettHann(seq []float64) []float64 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 4, ΔF_0.5 = 1.33, K = 2, ɣ_max = -42, β = -5.37.
+// Spectral leakage parameters: ΔF_0 = 4, ΔF_0.5 = 1.3, ENBW = 1.36, K = 2, ɣ_max = -42.7, β = -5.35.
 func Hamming(seq []float64) []float64 {
 	const (
 		a0 = 0.54
@@ -184,7 +184,7 @@ func Hamming(seq []float64) []float64 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 6, ΔF_0.5 = 1.7, K = 3, ɣ_max = -58, β = -7.54.
+// Spectral leakage parameters: ΔF_0 = 6, ΔF_0.5 = 1.64, ENBW = 1.73, K = 3, ɣ_max = -58.1, β = -7.54.
 func Blackman(seq []float64) []float64 {
 	const (
 		a0 = 0.42
@@ -214,7 +214,7 @@ func Blackman(seq []float64) []float64 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters:  ΔF_0 = 8, ΔF_0.5 = 1.97, K = 4, ɣ_max = -92, β = -8.91.
+// Spectral leakage parameters: ΔF_0 = 8, ΔF_0.5 = 1.9, ENBW = 2.01, K = 4, ɣ_max = -92, β = -8.91.
 func BlackmanHarris(seq []float64) []float64 {
 	const (
 		a0 = 0.35875
@@ -244,7 +244,7 @@ func BlackmanHarris(seq []float64) []float64 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 8, ΔF_0.5 = 1.98, K = 4, ɣ_max = -93, β = -9.
+// Spectral leakage parameters: ΔF_0 = 8, ΔF_0.5 = 1.91, ENBW = 2.02, K = 4, ɣ_max = -93.3, β = -8.98.
 func Nuttall(seq []float64) []float64 {
 	const (
 		a0 = 0.355768
@@ -275,7 +275,7 @@ func Nuttall(seq []float64) []float64 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 8, ΔF_0.5 = 1.94, K = 4, ɣ_max = -98, β = -8.8.
+// Spectral leakage parameters: ΔF_0 = 8, ΔF_0.5 = 1.87, ENBW = 1.98, K = 4, ɣ_max = -98.2, β = -8.79.
 func BlackmanNuttall(seq []float64) []float64 {
 	const (
 		a0 = 0.3635819
@@ -307,7 +307,7 @@ func BlackmanNuttall(seq []float64) []float64 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 10, ΔF_0.5 = 3.72, K = 5, ɣ_max = -93.0, β = -13.34.
+// Spectral leakage parameters: ΔF_0 = 9.44, ΔF_0.5 = 3.16, ENBW = 3.77, K = 4.72, ɣ_max = -93, β = -13.33.
 func FlatTop(seq []float64) []float64 {
 	const (
 		a0 = 0.21557895

--- a/dsp/window/window_complex.go
+++ b/dsp/window/window_complex.go
@@ -21,7 +21,7 @@ import "math"
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 2, ΔF_0.5 = 0.89, K = 1, ɣ_max = -13, β = 0.
+// Spectral leakage parameters: ΔF_0 = 2, ΔF_0.5 = 0.88, ENBW = 1, K = 1, ɣ_max = -13.3, β = 0.
 func RectangularComplex(seq []complex128) []complex128 {
 	return seq
 }
@@ -39,7 +39,7 @@ func RectangularComplex(seq []complex128) []complex128 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 3, ΔF_0.5 = 1.23, K = 1.5, ɣ_max = -23, β = -3.93.
+// Spectral leakage parameters: ΔF_0 = 3, ΔF_0.5 = 1.19, ENBW = 1.23, K = 1.5, ɣ_max = -23, β = -3.92.
 func SineComplex(seq []complex128) []complex128 {
 	k := math.Pi / float64(len(seq)-1)
 	for i, v := range seq {
@@ -62,7 +62,7 @@ func SineComplex(seq []complex128) []complex128 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 3.24, ΔF_0.5 = 1.3, K = 1.62, ɣ_max = -26.4, β = -4.6.
+// Spectral leakage parameters: ΔF_0 = 3.28, ΔF_0.5 = 1.25, ENBW = 1.3, K = 1.64, ɣ_max = -26.4, β = -4.59.
 func LanczosComplex(seq []complex128) []complex128 {
 	k := 2 / float64(len(seq)-1)
 	for i, v := range seq {
@@ -90,7 +90,7 @@ func LanczosComplex(seq []complex128) []complex128 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 4, ΔF_0.5 = 1.33, K = 2, ɣ_max = -26.5, β = -6.
+// Spectral leakage parameters: ΔF_0 = 4, ΔF_0.5 = 1.27, ENBW = 1.33, K = 2, ɣ_max = -26.5, β = -6.02.
 func TriangularComplex(seq []complex128) []complex128 {
 	a := float64(len(seq)-1) / 2
 	for i, v := range seq {
@@ -112,7 +112,7 @@ func TriangularComplex(seq []complex128) []complex128 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 4, ΔF_0.5 = 1.5, K = 2, ɣ_max = -31.5, β = -6.
+// Spectral leakage parameters: ΔF_0 = 4, ΔF_0.5 = 1.44, ENBW = 1.5, K = 2, ɣ_max = -31.5, β = -6.02.
 func HannComplex(seq []complex128) []complex128 {
 	k := 2 * math.Pi / float64(len(seq)-1)
 	for i, v := range seq {
@@ -135,7 +135,7 @@ func HannComplex(seq []complex128) []complex128 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 4, ΔF_0.5 = 1.45, K = 2, ɣ_max = -35.9, β = -6.
+// Spectral leakage parameters: ΔF_0 = 4, ΔF_0.5 = 1.39, ENBW = 1.46, K = 2, ɣ_max = -35.9, β = -6.02.
 func BartlettHannComplex(seq []complex128) []complex128 {
 	const (
 		a0 = 0.62
@@ -165,7 +165,7 @@ func BartlettHannComplex(seq []complex128) []complex128 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 4, ΔF_0.5 = 1.33, K = 2, ɣ_max = -42, β = -5.37.
+// Spectral leakage parameters: ΔF_0 = 4, ΔF_0.5 = 1.3, ENBW = 1.36, K = 2, ɣ_max = -42.7, β = -5.35.
 func HammingComplex(seq []complex128) []complex128 {
 	const (
 		a0 = 0.54
@@ -193,7 +193,7 @@ func HammingComplex(seq []complex128) []complex128 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 6, ΔF_0.5 = 1.7, K = 3, ɣ_max = -58, β = -7.54.
+// Spectral leakage parameters: ΔF_0 = 6, ΔF_0.5 = 1.64, ENBW = 1.73, K = 3, ɣ_max = -58.1, β = -7.54.
 func BlackmanComplex(seq []complex128) []complex128 {
 	const (
 		a0 = 0.42
@@ -224,7 +224,7 @@ func BlackmanComplex(seq []complex128) []complex128 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters:  ΔF_0 = 8, ΔF_0.5 = 1.97, K = 4, ɣ_max = -92, β = -8.91.
+// Spectral leakage parameters: ΔF_0 = 8, ΔF_0.5 = 1.9, ENBW = 2.01, K = 4, ɣ_max = -92, β = -8.91.
 func BlackmanHarrisComplex(seq []complex128) []complex128 {
 	const (
 		a0 = 0.35875
@@ -256,7 +256,7 @@ func BlackmanHarrisComplex(seq []complex128) []complex128 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 8, ΔF_0.5 = 1.98, K = 4, ɣ_max = -93, β = -9.
+// Spectral leakage parameters: ΔF_0 = 8, ΔF_0.5 = 1.91, ENBW = 2.02, K = 4, ɣ_max = -93.3, β = -8.98.
 func NuttallComplex(seq []complex128) []complex128 {
 	const (
 		a0 = 0.355768
@@ -288,7 +288,7 @@ func NuttallComplex(seq []complex128) []complex128 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 8, ΔF_0.5 = 1.94, K = 4, ɣ_max = -98, β = -8.8.
+// Spectral leakage parameters: ΔF_0 = 8, ΔF_0.5 = 1.87, ENBW = 1.98, K = 4, ɣ_max = -98.2, β = -8.79.
 func BlackmanNuttallComplex(seq []complex128) []complex128 {
 	const (
 		a0 = 0.3635819
@@ -321,7 +321,7 @@ func BlackmanNuttallComplex(seq []complex128) []complex128 {
 //
 // for k=0,1,...,N-1 where N is the length of the window.
 //
-// Spectral leakage parameters: ΔF_0 = 10, ΔF_0.5 = 3.72, K = 5, ɣ_max = -93.0, β = -13.34.
+// Spectral leakage parameters: ΔF_0 = 9.44, ΔF_0.5 = 3.16, ENBW = 3.77, K = 4.72, ɣ_max = -93, β = -13.33.
 func FlatTopComplex(seq []complex128) []complex128 {
 	const (
 		a0 = 0.21557895


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."

Do not delete any of this templated text in the PR description, but
feel free to add additional context.
-->

Fixes #1457.

Following the discussion on the issue, this is one change rather than three.

**Measurement.** `parameters` took `spectrum[0]` as the reference, assuming the peak is at DC. A flat top window is built to have a flat passband and peaks a little away from zero frequency, so for `FlatTop` the main lobe width, `K` and the maximum sidelobe were not measuring anything — it reported `ΔF_0 = 0.005`, `K = 0.00` and a positive `ɣ_max = +0.002`. The peak is now located. The half power width is also interpolated between the samples that straddle the −3 dB crossing rather than snapping to the last one above it, which biased it low by up to a bin.

**Convergence.** The parameters are asymptotic in the window length and the default of 20 was too short for them to settle:

| n | ΔF_0 | ɣ_max | β |
|---:|---:|---:|---:|
| 20 | 9.56 | −85.08 | −9.23 |
| 100 | 8.19 | −96.00 | −8.88 |
| 400 | 8.04 | −98.08 | −8.81 |
| converged | 8 | −98.2 | −8.79 |

The default is now 1024 with a matching `-m`, and `-eps` recomputes at twice the window length and warns about any parameter that has not converged to that relative tolerance. It defaults to 1e-3 and can be disabled with `-eps 0`. This seemed better than only raising the default, since it tells the next person when the length they have chosen is not enough.

**ENBW.** Reported alongside `ΔF_0.5` and documented in `doc.go` as the distinct parameter it is. This is what made the existing figures hard to reconcile: ten of the twelve documented `ΔF_0.5` values were equivalent noise bandwidths rather than half power widths. Hann documented 1.5, whose ENBW is 1.500 and whose ΔF_0.5 is 1.44; `Rectangular` documented 0.89, which is its ΔF_0.5, its ENBW being exactly 1. Both are now given for every window so there is nothing left to infer.

All values in `window.go` and `window_complex.go` were measured at `-n 4096 -m 262144` with the convergence check silent. `ΔF_0` and `K` for `Lanczos` and `FlatTop` move as a result of the peak fix; the rest of `ΔF_0`, `K`, `ɣ_max` and `β` were already correct and are unchanged apart from precision.

`go test ./dsp/window/...`, `go vet` and `gofmt -l` are clean.
