### PR TITLE
internal/asm: fix AMD64 GER negative increments

### DIFF
--- a/blas/gonum/ger_negative_stride_test.go
+++ b/blas/gonum/ger_negative_stride_test.go
@@ -1,0 +1,81 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gonum
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGerNegativeStrides(t *testing.T) {
+	t.Run("Sger", func(t *testing.T) { testGerNegativeStrides(t, Implementation{}.Sger, nil) })
+	t.Run("Dger", func(t *testing.T) { testGerNegativeStrides(t, Implementation{}.Dger, nil) })
+}
+func testGerNegativeStrides[T ~float32 | ~float64](t *testing.T, ger func(int, int, T, []T, int, []T, int, []T, int), alloc func(*testing.T, int) []T) {
+	if alloc == nil {
+		alloc = func(_ *testing.T, n int) []T { return make([]T, n) }
+	}
+	for _, shape := range [][2]int{{1, 1}, {1, 8}, {8, 1}, {2, 3}, {3, 2}, {4, 4}, {5, 9}, {7, 15}, {8, 8}, {64, 8}} {
+		m, n := shape[0], shape[1]
+		for _, incs := range [][2]int{{-3, -3}, {-3, 1}, {1, -3}, {-1, 3}, {3, -1}, {1, 1}, {3, 7}} {
+			incX, incY := incs[0], incs[1]
+			t.Run(fmt.Sprintf("m=%d/n=%d/incX=%d/incY=%d", m, n, incX, incY), func(t *testing.T) {
+				defer func() {
+					if p := recover(); p != nil {
+						t.Fatalf("unexpected memory access or panic: %v", p)
+					}
+				}()
+				abs := func(v int) int {
+					if v < 0 {
+						return -v
+					}
+					return v
+				}
+				x, y := alloc(t, 1+(m-1)*abs(incX)), alloc(t, 1+(n-1)*abs(incY))
+				for i := range x {
+					x[i] = T(i%19+1) / 8
+				}
+				for i := range y {
+					y[i] = T(i%13+1) / 4
+				}
+				lda := n + 3
+				a := alloc(t, (m-1)*lda+n)
+				for i := range a {
+					a[i] = T(i%17-8) / 16
+				}
+				originalX, originalY := append([]T(nil), x...), append([]T(nil), y...)
+				want := append([]T(nil), a...)
+				ix, iy := 0, 0
+				if incX < 0 {
+					ix = (1 - m) * incX
+				}
+				if incY < 0 {
+					iy = (1 - n) * incY
+				}
+				for i := 0; i < m; i++ {
+					for j := 0; j < n; j++ {
+						want[i*lda+j] += (T(.5) * x[ix+i*incX]) * y[iy+j*incY]
+					}
+				}
+				ger(m, n, T(.5), x, incX, y, incY, a, lda)
+				for i, v := range a {
+					if v != want[i] {
+						t.Fatalf("matrix/padding index%d got%g want%g", i, v, want[i])
+					}
+				}
+				for i, v := range x {
+					if v != originalX[i] {
+						t.Fatalf("x index%d changed", i)
+					}
+				}
+				for i, v := range y {
+					if v != originalY[i] {
+						t.Fatalf("y index%d changed", i)
+					}
+				}
+			})
+		}
+	}
+}

--- a/internal/asm/f32/ge_amd64.s
+++ b/internal/asm/f32/ge_amd64.s
@@ -570,7 +570,7 @@ inc:  // Algorithm for incY != 0 ( split loads in kernel )
 	NEGQ    TMP1
 	CMPQ    INC_X, $0
 	CMOVQLT TMP1, TMP2
-	LEAQ    (X_PTR)(TMP2*SIZE), X_PTR
+	LEAQ    (X_PTR)(TMP2*1), X_PTR
 
 	XORQ    TMP2, TMP2
 	MOVQ    N, TMP1
@@ -579,7 +579,8 @@ inc:  // Algorithm for incY != 0 ( split loads in kernel )
 	NEGQ    TMP1
 	CMPQ    INC_Y, $0
 	CMOVQLT TMP1, TMP2
