### PR TITLE
internal/asm: fix complex AMD64 AXPY alignment and exhausted tails

### DIFF
--- a/internal/asm/c128/axpy_alignment_test.go
+++ b/internal/asm/c128/axpy_alignment_test.go
@@ -1,0 +1,96 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package c128_test
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+	"unsafe"
+
+	"gonum.org/v1/gonum/internal/asm/c128"
+)
+
+func alignedAxpyStorage(t *testing.T, mod uintptr) []complex128 {
+	t.Helper()
+	storage := new(struct {
+		A   [128]complex128
+		Pad uint64
+		B   [128]complex128
+	})
+	for _, v := range [][]complex128{storage.A[:], storage.B[:]} {
+		for i := 0; i < 4; i++ {
+			if uintptr(unsafe.Pointer(&v[i]))%16 == mod {
+				return v[i:]
+			}
+		}
+	}
+	t.Fatal("alignment fixture")
+	return nil
+}
+
+func TestAxpyAlignment(t *testing.T) {
+	for _, n := range []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17} {
+		for _, mod := range []uintptr{0, 8} {
+			for _, op := range []string{"Unitary", "UnitaryTo", "Inc", "IncTo"} {
+				for _, alias := range []string{"none", "x", "y"} {
+					t.Run(fmt.Sprintf("%s/n=%d/mod=%d/alias=%s", op, n, mod, alias), func(t *testing.T) {
+						inc := 1
+						if op == "Inc" || op == "IncTo" {
+							inc = 2
+						}
+						span := 1
+						if n > 0 {
+							span = 1 + (n-1)*inc
+						}
+						x := make([]complex128, span+1)
+						y := alignedAxpyStorage(t, mod)[:span+1]
+						dst := make([]complex128, span+1)
+						for i := range x {
+							x[i] = complex128(complex(float64(i+1), -2))
+							y[i] = complex128(complex(3, float64(i)))
+							dst[i] = 99
+						}
+						if alias == "x" {
+							dst = x
+						}
+						if alias == "y" {
+							dst = y
+						}
+						if op == "Unitary" || op == "Inc" {
+							dst = y
+						}
+						beforeX, beforeY := slices.Clone(x), slices.Clone(y)
+						want := slices.Clone(dst)
+						const alpha = complex128(2 - 3i)
+						for i := 0; i < n; i++ {
+							j := i * inc
+							want[j] = alpha*x[j] + y[j]
+						}
+						switch op {
+						case "Unitary":
+							c128.AxpyUnitary(alpha, x[:n], y[:n])
+						case "UnitaryTo":
+							c128.AxpyUnitaryTo(dst[:n], alpha, x[:n], y[:n])
+						case "Inc":
+							c128.AxpyInc(alpha, x[:span], y[:span], uintptr(n), uintptr(inc), uintptr(inc), 0, 0)
+						case "IncTo":
+							c128.AxpyIncTo(dst[:span], uintptr(inc), 0, alpha, x[:span], y[:span], uintptr(n), uintptr(inc), uintptr(inc), 0, 0)
+						}
+						if !slices.Equal(dst, want) {
+							t.Fatalf("got %v, want %v", dst, want)
+						}
+						if &dst[0] != &x[0] && !slices.Equal(x, beforeX) {
+							t.Fatal("x changed")
+						}
+						if &dst[0] != &y[0] && !slices.Equal(y, beforeY) {
+							t.Fatal("y changed")
+						}
+					})
+				}
+			}
+		}
+	}
+}

--- a/internal/asm/c128/axpyinc_amd64.s
+++ b/internal/asm/c128/axpyinc_amd64.s
@@ -92,11 +92,15 @@ axpyi_loop: // do {
 	ADDSUBPD_X8_X9
 
 	// X_(i+1) = { imag(result[i]) + imag(y[i]), real(result[i]) + real(y[i]) }
-	ADDPD  (DX), X3
-	ADDPD  (DX)(R9*1), X5
+	MOVUPS (DX), X2
+	ADDPD  X2, X3
+	MOVUPS (DX)(R9*1), X4
+	ADDPD  X4, X5
 	LEAQ   (DX)(R9*2), DX // DX = &(DX[incY*2])
