### PR TITLE
internal/asm/f64: fix AMD64 absolute sums for infinities and zero stride

### DIFF
--- a/internal/asm/f64/abssum_amd64.s
+++ b/internal/asm/f64/abssum_amd64.s
@@ -8,75 +8,60 @@
 
 // func L1Norm(x []float64) float64
 TEXT ·L1Norm(SB), NOSPLIT, $0
-	MOVQ x_base+0(FP), SI // SI = &x
-	MOVQ x_len+8(FP), CX  // CX = len(x)
-	XORQ AX, AX           // i = 0
-	PXOR X0, X0           // p_sum_i = 0
-	PXOR X1, X1
+	MOVQ x_base+0(FP), SI
+	MOVQ x_len+8(FP), CX
+	XORQ AX, AX
+	PXOR X0, X0
 	PXOR X2, X2
-	PXOR X3, X3
 	PXOR X4, X4
-	PXOR X5, X5
 	PXOR X6, X6
-	PXOR X7, X7
-	CMPQ CX, $0           // if CX == 0 { return 0 }
+	CMPQ CX, $0
 	JE   absum_end
+	// Clear each input sign before addition. Computing max(sum+x, sum-x)
+	// instead can select NaN from Inf-Inf when sum and x are both +Inf.
+	PCMPEQL X12, X12
+	PSRLQ   $1, X12 // two copies of 0x7fffffffffffffff
 	MOVQ CX, BX
-	ANDQ $7, BX           // BX = len(x) % 8
-	SHRQ $3, CX           // CX = floor( len(x) / 8 )
-	JZ   absum_tail_start // if CX == 0 { goto absum_tail_start }
+	ANDQ $7, BX
+	SHRQ $3, CX
+	JZ   absum_tail_start
 
-absum_loop: // do {
-	// p_sum += max( p_sum + x[i], p_sum - x[i] )
-	MOVUPS (SI)(AX*8), X8    // X_i = x[i:i+1]
+absum_loop:
+	MOVUPS (SI)(AX*8), X8
 	MOVUPS 16(SI)(AX*8), X9
 	MOVUPS 32(SI)(AX*8), X10
 	MOVUPS 48(SI)(AX*8), X11
-	ADDPD  X8, X0            // p_sum_i += X_i  ( positive values )
-	ADDPD  X9, X2
-	ADDPD  X10, X4
-	ADDPD  X11, X6
-	SUBPD  X8, X1            // p_sum_(i+1) -= X_i  ( negative values )
-	SUBPD  X9, X3
-	SUBPD  X10, X5
-	SUBPD  X11, X7
-	MAXPD  X1, X0            // p_sum_i = max( p_sum_i, p_sum_(i+1) )
-	MAXPD  X3, X2
-	MAXPD  X5, X4
-	MAXPD  X7, X6
-	MOVAPS X0, X1            // p_sum_(i+1) = p_sum_i
-	MOVAPS X2, X3
-	MOVAPS X4, X5
-	MOVAPS X6, X7
-	ADDQ   $8, AX            // i += 8
-	LOOP   absum_loop        // } while --CX > 0
+	ANDPD X12, X8
+	ANDPD X12, X9
+	ANDPD X12, X10
+	ANDPD X12, X11
+	ADDPD X8, X0
+	ADDPD X9, X2
+	ADDPD X10, X4
+	ADDPD X11, X6
+	ADDQ $8, AX
+	LOOP absum_loop
 
-	// p_sum_0 = \sum_{i=1}^{3}( p_sum_(i*2) )
-	ADDPD X3, X0
-	ADDPD X5, X7
-	ADDPD X7, X0
-
-	// p_sum_0[0] = p_sum_0[0] + p_sum_0[1]
+	// Preserve the original lane and horizontal addition order.
+	ADDPD X2, X0
+	ADDPD X4, X6
+	ADDPD X6, X0
 	MOVAPS X0, X1
-	SHUFPD $0x3, X0, X0 // lower( p_sum_0 ) = upper( p_sum_0 )
-	ADDSD  X1, X0
-	CMPQ   BX, $0
-	JE     absum_end    // if BX == 0 { goto absum_end }
+	SHUFPD $0x3, X0, X0
+	ADDSD X1, X0
+	CMPQ BX, $0
+	JE absum_end
 
-absum_tail_start: // Reset loop registers
-	MOVQ  BX, CX // Loop counter:  CX = BX
-	XORPS X8, X8 // X_8 = 0
+absum_tail_start:
+	MOVQ BX, CX
 