-	LEAQ    (Y_PTR)(TMP2*SIZE), Y_PTR
+	LEAQ    (Y_PTR)(TMP2*1), Y_PTR
+	MOVQ    Y_PTR, TMP2 // Retain the adjusted start for subsequent row blocks.
 
 	SHRQ $2, M
 	JZ   inc_r2
@@ -636,7 +637,7 @@ inc_r4c1:
 
 inc_r4end:
 	LEAQ (X_PTR)(INC_X*4), X_PTR
-	MOVQ Y, Y_PTR
+	MOVQ TMP2, Y_PTR
 	LEAQ (A_ROW)(LDA*4), A_ROW
 	MOVQ A_ROW, A_PTR
 
@@ -698,7 +699,7 @@ inc_r2c1:
 
 inc_r2end:
 	LEAQ (X_PTR)(INC_X*2), X_PTR
-	MOVQ Y, Y_PTR
+	MOVQ TMP2, Y_PTR
 	LEAQ (A_ROW)(LDA*2), A_ROW
 	MOVQ A_ROW, A_PTR
 

--- a/internal/asm/f64/ger_amd64.s
+++ b/internal/asm/f64/ger_amd64.s
@@ -272,11 +272,11 @@ TEXT ·Ger(SB), NOSPLIT, $0
 	NEGQ    TMP1
 	CMPQ    INC_X, $0
 	CMOVQLT TMP1, TMP2
-	LEAQ    (X_PTR)(TMP2*SIZE), X_PTR
+	LEAQ    (X_PTR)(TMP2*1), X_PTR
 
 	CMPQ incY+80(FP), $1 // Check for dense vector Y (fast-path)
 	JG   inc
-	JL   end
+	JL   negative_y
 
 	SHRQ $2, M
 	JZ   r2
@@ -441,7 +441,8 @@ inc:  // Algorithm for incY != 1 ( split loads in kernel )
 	NEGQ    TMP1
 	CMPQ    INC_Y, $0
 	CMOVQLT TMP1, TMP2
-	LEAQ    (Y_PTR)(TMP2*SIZE), Y_PTR
+	LEAQ    (Y_PTR)(TMP2*1), Y_PTR
+	MOVQ    Y_PTR, TMP2 // Retain the adjusted start for subsequent row blocks.
 
 	SHRQ $2, M
 	JZ   inc_r2
@@ -490,7 +491,7 @@ inc_r4c1:
 
 inc_r4end:
 	LEAQ (X_PTR)(INC_X*4), X_PTR
-	MOVQ Y, Y_PTR
+	MOVQ TMP2, Y_PTR
 	LEAQ (A_ROW)(LDA*4), A_ROW
 	MOVQ A_ROW, A_PTR
 
@@ -541,7 +542,7 @@ inc_r2c1:
 
 inc_r2end:
 	LEAQ (X_PTR)(INC_X*2), X_PTR
-	MOVQ Y, Y_PTR
+	MOVQ TMP2, Y_PTR
 	LEAQ (A_ROW)(LDA*2), A_ROW
 	MOVQ A_ROW, A_PTR
 
@@ -589,3 +590,10 @@ inc_r1c1:
 
 inc_end:
 	RET
+
+// Negative increments use the split-load path. Preserve the existing zero-Y
+// increment quick return; public BLAS rejects zero increments.
+negative_y:
+	CMPQ incY+80(FP), $0
+	JE   end
+	JMP  inc


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."

Do not delete any of this templated text in the PR description, but
feel free to add additional context.
-->

Fixes #2105.

Apply negative-stride byte offsets once, preserve adjusted y starts, and handle negative incY in f64. Test Sger/Dger across row blocks and strides.

Tests: affected packages pass on darwin/arm64 (default, safe/noasm, race, vet); repaired AMD64 package suites pass under Rosetta, Go 1.27.1. The original produces incorrect matrices under Rosetta; repaired tests pass. No native AMD64 performance claim.