-	ADDPD  (DX), X7
-	ADDPD  (DX)(R9*1), X9
+	MOVUPS (DX), X6
+	ADDPD  X6, X7
+	MOVUPS (DX)(R9*1), X8
+	ADDPD  X8, X9
 	MOVUPS X3, (DI)       // dst[i] = X_(i+1)
 	MOVUPS X5, (DI)(R9*1)
 	LEAQ   (DI)(R9*2), DI
@@ -124,7 +128,8 @@ axpyi_tail: // do {
 	ADDSUBPD_X2_X3
 
 	// X_(i+1) = { imag(result[i]) + imag(y[i]), real(result[i]) + real(y[i]) }
-	ADDPD  (DI), X3
+	MOVUPS (DI), X2
+	ADDPD  X2, X3
 	MOVUPS X3, (DI)   // y[i] = X_i
 	ADDQ   R8, SI     // SI = &(SI[incX])
 	ADDQ   R9, DI     // DI = &(DI[incY])

--- a/internal/asm/c128/axpyincto_amd64.s
+++ b/internal/asm/c128/axpyincto_amd64.s
@@ -98,11 +98,15 @@ axpyi_loop: // do {
 	ADDSUBPD_X8_X9
 
 	// X_(i+1) = { imag(result[i]) + imag(y[i]), real(result[i]) + real(y[i]) }
-	ADDPD  (DX), X3
-	ADDPD  (DX)(R9*1), X5
+	MOVUPS (DX), X2
+	ADDPD  X2, X3
+	MOVUPS (DX)(R9*1), X4
+	ADDPD  X4, X5
 	LEAQ   (DX)(R9*2), DX  // DX = &(DX[incY*2])
-	ADDPD  (DX), X7
-	ADDPD  (DX)(R9*1), X9
+	MOVUPS (DX), X6
+	ADDPD  X6, X7
+	MOVUPS (DX)(R9*1), X8
+	ADDPD  X8, X9
 	MOVUPS X3, (DI)        // dst[i] = X_(i+1)
 	MOVUPS X5, (DI)(R10*1)
 	LEAQ   (DI)(R10*2), DI
@@ -130,7 +134,8 @@ axpyi_tail: // do {
 	ADDSUBPD_X2_X3
 
 	// X_(i+1) = { imag(result[i]) + imag(y[i]), real(result[i]) + real(y[i]) }
-	ADDPD  (DX), X3
+	MOVUPS (DX), X2
+	ADDPD  X2, X3
 	MOVUPS X3, (DI)   // y[i] X_(i+1)
 	ADDQ   R8, SI     // SI += incX
 	ADDQ   R9, DX     // DX += incY

--- a/internal/asm/c128/axpyunitary_amd64.s
+++ b/internal/asm/c128/axpyunitary_amd64.s
@@ -85,10 +85,14 @@ caxy_loop: // do {
 	ADDSUBPD_X8_X9
 
 	// X_(i+1) = { imag(result[i]) + imag(y[i]), real(result[i]) + real(y[i]) }
-	ADDPD  (DI)(AX*8), X3
-	ADDPD  16(DI)(AX*8), X5
-	ADDPD  32(DI)(AX*8), X7
-	ADDPD  48(DI)(AX*8), X9
+	MOVUPS (DI)(AX*8), X2
+	ADDPD  X2, X3
+	MOVUPS 16(DI)(AX*8), X4
+	ADDPD  X4, X5
+	MOVUPS 32(DI)(AX*8), X6
+	ADDPD  X6, X7
+	MOVUPS 48(DI)(AX*8), X8
+	ADDPD  X8, X9
 	MOVUPS X3, (DI)(AX*8)   // y[i] = X_(i+1)
 	MOVUPS X5, 16(DI)(AX*8)
 	MOVUPS X7, 32(DI)(AX*8)