-absum_tail: // do {
-	// p_sum += max( p_sum + x[i], p_sum - x[i] )
-	MOVSD (SI)(AX*8), X8 // X_8 = x[i]
-	MOVSD X0, X1         // p_sum_1 = p_sum_0
-	ADDSD X8, X0         // p_sum_0 += X_8
-	SUBSD X8, X1         // p_sum_1 -= X_8
-	MAXSD X1, X0         // p_sum_0 = max( p_sum_0, p_sum_1 )
-	INCQ  AX             // i++
-	LOOP  absum_tail     // } while --CX > 0
+absum_tail:
+	MOVSD (SI)(AX*8), X8
+	ANDPD X12, X8
+	ADDSD X8, X0
+	INCQ AX
+	LOOP absum_tail
 
-absum_end: // return p_sum_0
+absum_end:
 	MOVSD X0, sum+24(FP)
 	RET

--- a/internal/asm/f64/abssuminc_amd64.s
+++ b/internal/asm/f64/abssuminc_amd64.s
@@ -11,26 +11,29 @@ TEXT ·L1NormInc(SB), NOSPLIT, $0
 	MOVQ  x_base+0(FP), SI // SI = &x
 	MOVQ  n+24(FP), CX     // CX = n
 	MOVQ  incX+32(FP), AX  // AX =  increment * sizeof( float64 )
+	// Zero stride follows the documented empty loop, without reading x.
+	TESTQ AX, AX
+	JE    absum_zero_stride
 	SHLQ  $3, AX
 	MOVQ  AX, DX           // DX = AX * 3
 	IMULQ $3, DX
 	PXOR  X0, X0           // p_sum_i = 0
-	PXOR  X1, X1
 	PXOR  X2, X2
-	PXOR  X3, X3
 	PXOR  X4, X4
-	PXOR  X5, X5
 	PXOR  X6, X6
-	PXOR  X7, X7
 	CMPQ  CX, $0           // if CX == 0 { return 0 }
 	JE    absum_end
+	// Clear the input sign before adding. max(sum+x, sum-x) can select
+	// NaN from Inf-Inf when an accumulated +Inf meets another +Inf.
+	PCMPEQL X12, X12
+	PSRLQ   $1, X12 // two copies of 0x7fffffffffffffff
 	MOVQ  CX, BX
 	ANDQ  $7, BX           // BX = n % 8
 	SHRQ  $3, CX           // CX = floor( n / 8 )
 	JZ    absum_tail_start // if CX == 0 { goto absum_tail_start }
 
 absum_loop: // do {
-	// p_sum = max( p_sum + x[i], p_sum - x[i] )
+	// Preserve the Inc lane packing: (0,4), (1,5), (2,6), (3,7).
 	MOVSD  (SI), X8        // X_i[0] = x[i]
 	MOVSD  (SI)(AX*1), X9
 	MOVSD  (SI)(AX*2), X10
@@ -40,29 +43,21 @@ absum_loop: // do {
 	MOVHPD (SI)(AX*1), X9
 	MOVHPD (SI)(AX*2), X10
 	MOVHPD (SI)(DX*1), X11
-	ADDPD  X8, X0          // p_sum_i += X_i  ( positive values )
+	ANDPD  X12, X8
+	ANDPD  X12, X9
+	ANDPD  X12, X10
+	ANDPD  X12, X11
+	ADDPD  X8, X0          // p_sum_i += abs(X_i)
 	ADDPD  X9, X2
 	ADDPD  X10, X4
 	ADDPD  X11, X6
-	SUBPD  X8, X1          // p_sum_(i+1) -= X_i  ( negative values )
-	SUBPD  X9, X3
-	SUBPD  X10, X5
-	SUBPD  X11, X7
-	MAXPD  X1, X0          // p_sum_i = max( p_sum_i, p_sum_(i+1) )
-	MAXPD  X3, X2
-	MAXPD  X5, X4
-	MAXPD  X7, X6
-	MOVAPS X0, X1          // p_sum_(i+1) = p_sum_i
-	MOVAPS X2, X3
-	MOVAPS X4, X5
-	MOVAPS X6, X7
 	LEAQ   (SI)(AX*4), SI  // SI = SI + 4
 	LOOP   absum_loop      // } while --CX > 0
 
-	// p_sum_0 = \sum_{i=1}^{3}( p_sum_(i*2) )
-	ADDPD X3, X0
-	ADDPD X5, X7
-	ADDPD X7, X0
+	// Preserve the original per-lane merge: (lane0+lane1)+(lane3+lane2).
+	ADDPD X2, X0
+	ADDPD X4, X6
+	ADDPD X6, X0
 
 	// p_sum_0[0] = p_sum_0[0] + p_sum_0[1]
 	MOVAPS X0, X1
@@ -73,18 +68,20 @@ absum_loop: // do {
 
 absum_tail_start: // Reset loop registers
 	MOVQ  BX, CX // Loop counter:  CX = BX
-	XORPS X8, X8 // X_8 = 0
 
 absum_tail: // do {