@@ -113,7 +117,8 @@ caxy_tail: // do {
 	ADDSUBPD_X2_X3
 
 	// X_(i+1) = { imag(result[i]) + imag(y[i]), real(result[i]) + real(y[i]) }
-	ADDPD  (DI)(AX*8), X3
+	MOVUPS (DI)(AX*8), X2
+	ADDPD  X2, X3
 	MOVUPS X3, (DI)(AX*8) // y[i] = X_(i+1)
 	ADDQ   $2, AX         // i += 2
 	LOOP   caxy_tail      // }  while --CX > 0

--- a/internal/asm/c128/axpyunitaryto_amd64.s
+++ b/internal/asm/c128/axpyunitaryto_amd64.s
@@ -86,10 +86,14 @@ caxy_loop: // do {
 	ADDSUBPD_X8_X9
 
 	// X_(i+1) = { imag(result[i]) + imag(y[i]), real(result[i]) + real(y[i]) }
-	ADDPD  (DX)(AX*8), X3
-	ADDPD  16(DX)(AX*8), X5
-	ADDPD  32(DX)(AX*8), X7
-	ADDPD  48(DX)(AX*8), X9
+	MOVUPS (DX)(AX*8), X2
+	ADDPD  X2, X3
+	MOVUPS 16(DX)(AX*8), X4
+	ADDPD  X4, X5
+	MOVUPS 32(DX)(AX*8), X6
+	ADDPD  X6, X7
+	MOVUPS 48(DX)(AX*8), X8
+	ADDPD  X8, X9
 	MOVUPS X3, (DI)(AX*8)   // y[i] = X_(i+1)
 	MOVUPS X5, 16(DI)(AX*8)
 	MOVUPS X7, 32(DI)(AX*8)
@@ -114,7 +118,8 @@ caxy_tail: // Same calculation, but read in values to avoid trampling memory
 	ADDSUBPD_X2_X3
 
 	// X_(i+1) = { imag(result[i]) + imag(y[i]), real(result[i]) + real(y[i]) }
-	ADDPD  (DX)(AX*8), X3
+	MOVUPS (DX)(AX*8), X2
+	ADDPD  X2, X3
 	MOVUPS X3, (DI)(AX*8) // y[i] = X_(i+1)
 	ADDQ   $2, AX         // i += 2
 	LOOP   caxy_tail      // }  while --CX > 0

--- a/internal/asm/c64/axpy_alignment_test.go
+++ b/internal/asm/c64/axpy_alignment_test.go
@@ -1,0 +1,93 @@
+// Copyright ©2026 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package c64_test
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+	"unsafe"
+
+	"gonum.org/v1/gonum/internal/asm/c64"
+)
+
+func alignedAxpyStorage(t *testing.T, mod uintptr) []complex64 {
+	t.Helper()
+	storage := new(struct {
+		A   [128]complex64
+		Pad float32
+		B   [128]complex64
+	})
+	for _, v := range [][]complex64{storage.A[:], storage.B[:]} {
+		for i := 0; i < 4; i++ {
+			if uintptr(unsafe.Pointer(&v[i]))%16 == mod {
+				return v[i:]
+			}
+		}
+	}
+	t.Fatal("alignment fixture")
+	return nil
+}
+
+func TestAxpyAlignment(t *testing.T) {
+	for _, n := range []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17} {
+		for _, mod := range []uintptr{0, 4, 8, 12} {
+			for _, op := range []string{"Unitary", "UnitaryTo"} {
+				for _, alias := range []string{"none", "x", "y"} {
+					t.Run(fmt.Sprintf("%s/n=%d/mod=%d/alias=%s", op, n, mod, alias), func(t *testing.T) {
+						inc := 1
+						if op == "Inc" || op == "IncTo" {
+							inc = 2
+						}
+						span := 1
+						if n > 0 {
+							span = 1 + (n-1)*inc
+						}
+						x := make([]complex64, span+1)
+						y := alignedAxpyStorage(t, mod)[:span+1]
+						dst := make([]complex64, span+1)
+						for i := range x {
+							x[i] = complex64(complex(float64(i+1), -2))
+							y[i] = complex64(complex(3, float64(i)))
+							dst[i] = 99
+						}
+						if alias == "x" {
+							dst = x
+						}
+						if alias == "y" {
+							dst = y
+						}
+						if op == "Unitary" || op == "Inc" {
+							dst = y
+						}
+						beforeX, beforeY := slices.Clone(x), slices.Clone(y)
+						want := slices.Clone(dst)
+						const alpha = complex64(2 - 3i)
+						for i := 0; i < n; i++ {
+							j := i * inc
+							want[j] = alpha*x[j] + y[j]
+						}
+						switch op {
+						case "Unitary":
+							c64.AxpyUnitary(alpha, x[:n], y[:n])
+						case "UnitaryTo":
+							c64.AxpyUnitaryTo(dst[:n], alpha, x[:n], y[:n])
+
+						}
+						if !slices.Equal(dst, want) {
+							t.Fatalf("got %v, want %v", dst, want)
+						}
+						if &dst[0] != &x[0] && !slices.Equal(x, beforeX) {
+							t.Fatal("x changed")
+						}
+						if &dst[0] != &y[0] && !slices.Equal(y, beforeY) {
+							t.Fatal("y changed")
+						}
+					})
+				}
+			}
+		}
+	}
+}