-	// p_sum += max( p_sum + x[i], p_sum - x[i] )
-	MOVSD (SI), X8   // X_8 = x[i]
-	MOVSD X0, X1     // p_sum_1 = p_sum_0
-	ADDSD X8, X0     // p_sum_0 += X_8
-	SUBSD X8, X1     // p_sum_1 -= X_8
-	MAXSD X1, X0     // p_sum_0 = max( p_sum_0, p_sum_1 )
+	// Add one absolute value in the original scalar-tail order.
+	MOVSD (SI), X8
+	ANDPD X12, X8
+	ADDSD X8, X0
 	ADDQ  AX, SI     // i++
 	LOOP  absum_tail // } while --CX > 0
 
 absum_end: // return p_sum_0
+	MOVSD X0, sum+40(FP)
+	RET
+
+absum_zero_stride:
+	PXOR  X0, X0
 	MOVSD X0, sum+40(FP)
 	RET

--- a/internal/asm/f64/l1norm_grouping_amd64_test.go
+++ b/internal/asm/f64/l1norm_grouping_amd64_test.go
@@ -1,0 +1,76 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build amd64 && !noasm && !safe && !gccgo
+
+package f64_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"gonum.org/v1/gonum/internal/asm/f64"
+)
+
+func TestL1NormFiniteGroupingAMD64(t *testing.T) {
+	for _, n := range []int{1, 2, 7, 8, 9, 15, 16, 17, 31, 32, 33, 127, 128, 129, 4095, 4096, 4097} {
+		for _, kind := range []string{"wide", "subnormal", "near-overflow", "large-small"} {
+			t.Run(fmt.Sprintf("n%d/%s", n, kind), func(t *testing.T) {
+				x := make([]float64, n)
+				for i := range x {
+					switch kind {
+					case "wide":
+						x[i] = math.Ldexp(1+float64(i%13)/1024, (73*i)%1901-1000)
+					case "subnormal":
+						x[i] = math.Float64frombits(uint64(i%127 + 1))
+					case "near-overflow":
+						x[i] = math.MaxFloat64 / float64(n)
+					case "large-small":
+						x[i] = 1
+						if i%5 == 0 {
+							x[i] = 0x1p54
+						}
+					}
+					if i%2 != 0 {
+						x[i] = -x[i]
+					}
+				}
+				// The old ASM computes this positive-addition graph for finite
+				// inputs. Preserve its rounding, including finite-input overflow.
+				var lanes [8]float64
+				i := 0
+				for ; i+8 <= n; i += 8 {
+					for j := range lanes {
+						lanes[j] += math.Abs(x[i+j])
+					}
+				}
+				lo := (lanes[0] + lanes[2]) + (lanes[6] + lanes[4])
+				hi := (lanes[1] + lanes[3]) + (lanes[7] + lanes[5])
+				want := hi + lo
+				for ; i < n; i++ {
+					want += math.Abs(x[i])
+				}
+				got := f64.L1Norm(x)
+				if math.Float64bits(got) != math.Float64bits(want) {
+					t.Fatalf("got %g (%016x), want %g (%016x)", got, math.Float64bits(got), want, math.Float64bits(want))
+				}
+				stridedWant := ((lanes[4] + lanes[5]) + (lanes[7] + lanes[6])) + ((lanes[0] + lanes[1]) + (lanes[3] + lanes[2]))
+				for j := n / 8 * 8; j < n; j++ {
+					stridedWant += math.Abs(x[j])
+				}
+				for _, inc := range []int{1, 3} {
+					strided := make([]float64, 1+(n-1)*inc)
+					for j, v := range x {
+						strided[j*inc] = v
+					}
+					got := f64.L1NormInc(strided, n, inc)
+					if math.Float64bits(got) != math.Float64bits(stridedWant) {
+						t.Fatalf("inc=%d: got %g, want %g", inc, got, stridedWant)
+					}
+				}
+			})
+		}
+	}
+}

--- a/internal/asm/f64/l1norm_ieee_test.go
+++ b/internal/asm/f64/l1norm_ieee_test.go
@@ -1,0 +1,90 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package f64_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"gonum.org/v1/gonum/internal/asm/f64"
+)
+
+func TestL1NormIEEEAccumulation(t *testing.T) {
+	lengths := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 31, 32, 33, 127, 128, 129, 4095, 4096, 4097}
+	patterns := []string{"zero", "negative-zero", "dyadic", "all-positive-inf", "all-negative-inf", "mixed-inf", "paired-positive-inf", "paired-negative-inf", "same-lane-inf", "nan-first", "nan-last", "inf-then-nan", "nan-then-inf"}
+	for _, n := range lengths {
+		for _, offset := range []int{0, 1} {
+			for _, pattern := range patterns {
+				t.Run(fmt.Sprintf("n%d/offset%d/%s", n, offset, pattern), func(t *testing.T) {
+					backing := make([]float64, n+2)
+					x := backing[offset : offset+n]
+					for i := range x {
+						switch pattern {
+						case "negative-zero":
+							x[i] = math.Copysign(0, -1)
+						case "dyadic":
+							x[i] = float64(i%17-8) / 4
+						case "all-positive-inf":
+							x[i] = math.Inf(1)
+						case "all-negative-inf":
+							x[i] = math.Inf(-1)
+						case "mixed-inf":
+							x[i] = math.Inf(2*(i%2) - 1)
+						}
+					}
+					if n > 0 {
+						nan := math.Float64frombits(0xfff8000000000042)
+						switch pattern {
+						case "paired-positive-inf":
+							x[0], x[n-1] = math.Inf(1), math.Inf(1)
+						case "paired-negative-inf":
+							x[0], x[n-1] = math.Inf(-1), math.Inf(-1)
+						case "same-lane-inf":
+							for i := 0; i < n; i += 8 {
+								x[i] = math.Inf(1)
+							}
+						case "nan-first":
+							x[0] = nan
+						case "nan-last":
+							x[n-1] = nan
+						case "inf-then-nan":
+							x[0] = math.Inf(1)
+							x[n-1] = nan
+						case "nan-then-inf":
+							x[n-1] = math.Inf(1)
+							x[0] = nan
+						}
+					}
+					before := make([]uint64, len(backing))
+					for i, v := range backing {
+						before[i] = math.Float64bits(v)
+					}
+					// Finite values in these fixtures are exact dyadic sums.
+					var want float64
+					for _, v := range x {
+						want += math.Abs(v)
+					}
+					got := f64.L1Norm(x)
+					if math.IsNaN(want) {
+						if !math.IsNaN(got) {
+							t.Fatalf("got %g, want NaN", got)
+						}
+					} else if math.Float64bits(got) != math.Float64bits(want) {
+						t.Fatalf("got %g (%016x), want %g (%016x)", got, math.Float64bits(got), want, math.Float64bits(want))
+					}
+					for i, v := range backing {
+						if math.Float64bits(v) != before[i] {
+							t.Fatalf("input or guard modified at %d", i)
+						}
+					}
+				})
+			}
+		}
+	}
+	if got := f64.L1Norm(nil); math.Float64bits(got) != 0 {
+		t.Fatalf("nil returned %g", got)
+	}
+}

--- a/internal/asm/f64/l1norminc_ieee_test.go
+++ b/internal/asm/f64/l1norminc_ieee_test.go
@@ -1,0 +1,51 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package f64_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"gonum.org/v1/gonum/internal/asm/f64"
+)
+
+func TestL1NormIncIEEE(t *testing.T) {
+	for _, n := range []int{1, 2, 3, 7, 8, 9, 15, 16, 17, 31, 32, 33} {
+		for _, inc := range []int{1, 2, 3, 7} {
+			for _, value := range []float64{0, math.Copysign(0, -1), -0.25, math.Inf(1), math.Inf(-1), math.NaN(), math.SmallestNonzeroFloat64} {
+				t.Run(fmt.Sprintf("n=%d/inc=%d/value=%g", n, inc, value), func(t *testing.T) {
+					x := make([]float64, 1+(n-1)*inc)
+					for i := range x {
+						x[i] = math.NaN()
+					}
+					var want float64
+					for i := 0; i < n; i++ {
+						x[i*inc] = value
+						want += math.Abs(value)
+					}
+					got := f64.L1NormInc(x, n, inc)
+					if math.IsNaN(want) {
+						if !math.IsNaN(got) {
+							t.Fatalf("got %g, want NaN", got)
+						}
+					} else if math.Float64bits(got) != math.Float64bits(want) {
+						t.Fatalf("got %g, want %g", got, want)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestL1NormIncZeroStride(t *testing.T) {
+	for _, n := range []int{0, 1, 2, 7, 8, 9, 17} {
+		for _, x := range [][]float64{nil, {}, {-3}, {math.NaN()}, {math.Inf(1)}} {
+			if got := f64.L1NormInc(x, n, 0); math.Float64bits(got) != 0 {
+				t.Fatalf("n=%d x=%v: got %g, want +0", n, x, got)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."

Do not delete any of this templated text in the PR description, but
feel free to add additional context.
-->

Fixes #2106.

Mask input signs before accumulation, preserve finite reduction order, and return without reads for zero stride.

Tests: affected packages pass on darwin/arm64 (default, safe/noasm, race, vet); repaired AMD64 package suites pass under Rosetta, Go 1.27.1. The original returns NaN/NaN/6 in the three issue cases under Rosetta; repaired tests pass. No native AMD64 performance claim.