--- a/internal/asm/c64/axpyunitary_amd64.s
+++ b/internal/asm/c64/axpyunitary_amd64.s
@@ -53,6 +53,8 @@ TEXT ·AxpyUnitary(SB), NOSPLIT, $0
 	MOVQ    DI, BX            // Align on 16-byte boundary for ADDPS
 	ANDQ    $15, BX           // BX = &y & 15
 	JZ      caxy_no_trim      // if BX == 0 { goto caxy_no_trim }
+	CMPQ    BX, $8           // Only 8-byte-aligned y can be trimmed to 16 bytes.
+	JNE     caxy_tail         // Otherwise use scalar loads for all elements.
 
 	// Trim first value in unaligned buffer
 	XORPS X2, X2         // Clear work registers and cache-align loop

--- a/internal/asm/c64/axpyunitaryto_amd64.s
+++ b/internal/asm/c64/axpyunitaryto_amd64.s
@@ -54,6 +54,8 @@ TEXT ·AxpyUnitaryTo(SB), NOSPLIT, $0
 	MOVQ    DX, BX             // Align on 16-byte boundary for ADDPS
 	ANDQ    $15, BX            // BX = &y & 15
 	JZ      caxy_no_trim       // if BX == 0 { goto caxy_no_trim }
+	CMPQ    BX, $8            // Only 8-byte-aligned y can be trimmed to 16 bytes.
+	JNE     caxy_tail          // Otherwise use scalar loads for all elements.
 
 	MOVSD (SI)(AX*8), X3 // X3 = { imag(x[i]), real(x[i]) }
 	MOVSHDUP_X3_X2       // X2 = { imag(x[i]), imag(x[i]) }
@@ -68,7 +70,7 @@ TEXT ·AxpyUnitaryTo(SB), NOSPLIT, $0
 	MOVSD X3, (DI)(AX*8) // dst[i]  = X3
 	INCQ  AX             // i++
 	DECQ  CX             // --CX
-	JZ    caxy_tail      // if BX == 0 { goto caxy_tail }
+	JZ    caxy_end       // if CX == 0 { return }
 
 caxy_no_trim:
 	MOVAPS X0, X10   // Copy X0 and X1 for pipelineing


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."

Do not delete any of this templated text in the PR description, but
feel free to add additional context.
-->

Fixes #2103.

Handle valid Go alignment in c64/c128 AXPY and return when the c64 alignment prefix exhausts the input.

Tests: affected packages pass on darwin/arm64 (default, safe/noasm, race, vet); repaired AMD64 package suites pass under Rosetta, Go 1.27.1. Rosetta reproduces the original exhausted-tail failure, but not alignment faults; native AMD64 alignment validation remains pending. No native AMD64 performance claim.

